### PR TITLE
feat(cli): expand proton doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,56 @@ sample executables), and are verified before replacing an existing package.
 Run `powershell -NoProfile -File scripts\windows_package_smoke.ps1` for the
 temporary self-signed development regression after `cef setup`.
 
+### Diagnose a Proton project
+
+`proton_cli doctor` is a read-only health check for the current project. The
+default run checks the environment, active runtime, host platform, frontend
+configuration, packages, extensions, and app configuration:
+
+```sh
+proton_cli doctor
+```
+
+Use the deeper checks when investigating a machine or a release candidate:
+
+```sh
+proton_cli doctor --deep                 # runtime manifest and ABI smoke test
+proton_cli doctor --frontend             # frontend package/config checks
+proton_cli doctor --frontend --run       # also run before_build and probe dev_url
+proton_cli doctor --release              # publish, generated files, and signing preflight
+```
+
+The release section intentionally reports missing local signing/notarization
+configuration and other publish failures; it does not change project files.
+Frontend commands and URL probes only run when `--run` is explicitly supplied.
+
+For automation, select sections and choose a stable output format:
+
+```sh
+proton_cli doctor --section runtime --section platform --json
+proton_cli doctor --json-lines --output target/doctor.jsonl
+proton_cli doctor --quiet
+```
+
+`--json` emits one schema-versioned object, while `--json-lines` emits one
+diagnostic per line followed by a summary record. Every diagnostic has a
+stable `code`, `status`, and `text`; `--quiet` prints only warnings and
+failures. `--verbose` includes the project section, and `--output` writes the
+selected rendering to a file instead of stdout.
+
+The only automatic repair supported today is regenerating stale extension
+artifacts through the existing code generator:
+
+```sh
+proton_cli doctor --fix --dry-run   # show the planned changes
+proton_cli doctor --fix             # apply only safe generated-file repairs
+```
+
+`--fix` never overwrites runtime manifests, dependencies, signing settings, or
+other user configuration. When sections are selected, the `fixes` result is
+included automatically; `--section fixes` is also available with `--fix`.
+Run the doctor again after applying fixes.
+
 `proton/native_link_config.mjs` resolves link inputs in this order:
 
 1. `PROTON_NATIVE_DIST`

--- a/cli/cef/cef_platform.mbt
+++ b/cli/cef/cef_platform.mbt
@@ -296,6 +296,17 @@ fn proton_prebuilt_relative_files(platform : ProtonPlatform) -> Array[String] {
 }
 
 ///|
+/// Returns the Proton-only prebuilt artifact list for a stable platform id.
+pub fn proton_prebuilt_relative_files_for_platform(
+  platform_id : String,
+) -> Array[String] {
+  match platform_from_override(Some(platform_id)) {
+    Some(platform) => proton_prebuilt_relative_files(platform)
+    None => []
+  }
+}
+
+///|
 fn runtime_required_relative_files(platform : ProtonPlatform) -> Array[String] {
   if platform.id == "win32-x64" {
     [

--- a/cli/cef/cef_platform.mbt
+++ b/cli/cef/cef_platform.mbt
@@ -319,6 +319,17 @@ fn runtime_required_relative_files(platform : ProtonPlatform) -> Array[String] {
 }
 
 ///|
+/// Returns the required runtime layout for a stable Proton platform id.
+pub fn runtime_required_relative_files_for_platform(
+  platform_id : String,
+) -> Array[String] {
+  match platform_from_override(Some(platform_id)) {
+    Some(platform) => runtime_required_relative_files(platform)
+    None => []
+  }
+}
+
+///|
 fn all_exist(root : String, files : Array[String]) -> Bool {
   guard files.length() > 0 else { return false }
   for file in files {

--- a/cli/cef/cef_platform_wbtest.mbt
+++ b/cli/cef/cef_platform_wbtest.mbt
@@ -17,6 +17,18 @@ test "darwin arm64 platform has proton and runtime artifact lists" {
 }
 
 ///|
+test "public runtime layout lookup follows stable platform ids" {
+  let macos = runtime_required_relative_files_for_platform("darwin-arm64")
+  assert_true(macos.contains("lib/libproton.dylib"))
+  assert_false(macos.contains("bin\\proton.dll"))
+  let windows = runtime_required_relative_files_for_platform("win32-x64")
+  assert_true(windows.contains("bin\\proton.dll"))
+  assert_true(
+    runtime_required_relative_files_for_platform("unknown").length() == 0,
+  )
+}
+
+///|
 test "host platform detection keeps macOS CPU architecture" {
   let arm64 = platform_from_host(windows=false, macos=true, arch=Some("arm64"))
   assert_eq(arm64.id, "darwin-arm64")

--- a/cli/cef/cef_platform_wbtest.mbt
+++ b/cli/cef/cef_platform_wbtest.mbt
@@ -29,6 +29,14 @@ test "public runtime layout lookup follows stable platform ids" {
 }
 
 ///|
+test "runtime manifests carry an explicit schema version" {
+  let manifest = runtime_manifest_json(
+    "0.1.5", "darwin-arm64", "cef-test", ".proton/runtime",
+  )
+  assert_true(manifest.contains("\"schema_version\":1"))
+}
+
+///|
 test "host platform detection keeps macOS CPU architecture" {
   let arm64 = platform_from_host(windows=false, macos=true, arch=Some("arm64"))
   assert_eq(arm64.id, "darwin-arm64")

--- a/cli/cef/cef_runtime_manifest.mbt
+++ b/cli/cef/cef_runtime_manifest.mbt
@@ -6,6 +6,7 @@ fn runtime_manifest_json(
   dist : String,
 ) -> String {
   Json::object({
+    "schema_version": Json::number(1.0, repr="1"),
     "platform": Json::string(platform),
     "proton_version": Json::string(proton_version),
     "cef_version": Json::string(cef_name),

--- a/cli/cef/pkg.generated.mbti
+++ b/cli/cef/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "justjavac/proton_cli/cef"
 // Values
 pub async fn current_platform_id() -> String
 
+pub fn proton_prebuilt_relative_files_for_platform(String) -> Array[String]
+
 pub async fn run_setup(String, Array[String]) -> Result[Unit, CefError]
 
 pub fn runtime_required_relative_files_for_platform(String) -> Array[String]

--- a/cli/cef/pkg.generated.mbti
+++ b/cli/cef/pkg.generated.mbti
@@ -6,6 +6,8 @@ pub async fn current_platform_id() -> String
 
 pub async fn run_setup(String, Array[String]) -> Result[Unit, CefError]
 
+pub fn runtime_required_relative_files_for_platform(String) -> Array[String]
+
 // Errors
 
 // Types and methods

--- a/cli/codegen/attribute_codegen_parse.mbt
+++ b/cli/codegen/attribute_codegen_parse.mbt
@@ -108,6 +108,18 @@ fn read_moon_ext_codegen_config_file(
 }
 
 ///|
+/// Validates a `moon.ext` file and returns its extension id and JavaScript namespace.
+pub fn read_moon_ext_identity(
+  path : String,
+) -> Result[(String, String), String] {
+  try read_moon_ext_codegen_config_file(path) catch {
+    err => Err(@debug.render(@debug.to_repr(err)))
+  } noraise {
+    result => result
+  }
+}
+
+///|
 fn read_moon_ext_codegen_config(
   path : String,
   text : String,

--- a/cli/codegen/pkg.generated.mbti
+++ b/cli/codegen/pkg.generated.mbti
@@ -12,6 +12,8 @@ pub fn generate_app_commands_from_file_with_metadata(String) -> Result[ProtonCom
 
 pub fn generate_app_commands_from_source(String, String, String) -> Result[ProtonCommandCodegenOutput, String]
 
+pub fn read_moon_ext_identity(String) -> Result[(String, String), String]
+
 // Errors
 
 // Types and methods

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -40,6 +40,9 @@ async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
   if options.includes("frontend") {
     sections.push(collect_frontend(project, run=options.run_frontend))
   }
+  if options.sections.contains("release") {
+    sections.push(collect_release(project))
+  }
   if options.includes("packages") {
     sections.push(
       collect_packages(

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -47,7 +47,7 @@ pub async fn run(
   dry_run~ : Bool,
   verbose~ : Bool,
   json~ : Bool,
-) -> Result[Unit, String] {
+) -> Result[Bool, String] {
   if !@mbfs.path_exists(cwd) {
     return Err("cwd does not exist: " + cwd)
   }
@@ -62,5 +62,5 @@ pub async fn run(
   } else {
     println(render_doctor_text(report))
   }
-  Ok(())
+  Ok(!report.has_errors())
 }

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -37,6 +37,9 @@ async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
   if options.includes("platform") {
     sections.push(collect_platform(project))
   }
+  if options.includes("frontend") {
+    sections.push(collect_frontend(project, run=options.run_frontend))
+  }
   if options.includes("packages") {
     sections.push(
       collect_packages(
@@ -62,6 +65,7 @@ pub async fn run(
   dry_run~ : Bool,
   verbose~ : Bool,
   deep~ : Bool,
+  run_frontend~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
@@ -80,6 +84,7 @@ pub async fn run(
     dry_run~,
     verbose~,
     deep~,
+    run_frontend~,
     json~,
     json_lines~,
     quiet~,

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -21,9 +21,18 @@ fn read_project_moon_pkg(
 ///|
 async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
   let project = discover_project(options.cwd)
+  let fix_section = if options.fix {
+    Some(apply_doctor_fixes(project, dry_run=options.dry_run))
+  } else {
+    None
+  }
   let module_config = read_project_moon_mod(project)
   let package_config = read_project_moon_pkg(project)
   let sections : Array[DoctorSection] = []
+  match fix_section {
+    Some(section) => sections.push(section)
+    None => ()
+  }
   if options.includes("project") &&
     (options.verbose || options.sections.contains("project")) {
     sections.push(collect_project(project))
@@ -69,6 +78,7 @@ pub async fn run(
   verbose~ : Bool,
   deep~ : Bool,
   run_frontend~ : Bool,
+  fix~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
@@ -88,6 +98,7 @@ pub async fn run(
     verbose~,
     deep~,
     run_frontend~,
+    fix~,
     json~,
     json_lines~,
     quiet~,

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -34,6 +34,9 @@ async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
   if options.includes("runtime") {
     sections.push(collect_runtime(project, deep=options.deep))
   }
+  if options.includes("platform") {
+    sections.push(collect_platform(project))
+  }
   if options.includes("packages") {
     sections.push(
       collect_packages(

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -24,20 +24,29 @@ async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
   let module_config = read_project_moon_mod(project)
   let package_config = read_project_moon_pkg(project)
   let sections : Array[DoctorSection] = []
-  if options.verbose {
+  if options.includes("project") &&
+    (options.verbose || options.sections.contains("project")) {
     sections.push(collect_project(project))
   }
-  sections.push(collect_environment(project))
-  sections.push(
-    collect_packages(
-      project,
-      module_config,
-      package_config,
-      verbose=options.verbose,
-    ),
-  )
-  sections.push(collect_extensions(project, package_config))
-  sections.push(collect_app(project))
+  if options.includes("environment") {
+    sections.push(collect_environment(project))
+  }
+  if options.includes("packages") {
+    sections.push(
+      collect_packages(
+        project,
+        module_config,
+        package_config,
+        verbose=options.verbose,
+      ),
+    )
+  }
+  if options.includes("extensions") {
+    sections.push(collect_extensions(project, package_config))
+  }
+  if options.includes("app") {
+    sections.push(collect_app(project))
+  }
   DoctorReport::new(sections, dry_run=options.dry_run)
 }
 
@@ -47,6 +56,10 @@ pub async fn run(
   dry_run~ : Bool,
   verbose~ : Bool,
   json~ : Bool,
+  json_lines~ : Bool,
+  quiet~ : Bool,
+  sections~ : Array[String],
+  output~ : String?,
 ) -> Result[Bool, String] {
   if !@mbfs.path_exists(cwd) {
     return Err("cwd does not exist: " + cwd)
@@ -55,12 +68,32 @@ pub async fn run(
   if !cwd_is_dir {
     return Err("cwd is not a directory: " + cwd)
   }
-  let options = DoctorOptions::new(cwd~, dry_run~, verbose~, json~)
+  let options = DoctorOptions::new(
+    cwd~,
+    dry_run~,
+    verbose~,
+    json~,
+    json_lines~,
+    quiet~,
+    sections~,
+    output~,
+  )
   let report = build_doctor_report(options)
-  if options.json {
-    println(render_doctor_json(report))
+  let rendered = if options.json {
+    render_doctor_json(report) + "\n"
+  } else if options.json_lines {
+    render_doctor_json_lines(report)
+  } else if options.quiet {
+    render_doctor_quiet(report)
   } else {
-    println(render_doctor_text(report))
+    render_doctor_text(report)
+  }
+  match options.output {
+    Some(path) =>
+      @mbfs.write_string_to_file(path, rendered, encoding="utf8") catch {
+        _ => return Err("failed to write doctor output: " + path)
+      }
+    None => println(rendered)
   }
   Ok(!report.has_errors())
 }

--- a/cli/doctor/doctor.mbt
+++ b/cli/doctor/doctor.mbt
@@ -29,7 +29,10 @@ async fn build_doctor_report(options : DoctorOptions) -> DoctorReport {
     sections.push(collect_project(project))
   }
   if options.includes("environment") {
-    sections.push(collect_environment(project))
+    sections.push(collect_environment())
+  }
+  if options.includes("runtime") {
+    sections.push(collect_runtime(project, deep=options.deep))
   }
   if options.includes("packages") {
     sections.push(
@@ -55,6 +58,7 @@ pub async fn run(
   cwd~ : String,
   dry_run~ : Bool,
   verbose~ : Bool,
+  deep~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
@@ -72,6 +76,7 @@ pub async fn run(
     cwd~,
     dry_run~,
     verbose~,
+    deep~,
     json~,
     json_lines~,
     quiet~,

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -1379,6 +1379,315 @@ async fn collect_frontend(
 }
 
 ///|
+fn collect_relative_files(
+  root : String,
+  relative : String,
+  depth : Int,
+) -> Array[String] {
+  guard depth >= 0 else { return [] }
+  let directory = if relative == "" { root } else { path_join(root, relative) }
+  let entries = @mbfs.read_dir(directory) catch { _ => [] }
+  let files : Array[String] = []
+  for entry in entries {
+    let child_relative = if relative == "" {
+      entry
+    } else {
+      relative + "/" + entry
+    }
+    let child = path_join(root, child_relative)
+    let is_file = @mbfs.is_file(child) catch { _ => false }
+    let is_dir = @mbfs.is_dir(child) catch { _ => false }
+    if is_file {
+      files.push(child_relative.replace_all(old="\\", new="/"))
+    } else if is_dir {
+      for nested in collect_relative_files(root, child_relative, depth - 1) {
+        files.push(nested)
+      }
+    }
+  }
+  files
+}
+
+///|
+fn push_release_metadata_line(
+  lines : Array[DoctorLine],
+  field : String,
+  value : String?,
+) -> Unit {
+  match value {
+    Some(value) if value.trim() != "" =>
+      lines.push(
+        DoctorLine::coded("release.metadata." + field, Ok, field + ": " + value),
+      )
+    _ =>
+      lines.push(
+        DoctorLine::coded(
+          "release.metadata." + field + ".missing",
+          Error,
+          "release metadata is missing `" + field + "`",
+        ),
+      )
+  }
+}
+
+///|
+async fn collect_release(project : ProjectDoctorInfo) -> DoctorSection {
+  let lines : Array[DoctorLine] = []
+  let module_config = match read_project_moon_mod(project) {
+    Some(Ok(config)) => config
+    Some(Err(error)) => {
+      lines.push(moon_config_error_line("moon.mod", error))
+      return DoctorSection::new(
+        "release",
+        "Release",
+        section_status(lines),
+        lines,
+      )
+    }
+    None => {
+      lines.push(
+        DoctorLine::coded(
+          "release.moon_mod.missing",
+          Error,
+          "release preflight requires moon.mod",
+        ),
+      )
+      return DoctorSection::new(
+        "release",
+        "Release",
+        section_status(lines),
+        lines,
+      )
+    }
+  }
+  push_release_metadata_line(lines, "name", module_config.name)
+  push_release_metadata_line(lines, "version", module_config.version)
+  push_release_metadata_line(lines, "readme", module_config.readme)
+  push_release_metadata_line(lines, "repository", module_config.repository)
+  push_release_metadata_line(lines, "license", module_config.license)
+  push_release_metadata_line(lines, "description", module_config.description)
+  match module_config.readme {
+    Some(readme) => {
+      let readme_path = if path_is_absolute_like(readme) {
+        readme
+      } else {
+        path_join(project.root, readme)
+      }
+      if !@mbfs.path_exists(readme_path) {
+        lines.push(
+          DoctorLine::coded(
+            "release.metadata.readme_file_missing",
+            Error,
+            "release readme file is missing: " + readme_path,
+          ),
+        )
+      }
+    }
+    None => ()
+  }
+  match module_config.repository {
+    Some(repository) if !(repository.has_prefix("https://") ||
+      repository.has_prefix("http://")) =>
+      lines.push(
+        DoctorLine::coded(
+          "release.metadata.repository_invalid",
+          Error,
+          "repository must be an http or https URL: " + repository,
+        ),
+      )
+    _ => ()
+  }
+
+  let module_name = module_config.name.unwrap_or("")
+  let excluded = module_name.has_suffix("/examples") ||
+    module_name.has_suffix("/e2e")
+  if excluded {
+    lines.push(
+      DoctorLine::coded(
+        "release.publish.excluded",
+        Neutral,
+        "module is intentionally excluded from publishing: " + module_name,
+      ),
+    )
+  } else {
+    let (status, output) = collect_command_status(
+      "moon",
+      ["publish", "--dry-run"],
+      Some(project.root),
+    )
+    if status == 0 {
+      lines.push(
+        DoctorLine::coded(
+          "release.publish.dry_run",
+          Ok,
+          "moon publish --dry-run succeeded",
+        ),
+      )
+    } else {
+      lines.push(
+        DoctorLine::coded(
+          "release.publish.dry_run_failed",
+          Error,
+          "moon publish --dry-run failed",
+          hint=first_non_empty_line(output).unwrap_or("publish dry-run failed"),
+        ),
+      )
+    }
+  }
+
+  match find_up(project.root, "scripts") {
+    Some(scripts_dir) => {
+      let verifier = @path.Path(path_join(scripts_dir, "verify_generated.mjs"))
+        .resolve()
+        .to_string()
+      if @mbfs.path_exists(verifier) {
+        let repository_root = @path.Path(
+            path_parent(scripts_dir).unwrap_or(project.root),
+          )
+          .resolve()
+          .to_string()
+        let (status, output) = collect_command_status(
+          "node",
+          [verifier],
+          Some(repository_root),
+        )
+        if status == 0 {
+          lines.push(
+            DoctorLine::coded(
+              "release.generated",
+              Ok,
+              "generated files are current",
+            ),
+          )
+        } else {
+          lines.push(
+            DoctorLine::coded(
+              "release.generated.stale",
+              Error,
+              "generated file verification failed",
+              hint=first_non_empty_line(output).unwrap_or(
+                "generated files are stale",
+              ),
+            ),
+          )
+        }
+      }
+    }
+    None => ()
+  }
+
+  let prebuilt_candidates = [
+    path_join(project.root, "prebuilt"),
+    path_join(path_join(project.root, "proton"), "prebuilt"),
+  ]
+  for prebuilt_root in prebuilt_candidates {
+    let prebuilt_exists = @mbfs.is_dir(prebuilt_root) catch { _ => false }
+    if prebuilt_exists {
+      let mut forbidden_count = 0
+      for platform_id in ["win32-x64", "darwin-arm64", "linux-x64"] {
+        let platform_root = path_join(prebuilt_root, platform_id)
+        let platform_exists = @mbfs.is_dir(platform_root) catch { _ => false }
+        if platform_exists {
+          let allowed = @cef.proton_prebuilt_relative_files_for_platform(
+            platform_id,
+          )
+          let normalized_allowed = allowed.map(fn(file) {
+            file.replace_all(old="\\", new="/")
+          })
+          normalized_allowed.push("include/proton_native.h")
+          normalized_allowed.push("manifest.json")
+          for file in collect_relative_files(platform_root, "", 5) {
+            if !normalized_allowed.contains(file) {
+              forbidden_count += 1
+              lines.push(
+                DoctorLine::coded(
+                  "release.prebuilt.forbidden",
+                  Error,
+                  "forbidden file in Proton prebuilt artifacts: " +
+                  platform_id +
+                  "/" +
+                  file,
+                ),
+              )
+            }
+          }
+        }
+      }
+      if forbidden_count == 0 {
+        lines.push(
+          DoctorLine::coded(
+            "release.prebuilt.checked",
+            Ok,
+            "Proton prebuilt directories contain only allowed artifacts",
+          ),
+        )
+      }
+      break
+    }
+  }
+
+  let platform_id = @cef.current_platform_id()
+  if platform_id.has_prefix("darwin-") {
+    match @sys.get_env_var("PROTON_MACOS_SIGNING_IDENTITY") {
+      Some(_) =>
+        lines.push(
+          DoctorLine::coded(
+            "release.signing.macos",
+            Ok,
+            "macOS signing identity is configured",
+          ),
+        )
+      None =>
+        lines.push(
+          DoctorLine::coded(
+            "release.signing.macos_missing",
+            Warn,
+            "PROTON_MACOS_SIGNING_IDENTITY is not configured",
+          ),
+        )
+    }
+    match @sys.get_env_var("PROTON_NOTARY_PROFILE") {
+      Some(_) =>
+        lines.push(
+          DoctorLine::coded(
+            "release.notary",
+            Ok,
+            "notary profile is configured",
+          ),
+        )
+      None =>
+        lines.push(
+          DoctorLine::coded(
+            "release.notary.missing",
+            Warn,
+            "PROTON_NOTARY_PROFILE is not configured",
+          ),
+        )
+    }
+  } else if platform_id == "win32-x64" {
+    match @sys.get_env_var("PROTON_WINDOWS_CERTIFICATE") {
+      Some(_) =>
+        lines.push(
+          DoctorLine::coded(
+            "release.signing.windows",
+            Ok,
+            "Windows certificate is configured",
+          ),
+        )
+      None =>
+        lines.push(
+          DoctorLine::coded(
+            "release.signing.windows_missing",
+            Warn,
+            "PROTON_WINDOWS_CERTIFICATE is not configured",
+          ),
+        )
+    }
+  }
+  DoctorSection::new("release", "Release", section_status(lines), lines)
+}
+
+///|
 fn option_path_or_missing(value : String?) -> String {
   match value {
     Some(path) => path

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -64,62 +64,60 @@ fn path_is_absolute_like(path : String) -> Bool {
 }
 
 ///|
-fn runtime_dist_from_manifest(project : ProjectDoctorInfo) -> String? {
+fn runtime_dist_from_manifest(
+  project : ProjectDoctorInfo,
+) -> Result[String?, String] {
   let manifest_path = path_join(
     path_join(project.root, ".proton"),
     "runtime.json",
   )
-  guard @mbfs.path_exists(manifest_path) else { return None }
+  guard @mbfs.path_exists(manifest_path) else { return Ok(None) }
   let text = @mbfs.read_file_to_string(manifest_path, encoding="utf8") catch {
-    _ => return None
+    _ => return Err("failed to read Proton runtime manifest: " + manifest_path)
   }
-  let json = @json.parse(text) catch { _ => return None }
+  let json = @json.parse(text) catch {
+    _ => return Err("failed to parse Proton runtime manifest: " + manifest_path)
+  }
   match json {
     Object(object) =>
       match object.get("dist") {
         Some(String(dist)) =>
           if path_is_absolute_like(dist) {
-            Some(dist)
+            Ok(Some(dist))
           } else {
-            Some(path_join(project.root, dist))
+            Ok(Some(path_join(project.root, dist)))
           }
-        _ => None
+        _ =>
+          Err("Proton runtime manifest has no string `dist`: " + manifest_path)
       }
-    _ => None
+    _ => Err("Proton runtime manifest must be a JSON object: " + manifest_path)
   }
 }
 
 ///|
-fn resolve_native_dist(project : ProjectDoctorInfo) -> String {
+fn development_native_dist(project : ProjectDoctorInfo) -> String {
+  let project_dist = path_join(path_join(project.root, "native"), "dist")
+  if @mbfs.path_exists(project_dist) {
+    project_dist
+  } else {
+    match find_up(project.root, "native") {
+      Some(path) => path_join(path, "dist")
+      None => project_dist
+    }
+  }
+}
+
+///|
+fn resolve_native_dist(project : ProjectDoctorInfo) -> Result[String, String] {
   match @sys.get_env_var("PROTON_NATIVE_DIST") {
-    Some(root) => root
+    Some(root) => Ok(root)
     None =>
       match runtime_dist_from_manifest(project) {
-        Some(path) => path
-        None => {
-          let project_dist = path_join(
-            path_join(project.root, "native"),
-            "dist",
-          )
-          if @mbfs.path_exists(project_dist) {
-            project_dist
-          } else {
-            match find_up(project.root, "native") {
-              Some(path) => path_join(path, "dist")
-              None => project_dist
-            }
-          }
-        }
+        Ok(Some(path)) => Ok(path)
+        Ok(None) => Ok(development_native_dist(project))
+        Err(message) => Err(message)
       }
   }
-}
-
-///|
-fn native_dist_required_layout_files() -> Array[String] {
-  [
-    "bin\\proton.dll", "bin\\cef_process.exe", "lib\\proton.lib", "bin\\libcef.dll",
-    "bin\\icudtl.dat", "Resources\\icudtl.dat", "Resources\\locales",
-  ]
 }
 
 ///|
@@ -199,13 +197,84 @@ async fn npm_version_line() -> DoctorLine {
 }
 
 ///|
+fn host_os_label(system : String?, arch : String?) -> String {
+  let os = match system {
+    Some(value) =>
+      match value.trim().to_lower() {
+        "darwin" => "macOS"
+        "linux" => "Linux"
+        "windows" | "windows_nt" => "Windows"
+        other if other != "" => other.to_owned()
+        _ => "unknown"
+      }
+    None => if @path.sep == '\\' { "Windows" } else { "unknown" }
+  }
+  let cpu = match arch {
+    Some(value) =>
+      match value.trim().to_lower() {
+        "aarch64" => "arm64"
+        "amd64" | "x64" => "x86_64"
+        other if other != "" => other.to_owned()
+        _ => "unknown"
+      }
+    None => "unknown"
+  }
+  os + " " + cpu
+}
+
+///|
+async fn uname_value(option : String) -> String? {
+  let (code, output) = @process.collect_output_merged("uname", [option]) catch {
+    _ => return None
+  }
+  guard code == 0 else { return None }
+  let value = output.text() catch { _ => return None }
+  let value = value.trim().to_owned()
+  if value == "" {
+    None
+  } else {
+    Some(value)
+  }
+}
+
+///|
+async fn host_os_line() -> DoctorLine {
+  let system = if @path.sep == '\\' {
+    Some("Windows")
+  } else {
+    uname_value("-s")
+  }
+  let arch = match @sys.get_env_var("PROCESSOR_ARCHITEW6432") {
+    Some(value) => Some(value)
+    None =>
+      match @sys.get_env_var("PROCESSOR_ARCHITECTURE") {
+        Some(value) => Some(value)
+        None => uname_value("-m")
+      }
+  }
+  DoctorLine::new(Ok, "OS: " + host_os_label(system, arch))
+}
+
+///|
 async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
   let lines : Array[DoctorLine] = []
-  lines.push(DoctorLine::new(Ok, "OS: Windows x86_64"))
+  lines.push(host_os_line())
   lines.push(tool_version_line("moon", ["moon"], ["version"]))
   lines.push(tool_version_line("node", ["node"], ["--version"]))
   lines.push(npm_version_line())
-  let native_dist = resolve_native_dist(project)
+  let native_dist = match resolve_native_dist(project) {
+    Ok(path) => path
+    Err(message) => {
+      lines.push(
+        DoctorLine::new(
+          Error,
+          "Proton runtime manifest is invalid",
+          hint=message,
+        ),
+      )
+      return DoctorSection::new("Environment", section_status(lines), lines)
+    }
+  }
   if @mbfs.path_exists(native_dist) {
     lines.push(DoctorLine::new(Ok, "Proton native dist: " + native_dist))
     let version_path = path_join(native_dist, "version.txt")
@@ -222,14 +291,21 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
       )
     }
     let missing : Array[String] = []
-    for required in native_dist_required_layout_files() {
+    let platform_id = @cef.current_platform_id()
+    let required_files = @cef.runtime_required_relative_files_for_platform(
+      platform_id,
+    )
+    for required in required_files {
       if !@mbfs.path_exists(path_join(native_dist, required)) {
         missing.push(required)
       }
     }
     if missing.length() == 0 {
       lines.push(
-        DoctorLine::new(Ok, "native layout: DLL, helper, lib, Resources found"),
+        DoctorLine::new(
+          Ok,
+          "native layout: required files found (" + platform_id + ")",
+        ),
       )
     } else {
       lines.push(
@@ -409,10 +485,7 @@ fn collect_extensions(
       package_imports_with_prefix(Some(config), "justjavac/proton_ext/")
     _ => []
   }
-  let extension_root = match find_up(project.root, "extensions") {
-    Some(path) => path
-    None => path_join(project.root, "extensions")
-  }
+  let extension_root = path_join(project.root, "extensions")
   let discovered = if @mbfs.path_exists(extension_root) {
     let entries = @mbfs.read_dir(extension_root) catch { _ => [] }
     let mut count = 0

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -56,6 +56,11 @@ fn option_string_or(value : String?, fallback : String) -> String {
 }
 
 ///|
+fn diagnostic_component(value : String) -> String {
+  value.replace_all(old="/", new=".").replace_all(old="\\", new=".")
+}
+
+///|
 fn path_is_absolute_like(path : String) -> Bool {
   path.has_prefix("\\") ||
   path.has_prefix("/") ||
@@ -126,11 +131,26 @@ fn moon_config_error_line(
   error : MoonConfigReadError,
 ) -> DoctorLine {
   match error {
-    MissingFile(path) => DoctorLine::new(Missing, "\{label}: missing \{path}")
+    MissingFile(path) =>
+      DoctorLine::coded(
+        "packages.config." + diagnostic_component(label) + ".missing",
+        Missing,
+        "\{label}: missing \{path}",
+      )
     ReadFailed(path, message) =>
-      DoctorLine::new(Error, "\{label}: failed to read \{path}", hint=message)
+      DoctorLine::coded(
+        "packages.config." + diagnostic_component(label) + ".read_failed",
+        Error,
+        "\{label}: failed to read \{path}",
+        hint=message,
+      )
     ParseFailed(path, message) =>
-      DoctorLine::new(Error, "\{label}: failed to parse \{path}", hint=message)
+      DoctorLine::coded(
+        "packages.config." + diagnostic_component(label) + ".parse_failed",
+        Error,
+        "\{label}: failed to parse \{path}",
+        hint=message,
+      )
   }
 }
 
@@ -159,9 +179,14 @@ async fn tool_version_line(
     match first_non_empty_line(text) {
       Some(line) =>
         if code == 0 {
-          return DoctorLine::new(Ok, label + ": " + line)
+          return DoctorLine::coded(
+            "environment.tool." + label,
+            Ok,
+            label + ": " + line,
+          )
         } else {
-          return DoctorLine::new(
+          return DoctorLine::coded(
+            "environment.tool." + label + ".failed",
             Warn,
             label + ": version command exited with code " + code.to_string(),
             hint=line,
@@ -169,16 +194,22 @@ async fn tool_version_line(
         }
       None =>
         if code == 0 {
-          return DoctorLine::new(Unknown, label + ": version output is empty")
+          return DoctorLine::coded(
+            "environment.tool." + label + ".empty",
+            Unknown,
+            label + ": version output is empty",
+          )
         } else {
-          return DoctorLine::new(
+          return DoctorLine::coded(
+            "environment.tool." + label + ".failed",
             Warn,
             label + ": version command exited with code " + code.to_string(),
           )
         }
     }
   }
-  DoctorLine::new(
+  DoctorLine::coded(
+    "environment.tool." + label + ".missing",
     Missing,
     label + ": not found",
     hint="make sure one of `" +
@@ -266,28 +297,48 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
     Ok(path) => path
     Err(message) => {
       lines.push(
-        DoctorLine::new(
+        DoctorLine::coded(
+          "runtime.manifest.invalid",
           Error,
           "Proton runtime manifest is invalid",
           hint=message,
         ),
       )
-      return DoctorSection::new("Environment", section_status(lines), lines)
+      return DoctorSection::new(
+        "environment",
+        "Environment",
+        section_status(lines),
+        lines,
+      )
     }
   }
   if @mbfs.path_exists(native_dist) {
-    lines.push(DoctorLine::new(Ok, "Proton native dist: " + native_dist))
+    lines.push(
+      DoctorLine::coded(
+        "runtime.dist",
+        Ok,
+        "Proton native dist: " + native_dist,
+      ),
+    )
     let version_path = path_join(native_dist, "version.txt")
     if @mbfs.path_exists(version_path) {
       let version = @mbfs.read_file_to_string(version_path, encoding="utf8") catch {
         _ => "unknown"
       }
       lines.push(
-        DoctorLine::new(Ok, "runtime version: " + version.trim().to_owned()),
+        DoctorLine::coded(
+          "runtime.version",
+          Ok,
+          "runtime version: " + version.trim().to_owned(),
+        ),
       )
     } else {
       lines.push(
-        DoctorLine::new(Unknown, "runtime version: version.txt missing"),
+        DoctorLine::coded(
+          "runtime.version.missing",
+          Unknown,
+          "runtime version: version.txt missing",
+        ),
       )
     }
     let missing : Array[String] = []
@@ -302,26 +353,32 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
     }
     if missing.length() == 0 {
       lines.push(
-        DoctorLine::new(
+        DoctorLine::coded(
+          "runtime.layout",
           Ok,
           "native layout: required files found (" + platform_id + ")",
         ),
       )
     } else {
       lines.push(
-        DoctorLine::new(Error, "native layout: missing " + missing.join(", ")),
+        DoctorLine::coded(
+          "runtime.layout.missing",
+          Error,
+          "native layout: missing " + missing.join(", "),
+        ),
       )
     }
   } else {
     lines.push(
-      DoctorLine::new(
+      DoctorLine::coded(
+        "runtime.dist.missing",
         Missing,
         "Proton native dist: not found",
         hint="run `proton_cli cef setup`, or set PROTON_NATIVE_DIST",
       ),
     )
   }
-  DoctorSection::new("Environment", section_status(lines), lines)
+  DoctorSection::new("environment", "Environment", section_status(lines), lines)
 }
 
 ///|
@@ -335,32 +392,49 @@ fn option_path_or_missing(value : String?) -> String {
 ///|
 fn collect_project(project : ProjectDoctorInfo) -> DoctorSection {
   let lines : Array[DoctorLine] = []
-  lines.push(DoctorLine::new(Neutral, "root: " + project.root))
-  lines.push(DoctorLine::new(Neutral, "package_dir: " + project.package_dir))
   lines.push(
-    DoctorLine::new(
+    DoctorLine::coded("project.root", Neutral, "root: " + project.root),
+  )
+  lines.push(
+    DoctorLine::coded(
+      "project.package_dir",
+      Neutral,
+      "package_dir: " + project.package_dir,
+    ),
+  )
+  lines.push(
+    DoctorLine::coded(
+      "project.moon_mod",
       Neutral,
       "moon.mod: " + option_path_or_missing(project.moon_mod_path),
     ),
   )
   lines.push(
-    DoctorLine::new(
+    DoctorLine::coded(
+      "project.moon_pkg",
       Neutral,
       "moon.pkg: " + option_path_or_missing(project.moon_pkg_path),
     ),
   )
   lines.push(
-    DoctorLine::new(
+    DoctorLine::coded(
+      "project.moon_proton",
       Neutral,
       "moon.proton: " + option_path_or_missing(project.moon_proton_path),
     ),
   )
   match project.app_json_path {
     Some(path) =>
-      lines.push(DoctorLine::new(Neutral, "legacy app.json: " + path))
+      lines.push(
+        DoctorLine::coded(
+          "project.legacy_app_json",
+          Neutral,
+          "legacy app.json: " + path,
+        ),
+      )
     None => ()
   }
-  DoctorSection::new("Project", Neutral, lines)
+  DoctorSection::new("project", "Project", Neutral, lines)
 }
 
 ///|
@@ -379,7 +453,13 @@ fn collect_packages(
     }
     None => {
       if project.mode != PlainDirectory {
-        lines.push(DoctorLine::new(Missing, "moon.mod: missing"))
+        lines.push(
+          DoctorLine::coded(
+            "packages.moon_mod.missing",
+            Missing,
+            "moon.mod: missing",
+          ),
+        )
       }
       None
     }
@@ -392,7 +472,13 @@ fn collect_packages(
     }
     None => {
       if project.mode == AppProject {
-        lines.push(DoctorLine::new(Warn, "moon.pkg: missing"))
+        lines.push(
+          DoctorLine::coded(
+            "packages.moon_pkg.missing",
+            Warn,
+            "moon.pkg: missing",
+          ),
+        )
       }
       None
     }
@@ -400,16 +486,29 @@ fn collect_packages(
   match module_value {
     Some(config) => {
       lines.push(
-        DoctorLine::new(
+        DoctorLine::coded(
+          "packages.module",
           Neutral,
           "module: " + option_string_or(config.name, "unknown"),
         ),
       )
       if verbose {
-        lines.push(DoctorLine::new(Neutral, "moon.mod path: " + config.path))
+        lines.push(
+          DoctorLine::coded(
+            "packages.moon_mod.path",
+            Neutral,
+            "moon.mod path: " + config.path,
+          ),
+        )
         match config.version {
           Some(version) =>
-            lines.push(DoctorLine::new(Neutral, "module version: " + version))
+            lines.push(
+              DoctorLine::coded(
+                "packages.module.version",
+                Neutral,
+                "module version: " + version,
+              ),
+            )
           None => ()
         }
       }
@@ -422,7 +521,13 @@ fn collect_packages(
     ] {
     match dependency_version(module_value, dep) {
       Some(version) =>
-        lines.push(DoctorLine::new(Neutral, dep + ": " + version))
+        lines.push(
+          DoctorLine::coded(
+            "packages.dependency." + diagnostic_component(dep),
+            Neutral,
+            dep + ": " + version,
+          ),
+        )
       None =>
         if dep == "justjavac/proton_ext" &&
           package_imports_with_prefix(package_value, "justjavac/proton_ext/").length() ==
@@ -430,7 +535,11 @@ fn collect_packages(
           ()
         } else {
           lines.push(
-            DoctorLine::new(Missing, dep + ": not declared in moon.mod"),
+            DoctorLine::coded(
+              "packages.dependency." + diagnostic_component(dep) + ".missing",
+              Missing,
+              dep + ": not declared in moon.mod",
+            ),
           )
         }
     }
@@ -439,7 +548,8 @@ fn collect_packages(
     match dependency_version(module_value, "justjavac/proton") {
       None =>
         lines.push(
-          DoctorLine::new(
+          DoctorLine::coded(
+            "packages.proton.import_without_dependency",
             Warn,
             "justjavac/proton imported by moon.pkg but missing in moon.mod",
           ),
@@ -450,17 +560,30 @@ fn collect_packages(
   if verbose {
     match package_value {
       Some(config) => {
-        lines.push(DoctorLine::new(Neutral, "moon.pkg path: " + config.path))
+        lines.push(
+          DoctorLine::coded(
+            "packages.moon_pkg.path",
+            Neutral,
+            "moon.pkg path: " + config.path,
+          ),
+        )
         match config.is_main {
           Some(value) =>
-            lines.push(DoctorLine::new(Neutral, "is-main: \{value}"))
+            lines.push(
+              DoctorLine::coded(
+                "packages.is_main",
+                Neutral,
+                "is-main: \{value}",
+              ),
+            )
           None => ()
         }
         for item in config.imports {
           match item.package_alias {
             Some(package_alias) =>
               lines.push(
-                DoctorLine::new(
+                DoctorLine::coded(
+                  "packages.import.alias",
                   Neutral,
                   "import alias: " + item.package_path + " as " + package_alias,
                 ),
@@ -472,7 +595,7 @@ fn collect_packages(
       None => ()
     }
   }
-  DoctorSection::new("Packages", section_status(lines), lines)
+  DoctorSection::new("packages", "Packages", section_status(lines), lines)
 }
 
 ///|
@@ -500,15 +623,31 @@ fn collect_extensions(
     0
   }
   let lines : Array[DoctorLine] = []
-  lines.push(DoctorLine::new(Neutral, "discovered: \{discovered}"))
+  lines.push(
+    DoctorLine::coded(
+      "extensions.discovered",
+      Neutral,
+      "discovered: \{discovered}",
+    ),
+  )
   if imported.length() > 0 {
     lines.push(
-      DoctorLine::new(Neutral, "imported packages: " + imported.join(", ")),
+      DoctorLine::coded(
+        "extensions.imported",
+        Neutral,
+        "imported packages: " + imported.join(", "),
+      ),
     )
   } else {
-    lines.push(DoctorLine::new(Neutral, "imported packages: none"))
+    lines.push(
+      DoctorLine::coded(
+        "extensions.imported",
+        Neutral,
+        "imported packages: none",
+      ),
+    )
   }
-  DoctorSection::new("Extensions", section_status(lines), lines)
+  DoctorSection::new("extensions", "Extensions", section_status(lines), lines)
 }
 
 ///|
@@ -567,10 +706,11 @@ fn push_entry_existence(
   match entry.kind {
     "file" =>
       if @mbfs.path_exists(path) {
-        lines.push(DoctorLine::new(Ok, "entry file exists"))
+        lines.push(DoctorLine::coded("app.entry.file", Ok, "entry file exists"))
       } else {
         lines.push(
-          DoctorLine::new(
+          DoctorLine::coded(
+            "app.entry.file.missing",
             Error,
             "entry file missing: " + project_relative_path(project, path),
           ),
@@ -578,10 +718,13 @@ fn push_entry_existence(
       }
     "asset" =>
       if @mbfs.path_exists(path) {
-        lines.push(DoctorLine::new(Ok, "entry asset exists"))
+        lines.push(
+          DoctorLine::coded("app.entry.asset", Ok, "entry asset exists"),
+        )
       } else {
         lines.push(
-          DoctorLine::new(
+          DoctorLine::coded(
+            "app.entry.asset.missing",
             Warn,
             "entry asset missing: " + project_relative_path(project, path),
             hint="run frontend.before_build before release builds",
@@ -599,7 +742,10 @@ fn push_optional_app_line(
   value : String?,
 ) -> Unit {
   match value {
-    Some(value) => lines.push(DoctorLine::new(Neutral, label + ": " + value))
+    Some(value) =>
+      lines.push(
+        DoctorLine::coded("app." + label, Neutral, label + ": " + value),
+      )
     None => ()
   }
 }
@@ -612,7 +758,8 @@ fn push_loaded_app(
 ) -> Unit {
   let window = config.window
   lines.push(
-    DoctorLine::new(
+    DoctorLine::coded(
+      "app.window",
       Neutral,
       "window: \"" +
       window.title +
@@ -625,10 +772,14 @@ fn push_loaded_app(
     ),
   )
   lines.push(
-    DoctorLine::new(Neutral, "entry: " + entry_text(project, config.entry)),
+    DoctorLine::coded(
+      "app.entry",
+      Neutral,
+      "entry: " + entry_text(project, config.entry),
+    ),
   )
   push_entry_existence(lines, project, config.entry)
-  lines.push(DoctorLine::new(Neutral, "debug: \{config.debug}"))
+  lines.push(DoctorLine::coded("app.debug", Neutral, "debug: \{config.debug}"))
   match config.frontend {
     Some(frontend) => {
       push_optional_app_line(lines, "before_dev_command", frontend.before_dev)
@@ -654,23 +805,36 @@ fn collect_app(project : ProjectDoctorInfo) -> DoctorSection {
         Ok(config) => push_loaded_app(lines, project, config)
         Err(error) =>
           lines.push(
-            DoctorLine::new(Error, "moon.proton: failed to load", hint=error),
+            DoctorLine::coded(
+              "app.config.invalid",
+              Error,
+              "moon.proton: failed to load",
+              hint=error,
+            ),
           )
       }
     None =>
       match project.app_json_path {
         Some(path) =>
           lines.push(
-            DoctorLine::new(
+            DoctorLine::coded(
+              "app.config.legacy",
               Warn,
               "app.json: legacy runtime manifest found at " + path,
               hint="create moon.proton; app.json is no longer the user-facing Proton config",
             ),
           )
-        None => lines.push(DoctorLine::new(Warn, "moon.proton: not found"))
+        None =>
+          lines.push(
+            DoctorLine::coded(
+              "app.config.missing",
+              Warn,
+              "moon.proton: not found",
+            ),
+          )
       }
   }
-  DoctorSection::new("App", section_status(lines), lines)
+  DoctorSection::new("app", "App", section_status(lines), lines)
 }
 
 ///|

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -69,9 +69,27 @@ fn path_is_absolute_like(path : String) -> Bool {
 }
 
 ///|
-fn runtime_dist_from_manifest(
+fn runtime_manifest_string_field(
+  object : Map[String, Json],
+  field : String,
+  manifest_path : String,
+) -> Result[String, String] {
+  match object.get(field) {
+    Some(String(value)) => Ok(value)
+    _ =>
+      Err(
+        "Proton runtime manifest has no string `" +
+        field +
+        "`: " +
+        manifest_path,
+      )
+  }
+}
+
+///|
+fn runtime_manifest_from_project(
   project : ProjectDoctorInfo,
-) -> Result[String?, String] {
+) -> Result[DoctorRuntimeManifest?, String] {
   let manifest_path = path_join(
     path_join(project.root, ".proton"),
     "runtime.json",
@@ -84,17 +102,66 @@ fn runtime_dist_from_manifest(
     _ => return Err("failed to parse Proton runtime manifest: " + manifest_path)
   }
   match json {
-    Object(object) =>
-      match object.get("dist") {
-        Some(String(dist)) =>
-          if path_is_absolute_like(dist) {
-            Ok(Some(dist))
-          } else {
-            Ok(Some(path_join(project.root, dist)))
-          }
-        _ =>
-          Err("Proton runtime manifest has no string `dist`: " + manifest_path)
+    Object(object) => {
+      let allowed = [
+        "schema_version", "platform", "proton_version", "cef_version", "dist",
+      ]
+      for key in object.keys() {
+        if !allowed.contains(key) {
+          return Err(
+            "Proton runtime manifest has unknown field `" +
+            key +
+            "`: " +
+            manifest_path,
+          )
+        }
       }
+      let schema_version : Int = match object.get("schema_version") {
+        Some(value) =>
+          @json.from_json(value) catch {
+            _ =>
+              return Err(
+                "Proton runtime manifest has invalid `schema_version`: " +
+                manifest_path,
+              )
+          }
+        None =>
+          return Err(
+            "Proton runtime manifest has no `schema_version`: " + manifest_path,
+          )
+      }
+      guard schema_version == 1 else {
+        return Err(
+          "Proton runtime manifest schema_version must be 1: " + manifest_path,
+        )
+      }
+      runtime_manifest_string_field(object, "platform", manifest_path)
+      .bind(fn(platform) {
+        runtime_manifest_string_field(object, "proton_version", manifest_path).bind(fn(
+            proton_version,
+          ) {
+            runtime_manifest_string_field(object, "cef_version", manifest_path).bind(fn(
+                cef_version,
+              ) {
+                runtime_manifest_string_field(object, "dist", manifest_path).map(fn(
+                    dist,
+                  ) {
+                    {
+                      schema_version,
+                      platform,
+                      proton_version,
+                      cef_version,
+                      dist,
+                    }
+                  },
+                )
+              },
+            )
+          },
+        )
+      })
+      .map(fn(manifest) { Some(manifest) })
+    }
     _ => Err("Proton runtime manifest must be a JSON object: " + manifest_path)
   }
 }
@@ -113,13 +180,22 @@ fn development_native_dist(project : ProjectDoctorInfo) -> String {
 }
 
 ///|
-fn resolve_native_dist(project : ProjectDoctorInfo) -> Result[String, String] {
+fn resolve_native_dist(
+  project : ProjectDoctorInfo,
+) -> Result[(String, DoctorRuntimeManifest?), String] {
   match @sys.get_env_var("PROTON_NATIVE_DIST") {
-    Some(root) => Ok(root)
+    Some(root) => Ok((root, None))
     None =>
-      match runtime_dist_from_manifest(project) {
-        Ok(Some(path)) => Ok(path)
-        Ok(None) => Ok(development_native_dist(project))
+      match runtime_manifest_from_project(project) {
+        Ok(Some(manifest)) => {
+          let path = if path_is_absolute_like(manifest.dist) {
+            manifest.dist
+          } else {
+            path_join(project.root, manifest.dist)
+          }
+          Ok((path, Some(manifest)))
+        }
+        Ok(None) => Ok((development_native_dist(project), None))
         Err(message) => Err(message)
       }
   }
@@ -287,14 +363,262 @@ async fn host_os_line() -> DoctorLine {
 }
 
 ///|
-async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
+fn runtime_library_relative_path(platform_id : String) -> String? {
+  match platform_id {
+    "win32-x64" => Some("bin\\proton.dll")
+    "darwin-arm64" | "darwin-x64" => Some("lib/libproton.dylib")
+    "linux-x64" => Some("lib/libproton.so")
+    _ => None
+  }
+}
+
+///|
+fn runtime_helper_relative_path(platform_id : String) -> String {
+  if platform_id == "win32-x64" {
+    "bin\\cef_process.exe"
+  } else {
+    "bin/cef_process"
+  }
+}
+
+///|
+fn json_object_int(object : Map[String, Json], field : String) -> Int? {
+  match object.get(field) {
+    Some(value) =>
+      try @json.from_json(value) catch {
+        _ => None
+      } noraise {
+        value => Some(value)
+      }
+    None => None
+  }
+}
+
+///|
+fn json_object_string(object : Map[String, Json], field : String) -> String? {
+  match object.get(field) {
+    Some(String(value)) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn json_object_bool(object : Map[String, Json], field : String) -> Bool? {
+  match object.get(field) {
+    Some(True) => Some(true)
+    Some(False) => Some(false)
+    _ => None
+  }
+}
+
+///|
+fn push_deep_runtime_probe(
+  lines : Array[DoctorLine],
+  native_dist : String,
+  platform_id : String,
+) -> Unit {
+  let library_relative = match runtime_library_relative_path(platform_id) {
+    Some(path) => path
+    None => {
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.unsupported_platform",
+          Warn,
+          "deep runtime probe is unavailable for " + platform_id,
+        ),
+      )
+      return
+    }
+  }
+  let library_path = path_join(native_dist, library_relative)
+  let config = Json::object({
+    "abi_version": Json::number(1.0, repr="1"),
+    "runtime_root": Json::string(native_dist),
+    "helper_path": Json::string(
+      path_join(native_dist, runtime_helper_relative_path(platform_id)),
+    ),
+  }).stringify()
+  match doctor_native_probe(library_path, config) {
+    Object(object) => {
+      match json_object_string(object, "load_error") {
+        Some(message) => {
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.load_failed",
+              Error,
+              "failed to load Proton dynamic library",
+              hint=message,
+            ),
+          )
+          return
+        }
+        None => ()
+      }
+      match json_object_string(object, "symbol_error") {
+        Some(message) => {
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.symbol_missing",
+              Error,
+              "Proton dynamic library is missing required ABI symbols",
+              hint=message,
+            ),
+          )
+          return
+        }
+        None => ()
+      }
+      match json_object_int(object, "abi_version") {
+        Some(1) =>
+          lines.push(
+            DoctorLine::coded("runtime.deep.abi", Ok, "Proton ABI version: 1"),
+          )
+        Some(version) =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.abi_mismatch",
+              Error,
+              "Proton ABI version mismatch: expected 1, got \{version}",
+            ),
+          )
+        None =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.abi_missing",
+              Error,
+              "Proton ABI version probe returned no value",
+            ),
+          )
+      }
+      match json_object_int(object, "info_status") {
+        Some(status) if status >= 0 => {
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.info",
+              Ok,
+              "runtime info ABI call succeeded",
+            ),
+          )
+          match object.get("info") {
+            Some(Object(info)) => {
+              let build_mode = json_object_string(info, "build_mode").unwrap_or(
+                "unknown",
+              )
+              let platform = json_object_string(info, "platform").unwrap_or(
+                "unknown",
+              )
+              if json_object_bool(info, "runtime_available") == Some(true) {
+                lines.push(
+                  DoctorLine::coded(
+                    "runtime.deep.engine",
+                    Ok,
+                    "native engine available: build_mode=" +
+                    build_mode +
+                    ", platform=" +
+                    platform,
+                  ),
+                )
+              } else {
+                lines.push(
+                  DoctorLine::coded(
+                    "runtime.deep.engine_unavailable",
+                    Error,
+                    "Proton library does not include the native engine",
+                  ),
+                )
+              }
+            }
+            _ =>
+              lines.push(
+                DoctorLine::coded(
+                  "runtime.deep.info_invalid",
+                  Error,
+                  "runtime info ABI returned invalid JSON",
+                ),
+              )
+          }
+        }
+        _ =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.info_failed",
+              Error,
+              "runtime info ABI call failed",
+            ),
+          )
+      }
+      match json_object_int(object, "probe_status") {
+        Some(status) if status >= 0 =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.probe",
+              Ok,
+              "runtime layout probe succeeded",
+            ),
+          )
+        _ =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.probe_failed",
+              Error,
+              "runtime layout probe failed",
+              hint=json_object_string(object, "probe_error").unwrap_or(
+                "native probe failed",
+              ),
+            ),
+          )
+      }
+      match json_object_int(object, "smoke_status") {
+        Some(status) if status >= 0 =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.smoke",
+              Ok,
+              "runtime create/destroy smoke test succeeded",
+            ),
+          )
+        _ =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.smoke_failed",
+              Error,
+              "runtime create/destroy smoke test failed",
+              hint=json_object_string(object, "probe_error").unwrap_or(
+                "native smoke test failed",
+              ),
+            ),
+          )
+      }
+    }
+    _ =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.invalid_result",
+          Error,
+          "native deep probe returned an invalid result",
+        ),
+      )
+  }
+}
+
+///|
+async fn collect_environment() -> DoctorSection {
   let lines : Array[DoctorLine] = []
   lines.push(host_os_line())
   lines.push(tool_version_line("moon", ["moon"], ["version"]))
   lines.push(tool_version_line("node", ["node"], ["--version"]))
   lines.push(npm_version_line())
-  let native_dist = match resolve_native_dist(project) {
-    Ok(path) => path
+  DoctorSection::new("environment", "Environment", section_status(lines), lines)
+}
+
+///|
+async fn collect_runtime(
+  project : ProjectDoctorInfo,
+  deep~ : Bool,
+) -> DoctorSection {
+  let lines : Array[DoctorLine] = []
+  let (native_dist, manifest) = match resolve_native_dist(project) {
+    Ok(value) => value
     Err(message) => {
       lines.push(
         DoctorLine::coded(
@@ -305,12 +629,58 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
         ),
       )
       return DoctorSection::new(
-        "environment",
-        "Environment",
+        "runtime",
+        "Runtime",
         section_status(lines),
         lines,
       )
     }
+  }
+  let platform_id = @cef.current_platform_id()
+  let mut platform_matches = true
+  match manifest {
+    Some(manifest) => {
+      lines.push(
+        DoctorLine::coded(
+          "runtime.manifest.schema",
+          Ok,
+          "runtime manifest schema: \{manifest.schema_version}",
+        ),
+      )
+      if manifest.platform == platform_id {
+        lines.push(
+          DoctorLine::coded(
+            "runtime.manifest.platform",
+            Ok,
+            "runtime manifest platform: " + manifest.platform,
+          ),
+        )
+      } else {
+        platform_matches = false
+        lines.push(
+          DoctorLine::coded(
+            "runtime.manifest.platform_mismatch",
+            Error,
+            "runtime platform mismatch: expected " +
+            platform_id +
+            ", got " +
+            manifest.platform,
+            hint="run `proton_cli cef setup` for the current platform",
+          ),
+        )
+      }
+      lines.push(
+        DoctorLine::coded(
+          "runtime.manifest.versions",
+          Neutral,
+          "runtime versions: proton=" +
+          manifest.proton_version +
+          ", cef=" +
+          manifest.cef_version,
+        ),
+      )
+    }
+    None => ()
   }
   if @mbfs.path_exists(native_dist) {
     lines.push(
@@ -342,7 +712,6 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
       )
     }
     let missing : Array[String] = []
-    let platform_id = @cef.current_platform_id()
     let required_files = @cef.runtime_required_relative_files_for_platform(
       platform_id,
     )
@@ -368,6 +737,17 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
         ),
       )
     }
+    if deep && platform_matches {
+      push_deep_runtime_probe(lines, native_dist, platform_id)
+    } else if deep {
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.skipped_platform_mismatch",
+          Warn,
+          "deep runtime probe skipped because the manifest platform does not match the host",
+        ),
+      )
+    }
   } else {
     lines.push(
       DoctorLine::coded(
@@ -378,7 +758,7 @@ async fn collect_environment(project : ProjectDoctorInfo) -> DoctorSection {
       ),
     )
   }
-  DoctorSection::new("environment", "Environment", section_status(lines), lines)
+  DoctorSection::new("runtime", "Runtime", section_status(lines), lines)
 }
 
 ///|

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -1138,21 +1138,153 @@ fn collect_extensions(
       package_imports_with_prefix(Some(config), "justjavac/proton_ext/")
     _ => []
   }
-  let extension_root = path_join(project.root, "extensions")
+  let nested_extension_root = path_join(project.root, "extensions")
+  let extension_root = if @mbfs.path_exists(nested_extension_root) {
+    nested_extension_root
+  } else {
+    project.root
+  }
+  let lines : Array[DoctorLine] = []
+  let namespaces : Map[String, String] = {}
   let discovered = if @mbfs.path_exists(extension_root) {
     let entries = @mbfs.read_dir(extension_root) catch { _ => [] }
     let mut count = 0
     for entry in entries {
-      let ext_path = path_join(path_join(extension_root, entry), "moon.ext")
+      let extension_dir = path_join(extension_root, entry)
+      let ext_path = path_join(extension_dir, "moon.ext")
       if (@mbfs.is_file(ext_path) catch { _ => false }) {
         count += 1
+        match @codegen.read_moon_ext_identity(ext_path) {
+          Ok((id, js_namespace)) => {
+            lines.push(
+              DoctorLine::coded(
+                "extensions.metadata",
+                Ok,
+                "extension metadata valid: " +
+                id +
+                " (namespace " +
+                js_namespace +
+                ")",
+              ),
+            )
+            match namespaces.get(js_namespace) {
+              Some(previous) =>
+                lines.push(
+                  DoctorLine::coded(
+                    "extensions.namespace.duplicate",
+                    Error,
+                    "duplicate extension namespace `" +
+                    js_namespace +
+                    "`: " +
+                    previous +
+                    " and " +
+                    ext_path,
+                  ),
+                )
+              None => namespaces[js_namespace] = ext_path
+            }
+          }
+          Err(error) =>
+            lines.push(
+              DoctorLine::coded(
+                "extensions.metadata.invalid",
+                Error,
+                "invalid extension metadata: " + ext_path,
+                hint=error,
+              ),
+            )
+        }
+        let moon_pkg_path = path_join(extension_dir, "moon.pkg")
+        if !@mbfs.path_exists(moon_pkg_path) {
+          lines.push(
+            DoctorLine::coded(
+              "extensions.moon_pkg.missing",
+              Error,
+              "extension package is missing moon.pkg: " + extension_dir,
+            ),
+          )
+        }
+        let source_path = path_join(extension_dir, "extension.mbt")
+        if !@mbfs.path_exists(source_path) {
+          lines.push(
+            DoctorLine::coded(
+              "extensions.source.missing",
+              Error,
+              "extension metadata has no extension.mbt: " + extension_dir,
+            ),
+          )
+        } else {
+          let source = @mbfs.read_file_to_string(source_path, encoding="utf8") catch {
+            _ => ""
+          }
+          let generated_path = path_join(extension_dir, "extension.g.mbt")
+          if source.contains("#proton.") {
+            match
+              @codegen.generate_app_commands_from_file_with_metadata(
+                source_path,
+              ) {
+              Ok(generated) =>
+                if !@mbfs.path_exists(generated_path) {
+                  lines.push(
+                    DoctorLine::coded(
+                      "extensions.generated.missing",
+                      Error,
+                      "generated extension file is missing: " + generated_path,
+                    ),
+                  )
+                } else {
+                  let committed = @mbfs.read_file_to_string(
+                    generated_path,
+                    encoding="utf8",
+                  ) catch {
+                    _ => ""
+                  }
+                  if committed == generated.source {
+                    lines.push(
+                      DoctorLine::coded(
+                        "extensions.generated.current",
+                        Ok,
+                        "generated extension file is current: " + generated_path,
+                      ),
+                    )
+                  } else {
+                    lines.push(
+                      DoctorLine::coded(
+                        "extensions.generated.stale",
+                        Error,
+                        "generated extension file is stale: " + generated_path,
+                        hint="regenerate it with `proton_cli codegen`",
+                      ),
+                    )
+                  }
+                }
+              Err(error) =>
+                lines.push(
+                  DoctorLine::coded(
+                    "extensions.codegen.invalid",
+                    Error,
+                    "extension command generation failed: " + source_path,
+                    hint=error,
+                  ),
+                )
+            }
+          } else if @mbfs.path_exists(generated_path) {
+            lines.push(
+              DoctorLine::coded(
+                "extensions.generated.unexpected",
+                Warn,
+                "generated extension file exists without #proton attributes: " +
+                generated_path,
+              ),
+            )
+          }
+        }
       }
     }
     count
   } else {
     0
   }
-  let lines : Array[DoctorLine] = []
   lines.push(
     DoctorLine::coded(
       "extensions.discovered",

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -48,6 +48,27 @@ fn package_imports_with_prefix(
 }
 
 ///|
+fn module_name_from_package(package_path : String) -> String? {
+  match package_path.split("/").collect() {
+    [owner, module_name, ..] =>
+      Some(owner.to_owned() + "/" + module_name.to_owned())
+    _ => None
+  }
+}
+
+///|
+fn module_has_dependency(
+  config : MoonModuleConfig?,
+  module_name : String,
+) -> Bool {
+  match config {
+    Some(config) =>
+      config.imports.any(fn(dep) { dep.module_name == module_name })
+    None => false
+  }
+}
+
+///|
 fn option_string_or(value : String?, fallback : String) -> String {
   match value {
     Some(value) => value
@@ -58,6 +79,14 @@ fn option_string_or(value : String?, fallback : String) -> String {
 ///|
 fn diagnostic_component(value : String) -> String {
   value.replace_all(old="/", new=".").replace_all(old="\\", new=".")
+}
+
+///|
+fn version_major_minor(version : String) -> String? {
+  match version.split(".").collect() {
+    [major, minor, ..] => Some(major.to_owned() + "." + minor.to_owned())
+    _ => None
+  }
 }
 
 ///|
@@ -892,36 +921,125 @@ fn collect_packages(
           None => ()
         }
       }
+      match config.preferred_target {
+        Some("native") =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.preferred",
+              Ok,
+              "preferred target: native",
+            ),
+          )
+        Some(target) =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.preferred_non_native",
+              Warn,
+              "preferred target is " +
+              target +
+              "; Proton apps require native builds",
+            ),
+          )
+        None =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.preferred_missing",
+              Unknown,
+              "preferred target is not declared",
+            ),
+          )
+      }
+      match config.supported_targets {
+        Some(targets) if targets.contains("native") =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.native",
+              Ok,
+              "native target is supported",
+            ),
+          )
+        Some(targets) =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.native_missing",
+              Error,
+              "supported targets do not include native: " + targets,
+            ),
+          )
+        None =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.target.unspecified",
+              Unknown,
+              "supported targets are not explicitly declared",
+            ),
+          )
+      }
     }
     None => ()
   }
+  match
+    (
+      dependency_version(module_value, "justjavac/proton"),
+      dependency_version(module_value, "justjavac/proton_ext"),
+    ) {
+    (Some(proton), Some(extension)) =>
+      if version_major_minor(proton) != version_major_minor(extension) {
+        lines.push(
+          DoctorLine::coded(
+            "packages.version.proton_extension_mismatch",
+            Warn,
+            "proton and proton_ext should use the same major/minor version: " +
+            proton +
+            " vs " +
+            extension,
+          ),
+        )
+      }
+    _ => ()
+  }
+  let is_proton_project = project.mode == AppProject ||
+    module_has_dependency(module_value, "justjavac/proton") ||
+    package_has_import(package_value, "justjavac/proton") ||
+    package_imports_with_prefix(package_value, "justjavac/proton_ext/").length() >
+    0
   for
     dep in [
       "justjavac/proton", "justjavac/proton_ext", "moonbitlang/async", "moonbitlang/x",
     ] {
-    match dependency_version(module_value, dep) {
-      Some(version) =>
-        lines.push(
-          DoctorLine::coded(
-            "packages.dependency." + diagnostic_component(dep),
-            Neutral,
-            dep + ": " + version,
-          ),
-        )
-      None =>
-        if dep == "justjavac/proton_ext" &&
-          package_imports_with_prefix(package_value, "justjavac/proton_ext/").length() ==
-          0 {
-          ()
-        } else {
+    if module_has_dependency(module_value, dep) {
+      match dependency_version(module_value, dep) {
+        Some(version) =>
           lines.push(
             DoctorLine::coded(
-              "packages.dependency." + diagnostic_component(dep) + ".missing",
-              Missing,
-              dep + ": not declared in moon.mod",
+              "packages.dependency." + diagnostic_component(dep),
+              Neutral,
+              dep + ": " + version,
             ),
           )
-        }
+        None =>
+          lines.push(
+            DoctorLine::coded(
+              "packages.dependency." + diagnostic_component(dep),
+              Neutral,
+              dep + ": declared without a pinned version",
+            ),
+          )
+      }
+    } else if !is_proton_project {
+      ()
+    } else if dep == "justjavac/proton_ext" &&
+      package_imports_with_prefix(package_value, "justjavac/proton_ext/").length() ==
+      0 {
+      ()
+    } else {
+      lines.push(
+        DoctorLine::coded(
+          "packages.dependency." + diagnostic_component(dep) + ".missing",
+          Missing,
+          dep + ": not declared in moon.mod",
+        ),
+      )
     }
   }
   if package_has_import(package_value, "justjavac/proton") {
@@ -936,6 +1054,38 @@ fn collect_packages(
         )
       Some(_) => ()
     }
+  }
+  match package_value {
+    Some(config) =>
+      for item in config.imports {
+        match module_name_from_package(item.package_path) {
+          Some(module_name) => {
+            let is_current_module = match module_value {
+              Some(module_config_value) =>
+                module_config_value.name == Some(module_name)
+              None => false
+            }
+            let is_core = module_name == "moonbitlang/core"
+            if !is_current_module &&
+              !is_core &&
+              !module_has_dependency(module_value, module_name) {
+              lines.push(
+                DoctorLine::coded(
+                  "packages.import.missing_dependency",
+                  Error,
+                  "package import `" +
+                  item.package_path +
+                  "` requires module dependency `" +
+                  module_name +
+                  "`",
+                ),
+              )
+            }
+          }
+          None => ()
+        }
+      }
+    None => ()
   }
   if verbose {
     match package_value {
@@ -1048,6 +1198,13 @@ fn project_relative_path(project : ProjectDoctorInfo, path : String) -> String {
 }
 
 ///|
+fn path_is_within_project(project : ProjectDoctorInfo, path : String) -> Bool {
+  let root = @path.Path(project.root).resolve().to_string()
+  let resolved = @path.Path(path).resolve().to_string()
+  resolved == root || resolved.has_prefix(root + @path.sep.to_string())
+}
+
+///|
 fn entry_path(project : ProjectDoctorInfo, entry : DoctorAppEntry) -> String {
   if entry.kind == "file" || entry.kind == "asset" {
     if entry.value.has_prefix("\\") ||
@@ -1083,6 +1240,17 @@ fn push_entry_existence(
   entry : DoctorAppEntry,
 ) -> Unit {
   let path = entry_path(project, entry)
+  if (entry.kind == "file" || entry.kind == "asset") &&
+    !path_is_within_project(project, path) {
+    lines.push(
+      DoctorLine::coded(
+        "app.entry.outside_project",
+        Error,
+        "entry path is outside the project root: " + path,
+      ),
+    )
+    return
+  }
   match entry.kind {
     "file" =>
       if @mbfs.path_exists(path) {
@@ -1131,12 +1299,70 @@ fn push_optional_app_line(
 }
 
 ///|
+fn push_frontend_path_check(
+  lines : Array[DoctorLine],
+  project : ProjectDoctorInfo,
+  code : String,
+  label : String,
+  value : String?,
+  required~ : Bool,
+) -> Unit {
+  match value {
+    Some(path) => {
+      let exists = @mbfs.is_dir(path) catch { _ => false }
+      if !path_is_within_project(project, path) {
+        lines.push(
+          DoctorLine::coded(
+            code + ".outside_project",
+            Error,
+            label + " is outside the project root: " + path,
+          ),
+        )
+      } else if exists {
+        lines.push(DoctorLine::coded(code, Ok, label + " exists: " + path))
+      } else if required {
+        lines.push(
+          DoctorLine::coded(
+            code + ".missing",
+            Error,
+            label + " is missing: " + path,
+          ),
+        )
+      } else {
+        lines.push(
+          DoctorLine::coded(
+            code + ".missing",
+            Warn,
+            label + " is missing: " + path,
+          ),
+        )
+      }
+    }
+    None => ()
+  }
+}
+
+///|
 fn push_loaded_app(
   lines : Array[DoctorLine],
   project : ProjectDoctorInfo,
   config : DoctorAppConfig,
 ) -> Unit {
   let window = config.window
+  if window.title.trim() == "" {
+    lines.push(
+      DoctorLine::coded("app.window.title_empty", Warn, "window title is empty"),
+    )
+  }
+  if window.width <= 0 || window.height <= 0 {
+    lines.push(
+      DoctorLine::coded(
+        "app.window.invalid_size",
+        Error,
+        "window width and height must be positive",
+      ),
+    )
+  }
   lines.push(
     DoctorLine::coded(
       "app.window",
@@ -1171,6 +1397,55 @@ fn push_loaded_app(
       push_optional_app_line(lines, "frontend_dist", frontend.dist)
       push_optional_app_line(lines, "dev_url", frontend.dev_url)
       push_optional_app_line(lines, "frontend_cwd", frontend.cwd)
+      push_frontend_path_check(
+        lines,
+        project,
+        "app.frontend.cwd",
+        "frontend cwd",
+        frontend.cwd,
+        required=true,
+      )
+      push_frontend_path_check(
+        lines,
+        project,
+        "app.frontend.dist",
+        "frontend dist",
+        frontend.dist,
+        required=false,
+      )
+      match frontend.dev_url {
+        Some(url) if !(url.has_prefix("http://") || url.has_prefix("https://")) =>
+          lines.push(
+            DoctorLine::coded(
+              "app.frontend.dev_url_invalid",
+              Error,
+              "frontend dev_url must use http or https: " + url,
+            ),
+          )
+        _ => ()
+      }
+      match frontend.before_dev {
+        Some(command) if command.trim() == "" =>
+          lines.push(
+            DoctorLine::coded(
+              "app.frontend.before_dev_empty",
+              Warn,
+              "frontend before_dev command is empty",
+            ),
+          )
+        _ => ()
+      }
+      match frontend.before_build {
+        Some(command) if command.trim() == "" =>
+          lines.push(
+            DoctorLine::coded(
+              "app.frontend.before_build_empty",
+              Warn,
+              "frontend before_build command is empty",
+            ),
+          )
+        _ => ()
+      }
     }
     None => ()
   }
@@ -1182,7 +1457,20 @@ fn collect_app(project : ProjectDoctorInfo) -> DoctorSection {
   match project.moon_proton_path {
     Some(path) =>
       match read_proton_project_config(path) {
-        Ok(config) => push_loaded_app(lines, project, config)
+        Ok(config) => {
+          push_loaded_app(lines, project, config)
+          match project.app_json_path {
+            Some(legacy) =>
+              lines.push(
+                DoctorLine::coded(
+                  "app.config.conflict",
+                  Warn,
+                  "moon.proton and legacy app.json both exist: " + legacy,
+                ),
+              )
+            None => ()
+          }
+        }
         Err(error) =>
           lines.push(
             DoctorLine::coded(

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -271,6 +271,18 @@ fn first_non_empty_line(text : String) -> String? {
 }
 
 ///|
+fn last_non_empty_line(text : String) -> String? {
+  let mut result : String? = None
+  for raw in text.replace(old="\r\n", new="\n").split("\n") {
+    let line = raw.trim().to_owned()
+    if line != "" {
+      result = Some(line)
+    }
+  }
+  result
+}
+
+///|
 async fn tool_version_line(
   label : String,
   commands : Array[String],
@@ -1529,7 +1541,7 @@ async fn collect_release(project : ProjectDoctorInfo) -> DoctorSection {
           "release.publish.dry_run_failed",
           Error,
           "moon publish --dry-run failed",
-          hint=first_non_empty_line(output).unwrap_or("publish dry-run failed"),
+          hint=last_non_empty_line(output).unwrap_or("publish dry-run failed"),
         ),
       )
     }
@@ -1565,7 +1577,7 @@ async fn collect_release(project : ProjectDoctorInfo) -> DoctorSection {
               "release.generated.stale",
               Error,
               "generated file verification failed",
-              hint=first_non_empty_line(output).unwrap_or(
+              hint=last_non_empty_line(output).unwrap_or(
                 "generated files are stale",
               ),
             ),

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -679,6 +679,26 @@ async fn platform_command_line(
 }
 
 ///|
+async fn collect_command_status(
+  command : String,
+  args : Array[String],
+  cwd : String?,
+) -> (Int, String) {
+  let result = match cwd {
+    Some(cwd) =>
+      @process.collect_output_merged(command, args, cwd~) catch {
+        _ => return (-1, "")
+      }
+    None =>
+      @process.collect_output_merged(command, args) catch {
+        _ => return (-1, "")
+      }
+  }
+  let (status, output) = result
+  (status, output.text() catch { _ => "" })
+}
+
+///|
 async fn collect_platform(project : ProjectDoctorInfo) -> DoctorSection {
   let lines : Array[DoctorLine] = []
   let platform_id = @cef.current_platform_id()
@@ -967,6 +987,395 @@ async fn collect_runtime(
     )
   }
   DoctorSection::new("runtime", "Runtime", section_status(lines), lines)
+}
+
+///|
+fn frontend_script_name(command : String) -> String? {
+  let trimmed = command.trim()
+  let rest = if trimmed.has_prefix("npm run ") {
+    Some(trimmed[8:])
+  } else if trimmed.has_prefix("yarn ") {
+    Some(trimmed[5:])
+  } else if trimmed.has_prefix("pnpm ") {
+    Some(trimmed[5:])
+  } else if trimmed.has_prefix("bun run ") {
+    Some(trimmed[8:])
+  } else {
+    None
+  }
+  match rest {
+    Some(rest) =>
+      match rest.trim().split(" ").collect() {
+        [name, ..] if name != "" => Some(name.to_owned())
+        _ => None
+      }
+    None => None
+  }
+}
+
+///|
+fn push_frontend_dist_diagnostics(
+  lines : Array[DoctorLine],
+  project : ProjectDoctorInfo,
+  dist : String?,
+) -> Unit {
+  push_frontend_path_check(
+    lines,
+    project,
+    "frontend.dist",
+    "frontend dist",
+    dist,
+    required=false,
+  )
+  match dist {
+    Some(dist) => {
+      let exists = @mbfs.is_dir(dist) catch { _ => false }
+      if exists {
+        let entries = @mbfs.read_dir(dist) catch { _ => [] }
+        if entries.length() > 0 {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.dist.nonempty",
+              Ok,
+              "frontend dist is non-empty",
+            ),
+          )
+        } else {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.dist.empty",
+              Warn,
+              "frontend dist is empty",
+            ),
+          )
+        }
+      }
+    }
+    None => ()
+  }
+}
+
+///|
+async fn collect_frontend(
+  project : ProjectDoctorInfo,
+  run~ : Bool,
+) -> DoctorSection {
+  let lines : Array[DoctorLine] = []
+  let config = match project.moon_proton_path {
+    Some(path) =>
+      match read_proton_project_config(path) {
+        Ok(config) => config
+        Err(error) => {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.config.invalid",
+              Error,
+              "moon.proton failed to load",
+              hint=error,
+            ),
+          )
+          return DoctorSection::new(
+            "frontend",
+            "Frontend",
+            section_status(lines),
+            lines,
+          )
+        }
+      }
+    None => {
+      lines.push(
+        DoctorLine::coded(
+          "frontend.config.missing",
+          Neutral,
+          "moon.proton has no frontend configuration",
+        ),
+      )
+      return DoctorSection::new(
+        "frontend",
+        "Frontend",
+        section_status(lines),
+        lines,
+      )
+    }
+  }
+  let frontend = match config.frontend {
+    Some(frontend) => frontend
+    None => {
+      lines.push(
+        DoctorLine::coded(
+          "frontend.not_configured",
+          Neutral,
+          "frontend is not configured",
+        ),
+      )
+      return DoctorSection::new(
+        "frontend",
+        "Frontend",
+        section_status(lines),
+        lines,
+      )
+    }
+  }
+  let frontend_root = frontend.cwd.unwrap_or(project.root)
+  if !path_is_within_project(project, frontend_root) {
+    lines.push(
+      DoctorLine::coded(
+        "frontend.cwd.outside_project",
+        Error,
+        "frontend cwd is outside the project root: " + frontend_root,
+      ),
+    )
+    return DoctorSection::new(
+      "frontend",
+      "Frontend",
+      section_status(lines),
+      lines,
+    )
+  }
+  if !(@mbfs.is_dir(frontend_root) catch { _ => false }) {
+    lines.push(
+      DoctorLine::coded(
+        "frontend.cwd.missing",
+        Error,
+        "frontend cwd is missing: " + frontend_root,
+      ),
+    )
+    return DoctorSection::new(
+      "frontend",
+      "Frontend",
+      section_status(lines),
+      lines,
+    )
+  }
+  lines.push(
+    DoctorLine::coded("frontend.cwd", Ok, "frontend cwd: " + frontend_root),
+  )
+  let package_path = path_join(frontend_root, "package.json")
+  let package_json = if @mbfs.path_exists(package_path) {
+    let text = @mbfs.read_file_to_string(package_path, encoding="utf8") catch {
+      _ => ""
+    }
+    let parsed = @json.parse(text) catch { _ => Json::null() }
+    match parsed {
+      Object(object) => {
+        lines.push(
+          DoctorLine::coded("frontend.package_json", Ok, "package.json found"),
+        )
+        Some(object)
+      }
+      _ => {
+        lines.push(
+          DoctorLine::coded(
+            "frontend.package_json.invalid",
+            Error,
+            "package.json is invalid",
+          ),
+        )
+        None
+      }
+    }
+  } else {
+    lines.push(
+      DoctorLine::coded(
+        "frontend.package_json.missing",
+        Warn,
+        "package.json is missing",
+      ),
+    )
+    None
+  }
+  let lock_candidates = [
+    ("package-lock.json", "npm"),
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("bun.lockb", "bun"),
+  ]
+  let mut manager : String? = None
+  let mut lock_count = 0
+  for item in lock_candidates {
+    let (lock_name, candidate) = item
+    if @mbfs.path_exists(path_join(frontend_root, lock_name)) {
+      lock_count += 1
+      if manager is None {
+        manager = Some(candidate)
+      }
+      lines.push(
+        DoctorLine::coded(
+          "frontend.lockfile",
+          Ok,
+          "lockfile: " + lock_name + " (" + candidate + ")",
+        ),
+      )
+    }
+  }
+  if lock_count > 1 {
+    lines.push(
+      DoctorLine::coded(
+        "frontend.lockfile.multiple",
+        Warn,
+        "multiple package-manager lockfiles were found",
+      ),
+    )
+  }
+  match manager {
+    Some(manager) =>
+      lines.push(
+        platform_command_line(
+          "frontend.manager",
+          manager,
+          manager,
+          ["--version"],
+          Warn,
+        ),
+      )
+    None =>
+      lines.push(
+        DoctorLine::coded(
+          "frontend.lockfile.missing",
+          Unknown,
+          "no supported package-manager lockfile found",
+        ),
+      )
+  }
+  match package_json {
+    Some(object) =>
+      match object.get("scripts") {
+        Some(Object(scripts)) =>
+          for
+            item in [
+              ("dev", frontend.before_dev),
+              ("build", frontend.before_build),
+            ] {
+            let (label, command) = item
+            match (command, frontend_script_name(command.unwrap_or(""))) {
+              (Some(_), Some(script_name)) if !scripts.contains(script_name) =>
+                lines.push(
+                  DoctorLine::coded(
+                    "frontend.script.missing",
+                    Error,
+                    "package.json is missing script `" +
+                    script_name +
+                    "` for " +
+                    label,
+                  ),
+                )
+              (Some(_), Some(script_name)) =>
+                lines.push(
+                  DoctorLine::coded(
+                    "frontend.script",
+                    Ok,
+                    "package.json script exists: " + script_name,
+                  ),
+                )
+              _ => ()
+            }
+          }
+        _ =>
+          lines.push(
+            DoctorLine::coded(
+              "frontend.scripts.missing",
+              Warn,
+              "package.json has no scripts object",
+            ),
+          )
+      }
+    None => ()
+  }
+  if !run {
+    push_frontend_dist_diagnostics(lines, project, frontend.dist)
+  }
+  if run {
+    match frontend.before_build {
+      Some(command) => {
+        let (shell, args) = if @path.sep == '\\' {
+          ("cmd", ["/c", command])
+        } else {
+          ("sh", ["-c", command])
+        }
+        let (status, output) = collect_command_status(
+          shell,
+          args,
+          Some(frontend_root),
+        )
+        if status == 0 {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.before_build.run",
+              Ok,
+              "before_build completed",
+            ),
+          )
+        } else {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.before_build.failed",
+              Error,
+              "before_build failed with code " + status.to_string(),
+              hint=first_non_empty_line(output).unwrap_or(
+                "build command failed",
+              ),
+            ),
+          )
+        }
+      }
+      None =>
+        lines.push(
+          DoctorLine::coded(
+            "frontend.before_build.not_configured",
+            Neutral,
+            "before_build is not configured",
+          ),
+        )
+    }
+    match frontend.dev_url {
+      Some(url) => {
+        let (status, body) = collect_command_status(
+          "curl",
+          ["-fsS", "--max-time", "2", url],
+          None,
+        )
+        if status == 0 {
+          let normalized = body.to_lower()
+          if normalized.contains("<html") || normalized.contains("<!doctype") {
+            lines.push(
+              DoctorLine::coded(
+                "frontend.dev_url.html",
+                Ok,
+                "dev_url is reachable and returned HTML",
+              ),
+            )
+          } else {
+            lines.push(
+              DoctorLine::coded(
+                "frontend.dev_url.non_html",
+                Warn,
+                "dev_url is reachable but did not return HTML",
+              ),
+            )
+          }
+        } else {
+          lines.push(
+            DoctorLine::coded(
+              "frontend.dev_url.unreachable",
+              Warn,
+              "dev_url is not reachable",
+            ),
+          )
+        }
+      }
+      None => ()
+    }
+    push_frontend_dist_diagnostics(lines, project, frontend.dist)
+  } else {
+    lines.push(
+      DoctorLine::coded(
+        "frontend.run.skipped",
+        Neutral,
+        "frontend commands and URL probes skipped; use --run",
+      ),
+    )
+  }
+  DoctorSection::new("frontend", "Frontend", section_status(lines), lines)
 }
 
 ///|

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -641,6 +641,185 @@ async fn collect_environment() -> DoctorSection {
 }
 
 ///|
+async fn platform_command_line(
+  code : String,
+  label : String,
+  command : String,
+  args : Array[String],
+  failure_status : DoctorStatus,
+) -> DoctorLine {
+  let (status, output) = @process.collect_output_merged(command, args) catch {
+    _ =>
+      return DoctorLine::coded(
+        code + ".missing",
+        Unknown,
+        label + ": command not available",
+        hint=command,
+      )
+  }
+  let text = output.text() catch { _ => "" }
+  match first_non_empty_line(text) {
+    Some(line) if status == 0 =>
+      DoctorLine::coded(code, Ok, label + ": " + line)
+    Some(line) =>
+      DoctorLine::coded(
+        code + ".failed",
+        failure_status,
+        label + ": command exited with code " + status.to_string(),
+        hint=line,
+      )
+    None if status == 0 => DoctorLine::coded(code, Ok, label + ": succeeded")
+    None =>
+      DoctorLine::coded(
+        code + ".failed",
+        failure_status,
+        label + ": command exited with code " + status.to_string(),
+      )
+  }
+}
+
+///|
+async fn collect_platform(project : ProjectDoctorInfo) -> DoctorSection {
+  let lines : Array[DoctorLine] = []
+  let platform_id = @cef.current_platform_id()
+  lines.push(DoctorLine::coded("platform.id", Ok, "platform: " + platform_id))
+  let runtime = resolve_native_dist(project)
+  match runtime {
+    Err(message) =>
+      lines.push(
+        DoctorLine::coded(
+          "platform.runtime_manifest",
+          Error,
+          "platform runtime unavailable",
+          hint=message,
+        ),
+      )
+    Ok((native_dist, _)) => {
+      match runtime_library_relative_path(platform_id) {
+        Some(relative) => {
+          let library_path = path_join(native_dist, relative)
+          if @mbfs.path_exists(library_path) {
+            lines.push(
+              platform_command_line(
+                "platform.library.file",
+                "native library",
+                "file",
+                [library_path],
+                Warn,
+              ),
+            )
+            if platform_id == "linux-x64" {
+              lines.push(
+                platform_command_line(
+                  "platform.library.ldd",
+                  "native library dependencies",
+                  "ldd",
+                  [library_path],
+                  Error,
+                ),
+              )
+            } else if platform_id == "darwin-arm64" ||
+              platform_id == "darwin-x64" {
+              lines.push(
+                platform_command_line(
+                  "platform.library.codesign",
+                  "native library signature",
+                  "codesign",
+                  ["--verify", "--deep", "--strict", library_path],
+                  Warn,
+                ),
+              )
+              lines.push(
+                platform_command_line(
+                  "platform.library.quarantine",
+                  "native library quarantine",
+                  "xattr",
+                  ["-p", "com.apple.quarantine", library_path],
+                  Neutral,
+                ),
+              )
+            }
+          } else {
+            lines.push(
+              DoctorLine::coded(
+                "platform.library.missing",
+                Unknown,
+                "native library not found: " + library_path,
+              ),
+            )
+          }
+        }
+        None => ()
+      }
+      let helper_path = path_join(
+        native_dist,
+        runtime_helper_relative_path(platform_id),
+      )
+      if @mbfs.path_exists(helper_path) {
+        lines.push(
+          platform_command_line(
+            "platform.helper.file",
+            "runtime helper",
+            "file",
+            [helper_path],
+            Warn,
+          ),
+        )
+      } else {
+        lines.push(
+          DoctorLine::coded(
+            "platform.helper.missing",
+            Unknown,
+            "runtime helper not found: " + helper_path,
+          ),
+        )
+      }
+    }
+  }
+  if platform_id == "win32-x64" {
+    lines.push(
+      platform_command_line(
+        "platform.msvc",
+        "MSVC compiler",
+        "where",
+        ["cl"],
+        Warn,
+      ),
+    )
+    lines.push(
+      platform_command_line(
+        "platform.dumpbin",
+        "dumpbin",
+        "where",
+        ["dumpbin"],
+        Unknown,
+      ),
+    )
+  } else if platform_id == "linux-x64" {
+    let display = @sys.get_env_var("DISPLAY")
+    let wayland = @sys.get_env_var("WAYLAND_DISPLAY")
+    if display is None && wayland is None {
+      lines.push(
+        DoctorLine::coded(
+          "platform.display.headless",
+          Warn,
+          "no DISPLAY or WAYLAND_DISPLAY is set; GUI launch may require a headless setup",
+        ),
+      )
+    } else {
+      lines.push(
+        DoctorLine::coded(
+          "platform.display",
+          Ok,
+          "display environment is configured",
+        ),
+      )
+    }
+  }
+  DoctorSection::new("platform", "Platform", section_status(lines), lines)
+}
+
+///|
 async fn collect_runtime(
   project : ProjectDoctorInfo,
   deep~ : Bool,

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -2035,12 +2035,7 @@ fn collect_extensions(
       package_imports_with_prefix(Some(config), "justjavac/proton_ext/")
     _ => []
   }
-  let nested_extension_root = path_join(project.root, "extensions")
-  let extension_root = if @mbfs.path_exists(nested_extension_root) {
-    nested_extension_root
-  } else {
-    project.root
-  }
+  let extension_root = extension_root_for_project(project)
   let lines : Array[DoctorLine] = []
   let namespaces : Map[String, String] = {}
   let discovered = if @mbfs.path_exists(extension_root) {
@@ -2207,6 +2202,106 @@ fn collect_extensions(
     )
   }
   DoctorSection::new("extensions", "Extensions", section_status(lines), lines)
+}
+
+///|
+fn extension_root_for_project(project : ProjectDoctorInfo) -> String {
+  let nested_extension_root = path_join(project.root, "extensions")
+  if @mbfs.path_exists(nested_extension_root) {
+    nested_extension_root
+  } else {
+    project.root
+  }
+}
+
+///|
+fn write_doctor_fix(path : String, text : String) -> Bool {
+  try @mbfs.write_string_to_file(path, text, encoding="utf8") catch {
+    _ => return false
+  } noraise {
+    _ => true
+  }
+}
+
+///|
+fn apply_doctor_fixes(
+  project : ProjectDoctorInfo,
+  dry_run~ : Bool,
+) -> DoctorSection {
+  let lines : Array[DoctorLine] = []
+  let extension_root = extension_root_for_project(project)
+  let entries = @mbfs.read_dir(extension_root) catch { _ => [] }
+  let mut changed = 0
+  for entry in entries {
+    let extension_dir = path_join(extension_root, entry)
+    let source_path = path_join(extension_dir, "extension.mbt")
+    let metadata_path = path_join(extension_dir, "moon.ext")
+    if !(@mbfs.is_file(source_path) catch { _ => false }) ||
+      !(@mbfs.is_file(metadata_path) catch { _ => false }) {
+      continue
+    }
+    let source = @mbfs.read_file_to_string(source_path, encoding="utf8") catch {
+      _ => ""
+    }
+    if !source.contains("#proton.") {
+      continue
+    }
+    let generated_path = path_join(extension_dir, "extension.g.mbt")
+    match @codegen.generate_app_commands_from_file_with_metadata(source_path) {
+      Ok(generated) => {
+        let current = @mbfs.read_file_to_string(generated_path, encoding="utf8") catch {
+          _ => ""
+        }
+        if current != generated.source {
+          changed += 1
+          if dry_run {
+            lines.push(
+              DoctorLine::coded(
+                "fix.generated.plan",
+                Neutral,
+                "would regenerate " + generated_path,
+              ),
+            )
+          } else if write_doctor_fix(generated_path, generated.source) {
+            lines.push(
+              DoctorLine::coded(
+                "fix.generated.applied",
+                Ok,
+                "regenerated " + generated_path,
+              ),
+            )
+          } else {
+            lines.push(
+              DoctorLine::coded(
+                "fix.generated.failed",
+                Error,
+                "failed to regenerate " + generated_path,
+              ),
+            )
+          }
+        }
+      }
+      Err(error) =>
+        lines.push(
+          DoctorLine::coded(
+            "fix.generated.invalid",
+            Error,
+            "cannot regenerate " + source_path,
+            hint=error,
+          ),
+        )
+    }
+  }
+  if changed == 0 && lines.length() == 0 {
+    lines.push(
+      DoctorLine::coded(
+        "fix.none",
+        Neutral,
+        "no safe automatic fixes are available",
+      ),
+    )
+  }
+  DoctorSection::new("fixes", "Fixes", section_status(lines), lines)
 }
 
 ///|

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -252,7 +252,7 @@ async fn host_os_line() -> DoctorLine {
         None => uname_value("-m")
       }
   }
-  DoctorLine::new(Ok, "OS: " + host_os_label(system, arch))
+  DoctorLine::coded("environment.os", Ok, "OS: " + host_os_label(system, arch))
 }
 
 ///|

--- a/cli/doctor/doctor_moon_config.mbt
+++ b/cli/doctor/doctor_moon_config.mbt
@@ -152,6 +152,8 @@ fn read_moon_mod(
           name: ast_string(ast_field(ast, "name")),
           version: ast_string(ast_field(ast, "version")),
           imports: parse_deps(ast),
+          preferred_target: ast_string(ast_field(ast, "preferred_target")),
+          supported_targets: ast_string(ast_field(ast, "supported_targets")),
         })
       }
     }

--- a/cli/doctor/doctor_moon_config.mbt
+++ b/cli/doctor/doctor_moon_config.mbt
@@ -154,6 +154,10 @@ fn read_moon_mod(
           imports: parse_deps(ast),
           preferred_target: ast_string(ast_field(ast, "preferred_target")),
           supported_targets: ast_string(ast_field(ast, "supported_targets")),
+          readme: ast_string(ast_field(ast, "readme")),
+          repository: ast_string(ast_field(ast, "repository")),
+          license: ast_string(ast_field(ast, "license")),
+          description: ast_string(ast_field(ast, "description")),
         })
       }
     }

--- a/cli/doctor/doctor_moon_config.mbt
+++ b/cli/doctor/doctor_moon_config.mbt
@@ -8,6 +8,14 @@ fn report_messages(reports : Array[@lexer_basic.Report]) -> String {
 }
 
 ///|
+fn reports_only_reject_source(reports : Array[@lexer_basic.Report]) -> Bool {
+  reports.length() > 0 &&
+  reports.all(fn(report) {
+    report.to_string().contains("unexpected key `source`")
+  })
+}
+
+///|
 fn ast_field(ast : @moon_config.Ast, key : String) -> @moon_config.Ast? {
   match ast {
     @moon_config.Ast::Obj(fields, ..) => {
@@ -136,7 +144,7 @@ fn read_moon_mod(
     Err(err) => Err(err)
     Ok(source) => {
       let (ast, reports) = @moon_config.parse_moon_mod(name=path, source)
-      if reports.length() > 0 {
+      if reports.length() > 0 && !reports_only_reject_source(reports) {
         Err(MoonConfigReadError::ParseFailed(path, report_messages(reports)))
       } else {
         Ok({

--- a/cli/doctor/doctor_native_probe.c
+++ b/cli/doctor/doctor_native_probe.c
@@ -1,0 +1,120 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "moonbit.h"
+
+#ifdef _WIN32
+#include <windows.h>
+typedef HMODULE doctor_library_t;
+#define doctor_open(path) LoadLibraryA(path)
+#define doctor_symbol(lib, name) GetProcAddress(lib, name)
+#define doctor_close(lib) FreeLibrary(lib)
+static const char *doctor_load_error(void) { return "LoadLibrary failed"; }
+#else
+#include <dlfcn.h>
+typedef void *doctor_library_t;
+#define doctor_open(path) dlopen(path, RTLD_NOW | RTLD_LOCAL)
+#define doctor_symbol(lib, name) dlsym(lib, name)
+#define doctor_close(lib) dlclose(lib)
+static const char *doctor_load_error(void) {
+  const char *error = dlerror();
+  return error == NULL ? "dlopen failed" : error;
+}
+#endif
+
+typedef int32_t (*doctor_abi_fn)(void);
+typedef int32_t (*doctor_info_fn)(char *, int32_t, int32_t *);
+typedef int32_t (*doctor_probe_fn)(const char *);
+typedef int32_t (*doctor_error_fn)(char *, int32_t);
+typedef int32_t (*doctor_create_fn)(const char *, int64_t *);
+typedef int32_t (*doctor_destroy_fn)(int64_t);
+
+static moonbit_bytes_t doctor_copy_text(const char *text) {
+  size_t length = strlen(text);
+  moonbit_bytes_t result = moonbit_make_bytes((int32_t)length + 1, 0);
+  memcpy(result, text, length + 1);
+  return result;
+}
+
+static void doctor_json_escape(char *output, size_t capacity, const char *text) {
+  size_t written = 0;
+  for (const unsigned char *cursor = (const unsigned char *)text;
+       *cursor != 0 && written + 2 < capacity; cursor++) {
+    unsigned char ch = *cursor;
+    if (ch == '\\' || ch == '"') {
+      output[written++] = '\\';
+      output[written++] = (char)ch;
+    } else if (ch == '\n' || ch == '\r' || ch == '\t') {
+      output[written++] = ' ';
+    } else if (ch >= 0x20) {
+      output[written++] = (char)ch;
+    }
+  }
+  output[written] = 0;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t proton_doctor_native_probe(
+    moonbit_bytes_t library_path, moonbit_bytes_t config_json) {
+  char result[4096] = {0};
+  doctor_library_t library = doctor_open((const char *)library_path);
+  if (library == NULL) {
+    char escaped[2048] = {0};
+    doctor_json_escape(escaped, sizeof(escaped), doctor_load_error());
+    snprintf(result, sizeof(result), "{\"load_error\":\"%s\"}", escaped);
+    return doctor_copy_text(result);
+  }
+
+  doctor_abi_fn abi = (doctor_abi_fn)doctor_symbol(library, "proton_abi_version");
+  doctor_info_fn info =
+      (doctor_info_fn)doctor_symbol(library, "proton_runtime_info_json");
+  doctor_probe_fn probe =
+      (doctor_probe_fn)doctor_symbol(library, "proton_runtime_probe_json");
+  doctor_error_fn last_error =
+      (doctor_error_fn)doctor_symbol(library, "proton_last_error_message");
+  doctor_create_fn create =
+      (doctor_create_fn)doctor_symbol(library, "proton_runtime_create_json");
+  doctor_destroy_fn destroy =
+      (doctor_destroy_fn)doctor_symbol(library, "proton_runtime_destroy");
+  if (abi == NULL || info == NULL || probe == NULL || last_error == NULL ||
+      create == NULL || destroy == NULL) {
+    snprintf(result, sizeof(result),
+             "{\"symbol_error\":\"required proton ABI symbol is missing\"}");
+    doctor_close(library);
+    return doctor_copy_text(result);
+  }
+
+  char info_json[1024] = {0};
+  int32_t required = 0;
+  int32_t info_status = info(info_json, (int32_t)sizeof(info_json), &required);
+  int32_t probe_status = probe((const char *)config_json);
+  char error[1024] = {0};
+  if (probe_status < 0) {
+    last_error(error, (int32_t)sizeof(error));
+  }
+  int32_t smoke_status = probe_status;
+  if (probe_status >= 0) {
+    int64_t runtime = 0;
+    smoke_status = create((const char *)config_json, &runtime);
+    if (smoke_status >= 0) {
+      smoke_status = destroy(runtime);
+    }
+    if (smoke_status < 0) {
+      last_error(error, (int32_t)sizeof(error));
+    }
+  }
+  char escaped_error[2048] = {0};
+  doctor_json_escape(escaped_error, sizeof(escaped_error), error);
+  if (info_status < 0) {
+    snprintf(info_json, sizeof(info_json), "null");
+  }
+  snprintf(result, sizeof(result),
+           "{\"abi_version\":%d,\"info_status\":%d,\"info\":%s,"
+           "\"probe_status\":%d,\"smoke_status\":%d,"
+           "\"probe_error\":\"%s\"}",
+           abi(), info_status, info_json, probe_status, smoke_status,
+           escaped_error);
+  doctor_close(library);
+  return doctor_copy_text(result);
+}

--- a/cli/doctor/doctor_native_probe.mbt
+++ b/cli/doctor/doctor_native_probe.mbt
@@ -1,0 +1,18 @@
+///|
+#borrow(library_path, config_json)
+extern "C" fn proton_doctor_native_probe_ffi(
+  library_path : Bytes,
+  config_json : Bytes,
+) -> Bytes = "proton_doctor_native_probe"
+
+///|
+fn doctor_native_probe(library_path : String, config_json : String) -> Json {
+  let result = proton_doctor_native_probe_ffi(
+    @ffi.to_cstr(library_path),
+    @ffi.to_cstr(config_json),
+  )
+  let text = @ffi.from_cstr(result)
+  @json.parse(text) catch {
+    _ => Json::object({ "parse_error": Json::string(text) })
+  }
+}

--- a/cli/doctor/doctor_paths.mbt
+++ b/cli/doctor/doctor_paths.mbt
@@ -5,7 +5,7 @@ fn path_join(base : String, name : String) -> String {
   } else if base.has_suffix("\\") || base.has_suffix("/") {
     base + name
   } else {
-    base + "\\" + name
+    base + @path.sep.to_string() + name
   }
 }
 

--- a/cli/doctor/doctor_render.mbt
+++ b/cli/doctor/doctor_render.mbt
@@ -72,12 +72,63 @@ fn doctor_summary_to_json(summary : DoctorSummary) -> Json {
 ///|
 fn doctor_section_to_json(section : DoctorSection) -> Json {
   Json::object({
+    "id": Json::string(section.id),
     "title": Json::string(section.title),
     "status": Json::string(section.status.json_name()),
     "lines": Json::array(
       section.lines.map(fn(line) { doctor_line_to_json(line) }),
     ),
   })
+}
+
+///|
+fn render_doctor_json_lines(report : DoctorReport) -> String {
+  let lines : Array[String] = []
+  for section in report.sections {
+    for line in section.lines {
+      let value = doctor_line_to_json(line)
+      match value {
+        Object(fields) => {
+          fields["section"] = Json::string(section.id)
+          lines.push(Json::object(fields).stringify())
+        }
+        _ => ()
+      }
+    }
+  }
+  lines.push(
+    Json::object({
+      "type": Json::string("summary"),
+      "summary": doctor_summary_to_json(report.summary()),
+    }).stringify(),
+  )
+  lines.join("\n") + "\n"
+}
+
+///|
+fn render_doctor_quiet(report : DoctorReport) -> String {
+  let builder = StringBuilder()
+  for section in report.sections {
+    for line in section.lines {
+      if line.status == Error || line.status == Missing || line.status == Warn {
+        builder.write_string(line.status.symbol())
+        builder.write_string(" [")
+        builder.write_string(line.code)
+        builder.write_string("] ")
+        builder.write_string(line.text)
+        builder.write_string("\n")
+      }
+    }
+  }
+  let summary = report.summary()
+  builder.write_string(
+    "Summary: " +
+    summary.errors.to_string() +
+    " errors, " +
+    summary.warnings.to_string() +
+    " warnings\n",
+  )
+  builder.to_string()
 }
 
 ///|

--- a/cli/doctor/doctor_render.mbt
+++ b/cli/doctor/doctor_render.mbt
@@ -28,12 +28,25 @@ fn render_doctor_text(report : DoctorReport) -> String {
   if report.dry_run {
     builder.write_string("\n- doctor is read-only; no files will be changed\n")
   }
+  let summary = report.summary()
+  builder.write_string(
+    "\nSummary: " +
+    summary.errors.to_string() +
+    " errors, " +
+    summary.warnings.to_string() +
+    " warnings, " +
+    summary.passed.to_string() +
+    " passed, " +
+    summary.unknown.to_string() +
+    " unknown\n",
+  )
   builder.to_string()
 }
 
 ///|
 fn doctor_line_to_json(line : DoctorLine) -> Json {
   let object : Map[String, Json] = {
+    "code": Json::string(line.code),
     "status": Json::string(line.status.json_name()),
     "text": Json::string(line.text),
   }
@@ -42,6 +55,18 @@ fn doctor_line_to_json(line : DoctorLine) -> Json {
     None => ()
   }
   Json::object(object)
+}
+
+///|
+fn doctor_summary_to_json(summary : DoctorSummary) -> Json {
+  Json::object({
+    "total": Json::number(summary.total.to_double()),
+    "passed": Json::number(summary.passed.to_double()),
+    "warnings": Json::number(summary.warnings.to_double()),
+    "errors": Json::number(summary.errors.to_double()),
+    "unknown": Json::number(summary.unknown.to_double()),
+    "neutral": Json::number(summary.neutral.to_double()),
+  })
 }
 
 ///|
@@ -60,6 +85,7 @@ fn render_doctor_json(report : DoctorReport) -> String {
   Json::object({
     "schema_version": Json::number(1),
     "dry_run": Json::boolean(report.dry_run),
+    "summary": doctor_summary_to_json(report.summary()),
     "sections": Json::array(
       report.sections.map(fn(section) { doctor_section_to_json(section) }),
     ),

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -34,6 +34,7 @@ fn DoctorStatus::json_name(self : DoctorStatus) -> String {
 
 ///|
 priv struct DoctorLine {
+  code : String
   status : DoctorStatus
   text : String
   hint : String?
@@ -45,7 +46,17 @@ fn DoctorLine::new(
   text : String,
   hint? : String,
 ) -> DoctorLine {
-  { status, text, hint }
+  { code: "doctor.unspecified", status, text, hint }
+}
+
+///|
+fn DoctorLine::coded(
+  code : String,
+  status : DoctorStatus,
+  text : String,
+  hint? : String,
+) -> DoctorLine {
+  { code, status, text, hint }
 }
 
 ///|
@@ -81,6 +92,39 @@ fn DoctorReport::new(
 ///|
 fn DoctorReport::has_errors(self : DoctorReport) -> Bool {
   self.sections.any(fn(section) { section.status == Error })
+}
+
+///|
+priv struct DoctorSummary {
+  total : Int
+  passed : Int
+  warnings : Int
+  errors : Int
+  unknown : Int
+  neutral : Int
+}
+
+///|
+fn DoctorReport::summary(self : DoctorReport) -> DoctorSummary {
+  let mut total = 0
+  let mut passed = 0
+  let mut warnings = 0
+  let mut errors = 0
+  let mut unknown = 0
+  let mut neutral = 0
+  for section in self.sections {
+    for line in section.lines {
+      total += 1
+      match line.status {
+        Ok => passed += 1
+        Warn => warnings += 1
+        Error | Missing => errors += 1
+        Unknown => unknown += 1
+        Neutral => neutral += 1
+      }
+    }
+  }
+  { total, passed, warnings, errors, unknown, neutral }
 }
 
 ///|

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -198,6 +198,8 @@ priv struct MoonModuleConfig {
   name : String?
   version : String?
   imports : Array[MoonDependency]
+  preferred_target : String?
+  supported_targets : String?
 }
 
 ///|

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -41,15 +41,6 @@ priv struct DoctorLine {
 }
 
 ///|
-fn DoctorLine::new(
-  status : DoctorStatus,
-  text : String,
-  hint? : String,
-) -> DoctorLine {
-  { code: "doctor.unspecified", status, text, hint }
-}
-
-///|
 fn DoctorLine::coded(
   code : String,
   status : DoctorStatus,
@@ -61,6 +52,7 @@ fn DoctorLine::coded(
 
 ///|
 priv struct DoctorSection {
+  id : String
   title : String
   status : DoctorStatus
   lines : Array[DoctorLine]
@@ -68,11 +60,12 @@ priv struct DoctorSection {
 
 ///|
 fn DoctorSection::new(
+  id : String,
   title : String,
   status : DoctorStatus,
   lines : Array[DoctorLine],
 ) -> DoctorSection {
-  { title, status, lines }
+  { id, title, status, lines }
 }
 
 ///|
@@ -133,6 +126,10 @@ priv struct DoctorOptions {
   dry_run : Bool
   verbose : Bool
   json : Bool
+  json_lines : Bool
+  quiet : Bool
+  sections : Array[String]
+  output : String?
 }
 
 ///|
@@ -141,8 +138,17 @@ fn DoctorOptions::new(
   dry_run~ : Bool,
   verbose~ : Bool,
   json~ : Bool,
+  json_lines~ : Bool,
+  quiet~ : Bool,
+  sections~ : Array[String],
+  output~ : String?,
 ) -> DoctorOptions {
-  { cwd, dry_run, verbose, json }
+  { cwd, dry_run, verbose, json, json_lines, quiet, sections, output }
+}
+
+///|
+fn DoctorOptions::includes(self : DoctorOptions, section : String) -> Bool {
+  self.sections.length() == 0 || self.sections.contains(section)
 }
 
 ///|

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -79,6 +79,11 @@ fn DoctorReport::new(
 }
 
 ///|
+fn DoctorReport::has_errors(self : DoctorReport) -> Bool {
+  self.sections.any(fn(section) { section.status == Error })
+}
+
+///|
 priv struct DoctorOptions {
   cwd : String
   dry_run : Bool

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -127,6 +127,7 @@ priv struct DoctorOptions {
   verbose : Bool
   deep : Bool
   run_frontend : Bool
+  fix : Bool
   json : Bool
   json_lines : Bool
   quiet : Bool
@@ -141,6 +142,7 @@ fn DoctorOptions::new(
   verbose~ : Bool,
   deep~ : Bool,
   run_frontend~ : Bool,
+  fix~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
@@ -153,6 +155,7 @@ fn DoctorOptions::new(
     verbose,
     deep,
     run_frontend,
+    fix,
     json,
     json_lines,
     quiet,

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -126,6 +126,7 @@ priv struct DoctorOptions {
   dry_run : Bool
   verbose : Bool
   deep : Bool
+  run_frontend : Bool
   json : Bool
   json_lines : Bool
   quiet : Bool
@@ -139,13 +140,25 @@ fn DoctorOptions::new(
   dry_run~ : Bool,
   verbose~ : Bool,
   deep~ : Bool,
+  run_frontend~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
   sections~ : Array[String],
   output~ : String?,
 ) -> DoctorOptions {
-  { cwd, dry_run, verbose, deep, json, json_lines, quiet, sections, output }
+  {
+    cwd,
+    dry_run,
+    verbose,
+    deep,
+    run_frontend,
+    json,
+    json_lines,
+    quiet,
+    sections,
+    output,
+  }
 }
 
 ///|

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -125,6 +125,7 @@ priv struct DoctorOptions {
   cwd : String
   dry_run : Bool
   verbose : Bool
+  deep : Bool
   json : Bool
   json_lines : Bool
   quiet : Bool
@@ -137,13 +138,14 @@ fn DoctorOptions::new(
   cwd~ : String,
   dry_run~ : Bool,
   verbose~ : Bool,
+  deep~ : Bool,
   json~ : Bool,
   json_lines~ : Bool,
   quiet~ : Bool,
   sections~ : Array[String],
   output~ : String?,
 ) -> DoctorOptions {
-  { cwd, dry_run, verbose, json, json_lines, quiet, sections, output }
+  { cwd, dry_run, verbose, deep, json, json_lines, quiet, sections, output }
 }
 
 ///|
@@ -167,6 +169,15 @@ priv struct ProjectDoctorInfo {
   moon_pkg_path : String?
   moon_proton_path : String?
   app_json_path : String?
+}
+
+///|
+priv struct DoctorRuntimeManifest {
+  schema_version : Int
+  platform : String
+  proton_version : String
+  cef_version : String
+  dist : String
 }
 
 ///|

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -213,6 +213,10 @@ priv struct MoonModuleConfig {
   imports : Array[MoonDependency]
   preferred_target : String?
   supported_targets : String?
+  readme : String?
+  repository : String?
+  license : String?
+  description : String?
 }
 
 ///|

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -23,6 +23,25 @@ test "doctor paths use the host separator" {
 }
 
 ///|
+test "doctor project boundary rejects parent paths" {
+  let project = discover_project("target/proton-doctor-boundary")
+  assert_true(
+    path_is_within_project(
+      project,
+      path_join("target/proton-doctor-boundary", "app.html"),
+    ),
+  )
+  assert_false(path_is_within_project(project, "target/outside.html"))
+}
+
+///|
+test "doctor compares dependency major minor versions" {
+  @debug.assert_eq(version_major_minor("0.1.5"), Some("0.1"))
+  @debug.assert_eq(version_major_minor("1.2.0-beta.1"), Some("1.2"))
+  assert_true(version_major_minor("invalid") is None)
+}
+
+///|
 test "doctor formats host OS labels" {
   assert_eq(host_os_label(Some("Darwin"), Some("arm64")), "macOS arm64")
   assert_eq(host_os_label(Some("Linux"), Some("x86_64")), "Linux x86_64")
@@ -186,6 +205,11 @@ test "moon_config adapter reads module deps and package imports" {
       #|
       #|source = ""
       #|
+      #|options(
+      #|  preferred_target: "native",
+      #|  supported_targets: "+native",
+      #|)
+      #|
     ),
     encoding="utf8",
   ) catch {
@@ -210,6 +234,8 @@ test "moon_config adapter reads module deps and package imports" {
   }
   let module_config = read_moon_mod(moon_mod_path).unwrap()
   @debug.assert_eq(module_config.name, Some("justjavac/proton-demo"))
+  @debug.assert_eq(module_config.preferred_target, Some("native"))
+  @debug.assert_eq(module_config.supported_targets, Some("+native"))
   @debug.assert_eq(
     dependency_version(Some(module_config), "justjavac/proton"),
     Some("0.1.10"),

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -17,6 +17,55 @@ fn assert_test_path_suffix(value : String, suffix : String) -> Unit {
 }
 
 ///|
+test "doctor paths use the host separator" {
+  let joined = path_join("..", "examples")
+  assert_eq(joined, ".." + @path.sep.to_string() + "examples")
+}
+
+///|
+test "doctor formats host OS labels" {
+  assert_eq(host_os_label(Some("Darwin"), Some("arm64")), "macOS arm64")
+  assert_eq(host_os_label(Some("Linux"), Some("x86_64")), "Linux x86_64")
+  assert_eq(host_os_label(Some("Windows_NT"), Some("AMD64")), "Windows x86_64")
+}
+
+///|
+test "doctor report records failing sections" {
+  let healthy = DoctorReport::new(
+    [DoctorSection::new("Environment", Ok, [])],
+    dry_run=false,
+  )
+  assert_false(healthy.has_errors())
+  let unhealthy = DoctorReport::new(
+    [DoctorSection::new("Environment", Error, [])],
+    dry_run=false,
+  )
+  assert_true(unhealthy.has_errors())
+}
+
+///|
+test "doctor reports invalid runtime manifests" {
+  let dir = "target/proton-doctor-invalid-runtime"
+  let proton_dir = path_join(dir, ".proton")
+  ensure_test_dir(dir)
+  @mbfs.create_dir(proton_dir) catch {
+    _ => ()
+  }
+  @mbfs.write_string_to_file(
+    path_join(proton_dir, "runtime.json"),
+    "{ invalid",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let project = discover_project(dir)
+  match resolve_native_dist(project) {
+    Err(message) => assert_true(message.contains("failed to parse"))
+    Ok(_) => abort("expected invalid runtime manifest error")
+  }
+}
+
+///|
 test "moon_config adapter reads module deps and package imports" {
   let dir = "target/proton-doctor-config"
   ensure_test_dir(dir)
@@ -35,6 +84,8 @@ test "moon_config adapter reads module deps and package imports" {
       #|  "moonbitlang/async@0.19.0",
       #|  "moonbitlang/x@0.4.43",
       #|}
+      #|
+      #|source = ""
       #|
     ),
     encoding="utf8",

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -89,6 +89,7 @@ test "doctor options filter sections" {
     cwd=".",
     dry_run=false,
     verbose=false,
+    deep=false,
     json=false,
     json_lines=false,
     quiet=false,
@@ -118,6 +119,48 @@ test "doctor reports invalid runtime manifests" {
   match resolve_native_dist(project) {
     Err(message) => assert_true(message.contains("failed to parse"))
     Ok(_) => abort("expected invalid runtime manifest error")
+  }
+}
+
+///|
+test "doctor validates runtime manifest schema" {
+  let dir = "target/proton-doctor-runtime-schema"
+  let proton_dir = path_join(dir, ".proton")
+  ensure_test_dir(dir)
+  @mbfs.create_dir(proton_dir) catch {
+    _ => ()
+  }
+  let manifest_path = path_join(proton_dir, "runtime.json")
+  @mbfs.write_string_to_file(
+    manifest_path,
+    (
+      #|{"schema_version":1,"platform":"darwin-arm64","proton_version":"0.1.5","cef_version":"cef-test","dist":"runtime"}
+    ),
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let project = discover_project(dir)
+  match runtime_manifest_from_project(project) {
+    Ok(Some(manifest)) => {
+      assert_eq(manifest.schema_version, 1)
+      assert_eq(manifest.platform, "darwin-arm64")
+      assert_eq(manifest.dist, "runtime")
+    }
+    _ => abort("expected valid runtime manifest")
+  }
+  @mbfs.write_string_to_file(
+    manifest_path,
+    (
+      #|{"schema_version":1,"platform":"darwin-arm64","proton_version":"0.1.5","cef_version":"cef-test","dist":"runtime","extra":true}
+    ),
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  match runtime_manifest_from_project(project) {
+    Err(message) => assert_true(message.contains("unknown field `extra`"))
+    _ => abort("expected unknown runtime manifest field error")
   }
 }
 

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -44,6 +44,30 @@ test "doctor report records failing sections" {
 }
 
 ///|
+test "doctor report summarizes line statuses" {
+  let report = DoctorReport::new(
+    [
+      DoctorSection::new("Environment", Error, [
+        DoctorLine::coded("environment.os", Ok, "OS"),
+        DoctorLine::coded("runtime.missing", Missing, "runtime"),
+        DoctorLine::coded("runtime.version", Unknown, "version"),
+        DoctorLine::coded("environment.node", Warn, "node"),
+      ]),
+    ],
+    dry_run=false,
+  )
+  let summary = report.summary()
+  assert_eq(summary.total, 4)
+  assert_eq(summary.passed, 1)
+  assert_eq(summary.errors, 1)
+  assert_eq(summary.warnings, 1)
+  assert_eq(summary.unknown, 1)
+  assert_true(
+    render_doctor_json(report).contains("\"code\": \"environment.os\""),
+  )
+}
+
+///|
 test "doctor reports invalid runtime manifests" {
   let dir = "target/proton-doctor-invalid-runtime"
   let proton_dir = path_join(dir, ".proton")
@@ -275,6 +299,8 @@ test "text renderer uses utf8 symbols and dry run note" {
       #|    hint: install Visual Studio
       #|
       #|- doctor is read-only; no files will be changed
+      #|
+      #|Summary: 0 errors, 1 warnings, 1 passed, 0 unknown
       #|
     ),
   )

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -82,6 +82,49 @@ async test "frontend run captures build command output" {
 }
 
 ///|
+test "doctor fix regenerates extensions and honors dry run" {
+  let root = "target/proton-doctor-fix"
+  let extension_dir = path_join(root, "sample")
+  ensure_test_dir(root)
+  @mbfs.create_dir(extension_dir) catch {
+    _ => ()
+  }
+  @mbfs.write_string_to_file(
+    path_join(extension_dir, "moon.ext"),
+    "id = \"company/sample\"\nnamespace = \"sample\"\n",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  @mbfs.write_string_to_file(
+    path_join(extension_dir, "extension.mbt"),
+    "#proton.command\nfn ping() -> Unit {}\n",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let generated_path = path_join(extension_dir, "extension.g.mbt")
+  @mbfs.write_string_to_file(generated_path, "stale", encoding="utf8") catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let project = discover_project(root)
+  let plan = apply_doctor_fixes(project, dry_run=true)
+  assert_true(plan.lines.any(fn(line) { line.code == "fix.generated.plan" }))
+  let stale = @mbfs.read_file_to_string(generated_path, encoding="utf8") catch {
+    _ => abort("failed to read stale generated file")
+  }
+  assert_eq(stale, "stale")
+  let applied = apply_doctor_fixes(project, dry_run=false)
+  assert_true(
+    applied.lines.any(fn(line) { line.code == "fix.generated.applied" }),
+  )
+  let generated = @mbfs.read_file_to_string(generated_path, encoding="utf8") catch {
+    _ => abort("failed to read generated file")
+  }
+  assert_true(generated.contains("__proton_command_ping"))
+}
+
+///|
 test "doctor formats host OS labels" {
   assert_eq(host_os_label(Some("Darwin"), Some("arm64")), "macOS arm64")
   assert_eq(host_os_label(Some("Linux"), Some("x86_64")), "Linux x86_64")
@@ -150,6 +193,7 @@ test "doctor options filter sections" {
     verbose=false,
     deep=false,
     run_frontend=false,
+    fix=false,
     json=false,
     json_lines=false,
     quiet=false,

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -364,6 +364,10 @@ test "doctor collector extracts first non-empty version line" {
     Some("moon 0.1.0"),
   )
   @debug.assert_eq(first_non_empty_line("\r\n\n"), None)
+  @debug.assert_eq(
+    last_non_empty_line("\r\nfirst\n  final diagnostic  \n"),
+    Some("final diagnostic"),
+  )
 }
 
 ///|

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -42,6 +42,46 @@ test "doctor compares dependency major minor versions" {
 }
 
 ///|
+test "doctor extracts frontend script names" {
+  @debug.assert_eq(
+    frontend_script_name("npm run build -- --mode prod"),
+    Some("build"),
+  )
+  @debug.assert_eq(frontend_script_name("pnpm dev"), Some("dev"))
+  @debug.assert_eq(frontend_script_name("bun run test"), Some("test"))
+  assert_true(frontend_script_name("vite build") is None)
+}
+
+///|
+async test "frontend run captures build command output" {
+  let dir = "target/proton-doctor-frontend-run"
+  ensure_test_dir(dir)
+  @mbfs.write_string_to_file(
+    path_join(dir, "moon.proton"),
+    (
+      #|window = { title: "Demo", width: 800, height: 600 }
+      #|entry = { kind: "html", value: "<h1>Demo</h1>" }
+      #|frontend = { before_build: "npm --version", cwd: "." }
+      #|
+    ),
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  @mbfs.write_string_to_file(
+    path_join(dir, "package.json"),
+    "{\"scripts\":{}}",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let section = collect_frontend(discover_project(dir), run=true)
+  assert_true(
+    section.lines.any(fn(line) { line.code == "frontend.before_build.run" }),
+  )
+}
+
+///|
 test "doctor formats host OS labels" {
   assert_eq(host_os_label(Some("Darwin"), Some("arm64")), "macOS arm64")
   assert_eq(host_os_label(Some("Linux"), Some("x86_64")), "Linux x86_64")
@@ -109,6 +149,7 @@ test "doctor options filter sections" {
     dry_run=false,
     verbose=false,
     deep=false,
+    run_frontend=false,
     json=false,
     json_lines=false,
     quiet=false,

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -32,12 +32,12 @@ test "doctor formats host OS labels" {
 ///|
 test "doctor report records failing sections" {
   let healthy = DoctorReport::new(
-    [DoctorSection::new("Environment", Ok, [])],
+    [DoctorSection::new("environment", "Environment", Ok, [])],
     dry_run=false,
   )
   assert_false(healthy.has_errors())
   let unhealthy = DoctorReport::new(
-    [DoctorSection::new("Environment", Error, [])],
+    [DoctorSection::new("environment", "Environment", Error, [])],
     dry_run=false,
   )
   assert_true(unhealthy.has_errors())
@@ -47,7 +47,7 @@ test "doctor report records failing sections" {
 test "doctor report summarizes line statuses" {
   let report = DoctorReport::new(
     [
-      DoctorSection::new("Environment", Error, [
+      DoctorSection::new("environment", "Environment", Error, [
         DoctorLine::coded("environment.os", Ok, "OS"),
         DoctorLine::coded("runtime.missing", Missing, "runtime"),
         DoctorLine::coded("runtime.version", Unknown, "version"),
@@ -65,6 +65,38 @@ test "doctor report summarizes line statuses" {
   assert_true(
     render_doctor_json(report).contains("\"code\": \"environment.os\""),
   )
+}
+
+///|
+test "doctor json lines carries section and summary records" {
+  let report = DoctorReport::new(
+    [
+      DoctorSection::new("environment", "Environment", Ok, [
+        DoctorLine::coded("environment.os", Ok, "OS"),
+      ]),
+    ],
+    dry_run=false,
+  )
+  let rendered = render_doctor_json_lines(report)
+  assert_true(rendered.contains("\"section\":\"environment\""))
+  assert_true(rendered.contains("\"type\":\"summary\""))
+  assert_false(rendered.contains("doctor.unspecified"))
+}
+
+///|
+test "doctor options filter sections" {
+  let options = DoctorOptions::new(
+    cwd=".",
+    dry_run=false,
+    verbose=false,
+    json=false,
+    json_lines=false,
+    quiet=false,
+    sections=["packages"],
+    output=None,
+  )
+  assert_true(options.includes("packages"))
+  assert_false(options.includes("environment"))
 }
 
 ///|
@@ -283,9 +315,14 @@ test "moon.proton reader rejects manifest extensions" {
 test "text renderer uses utf8 symbols and dry run note" {
   let report = DoctorReport::new(
     [
-      DoctorSection::new("Environment", Ok, [
-        DoctorLine::new(Ok, "OS: Windows x86_64"),
-        DoctorLine::new(Warn, "MSVC: not found", hint="install Visual Studio"),
+      DoctorSection::new("environment", "Environment", Ok, [
+        DoctorLine::coded("environment.os", Ok, "OS: Windows x86_64"),
+        DoctorLine::coded(
+          "environment.msvc.missing",
+          Warn,
+          "MSVC: not found",
+          hint="install Visual Studio",
+        ),
       ]),
     ],
     dry_run=true,
@@ -310,8 +347,12 @@ test "text renderer uses utf8 symbols and dry run note" {
 test "json renderer does not include utf8 status symbols" {
   let report = DoctorReport::new(
     [
-      DoctorSection::new("Packages", Missing, [
-        DoctorLine::new(Missing, "justjavac/proton: not declared"),
+      DoctorSection::new("packages", "Packages", Missing, [
+        DoctorLine::coded(
+          "packages.dependency.justjavac/proton.missing",
+          Missing,
+          "justjavac/proton: not declared",
+        ),
       ]),
     ],
     dry_run=false,

--- a/cli/doctor/moon.pkg
+++ b/cli/doctor/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "justjavac/proton_config",
+  "justjavac/proton_cli/cef",
   "moonbitlang/async/io",
   "moonbitlang/async/process",
   "moonbitlang/core/debug",
@@ -7,6 +8,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/lexer/basic" @lexer_basic,
   "moonbitlang/x/fs" @mbfs,
+  "moonbitlang/x/path",
   "moonbitlang/x/sys",
   "moonbitlang/moon_config",
 }

--- a/cli/doctor/moon.pkg
+++ b/cli/doctor/moon.pkg
@@ -15,6 +15,10 @@ import {
   "moonbitlang/moon_config",
 }
 
+import {
+  "moonbitlang/async",
+} for "wbtest"
+
 supported_targets = "native"
 
 options(

--- a/cli/doctor/moon.pkg
+++ b/cli/doctor/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "justjavac/proton_config",
   "justjavac/proton_cli/cef",
+  "justjavac/proton_cli/codegen",
   "justjavac/ffi",
   "moonbitlang/async/io",
   "moonbitlang/async/process",

--- a/cli/doctor/moon.pkg
+++ b/cli/doctor/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "justjavac/proton_config",
   "justjavac/proton_cli/cef",
+  "justjavac/ffi",
   "moonbitlang/async/io",
   "moonbitlang/async/process",
   "moonbitlang/core/debug",
@@ -14,3 +15,7 @@ import {
 }
 
 supported_targets = "native"
+
+options(
+  "native-stub": [ "doctor_native_probe.c" ],
+)

--- a/cli/doctor/pkg.generated.mbti
+++ b/cli/doctor/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "justjavac/proton_cli/doctor"
 
 // Values
-pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, json~ : Bool) -> Result[Unit, String]
+pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, deep~ : Bool, json~ : Bool, json_lines~ : Bool, quiet~ : Bool, sections~ : Array[String], output~ : String?) -> Result[Bool, String]
 
 // Errors
 

--- a/cli/doctor/pkg.generated.mbti
+++ b/cli/doctor/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "justjavac/proton_cli/doctor"
 
 // Values
-pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, deep~ : Bool, run_frontend~ : Bool, json~ : Bool, json_lines~ : Bool, quiet~ : Bool, sections~ : Array[String], output~ : String?) -> Result[Bool, String]
+pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, deep~ : Bool, run_frontend~ : Bool, fix~ : Bool, json~ : Bool, json_lines~ : Bool, quiet~ : Bool, sections~ : Array[String], output~ : String?) -> Result[Bool, String]
 
 // Errors
 

--- a/cli/doctor/pkg.generated.mbti
+++ b/cli/doctor/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "justjavac/proton_cli/doctor"
 
 // Values
-pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, deep~ : Bool, json~ : Bool, json_lines~ : Bool, quiet~ : Bool, sections~ : Array[String], output~ : String?) -> Result[Bool, String]
+pub async fn run(cwd~ : String, dry_run~ : Bool, verbose~ : Bool, deep~ : Bool, run_frontend~ : Bool, json~ : Bool, json_lines~ : Bool, quiet~ : Bool, sections~ : Array[String], output~ : String?) -> Result[Bool, String]
 
 // Errors
 

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -334,10 +334,16 @@ async fn run_doctor_from_args(
       CliError::UsageError("--run requires the frontend section", false),
     )
   }
+  if fix && sections.length() > 0 && !sections.contains("fixes") {
+    sections.push("fixes")
+  }
+  if sections.contains("fixes") && !fix {
+    return Err(CliError::UsageError("the fixes section requires --fix", false))
+  }
   for section in sections {
     if ![
         "project", "environment", "runtime", "platform", "packages", "extensions",
-        "app", "frontend", "release",
+        "app", "frontend", "release", "fixes",
       ].contains(section) {
       return Err(
         CliError::UsageError("unknown doctor section: " + section, false),

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -7,7 +7,7 @@ fn print_usage() -> Unit {
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]
-    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
+    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
     #|  proton_cli codegen <input.mbt> -o <output.g.mbt>
     #|  proton_cli cef setup [--name <cef_binary_name>] [--url <url>]
     #|
@@ -284,6 +284,7 @@ async fn run_doctor_from_args(
       "--deep" => deep = true
       "--run" => run_frontend = true
       "--frontend" => sections.push("frontend")
+      "--release" => sections.push("release")
       "--json" => json = true
       "--json-lines" => json_lines = true
       "--quiet" => quiet = true
@@ -303,7 +304,7 @@ async fn run_doctor_from_args(
       }
       "-h" | "--help" => {
         println(
-          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
+          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
         )
         return Ok(())
       }
@@ -334,7 +335,7 @@ async fn run_doctor_from_args(
   for section in sections {
     if ![
         "project", "environment", "runtime", "platform", "packages", "extensions",
-        "app", "frontend",
+        "app", "frontend", "release",
       ].contains(section) {
       return Err(
         CliError::UsageError("unknown doctor section: " + section, false),

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -7,7 +7,7 @@ fn print_usage() -> Unit {
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]
-    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
+    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
     #|  proton_cli codegen <input.mbt> -o <output.g.mbt>
     #|  proton_cli cef setup [--name <cef_binary_name>] [--url <url>]
     #|
@@ -268,6 +268,7 @@ async fn run_doctor_from_args(
 ) -> Result[Unit, CliError] {
   let mut dry_run = false
   let mut verbose = false
+  let mut deep = false
   let mut json = false
   let mut json_lines = false
   let mut quiet = false
@@ -279,6 +280,7 @@ async fn run_doctor_from_args(
     match arg {
       "--dry-run" => dry_run = true
       "--verbose" => verbose = true
+      "--deep" => deep = true
       "--json" => json = true
       "--json-lines" => json_lines = true
       "--quiet" => quiet = true
@@ -298,7 +300,7 @@ async fn run_doctor_from_args(
       }
       "-h" | "--help" => {
         println(
-          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
+          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
         )
         return Ok(())
       }
@@ -322,7 +324,7 @@ async fn run_doctor_from_args(
     )
   }
   for section in sections {
-    if !["project", "environment", "packages", "extensions", "app"].contains(
+    if !["project", "environment", "runtime", "packages", "extensions", "app"].contains(
         section,
       ) {
       return Err(
@@ -335,6 +337,7 @@ async fn run_doctor_from_args(
       cwd~,
       dry_run~,
       verbose~,
+      deep~,
       json~,
       json_lines~,
       quiet~,

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -7,7 +7,7 @@ fn print_usage() -> Unit {
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]
-    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json]
+    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
     #|  proton_cli codegen <input.mbt> -o <output.g.mbt>
     #|  proton_cli cef setup [--name <cef_binary_name>] [--url <url>]
     #|
@@ -269,22 +269,78 @@ async fn run_doctor_from_args(
   let mut dry_run = false
   let mut verbose = false
   let mut json = false
-  for arg in args {
+  let mut json_lines = false
+  let mut quiet = false
+  let sections : Array[String] = []
+  let mut output : String? = None
+  let mut index = 0
+  while index < args.length() {
+    let arg = args[index]
     match arg {
       "--dry-run" => dry_run = true
       "--verbose" => verbose = true
       "--json" => json = true
+      "--json-lines" => json_lines = true
+      "--quiet" => quiet = true
+      "--section" => {
+        guard index + 1 < args.length() else {
+          return Err(CliError::UsageError("missing value for --section", false))
+        }
+        sections.push(args[index + 1])
+        index += 1
+      }
+      "--output" => {
+        guard index + 1 < args.length() else {
+          return Err(CliError::UsageError("missing value for --output", false))
+        }
+        output = Some(resolve_cli_path(cwd, args[index + 1]))
+        index += 1
+      }
       "-h" | "--help" => {
         println(
-          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json]",
+          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
         )
         return Ok(())
       }
       _ =>
         return Err(CliError::UsageError("unknown doctor option: " + arg, false))
     }
+    index += 1
   }
-  match @doctor.run(cwd~, dry_run~, verbose~, json~) {
+  if json && json_lines {
+    return Err(
+      CliError::UsageError(
+        "--json and --json-lines are mutually exclusive", false,
+      ),
+    )
+  }
+  if quiet && (json || json_lines) {
+    return Err(
+      CliError::UsageError(
+        "--quiet cannot be combined with --json or --json-lines", false,
+      ),
+    )
+  }
+  for section in sections {
+    if !["project", "environment", "packages", "extensions", "app"].contains(
+        section,
+      ) {
+      return Err(
+        CliError::UsageError("unknown doctor section: " + section, false),
+      )
+    }
+  }
+  match
+    @doctor.run(
+      cwd~,
+      dry_run~,
+      verbose~,
+      json~,
+      json_lines~,
+      quiet~,
+      sections~,
+      output~,
+    ) {
     Ok(true) => Ok(())
     Ok(false) => Err(CliError::ReportedError)
     Err(message) => Err(CliError::CommandError(message))

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -7,7 +7,7 @@ fn print_usage() -> Unit {
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]
-    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
+    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--fix] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
     #|  proton_cli codegen <input.mbt> -o <output.g.mbt>
     #|  proton_cli cef setup [--name <cef_binary_name>] [--url <url>]
     #|
@@ -270,6 +270,7 @@ async fn run_doctor_from_args(
   let mut verbose = false
   let mut deep = false
   let mut run_frontend = false
+  let mut fix = false
   let mut json = false
   let mut json_lines = false
   let mut quiet = false
@@ -283,6 +284,7 @@ async fn run_doctor_from_args(
       "--verbose" => verbose = true
       "--deep" => deep = true
       "--run" => run_frontend = true
+      "--fix" => fix = true
       "--frontend" => sections.push("frontend")
       "--release" => sections.push("release")
       "--json" => json = true
@@ -304,7 +306,7 @@ async fn run_doctor_from_args(
       }
       "-h" | "--help" => {
         println(
-          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
+          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--release] [--run] [--fix] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
         )
         return Ok(())
       }
@@ -349,6 +351,7 @@ async fn run_doctor_from_args(
       verbose~,
       deep~,
       run_frontend~,
+      fix~,
       json~,
       json_lines~,
       quiet~,

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -7,7 +7,7 @@ fn print_usage() -> Unit {
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]
-    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
+    #|  proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--frontend] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]
     #|  proton_cli codegen <input.mbt> -o <output.g.mbt>
     #|  proton_cli cef setup [--name <cef_binary_name>] [--url <url>]
     #|
@@ -269,6 +269,7 @@ async fn run_doctor_from_args(
   let mut dry_run = false
   let mut verbose = false
   let mut deep = false
+  let mut run_frontend = false
   let mut json = false
   let mut json_lines = false
   let mut quiet = false
@@ -281,6 +282,8 @@ async fn run_doctor_from_args(
       "--dry-run" => dry_run = true
       "--verbose" => verbose = true
       "--deep" => deep = true
+      "--run" => run_frontend = true
+      "--frontend" => sections.push("frontend")
       "--json" => json = true
       "--json-lines" => json_lines = true
       "--quiet" => quiet = true
@@ -300,7 +303,7 @@ async fn run_doctor_from_args(
       }
       "-h" | "--help" => {
         println(
-          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
+          "Usage: proton_cli [-C DIR] doctor [--dry-run] [--verbose] [--deep] [--run] [--json|--json-lines] [--quiet] [--section <name>]... [--output <path>]",
         )
         return Ok(())
       }
@@ -323,10 +326,15 @@ async fn run_doctor_from_args(
       ),
     )
   }
+  if run_frontend && sections.length() > 0 && !sections.contains("frontend") {
+    return Err(
+      CliError::UsageError("--run requires the frontend section", false),
+    )
+  }
   for section in sections {
     if ![
         "project", "environment", "runtime", "platform", "packages", "extensions",
-        "app",
+        "app", "frontend",
       ].contains(section) {
       return Err(
         CliError::UsageError("unknown doctor section: " + section, false),
@@ -339,6 +347,7 @@ async fn run_doctor_from_args(
       dry_run~,
       verbose~,
       deep~,
+      run_frontend~,
       json~,
       json_lines~,
       quiet~,

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -324,9 +324,10 @@ async fn run_doctor_from_args(
     )
   }
   for section in sections {
-    if !["project", "environment", "runtime", "packages", "extensions", "app"].contains(
-        section,
-      ) {
+    if ![
+        "project", "environment", "runtime", "platform", "packages", "extensions",
+        "app",
+      ].contains(section) {
       return Err(
         CliError::UsageError("unknown doctor section: " + section, false),
       )

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -33,6 +33,7 @@ priv struct CliVersion {
 priv enum CliError {
   UsageError(String, Bool)
   CommandError(String)
+  ReportedError
 }
 
 ///|
@@ -283,9 +284,11 @@ async fn run_doctor_from_args(
         return Err(CliError::UsageError("unknown doctor option: " + arg, false))
     }
   }
-  @doctor.run(cwd~, dry_run~, verbose~, json~).map_err(fn(message) {
-    CliError::CommandError(message)
-  })
+  match @doctor.run(cwd~, dry_run~, verbose~, json~) {
+    Ok(true) => Ok(())
+    Ok(false) => Err(CliError::ReportedError)
+    Err(message) => Err(CliError::CommandError(message))
+  }
 }
 
 ///|
@@ -393,5 +396,6 @@ async fn main {
       print_error_message(message)
       @sys.exit(1)
     }
+    Err(CliError::ReportedError) => @sys.exit(1)
   }
 }

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -12,6 +12,7 @@ import {
   "moonbitlang/async@0.19.4",
   "justjavac/ci@0.1.1",
   "justjavac/template@0.1.1",
+  "justjavac/ffi@0.2.1",
 }
 
 readme = "codegen/README.md"


### PR DESCRIPTION
## Summary

- harden cross-platform doctor discovery, stable diagnostic codes, summaries, section filters, JSON/JSONL/quiet/output rendering, and failure exit codes
- add deep runtime manifest/ABI/native library probes, MoonBit project and dependency validation, extension metadata/generated-file checks, and platform-specific diagnostics
- add frontend execution probes, release preflight checks, and a safe extension-only `--fix` mode with dry-run support
- document doctor workflows and safety boundaries

## Validation

- `moon fmt --check`
- `moon -C cli test doctor --target native --diagnostic-limit 80` (20 passed)
- `moon -C cli test cef --target native --diagnostic-limit 80` (7 passed)
- `moon -C cli check --target native --diagnostic-limit 80`
- `moon -C cli test --target native --diagnostic-limit 80` (31 passed before rebase)
- `moon check --target native --diagnostic-limit 80`
- `moon -C proton test native --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `ctest --test-dir native/build-doctor -C Debug --output-on-failure` (2 passed)
- `node scripts/verify_generated.mjs`

## Notes

Release preflight intentionally reports real project/environment issues instead of hiding them, including missing package README files, registry dependency/API mismatches, and absent signing/notarization configuration.
