### PR TITLE
feat(cli): make new projects package-ready

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,70 @@ native checks before handing off larger refactors.
 - Keep release validation for standalone users explicit: run `moon publish --dry-run` in each published module, and smoke-check an independent app with remote `justjavac/proton` and `justjavac/proton_ext` dependencies after publishing.
 - Keep `examples/` and `e2e/` out of release publishing unless explicitly requested; they are validation/demo modules, not release packages.
 
+### Release Checklist
+
+- Publish the dependency chain in this order: `justjavac/proton_config`, then
+  `justjavac/proton`, then `justjavac/proton_cli`. For the currently prepared
+  release, the chain is `proton_config 0.1.5` -> `proton 0.1.10` ->
+  `proton_cli 0.1.6`.
+- Before publishing, keep these values aligned:
+  - `config/moon.mod` version;
+  - the `justjavac/proton_config@...` requirements in `proton/moon.mod` and
+    `cli/moon.mod`;
+  - `proton/moon.mod`, `proton/prebuilt/*/manifest.json`, and
+    `cli/new/templates.mbt`'s `default_proton_version`;
+  - `cli/moon.mod` and `cli/main.mbt`'s `cli_current_version`.
+- Run the release checks before the first publish:
+
+  ```sh
+  moon fmt --check
+  node scripts/verify_generated.mjs
+  moon -C cli test --target native --diagnostic-limit 80
+  moon -C proton check --target native --diagnostic-limit 80
+  ```
+
+- Dry-run and publish each module separately, waiting until the new version is
+  visible in the Mooncakes manifest before moving to its dependent module:
+
+  ```sh
+  moon -C config publish --dry-run
+  moon -C config publish
+
+  moon -C proton publish --dry-run
+  moon -C proton publish
+
+  moon -C cli publish --dry-run
+  moon -C cli publish
+  ```
+
+- Never publish `proton_cli` while the version referenced by the `proton new`
+  template is absent from Mooncakes. A template dependency must be published
+  and independently resolvable before the CLI release becomes visible.
+- Some Moon CLI versions print a final generic failure after a successful
+  dry-run response. Treat the dry run as accepted only when the server reports
+  `202 Accepted` and explicitly says no changes were made. Compilation,
+  dependency-resolution, validation, or non-202 server errors are failures.
+- After all packages are visible, install the registry CLI and run a smoke test
+  from a temporary directory outside this repository and outside any parent
+  `moon.work`. Do not use symlinks, local module members, or source overrides:
+
+  ```sh
+  moon install justjavac/proton_cli
+  tmp_dir="$(mktemp -d)"
+  proton_cli -C "$tmp_dir" new release-smoke \
+    --title "Release Smoke" \
+    --identifier "com.example.proton-release-smoke" \
+    -y --no-git
+  proton_cli -C "$tmp_dir/release-smoke" cef setup
+  proton_cli -C "$tmp_dir/release-smoke" build
+  proton_cli -C "$tmp_dir/release-smoke" package app --dry-run
+  proton_cli -C "$tmp_dir/release-smoke" package app
+  ```
+
+- The release is not complete until the independent scaffold passes its default
+  `moon check`, native build, package-plan validation, and real package creation
+  using registry dependencies and the setup-managed runtime.
+
 ## Coding Conventions
 - Use MoonBit with 2-space indentation and `///|` top-level separators.
 - Keep public APIs documented with `///|` comments.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ directly and does not provide a compatibility layer for the old runtime route.
 
 CMake is the only native build entry point.
 
-For release packaging, build the Windows engine-backed native runtime, then
-stage only the Proton artifacts into `proton/prebuilt/win32-x64/`:
+For release packaging, build the engine-backed native runtime for the target
+platform, then stage only the Proton artifacts into
+`proton/prebuilt/<platform>/`. For example, on Windows:
 
 ```powershell
 cmake -S native -B native\build-engine `
@@ -30,21 +31,24 @@ cmake --build native\build-engine --config Debug
 cmake --install native\build-engine --config Debug
 ```
 
-The package ships these files:
+The published module uses the same platform layout everywhere:
 
 ```text
+proton/prebuilt/<platform>/bin/cef_process(.exe)
 proton/prebuilt/win32-x64/bin/proton.dll
-proton/prebuilt/win32-x64/bin/cef_process.exe
 proton/prebuilt/win32-x64/lib/proton.lib
-proton/prebuilt/win32-x64/include/proton_native.h
+proton/prebuilt/darwin-*/lib/libproton.dylib
+proton/prebuilt/linux-*/lib/libproton.so
+proton/prebuilt/<platform>/include/proton_native.h
+proton/prebuilt/<platform>/manifest.json
 ```
 
 CEF files are not shipped in the package. `proton_cli cef setup` downloads or
 reuses CEF and assembles the complete project runtime under `.proton/`.
 
-Platform prebuilds live under `proton/prebuilt/<platform>/`. The currently
-shipped prebuild is `win32-x64`; macOS packaging should use `darwin-arm64`
-and/or `darwin-x64` with the same Proton-only rule.
+The currently shipped prebuilds are `win32-x64`, `darwin-arm64`, and
+`linux-x64`. Adding another platform requires the same Proton-only artifact
+rule and a matching manifest.
 
 The ABI-only build is still useful for binding tests:
 
@@ -54,9 +58,9 @@ cmake --build native\build --config Debug
 cmake --install native\build --config Debug
 ```
 
-On non-Windows platforms the CMake install layout uses `libproton.so` or
-`libproton.dylib`. Engine-backed CMake builds are wired for Windows and macOS;
-`proton_cli cef setup` packaging is currently Windows-only.
+`proton_cli cef setup` detects the host platform, requires a matching Proton
+prebuild, downloads or reuses the platform CEF archive, and writes the active
+runtime manifest under `.proton/runtime.json`.
 
 ## Link From MoonBit
 
@@ -78,17 +82,16 @@ options(
 )
 ```
 
-Install the CLI and assemble the active native runtime:
+Install the CLI:
 
 ```powershell
 moon install justjavac/proton_cli
-proton_cli cef setup
 ```
 
 Create a new native app scaffold:
 
 ```powershell
-proton_cli new my-counter --title "My Counter"
+proton_cli new my-counter --title "My Counter" --identifier "com.example.my-counter"
 ```
 
 `proton_cli new` generates a native-first MoonBit project with `app/` as the
@@ -97,6 +100,13 @@ runnable package, `extensions/counter/` as a reusable command-bridge extension,
 uses `@proton.app()` to load the nearest `moon.proton` config. It runs the
 native check by default; use `--no-check` to skip that check, or `-y/--yes` in
 scripts to accept defaults and skip prompts.
+
+The scaffold includes a reverse-DNS application identifier and an active
+`bundle` block targeting both the platform application and zip archive. When
+`--identifier` is omitted, Proton derives `dev.proton.<project-name>`.
+
+See [Creating a Proton project](docs/new-project.md) for all creation options,
+the generated layout, and the complete development and packaging workflow.
 
 Run a scaffolded app through the development supervisor:
 
@@ -129,8 +139,9 @@ development and runtime environment variables injected. Vite/Next own HMR;
 Proton keeps command handlers in the MoonBit app process.
 
 `proton_cli package` builds a release application from the same `moon.proton`
-configuration and active `.proton/runtime.json` used by development. Enable the
-bundle block first:
+configuration and active `.proton/runtime.json` used by development. Projects
+created by the current `proton_cli new` already contain an active bundle block.
+For an existing project, add one manually:
 
 ```moonbit
 bundle = {

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -3,7 +3,7 @@ fn print_usage() -> Unit {
   let usage =
     #|Usage:
     #|  proton_cli version
-    #|  proton_cli [-C DIR] new [PATH] [--title <title>] [--module <module>] [--width <px>] [--height <px>] [--no-check] [-y|--yes]
+    #|  proton_cli [-C DIR] new [PATH] [--title <title>] [--module <module>] [--identifier <id>] [--width <px>] [--height <px>] [--no-check] [-y|--yes]
     #|  proton_cli [-C DIR] dev [PACKAGE] [--config <path>] [--url <url>] [--command <command>] [--frontend-cwd <dir>] [-- [APP_ARGS]...]
     #|  proton_cli [-C DIR] build [PACKAGE] [--config <path>] [--no-frontend] [-- [MOON_BUILD_ARGS]...]
     #|  proton_cli [-C DIR] package [PACKAGE] [--config <path>] [--target <app|zip>] [--output <dir>] [--no-build] [--dry-run] [--sign] [--notarize]

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -17,7 +17,7 @@ fn print_usage() -> Unit {
 }
 
 ///|
-let cli_current_version : String = "0.1.5"
+let cli_current_version : String = "0.1.6"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/justjavac/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,15 +1,15 @@
 name = "justjavac/proton_cli"
 
-version = "0.1.5"
+version = "0.1.6"
 
 import {
-  "justjavac/proton_config@0.1.4",
+  "justjavac/proton_config@0.1.5",
   "moonbitlang/x@0.4.43",
   "moonbitlang/parser@0.3.2",
   "justjavac/case@0.2.0",
   "moonbitlang/moon_config@0.3.5",
   "moonbitlang/lexer@0.3.5",
-  "moonbitlang/async@0.19.4",
+  "moonbitlang/async@0.20.1",
   "justjavac/ci@0.1.1",
   "justjavac/template@0.1.1",
 }

--- a/cli/new/new_project.mbt
+++ b/cli/new/new_project.mbt
@@ -3,6 +3,7 @@ struct RawNewProjectOptions {
   path : String?
   title : String?
   module_name : String?
+  identifier : String?
   width : String?
   height : String?
   check : Bool?
@@ -18,6 +19,7 @@ struct NewProjectOptions {
   resolved_target_dir : String
   title : String
   module_name : String
+  identifier : String
   width : Int
   height : Int
   run_check : Bool
@@ -52,6 +54,7 @@ pub async fn run(cwd : String, args : Array[String]) -> Result[Unit, String] {
     plan_project_files(
       options.title,
       options.module_name,
+      options.identifier,
       options.width,
       options.height,
     ) {
@@ -111,6 +114,11 @@ fn new_arg_parser() -> @argparse.Command {
     options=[
       OptionArg("title", long="title", about="Application and window title"),
       OptionArg("module", long="module", about="moon.mod module name"),
+      OptionArg(
+        "identifier",
+        long="identifier",
+        about="Reverse-DNS application bundle identifier",
+      ),
       OptionArg("width", long="width", about="Window width in pixels"),
       OptionArg("height", long="height", about="Window height in pixels"),
     ],
@@ -131,6 +139,7 @@ fn parse_new_args(args : Array[String]) -> RawNewProjectOptions raise {
     path: match_value(matches, "path"),
     title: match_value(matches, "title"),
     module_name: match_value(matches, "module"),
+    identifier: match_value(matches, "identifier"),
     width: match_value(matches, "width"),
     height: match_value(matches, "height"),
     check: match_flag(matches, "check"),
@@ -165,6 +174,7 @@ fn options_from_raw(
   let slug = project_slug(cwd, target_dir)
   let title = raw.title.unwrap_or(slug_to_title(slug))
   let module_name = raw.module_name.unwrap_or(slug)
+  let identifier = raw.identifier.unwrap_or(default_bundle_identifier(slug))
   let width = match raw.width {
     Some(value) =>
       match parse_positive_int(value, "width") {
@@ -188,6 +198,7 @@ fn options_from_raw(
     resolved_target_dir: resolve_new_path(cwd, target_dir),
     title,
     module_name,
+    identifier,
     width,
     height,
     run_check,
@@ -211,6 +222,10 @@ fn validate_options(
     Err(message) => return Err(message)
   }
   match validate_module_name(options.module_name) {
+    Ok(_) => ()
+    Err(message) => return Err(message)
+  }
+  match validate_bundle_identifier(options.identifier) {
     Ok(_) => ()
     Err(message) => return Err(message)
   }
@@ -383,4 +398,7 @@ fn print_success(options : NewProjectOptions, checked~ : Bool) -> Unit {
   println("  cd " + options.target_dir)
   println("  proton_cli cef setup")
   println("  proton_cli dev")
+  println("  proton_cli build")
+  println("  proton_cli package app --dry-run")
+  println("  proton_cli package app")
 }

--- a/cli/new/new_project_wbtest.mbt
+++ b/cli/new/new_project_wbtest.mbt
@@ -19,6 +19,7 @@ fn must_plan(options : NewProjectOptions) -> Array[PlannedFile] {
     plan_project_files(
       options.title,
       options.module_name,
+      options.identifier,
       options.width,
       options.height,
     ) {
@@ -43,6 +44,7 @@ test "default new options" {
   assert_eq(options.target_dir, "counter")
   assert_eq(options.title, "Counter")
   assert_eq(options.module_name, "counter")
+  assert_eq(options.identifier, "dev.proton.counter")
   assert_eq(options.width, 960)
   assert_eq(options.height, 640)
   assert_true(options.run_check)
@@ -56,6 +58,7 @@ test "path slug drives default title and module" {
   assert_eq(options.target_dir, "tools/my-counter")
   assert_eq(options.title, "My Counter")
   assert_eq(options.module_name, "my-counter")
+  assert_eq(options.identifier, "dev.proton.my-counter")
 }
 
 ///|
@@ -68,16 +71,19 @@ test "current directory path uses cwd basename as default slug" {
   assert_eq(options.target_dir, ".")
   assert_eq(options.title, "Sample App")
   assert_eq(options.module_name, "sample-app")
+  assert_eq(options.identifier, "dev.proton.sample-app")
 }
 
 ///|
 test "explicit title module size and flags override defaults" {
   let options = must_options([
-    "demo", "--title", "Demo App", "--module", "justjavac/demo", "--width", "1024",
-    "--height", "720", "--no-check", "--dry-run", "-y",
+    "demo", "--title", "Demo App", "--module", "justjavac/demo", "--identifier",
+    "com.justjavac.demo", "--width", "1024", "--height", "720", "--no-check", "--dry-run",
+    "-y",
   ])
   assert_eq(options.title, "Demo App")
   assert_eq(options.module_name, "justjavac/demo")
+  assert_eq(options.identifier, "com.justjavac.demo")
   assert_eq(options.width, 1024)
   assert_eq(options.height, 720)
   assert_false(options.run_check)
@@ -123,6 +129,28 @@ test "invalid module fails" {
 }
 
 ///|
+test "default identifier normalizes common slug separators" {
+  assert_eq(must_options(["my_app.demo"]).identifier, "dev.proton.my-app-demo")
+}
+
+///|
+test "invalid identifier fails" {
+  match options_from_raw(".", must_parse(["demo", "--identifier", "demo"])) {
+    Ok(_) => abort("expected identifier to fail")
+    Err(message) =>
+      assert_true(message.contains("reverse-DNS bundle identifier"))
+  }
+  match
+    options_from_raw(
+      ".",
+      must_parse(["demo", "--identifier", "com.example.bad_value"]),
+    ) {
+    Ok(_) => abort("expected identifier character to fail")
+    Err(message) => assert_true(message.contains("unsupported character"))
+  }
+}
+
+///|
 test "file plan contains expected scaffold paths" {
   let files = must_plan(must_options(["my-counter"]))
   for
@@ -141,8 +169,8 @@ test "file plan contains expected scaffold paths" {
 test "templates receive final module title and size" {
   let files = must_plan(
     must_options([
-      "demo", "--title", "Demo App", "--module", "justjavac/demo", "--width", "1000",
-      "--height", "700",
+      "demo", "--title", "Demo App", "--module", "justjavac/demo", "--identifier",
+      "com.justjavac.demo", "--width", "1000", "--height", "700",
     ]),
   )
   guard find_planned_file(files, "app/moon.pkg") is Some(app_pkg) else {
@@ -159,9 +187,14 @@ test "templates receive final module title and size" {
     abort("missing moon.proton")
   }
   assert_true(config.contains("product_name = \"Demo App\""))
+  assert_true(config.contains("identifier = \"com.justjavac.demo\""))
   assert_true(config.contains("title: \"Demo App\""))
   assert_true(config.contains("width: 1000"))
   assert_true(config.contains("height: 700"))
+  assert_true(config.contains("bundle = {"))
+  assert_true(config.contains("active: true"))
+  assert_true(config.contains("targets: [\"app\", \"zip\"]"))
+  assert_true(config.contains("output: \"target/proton-dist\""))
 }
 
 ///|
@@ -177,7 +210,7 @@ test "user title can contain template braces" {
 
 ///|
 test "template render error names template" {
-  let context = template_context("Demo", "demo", 960, 640)
+  let context = template_context("Demo", "demo", "dev.proton.demo", 960, 640)
   let result = render_template(
     {
       output_path: "broken",

--- a/cli/new/prompt.mbt
+++ b/cli/new/prompt.mbt
@@ -41,8 +41,12 @@ async fn prompt_new_project_options(
   let slug = project_slug(defaults.cwd, target_dir)
   let title_default = raw.title.unwrap_or(slug_to_title(slug))
   let module_default = raw.module_name.unwrap_or(slug)
+  let identifier_default = raw.identifier.unwrap_or(
+    default_bundle_identifier(slug),
+  )
   let title = prompt_text("App title", title_default)
   let module_name = prompt_text("Module name", module_default)
+  let identifier = prompt_text("Bundle identifier", identifier_default)
   let width_text = prompt_text("Window width", defaults.width.to_string())
   let height_text = prompt_text("Window height", defaults.height.to_string())
   let run_check = prompt_bool(
@@ -63,6 +67,7 @@ async fn prompt_new_project_options(
     resolved_target_dir: resolve_new_path(defaults.cwd, target_dir),
     title,
     module_name,
+    identifier,
     width,
     height,
     run_check,
@@ -76,6 +81,7 @@ async fn confirm_create(options : NewProjectOptions) -> Bool {
   println("Project directory: " + options.target_dir)
   println("App title: " + options.title)
   println("Module name: " + options.module_name)
+  println("Bundle identifier: " + options.identifier)
   println(
     "Window: " + options.width.to_string() + "x" + options.height.to_string(),
   )

--- a/cli/new/templates.generated.mbt
+++ b/cli/new/templates.generated.mbt
@@ -39,6 +39,7 @@ fn generated_template_specs() -> Array[TemplateSpec] {
       template_name: "moon.proton.mtpl",
       template_source: (
           #|product_name = {{title_mbt}}
+          #|identifier = {{identifier_mbt}}
           #|
           #|window = {
           #|  title: {{title_mbt}},
@@ -53,6 +54,12 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|}
           #|
           #|debug = true
+          #|
+          #|bundle = {
+          #|  active: true,
+          #|  targets: ["app", "zip"],
+          #|  output: "target/proton-dist",
+          #|}
           #|
       ),
     },
@@ -384,6 +391,9 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|- Format with `moon fmt`.
           #|- Check with `moon check --target native --diagnostic-limit 80`.
           #|- Run with `proton_cli dev` from the project root.
+          #|- Build with `proton_cli build`.
+          #|- Inspect packaging with `proton_cli package app --dry-run`.
+          #|- Package with `proton_cli package app`.
           #|- If the Proton runtime is not configured, run `proton_cli cef setup`.
           #|
           #|## Project Notes
@@ -422,11 +432,27 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|proton_cli dev
           #|```
           #|
+          #|## Build
+          #|
+          #|```sh
+          #|proton_cli build
+          #|```
+          #|
+          #|## Package
+          #|
+          #|Inspect the resolved package plan, then create the application and zip archive:
+          #|
+          #|```sh
+          #|proton_cli package app --dry-run
+          #|proton_cli package app
+          #|```
+          #|
           #|## Layout
           #|
           #|- `app/` is the runnable application.
           #|- `extensions/counter/` is the counter extension used by the app.
           #|- `extensions/counter/` cannot be run directly.
+          #|- `target/proton-dist/` contains packaged application artifacts.
           #|
       ),
     },

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -11,6 +11,7 @@ priv struct TemplateContext {
   title_mbt : String
   module_name : String
   module_mbt : String
+  identifier_mbt : String
   module_counter_import_mbt : String
   counter_extension_id_mbt : String
   width : Int
@@ -42,6 +43,7 @@ struct PlannedFile {
 fn template_context(
   title : String,
   module_name : String,
+  identifier : String,
   width : Int,
   height : Int,
 ) -> TemplateContext {
@@ -51,6 +53,7 @@ fn template_context(
     title_mbt: mbt_string(title),
     module_name,
     module_mbt: mbt_string(module_name),
+    identifier_mbt: mbt_string(identifier),
     module_counter_import_mbt: mbt_string(module_name + "/extensions/counter"),
     counter_extension_id_mbt: mbt_string(module_name + "/counter"),
     width,
@@ -68,6 +71,7 @@ fn template_vars(context : TemplateContext) -> Array[TemplateVar] {
     { name: "title_mbt", value: context.title_mbt },
     { name: "module_name", value: context.module_name },
     { name: "module_mbt", value: context.module_mbt },
+    { name: "identifier_mbt", value: context.identifier_mbt },
     {
       name: "module_counter_import_mbt",
       value: context.module_counter_import_mbt,
@@ -146,10 +150,11 @@ fn validate_template_placeholders(
 fn plan_project_files(
   title : String,
   module_name : String,
+  identifier : String,
   width : Int,
   height : Int,
 ) -> Result[Array[PlannedFile], String] {
-  let context = template_context(title, module_name, width, height)
+  let context = template_context(title, module_name, identifier, width, height)
   let files : Array[PlannedFile] = []
   for spec in template_specs() {
     match render_template(spec, context) {

--- a/cli/new/templates/counter/files/AGENTS.md.mtpl
+++ b/cli/new/templates/counter/files/AGENTS.md.mtpl
@@ -7,6 +7,9 @@ This is a MoonBit Proton native desktop app.
 - Format with `moon fmt`.
 - Check with `moon check --target native --diagnostic-limit 80`.
 - Run with `proton_cli dev` from the project root.
+- Build with `proton_cli build`.
+- Inspect packaging with `proton_cli package app --dry-run`.
+- Package with `proton_cli package app`.
 - If the Proton runtime is not configured, run `proton_cli cef setup`.
 
 ## Project Notes

--- a/cli/new/templates/counter/files/README.mbt.md.mtpl
+++ b/cli/new/templates/counter/files/README.mbt.md.mtpl
@@ -21,8 +21,24 @@ moon check --target native --diagnostic-limit 80
 proton_cli dev
 ```
 
+## Build
+
+```sh
+proton_cli build
+```
+
+## Package
+
+Inspect the resolved package plan, then create the application and zip archive:
+
+```sh
+proton_cli package app --dry-run
+proton_cli package app
+```
+
 ## Layout
 
 - `app/` is the runnable application.
 - `extensions/counter/` is the counter extension used by the app.
 - `extensions/counter/` cannot be run directly.
+- `target/proton-dist/` contains packaged application artifacts.

--- a/cli/new/templates/counter/files/moon.proton.mtpl
+++ b/cli/new/templates/counter/files/moon.proton.mtpl
@@ -1,4 +1,5 @@
 product_name = {{title_mbt}}
+identifier = {{identifier_mbt}}
 
 window = {
   title: {{title_mbt}},
@@ -13,3 +14,9 @@ entry = {
 }
 
 debug = true
+
+bundle = {
+  active: true,
+  targets: ["app", "zip"],
+  output: "target/proton-dist",
+}

--- a/cli/new/validation.mbt
+++ b/cli/new/validation.mbt
@@ -92,6 +92,59 @@ fn slug_to_title(slug : String) -> String {
 }
 
 ///|
+fn default_bundle_identifier(slug : String) -> String {
+  let component = slug
+    .replace_all(old="_", new="-")
+    .replace_all(old=".", new="-")
+  let component = if component == "" {
+    "app"
+  } else if starts_with_ascii_alphanumeric(component) {
+    component
+  } else {
+    "app-" + component
+  }
+  "dev.proton." + component
+}
+
+///|
+fn starts_with_ascii_alphanumeric(value : String) -> Bool {
+  for char in value {
+    return char.is_ascii_alphabetic() || char.is_ascii_digit()
+  }
+  false
+}
+
+///|
+fn validate_bundle_identifier(identifier : String) -> Result[Unit, String] {
+  let value = identifier.trim().to_owned()
+  let components : Array[StringView] = value.split(".").collect()
+  guard components.length() >= 2 else {
+    return Err("identifier must be a reverse-DNS bundle identifier: " + value)
+  }
+  for component in components {
+    guard component.length() > 0 else {
+      return Err("identifier contains an empty component: " + value)
+    }
+    let mut at_start = true
+    for char in component {
+      if at_start {
+        guard char.is_ascii_alphabetic() || char.is_ascii_digit() else {
+          return Err(
+            "identifier component must start with an ASCII letter or digit: " +
+            value,
+          )
+        }
+        at_start = false
+      }
+      guard char.is_ascii_alphabetic() || char.is_ascii_digit() || char == '-' else {
+        return Err("identifier contains an unsupported character: " + value)
+      }
+    }
+  }
+  Ok(())
+}
+
+///|
 fn parse_positive_int(value : String, label : String) -> Result[Int, String] {
   let parsed = @string.parse_int(value[:]) catch {
     _ => return Err(label + " must be a positive integer: " + value)

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "justjavac/proton_config"
 
-version = "0.1.4"
+version = "0.1.5"
 
 import {
   "moonbitlang/lexer@0.3.4",

--- a/docs/new-project.md
+++ b/docs/new-project.md
@@ -1,0 +1,120 @@
+# Creating a Proton project
+
+`proton_cli new` creates a native-first MoonBit desktop application with a
+runnable `app` package, a reusable counter command extension, project runtime
+configuration, and package-ready bundle metadata.
+
+## Create the project
+
+Install the CLI, then create the project before setting up its native runtime:
+
+```sh
+moon install justjavac/proton_cli
+proton_cli new my-counter \
+  --title "My Counter" \
+  --identifier "com.example.my-counter"
+cd my-counter
+proton_cli cef setup
+```
+
+The application identifier must use reverse-DNS form. If `--identifier` is
+omitted, Proton derives `dev.proton.<project-name>`, replacing `_` and `.` in
+the project name with `-`.
+
+Useful creation options:
+
+- `--title <title>` sets the product and initial window title.
+- `--module <name>` sets the `moon.mod` module name.
+- `--identifier <id>` sets the application bundle identifier.
+- `--width <px>` and `--height <px>` set the initial window size.
+- `--no-check` skips the native `moon check` run after file creation.
+- `--git` initializes a Git repository; `--no-git` explicitly disables it.
+- `-y` or `--yes` accepts defaults and disables interactive prompts.
+- `--dry-run` prints the file plan without writing the project.
+
+By default, `new` runs:
+
+```sh
+moon check --target native --diagnostic-limit 80
+```
+
+This check resolves the registry versions recorded in the generated
+`moon.mod`. Use `--no-check` only for offline scaffolding or when dependency
+resolution will be performed later.
+
+## Generated layout
+
+```text
+my-counter/
+├── app/
+│   ├── app.html
+│   ├── main.mbt
+│   └── moon.pkg
+├── extensions/
+│   └── counter/
+│       ├── counter.mbt
+│       ├── moon.pkg
+│       └── README.mbt.md
+├── AGENTS.md
+├── README.mbt.md
+├── LICENSE
+├── moon.mod
+└── moon.proton
+```
+
+- `app/` is the only runnable application package.
+- `extensions/counter/` exposes the example command bridge extension used by
+  the app; it is not a standalone executable.
+- `moon.proton` owns the application identifier, window, entry, development,
+  and packaging configuration.
+- `.proton/` is created later by `proton_cli cef setup` and must not be
+  committed.
+
+## Develop and build
+
+Run these commands from the generated project root:
+
+```sh
+proton_cli dev
+proton_cli build
+```
+
+`dev` runs the `app` package with the setup-managed runtime. `build` performs
+the release frontend step when configured and builds `app` for the native
+target.
+
+## Package
+
+The generated `moon.proton` is package-ready by default:
+
+```moonbit
+bundle = {
+  active: true,
+  targets: ["app", "zip"],
+  output: "target/proton-dist",
+}
+```
+
+Inspect the resolved plan before creating artifacts:
+
+```sh
+proton_cli package app --dry-run
+proton_cli package app
+```
+
+The real package command requires the active runtime created by
+`proton_cli cef setup`. Output is written to `target/proton-dist` unless
+`bundle.output` or `--output` overrides it.
+
+See [Packaging and signing](packaging.md) for icons, resources, platform
+layouts, signing, notarization, and Windows Authenticode configuration.
+
+## Frontend projects
+
+For Vite, Next, or another frontend toolchain, add a `frontend` block to
+`moon.proton` and point the production `entry` at the generated frontend file.
+`proton_cli dev` owns the development server lifecycle, while `build` and
+`package` run `frontend.before_build` and validate `frontend.dist`.
+
+The repository's root [README](../README.md) contains a complete frontend
+configuration example.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -6,9 +6,13 @@ development. Packaging does not download or link a second native runtime.
 
 ## Bundle configuration
 
-Enable the bundle block in `moon.proton`:
+Projects created by the current `proton_cli new` already include a reverse-DNS
+identifier and an active bundle targeting `app` and `zip`. Existing projects
+must add an `identifier` and enable the bundle block in `moon.proton`:
 
 ```moonbit
+identifier = "com.example.my-app"
+
 bundle = {
   active: true,
   targets: ["app", "zip"],

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.10"
 
 import {
   "justjavac/ffi@0.2.1",
-  "justjavac/proton_config@0.1.4",
+  "justjavac/proton_config@0.1.5",
   "moonbitlang/async@0.19.4",
   "moonbitlang/x@0.4.43",
   "moonbitlang/lexer@0.3.4",

--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -33,7 +33,9 @@ put `dev_build` or repository-relative codegen rules back into `proton` or
 ## `verify_release_metadata.mjs`
 
 Checks that `proton/prebuilt/*/manifest.json` and the `proton new` template
-default version match `proton/moon.mod`.
+default version match `proton/moon.mod`. It also checks the published-module
+dependency chain from `proton_config` into `proton` and `proton_cli`, plus the
+CLI's embedded version string.
 
 ```sh
 node ./scripts/verify_release_metadata.mjs

--- a/scripts/verify_release_metadata.mjs
+++ b/scripts/verify_release_metadata.mjs
@@ -12,11 +12,30 @@ function readText(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
-function protonModuleVersion() {
-  const text = readText("proton/moon.mod");
+function moduleVersion(relativePath) {
+  const text = readText(relativePath);
   const match = text.match(/^version\s*=\s*"([^"]+)"/m);
   if (!match) {
-    throw new Error("proton/moon.mod is missing a version field");
+    throw new Error(`${relativePath} is missing a version field`);
+  }
+  return match[1];
+}
+
+function moduleImportVersion(relativePath, moduleName) {
+  const text = readText(relativePath);
+  const escapedName = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = text.match(new RegExp(`"${escapedName}@([^"]+)"`));
+  if (!match) {
+    throw new Error(`${relativePath} is missing ${moduleName} dependency`);
+  }
+  return match[1];
+}
+
+function cliEmbeddedVersion() {
+  const text = readText("cli/main.mbt");
+  const match = text.match(/^let cli_current_version\s*:\s*String\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error("cli/main.mbt is missing cli_current_version");
   }
   return match[1];
 }
@@ -64,9 +83,22 @@ function checkTemplateDefaults(expectedVersion) {
   );
 }
 
-const expectedVersion = protonModuleVersion();
-checkPrebuiltManifests(expectedVersion);
-checkTemplateDefaults(expectedVersion);
+const protonVersion = moduleVersion("proton/moon.mod");
+const configVersion = moduleVersion("config/moon.mod");
+const cliVersion = moduleVersion("cli/moon.mod");
+checkPrebuiltManifests(protonVersion);
+checkTemplateDefaults(protonVersion);
+checkEqual(
+  "proton/moon.mod proton_config dependency",
+  moduleImportVersion("proton/moon.mod", "justjavac/proton_config"),
+  configVersion,
+);
+checkEqual(
+  "cli/moon.mod proton_config dependency",
+  moduleImportVersion("cli/moon.mod", "justjavac/proton_config"),
+  configVersion,
+);
+checkEqual("cli/main.mbt cli_current_version", cliEmbeddedVersion(), cliVersion);
 
 if (failures.length > 0) {
   console.error("Release metadata is stale:");
@@ -75,5 +107,7 @@ if (failures.length > 0) {
   }
   process.exitCode = 1;
 } else {
-  console.log(`[OK] Release metadata matches proton ${expectedVersion}.`);
+  console.log(
+    `[OK] Release metadata matches config ${configVersion}, proton ${protonVersion}, and CLI ${cliVersion}.`,
+  );
 }


### PR DESCRIPTION
## Summary

- add reverse-DNS identifier support to `proton new`
- generate package-ready app and zip bundle configuration by default
- align the proton_config, proton, and proton_cli release version chain
- document project creation, packaging, and registry-only release validation

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C cli test --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- generated a temporary project and verified package dry-run, native check, and native build
