### PR TITLE
refactor(devtools): split native logic from extension adapter

### DIFF
--- a/extensions/devtools/devtools.mbt
+++ b/extensions/devtools/devtools.mbt
@@ -1,0 +1,76 @@
+///|
+struct DevtoolsReply {
+  opened : Bool
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+extern "C" fn is_windows_ffi() -> Bool = "extensions_devtools_is_windows"
+
+///|
+extern "C" fn open_devtools_ffi(browser_handle : Int64) -> Int = "extensions_devtools_open"
+
+///|
+let open_status_ok = 0
+
+///|
+let open_status_unsupported = 1
+
+///|
+let open_status_invalid_handle = 2
+
+///|
+let open_status_get_webview_failed = 3
+
+///|
+let open_status_open_failed = 4
+
+///|
+/// Verifies that the devtools extension is available on the current platform.
+fn ensure_supported() -> Result[Unit, String] {
+  if is_windows_ffi() {
+    Ok(())
+  } else {
+    Err(
+      "devtools extension currently supports Windows WebView2 native builds only",
+    )
+  }
+}
+
+///|
+/// Converts native open status codes into JavaScript-facing errors.
+fn open_status_error(status : Int) -> String {
+  if status == open_status_unsupported {
+    "devtools extension currently supports Windows WebView2 native builds only"
+  } else if status == open_status_invalid_handle {
+    "devtools.open failed: native browser handle is unavailable"
+  } else if status == open_status_get_webview_failed {
+    "devtools.open failed: WebView2 controller did not return a browser"
+  } else if status == open_status_open_failed {
+    "devtools.open failed: WebView2 rejected OpenDevToolsWindow"
+  } else {
+    "devtools.open failed: unknown native status \{status}"
+  }
+}
+
+///|
+/// Converts the native open status into a typed reply.
+fn open_reply_from_status(status : Int) -> Result[DevtoolsReply, String] {
+  if status == open_status_ok {
+    Ok(DevtoolsReply::{ opened: true })
+  } else {
+    Err(open_status_error(status))
+  }
+}
+
+///|
+/// Opens developer tools for a native browser handle.
+fn open_devtools_for_browser(
+  browser_handle : Int64,
+) -> Result[DevtoolsReply, String] {
+  ensure_supported().bind(fn(_) {
+    guard browser_handle != 0 else {
+      return Err("devtools.open failed: native browser handle is unavailable")
+    }
+    open_reply_from_status(open_devtools_ffi(browser_handle))
+  })
+}

--- a/extensions/devtools/extension.mbt
+++ b/extensions/devtools/extension.mbt
@@ -5,73 +5,9 @@ let extension_id = "justjavac/lepus-devtools"
 let extension_namespace = "devtools"
 
 ///|
-struct DevtoolsReply {
-  opened : Bool
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 struct DevtoolsActivity {
   operation : String
 } derive(ToJson, FromJson, Debug, Eq)
-
-///|
-extern "C" fn is_windows_ffi() -> Bool = "extensions_devtools_is_windows"
-
-///|
-extern "C" fn open_devtools_ffi(browser_handle : Int64) -> Int = "extensions_devtools_open"
-
-///|
-let open_status_ok = 0
-
-///|
-let open_status_unsupported = 1
-
-///|
-let open_status_invalid_handle = 2
-
-///|
-let open_status_get_webview_failed = 3
-
-///|
-let open_status_open_failed = 4
-
-///|
-/// Verifies that the devtools extension is available on the current platform.
-fn ensure_supported() -> Result[Unit, String] {
-  if is_windows_ffi() {
-    Ok(())
-  } else {
-    Err(
-      "devtools extension currently supports Windows WebView2 native builds only",
-    )
-  }
-}
-
-///|
-/// Converts native open status codes into JavaScript-facing errors.
-fn open_status_error(status : Int) -> String {
-  if status == open_status_unsupported {
-    "devtools extension currently supports Windows WebView2 native builds only"
-  } else if status == open_status_invalid_handle {
-    "devtools.open failed: native browser handle is unavailable"
-  } else if status == open_status_get_webview_failed {
-    "devtools.open failed: WebView2 controller did not return a browser"
-  } else if status == open_status_open_failed {
-    "devtools.open failed: WebView2 rejected OpenDevToolsWindow"
-  } else {
-    "devtools.open failed: unknown native status \{status}"
-  }
-}
-
-///|
-/// Converts the native open status into a typed reply.
-fn open_reply_from_status(status : Int) -> Result[DevtoolsReply, String] {
-  if status == open_status_ok {
-    Ok(DevtoolsReply::{ opened: true })
-  } else {
-    Err(open_status_error(status))
-  }
-}
 
 ///|
 /// Emits a devtools activity event for JavaScript listeners.
@@ -87,17 +23,12 @@ fn emit_activity(
 fn open_devtools(
   extension : @core.ExtensionContext,
 ) -> Result[DevtoolsReply, String] {
-  ensure_supported().bind(fn(_) {
-    let browser_handle = extension
-      .webview()
-      .get_native_handle(@webview.NativeHandleKind::Browser)
-    guard browser_handle != 0 else {
-      return Err("devtools.open failed: native browser handle is unavailable")
-    }
-    open_reply_from_status(open_devtools_ffi(browser_handle)).map(fn(reply) {
-      emit_activity(extension, "open")
-      reply
-    })
+  let browser_handle = extension
+    .webview()
+    .get_native_handle(@webview.NativeHandleKind::Browser)
+  open_devtools_for_browser(browser_handle).map(fn(reply) {
+    emit_activity(extension, "open")
+    reply
   })
 }
 

--- a/extensions/devtools/moon.pkg
+++ b/extensions/devtools/moon.pkg
@@ -9,6 +9,7 @@ supported_targets = "native"
 options(
   "native-stub": [ "devtools_native.c" ],
   targets: {
+    "devtools.mbt": [ "native" ],
     "extension.mbt": [ "native" ],
     "extension_wbtest.mbt": [ "native" ],
   },


### PR DESCRIPTION
## Summary
- split devtools native support/open-status logic into devtools.mbt
- keep extension.mbt focused on the core extension adapter and event emission
- keep devtools as a synchronous core extension because it needs the framework webview native handle

## Why not attribute codegen
Current #lepus attribute codegen generates @app.AppCommandExtensionSpec. devtools.open needs @core.ExtensionContext to access the current webview browser native handle in the framework process, so converting it to an app-command extension would lose the handle required to open WebView2 DevTools.

## Validation
- moon fmt --check
- moon -C extensions check --target native --deny-warn
- moon -C extensions test devtools --target native
- moon -C examples build 36_app_devtools --target native
- moon check --target native --deny-warn

Note: existing auto_launch codegen on main prints three informational sync-command messages during some checks; this PR does not change that code.