### PR TITLE
fix(proton): run extension destroy hooks

### DIFF
--- a/proton/extension/extension.mbt
+++ b/proton/extension/extension.mbt
@@ -84,17 +84,20 @@ fn core_command_spec(
 ) -> @proton_command.AppCommandExtensionSpec? {
   match core_command_descriptor(spec) {
     Err(_) => None
-    Ok(descriptor) =>
+    Ok(descriptor) => {
+      let core_host_ref : Ref[@core.ExtensionHost?] = Ref(None)
       Some(
         @proton_command.AppCommandExtensionSpec::new(
           spec.id(),
           spec.js_namespace(),
           descriptor.apis,
-          fn(context) { register_core_commands(spec, context) },
+          fn(context) { register_core_commands(spec, context, core_host_ref) },
           scripts=descriptor.scripts,
           dependencies=spec.dependencies(),
+          on_destroy=fn(_context) { destroy_core_command_host(core_host_ref) },
         ),
       )
+    }
   }
 }
 
@@ -123,7 +126,9 @@ fn core_command_descriptor(
 fn register_core_commands(
   spec : @core.ExtensionSpec,
   context : @proton_command.AppCommandExtensionContext,
+  core_host_ref : Ref[@core.ExtensionHost?],
 ) -> Result[Unit, String] {
+  destroy_core_command_host(core_host_ref)
   let core_context = @core.ExtensionBuildContext::new(
     options=context.options(),
     base_dir=context.base_dir(),
@@ -139,7 +144,19 @@ fn register_core_commands(
           core_host.dispatch_op(op_name, payload)
         })
       }
+      core_host_ref.val = Some(core_host)
       Ok(())
     }
+  }
+}
+
+///|
+fn destroy_core_command_host(core_host_ref : Ref[@core.ExtensionHost?]) -> Unit {
+  match core_host_ref.val {
+    Some(core_host) => {
+      core_host.destroy()
+      core_host_ref.val = None
+    }
+    None => ()
   }
 }

--- a/proton/facade_bridge.mbt
+++ b/proton/facade_bridge.mbt
@@ -3,8 +3,9 @@ fn build_command_host(
   manifest : @manifest.AppManifest,
   command_extensions : Map[String, @proton_command.AppCommandExtensionSpec],
   base_dir : String?,
-) -> Result[@core.AppCommandHost?, String] {
+) -> Result[CommandHostRuntime?, String] {
   let host = @core.AppCommandHost::new()
+  let destroy_hooks : Array[() -> Unit] = []
   let mut has_commands = false
   for id, spec in command_extensions {
     match manifest.extension_setting(id) {
@@ -19,10 +20,13 @@ fn build_command_host(
           )
           match spec.register(context) {
             Err(error) => {
-              host.close()
+              close_command_host_runtime(host, destroy_hooks)
               return Err(error)
             }
-            Ok(_) => has_commands = true
+            Ok(_) => {
+              has_commands = true
+              destroy_hooks.push(fn() { spec.destroy(context) })
+            }
           }
         }
       None => ()
@@ -30,11 +34,23 @@ fn build_command_host(
   }
   if has_commands {
     host.seal_registrations()
-    Ok(Some(host))
+    Ok(Some(CommandHostRuntime::{ host, destroy_hooks, closed: false }))
   } else {
-    host.close()
+    close_command_host_runtime(host, destroy_hooks)
     Ok(None)
   }
+}
+
+///|
+fn close_command_host_runtime(
+  host : @core.AppCommandHost,
+  destroy_hooks : Array[() -> Unit],
+) -> Unit {
+  let hook_count = destroy_hooks.length()
+  for index in 0..<hook_count {
+    destroy_hooks[hook_count - index - 1]()
+  }
+  host.close()
 }
 
 ///|

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -79,7 +79,7 @@ async fn run_manifest(
   }
   match command_host {
     Some(host) => {
-      let ops = host.registered_ops()
+      let ops = host.host.registered_ops()
       match
         native_unit_result(
           "install bridge",
@@ -91,7 +91,7 @@ async fn run_manifest(
           ignore(runtime.destroy())
           return Err(error)
         }
-        Ok(_) => install_extension_event_sender(window, host)
+        Ok(_) => install_extension_event_sender(window, host.host)
       }
     }
     None => ()
@@ -113,7 +113,7 @@ async fn run_manifest(
         }
         Ok(_) => {
           let run_result = match command_host {
-            Some(host) => run_bridge_pump(runtime, window, host)
+            Some(host) => run_bridge_pump(runtime, window, host.host)
             None => run_window_pump(runtime)
           }
           close_command_host(command_host)
@@ -139,11 +139,18 @@ fn app_config_base_dir(file_path : String?) -> String? {
 }
 
 ///|
-fn close_command_host(host : @core.AppCommandHost?) -> Unit {
+fn close_command_host(host : CommandHostRuntime?) -> Unit {
   match host {
     Some(value) => value.close()
     None => ()
   }
+}
+
+///|
+fn CommandHostRuntime::close(self : CommandHostRuntime) -> Unit {
+  guard !self.closed else { return }
+  self.closed = true
+  close_command_host_runtime(self.host, self.destroy_hooks)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -19,3 +19,10 @@ priv struct BridgeDispatchTask {
   request_id : Int64
   task : @async.Task[@native.BridgeResponse]
 }
+
+///|
+priv struct CommandHostRuntime {
+  host : @core.AppCommandHost
+  destroy_hooks : Array[() -> Unit]
+  mut closed : Bool
+}

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -119,6 +119,71 @@ test "command proxy script ignores disabled command extensions" {
 }
 
 ///|
+test "command host close runs extension destroy hooks once" {
+  let extension_id = "examples/destroy"
+  let destroyed = Ref(0)
+  let manifest = test_command_manifest(extension_id)
+  let command_extensions : Map[String, @proton_command.AppCommandExtensionSpec] = {}
+  command_extensions[extension_id] = @proton_command.AppCommandExtensionSpec::new(
+    extension_id,
+    "destroyTest",
+    [@proton_command.AppCommandApiDescriptor::new("ping")],
+    fn(context) {
+      context.op("ping", fn(_payload : Unit) { "pong" })
+      Ok(())
+    },
+    on_destroy=fn(context) {
+      if context.extension_id() == extension_id {
+        destroyed.val = destroyed.val + 1
+      }
+    },
+  )
+  match build_command_host(manifest, command_extensions, None) {
+    Ok(Some(host)) => {
+      close_command_host(Some(host))
+      assert_eq(destroyed.val, 1)
+      close_command_host(Some(host))
+      assert_eq(destroyed.val, 1)
+    }
+    _ => fail("expected command host")
+  }
+}
+
+///|
+test "core spec command wrapper destroys runtime core host" {
+  let extension_id = "examples/core-destroy"
+  let destroyed = Ref(0)
+  let core_spec = @core.ExtensionSpec::new(extension_id, "coreDestroy", fn(
+    _context,
+  ) {
+    Ok(
+      @core.Extension::new(
+        extension_id,
+        "coreDestroy",
+        fn(extension) { extension.op("ping", fn(_payload : Unit) { "pong" }) },
+        on_destroy=fn(_extension) { destroyed.val = destroyed.val + 1 },
+      ),
+    )
+  })
+  let command_spec = match
+    @proton_extension.from_core_spec(core_spec).command_spec() {
+    Some(spec) => spec
+    None => fail("expected command spec")
+  }
+  assert_eq(destroyed.val, 1)
+  let manifest = test_command_manifest(extension_id)
+  let command_extensions : Map[String, @proton_command.AppCommandExtensionSpec] = {}
+  command_extensions[extension_id] = command_spec
+  match build_command_host(manifest, command_extensions, None) {
+    Ok(Some(host)) => {
+      close_command_host(Some(host))
+      assert_eq(destroyed.val, 2)
+    }
+    _ => fail("expected command host")
+  }
+}
+
+///|
 test "command proxy script rejects invalid namespace and API names" {
   let namespace_extension_id = "examples/bad-namespace"
   let namespace_manifest = test_command_manifest(namespace_extension_id)


### PR DESCRIPTION
## Summary
- run facade command extension destroy hooks once, in reverse registration order
- keep core-spec extension host references so wrapper cleanup tears them down
- add white-box coverage for destroy hooks and core-spec wrapper cleanup

## Validation
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test . --target native --filter '*destroy*' --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80`
- `ctest --test-dir native/build --output-on-failure`
- `cmake -S native -B native/build -DCMAKE_INSTALL_PREFIX=native/dist`
- `cmake --build native/build`
- `cmake --install native/build`
- `moon -C proton info --target native`
- `git diff --check`