### PR TITLE
fix(proton): inject bridge proxy for asset entries

### DIFF
--- a/proton/facade_entry.mbt
+++ b/proton/facade_entry.mbt
@@ -16,9 +16,13 @@ fn load_entry_after_create(
     @manifest.AppEntry::Url(url) =>
       native_unit_result("load url", window.load_url(url))
     @manifest.AppEntry::File(path) =>
-      native_unit_result("load file", window.load_url(file_url(path)))
+      load_file_entry_after_create(
+        window, "load file", path, command_proxy_script,
+      )
     @manifest.AppEntry::Asset(path) =>
-      native_unit_result("load asset", window.load_url(file_url(path)))
+      load_file_entry_after_create(
+        window, "load asset", path, command_proxy_script,
+      )
   }
 }
 
@@ -26,19 +30,83 @@ fn load_entry_after_create(
 fn inject_command_proxy_script(html : String, script : String?) -> String {
   match script {
     None => html
-    Some(value) => {
-      let tag = "<script>" +
-        value.replace_all(old="</script", new="<\\/script") +
-        "</script>\n"
-      if html.contains("<head>") {
-        html.replace(old="<head>", new="<head>\n" + tag)
-      } else if html.contains("<body>") {
-        html.replace(old="<body>", new=tag + "<body>")
-      } else {
-        tag + html
-      }
-    }
+    Some(value) => inject_html_bootstrap(html, script_tag(value))
   }
+}
+
+///|
+fn load_file_entry_after_create(
+  window : @native.Window,
+  action : String,
+  path : String,
+  command_proxy_script : String?,
+) -> Result[Unit, String] {
+  match command_proxy_script {
+    None => native_unit_result(action, window.load_url(file_url(path)))
+    Some(script) =>
+      match read_file_entry_html(path, action) {
+        Err(error) => Err(error)
+        Ok(html) => {
+          let bootstrap = base_tag(file_base_url(path)) + script_tag(script)
+          native_unit_result(
+            action,
+            window.load_html(
+              inject_html_bootstrap(html, bootstrap),
+              "proton://app/",
+            ),
+          )
+        }
+      }
+  }
+}
+
+///|
+fn read_file_entry_html(
+  path : String,
+  action : String,
+) -> Result[String, String] {
+  try @mbfs.read_file_to_string(path) catch {
+    error =>
+      Err(
+        action +
+        " failed: failed to read HTML entry: " +
+        @debug.render(@debug.to_repr(error)),
+      )
+  } noraise {
+    text => Ok(text)
+  }
+}
+
+///|
+fn inject_html_bootstrap(html : String, bootstrap : String) -> String {
+  if html.contains("<head>") {
+    html.replace(old="<head>", new="<head>\n" + bootstrap)
+  } else if html.contains("<body>") {
+    html.replace(old="<body>", new=bootstrap + "<body>")
+  } else {
+    bootstrap + html
+  }
+}
+
+///|
+fn script_tag(script : String) -> String {
+  "<script>" +
+  script.replace_all(old="</script", new="<\\/script") +
+  "</script>\n"
+}
+
+///|
+fn base_tag(href : String) -> String {
+  "<base href=\"" + html_attribute_escape(href) + "\">\n"
+}
+
+///|
+fn html_attribute_escape(value : String) -> String {
+  value
+  .replace_all(old="&", new="&amp;")
+  .replace_all(old="\"", new="&quot;")
+  .replace_all(old="<", new="&lt;")
+  .replace_all(old=">", new="&gt;")
 }
 
 ///|
@@ -75,6 +143,26 @@ fn file_url(path : String) -> String {
       "file://" + normalized
     } else {
       "file:///" + normalized
+    }
+  }
+}
+
+///|
+fn file_base_url(path : String) -> String {
+  if path.has_prefix("file://") {
+    let index = path.rev_find("/")
+    match index {
+      Some(value) => path[:value + 1].to_owned()
+      None => path
+    }
+  } else {
+    let file_path : @mbpath.Path = path
+    let dir = file_path.resolve().dirname().to_string()
+    let url = file_url(dir)
+    if url.has_suffix("/") {
+      url
+    } else {
+      url + "/"
     }
   }
 }

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -97,6 +97,41 @@ test "extension event dispatch script calls page event emitter with JSON data" {
 }
 
 ///|
+test "file entry bootstrap keeps relative assets under original directory" {
+  let html =
+    #|<html><head><link rel="stylesheet" href="app.css"></head><body><script src="app.js"></script></body></html>
+  let injected = inject_html_bootstrap(
+    html,
+    base_tag("file:///D:/Code/proton-demo/app/") +
+    script_tag("window.__MoonBit__ = {};</script><p>tail</p>"),
+  )
+  assert_true(
+    injected.contains(
+      "<head>\n<base href=\"file:///D:/Code/proton-demo/app/\">\n<script>",
+    ),
+  )
+  assert_true(injected.contains("href=\"app.css\""))
+  assert_true(injected.contains("src=\"app.js\""))
+  inspect(injected.contains("</script><p>tail</p>"), content="false")
+  inspect(injected.contains("<\\/script><p>tail</p>"), content="true")
+}
+
+///|
+test "file base url resolves local path directory" {
+  let base = file_base_url("app/app.html").replace_all(old="\\", new="/")
+  assert_true(base.has_prefix("file:///"))
+  assert_true(base.has_suffix("/"))
+  inspect(
+    file_base_url("file:///D:/Code/proton-demo/app/app.html"),
+    content="file:///D:/Code/proton-demo/app/",
+  )
+  inspect(
+    base_tag("file:///tmp/a&b\"c/"),
+    content="<base href=\"file:///tmp/a&amp;b&quot;c/\">\n",
+  )
+}
+
+///|
 test "extension event dispatch script can target a page instance" {
   let event = @ipc.IpcExtensionEvent::new("ticker", "done", Json::null())
   let script = extension_event_dispatch_script(event, Some("page-1"))

--- a/proton/moon.pkg
+++ b/proton/moon.pkg
@@ -1,8 +1,10 @@
 import {
   "moonbitlang/async",
+  "moonbitlang/core/debug",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
+  "moonbitlang/x/fs" @mbfs,
   "moonbitlang/x/path" @mbpath,
   "justjavac/proton/bootstrap",
   "justjavac/proton/command" @proton_command,

--- a/proton/native_link_config.mjs
+++ b/proton/native_link_config.mjs
@@ -52,6 +52,10 @@ function platformId() {
   return `${process.platform}-${process.arch}`;
 }
 
+function packagePrebuiltDist() {
+  return path.resolve(moduleRoot, "prebuilt", platformId());
+}
+
 function findProjectRootWithRuntime(start) {
   for (let current = path.resolve(start); ; current = path.dirname(current)) {
     const manifest = path.join(current, ".proton", "runtime.json");
@@ -93,6 +97,7 @@ function defaultDist() {
     return activeDist;
   }
   return firstExistingDist([
+    packagePrebuiltDist(),
     path.resolve(moduleRoot, "..", "native", "dist"),
   ]);
 }


### PR DESCRIPTION
## Summary
- Load file/asset HTML through the Proton app origin when command extensions need proxy injection
- Preserve relative asset resolution by injecting a file:// base tag before the generated command proxy
- Prefer shipped proton/prebuilt/<platform> native artifacts before falling back to native/dist in native_link_config.mjs

## Validation
- moon fmt
- moon -C proton test . --target native --diagnostic-limit 80
- moon -C proton check --target native --diagnostic-limit 80
- moon check --target native --diagnostic-limit 80
- moon -C proton info --target native
- node native/scripts/verify_link_config.mjs proton/prebuilt/win32-x64
- moon -C examples build --target native --diagnostic-limit 80