### PR TITLE
refactor(cli): move doctor native probe logic to MoonBit

### DIFF
--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -386,32 +386,209 @@ fn runtime_helper_relative_path(platform_id : String) -> String {
 }
 
 ///|
-fn json_object_int(object : Map[String, Json], field : String) -> Int? {
-  match object.get(field) {
-    Some(value) =>
-      try @json.from_json(value) catch {
-        _ => None
-      } noraise {
-        value => Some(value)
+priv struct DoctorNativeRuntimeInfo {
+  abi_version : Int
+  runtime_available : Bool
+  build_mode : String
+  platform : String
+  features : Array[String]
+} derive(FromJson)
+
+///|
+fn doctor_native_runtime_info_from_text(
+  text : String,
+) -> Result[DoctorNativeRuntimeInfo, String] {
+  let json = @json.parse(text) catch {
+    error => return Err("invalid runtime info JSON: " + error.to_string())
+  }
+  let info : DoctorNativeRuntimeInfo = @json.from_json(json) catch {
+    error => return Err("invalid runtime info schema: " + error.to_string())
+  }
+  if info.abi_version != doctor_native_expected_abi_version {
+    Err(
+      "runtime info ABI version mismatch: expected " +
+      doctor_native_expected_abi_version.to_string() +
+      ", got " +
+      info.abi_version.to_string(),
+    )
+  } else if info.build_mode == "" || info.platform == "" {
+    Err("runtime info build_mode and platform must not be empty")
+  } else if info.features.any(fn(feature) { feature == "" }) {
+    Err("runtime info features must not contain empty strings")
+  } else {
+    Ok(info)
+  }
+}
+
+///|
+fn push_deep_runtime_probe_result(
+  lines : Array[DoctorLine],
+  result : DoctorNativeProbeResult,
+) -> Unit {
+  lines.push(
+    DoctorLine::coded(
+      "runtime.deep.abi",
+      Ok,
+      "Proton ABI version: " + doctor_native_expected_abi_version.to_string(),
+    ),
+  )
+  match result.info {
+    Ok(text) => {
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.info",
+          Ok,
+          "runtime info ABI call succeeded",
+        ),
+      )
+      match doctor_native_runtime_info_from_text(text) {
+        Ok(info) =>
+          if info.runtime_available {
+            lines.push(
+              DoctorLine::coded(
+                "runtime.deep.engine",
+                Ok,
+                "native engine available: build_mode=" +
+                info.build_mode +
+                ", platform=" +
+                info.platform,
+              ),
+            )
+          } else {
+            lines.push(
+              DoctorLine::coded(
+                "runtime.deep.engine_unavailable",
+                Error,
+                "Proton library does not include the native engine",
+              ),
+            )
+          }
+        Err(message) =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.deep.info_invalid",
+              Error,
+              "runtime info ABI returned an invalid payload",
+              hint=message,
+            ),
+          )
       }
-    None => None
+    }
+    Err(error) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.info_failed",
+          Error,
+          "runtime info ABI call failed",
+          hint=error.hint("runtime info ABI call failed"),
+        ),
+      )
+  }
+  match result.probe {
+    Ok(_) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.probe",
+          Ok,
+          "runtime layout probe succeeded",
+        ),
+      )
+    Err(error) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.probe_failed",
+          Error,
+          "runtime layout probe failed",
+          hint=error.hint("native probe failed"),
+        ),
+      )
+  }
+  match result.smoke {
+    Succeeded =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.smoke",
+          Ok,
+          "runtime create/destroy smoke test succeeded",
+        ),
+      )
+    Skipped =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.smoke_skipped",
+          Neutral,
+          "runtime create/destroy smoke test skipped because the layout probe failed",
+        ),
+      )
+    CreateFailed(error) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.smoke_failed",
+          Error,
+          "runtime creation smoke test failed",
+          hint=error.hint("runtime creation smoke test failed"),
+        ),
+      )
+    DestroyFailed(error) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.smoke_failed",
+          Error,
+          "runtime destruction smoke test failed",
+          hint=error.hint("runtime destruction smoke test failed"),
+        ),
+      )
   }
 }
 
 ///|
-fn json_object_string(object : Map[String, Json], field : String) -> String? {
-  match object.get(field) {
-    Some(String(value)) => Some(value)
-    _ => None
-  }
-}
-
-///|
-fn json_object_bool(object : Map[String, Json], field : String) -> Bool? {
-  match object.get(field) {
-    Some(True) => Some(true)
-    Some(False) => Some(false)
-    _ => None
+fn push_deep_runtime_probe_error(
+  lines : Array[DoctorLine],
+  error : DoctorNativeProbeError,
+) -> Unit {
+  match error {
+    LoadFailed(message) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.load_failed",
+          Error,
+          "failed to load Proton dynamic library",
+          hint=message,
+        ),
+      )
+    SymbolsMissing(message) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.symbol_missing",
+          Error,
+          "Proton dynamic library is missing required ABI symbols",
+          hint=message,
+        ),
+      )
+    AbiMismatch(version) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.abi_mismatch",
+          Error,
+          "Proton ABI version mismatch: expected " +
+          doctor_native_expected_abi_version.to_string() +
+          ", got " +
+          version.to_string(),
+        ),
+      )
+    OpenFailed(status, message) =>
+      lines.push(
+        DoctorLine::coded(
+          "runtime.deep.invalid_result",
+          Error,
+          "native deep probe could not open the Proton library",
+          hint=if message == "" {
+            "native probe bridge failed with status " + status.to_string()
+          } else {
+            message
+          },
+        ),
+      )
   }
 }
 
@@ -436,172 +613,18 @@ fn push_deep_runtime_probe(
   }
   let library_path = path_join(native_dist, library_relative)
   let config = Json::object({
-    "abi_version": Json::number(1.0, repr="1"),
+    "abi_version": Json::number(
+      doctor_native_expected_abi_version.to_double(),
+      repr=doctor_native_expected_abi_version.to_string(),
+    ),
     "runtime_root": Json::string(native_dist),
     "helper_path": Json::string(
       path_join(native_dist, runtime_helper_relative_path(platform_id)),
     ),
   }).stringify()
   match doctor_native_probe(library_path, config) {
-    Object(object) => {
-      match json_object_string(object, "load_error") {
-        Some(message) => {
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.load_failed",
-              Error,
-              "failed to load Proton dynamic library",
-              hint=message,
-            ),
-          )
-          return
-        }
-        None => ()
-      }
-      match json_object_string(object, "symbol_error") {
-        Some(message) => {
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.symbol_missing",
-              Error,
-              "Proton dynamic library is missing required ABI symbols",
-              hint=message,
-            ),
-          )
-          return
-        }
-        None => ()
-      }
-      match json_object_int(object, "abi_version") {
-        Some(1) =>
-          lines.push(
-            DoctorLine::coded("runtime.deep.abi", Ok, "Proton ABI version: 1"),
-          )
-        Some(version) =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.abi_mismatch",
-              Error,
-              "Proton ABI version mismatch: expected 1, got \{version}",
-            ),
-          )
-        None =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.abi_missing",
-              Error,
-              "Proton ABI version probe returned no value",
-            ),
-          )
-      }
-      match json_object_int(object, "info_status") {
-        Some(status) if status >= 0 => {
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.info",
-              Ok,
-              "runtime info ABI call succeeded",
-            ),
-          )
-          match object.get("info") {
-            Some(Object(info)) => {
-              let build_mode = json_object_string(info, "build_mode").unwrap_or(
-                "unknown",
-              )
-              let platform = json_object_string(info, "platform").unwrap_or(
-                "unknown",
-              )
-              if json_object_bool(info, "runtime_available") == Some(true) {
-                lines.push(
-                  DoctorLine::coded(
-                    "runtime.deep.engine",
-                    Ok,
-                    "native engine available: build_mode=" +
-                    build_mode +
-                    ", platform=" +
-                    platform,
-                  ),
-                )
-              } else {
-                lines.push(
-                  DoctorLine::coded(
-                    "runtime.deep.engine_unavailable",
-                    Error,
-                    "Proton library does not include the native engine",
-                  ),
-                )
-              }
-            }
-            _ =>
-              lines.push(
-                DoctorLine::coded(
-                  "runtime.deep.info_invalid",
-                  Error,
-                  "runtime info ABI returned invalid JSON",
-                ),
-              )
-          }
-        }
-        _ =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.info_failed",
-              Error,
-              "runtime info ABI call failed",
-            ),
-          )
-      }
-      match json_object_int(object, "probe_status") {
-        Some(status) if status >= 0 =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.probe",
-              Ok,
-              "runtime layout probe succeeded",
-            ),
-          )
-        _ =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.probe_failed",
-              Error,
-              "runtime layout probe failed",
-              hint=json_object_string(object, "probe_error").unwrap_or(
-                "native probe failed",
-              ),
-            ),
-          )
-      }
-      match json_object_int(object, "smoke_status") {
-        Some(status) if status >= 0 =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.smoke",
-              Ok,
-              "runtime create/destroy smoke test succeeded",
-            ),
-          )
-        _ =>
-          lines.push(
-            DoctorLine::coded(
-              "runtime.deep.smoke_failed",
-              Error,
-              "runtime create/destroy smoke test failed",
-              hint=json_object_string(object, "probe_error").unwrap_or(
-                "native smoke test failed",
-              ),
-            ),
-          )
-      }
-    }
-    _ =>
-      lines.push(
-        DoctorLine::coded(
-          "runtime.deep.invalid_result",
-          Error,
-          "native deep probe returned an invalid result",
-        ),
-      )
+    Ok(result) => push_deep_runtime_probe_result(lines, result)
+    Err(error) => push_deep_runtime_probe_error(lines, error)
   }
 }
 

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -411,8 +411,12 @@ fn doctor_native_runtime_info_from_text(
       ", got " +
       info.abi_version.to_string(),
     )
-  } else if info.build_mode == "" || info.platform == "" {
-    Err("runtime info build_mode and platform must not be empty")
+  } else if info.build_mode != "runtime" && info.build_mode != "abi-only" {
+    Err("runtime info build_mode must be `runtime` or `abi-only`")
+  } else if info.runtime_available != (info.build_mode == "runtime") {
+    Err("runtime info runtime_available is inconsistent with build_mode")
+  } else if info.platform == "" {
+    Err("runtime info platform must not be empty")
   } else if info.features.any(fn(feature) { feature == "" }) {
     Err("runtime info features must not contain empty strings")
   } else {

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -158,8 +158,26 @@ fn development_native_dist(project : ProjectDoctorInfo) -> String {
 fn resolve_native_dist(
   project : ProjectDoctorInfo,
 ) -> (String, DoctorRuntimeManifest?) raise DoctorRuntimeManifestError {
-  match @sys.get_env_var("PROTON_NATIVE_DIST") {
-    Some(root) => (root, None)
+  let native_dist_override = match @sys.get_env_var("PROTON_NATIVE_DIST") {
+    Some(root) => {
+      let root = root.trim().to_owned()
+      if root == "" {
+        None
+      } else {
+        Some(root)
+      }
+    }
+    None => None
+  }
+  match native_dist_override {
+    Some(root) => {
+      let path = if path_is_absolute_like(root) {
+        root
+      } else {
+        path_join(project.root, root)
+      }
+      (@path.Path(path).resolve().to_string(), None)
+    }
     None =>
       match runtime_manifest_from_project(project) {
         Some(manifest) => {
@@ -168,7 +186,7 @@ fn resolve_native_dist(
           } else {
             path_join(project.root, manifest.dist)
           }
-          (path, Some(manifest))
+          (@path.Path(path).resolve().to_string(), Some(manifest))
         }
         None => (development_native_dist(project), None)
       }
@@ -2265,9 +2283,7 @@ fn project_relative_path(project : ProjectDoctorInfo, path : String) -> String {
 
 ///|
 fn path_is_within_project(project : ProjectDoctorInfo, path : String) -> Bool {
-  let root = @path.Path(project.root).resolve().to_string()
-  let resolved = @path.Path(path).resolve().to_string()
-  resolved == root || resolved.has_prefix(root + @path.sep.to_string())
+  path_is_within_root(project.root, path)
 }
 
 ///|

--- a/cli/doctor/doctor_native_probe.c
+++ b/cli/doctor/doctor_native_probe.c
@@ -149,9 +149,9 @@ static void doctor_release_context(doctor_native_library_t *context) {
 
 /*
  * Logically close the MoonBit handle without decrementing the platform loader
- * reference. This is used only when a runtime could not be destroyed: keeping
- * the module mapped is safer than unloading code that its threads may still
- * execute. The operating system reclaims the module when the process exits.
+ * reference. Once a runtime has been created, keeping the module mapped is
+ * safer than unloading code that delayed platform cleanup may still execute.
+ * The operating system reclaims the module when the process exits.
  */
 static void doctor_abandon_context(doctor_native_library_t *context) {
   if (!doctor_context_is_open(context)) {

--- a/cli/doctor/doctor_native_probe.c
+++ b/cli/doctor/doctor_native_probe.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -5,24 +6,141 @@
 
 #include "moonbit.h"
 
+static int32_t doctor_copy_text(char *buffer, int32_t buffer_len,
+                                const char *text);
+
+/*
+ * Keep this stub limited to the platform dynamic-loader boundary. Probe
+ * sequencing, buffer sizing, user-facing diagnostics, and JSON interpretation
+ * belong in doctor_native_probe.mbt.
+ */
 #ifdef _WIN32
 #include <windows.h>
 typedef HMODULE doctor_library_t;
-#define doctor_open(path) LoadLibraryA(path)
 #define doctor_symbol(lib, name) GetProcAddress(lib, name)
 #define doctor_close(lib) FreeLibrary(lib)
-static const char *doctor_load_error(void) { return "LoadLibrary failed"; }
+
+static void doctor_windows_error(char *buffer, int32_t buffer_len,
+                                 DWORD error_code) {
+  if (buffer == NULL || buffer_len <= 0) {
+    return;
+  }
+
+  LPWSTR wide_message = NULL;
+  DWORD wide_length = FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL, error_code, 0, (LPWSTR)&wide_message, 0, NULL);
+  if (wide_length == 0 || wide_message == NULL) {
+    if (wide_message != NULL) {
+      LocalFree(wide_message);
+    }
+    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
+             (unsigned long)error_code);
+    return;
+  }
+  while (wide_length > 0 &&
+         (wide_message[wide_length - 1] == L'\r' ||
+          wide_message[wide_length - 1] == L'\n' ||
+          wide_message[wide_length - 1] == L' ')) {
+    wide_length--;
+  }
+  if (wide_length == 0) {
+    LocalFree(wide_message);
+    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
+             (unsigned long)error_code);
+    return;
+  }
+
+  int utf8_required = WideCharToMultiByte(
+      CP_UTF8, 0, wide_message, (int)wide_length, NULL, 0, NULL, NULL);
+  if (utf8_required <= 0) {
+    LocalFree(wide_message);
+    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
+             (unsigned long)error_code);
+    return;
+  }
+  char *utf8_message = (char *)malloc((size_t)utf8_required + 1);
+  if (utf8_message == NULL) {
+    LocalFree(wide_message);
+    doctor_copy_text(buffer, buffer_len,
+                     "out of memory while formatting Windows error");
+    return;
+  }
+  int converted = WideCharToMultiByte(CP_UTF8, 0, wide_message,
+                                      (int)wide_length, utf8_message,
+                                      utf8_required, NULL, NULL);
+  LocalFree(wide_message);
+  if (converted <= 0) {
+    free(utf8_message);
+    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
+             (unsigned long)error_code);
+    return;
+  }
+  utf8_message[converted] = '\0';
+  snprintf(buffer, (size_t)buffer_len, "Windows error %lu: %s",
+           (unsigned long)error_code, utf8_message);
+  free(utf8_message);
+}
+
+static doctor_library_t doctor_open(const char *path, char *error_buffer,
+                                    int32_t error_buffer_len) {
+  int wide_length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1,
+                                        NULL, 0);
+  if (wide_length <= 0) {
+    doctor_windows_error(error_buffer, error_buffer_len, GetLastError());
+    return NULL;
+  }
+  wchar_t *wide_path =
+      (wchar_t *)malloc((size_t)wide_length * sizeof(wchar_t));
+  if (wide_path == NULL) {
+    doctor_copy_text(error_buffer, error_buffer_len,
+                     "out of memory while converting UTF-8 library path");
+    return NULL;
+  }
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wide_path,
+                          wide_length) != wide_length) {
+    DWORD error_code = GetLastError();
+    free(wide_path);
+    doctor_windows_error(error_buffer, error_buffer_len, error_code);
+    return NULL;
+  }
+  doctor_library_t library = LoadLibraryW(wide_path);
+  DWORD error_code = library == NULL ? GetLastError() : ERROR_SUCCESS;
+  free(wide_path);
+  if (library == NULL) {
+    doctor_windows_error(error_buffer, error_buffer_len, error_code);
+  }
+  return library;
+}
 #else
 #include <dlfcn.h>
 typedef void *doctor_library_t;
-#define doctor_open(path) dlopen(path, RTLD_NOW | RTLD_LOCAL)
 #define doctor_symbol(lib, name) dlsym(lib, name)
 #define doctor_close(lib) dlclose(lib)
-static const char *doctor_load_error(void) {
-  const char *error = dlerror();
-  return error == NULL ? "dlopen failed" : error;
+
+static doctor_library_t doctor_open(const char *path, char *error_buffer,
+                                    int32_t error_buffer_len) {
+  doctor_library_t library = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  if (library == NULL) {
+    const char *error = dlerror();
+    doctor_copy_text(error_buffer, error_buffer_len,
+                     error == NULL ? "dlopen failed" : error);
+  }
+  return library;
 }
 #endif
+
+enum {
+  DOCTOR_NATIVE_OK = 0,
+  DOCTOR_NATIVE_LOAD_ERROR = -1,
+  DOCTOR_NATIVE_SYMBOL_ERROR = -2,
+  DOCTOR_NATIVE_INVALID_ARGUMENT = -4,
+  DOCTOR_NATIVE_INVALID_HANDLE = -5,
+  DOCTOR_NATIVE_ABI_MISMATCH = -6,
+};
+
+#define DOCTOR_NATIVE_MAGIC UINT32_C(0x50524f42)
 
 typedef int32_t (*doctor_abi_fn)(void);
 typedef int32_t (*doctor_info_fn)(char *, int32_t, int32_t *);
@@ -31,90 +149,269 @@ typedef int32_t (*doctor_error_fn)(char *, int32_t);
 typedef int32_t (*doctor_create_fn)(const char *, int64_t *);
 typedef int32_t (*doctor_destroy_fn)(int64_t);
 
-static moonbit_bytes_t doctor_copy_text(const char *text) {
-  size_t length = strlen(text);
-  moonbit_bytes_t result = moonbit_make_bytes((int32_t)length + 1, 0);
-  memcpy(result, text, length + 1);
-  return result;
+/*
+ * This is the payload of a MoonBit external object. The object container is
+ * owned by the MoonBit GC; only the dynamic library resource is released by
+ * the finalizer or by an explicit close.
+ */
+typedef struct doctor_native_library {
+  uint32_t magic;
+  int32_t closed;
+  doctor_library_t library;
+  doctor_info_fn info;
+  doctor_probe_fn probe;
+  doctor_error_fn last_error;
+  doctor_create_fn create;
+  doctor_destroy_fn destroy;
+} doctor_native_library_t;
+
+static int doctor_context_is_valid(const doctor_native_library_t *context) {
+  return context != NULL && context->magic == DOCTOR_NATIVE_MAGIC;
 }
 
-static void doctor_json_escape(char *output, size_t capacity, const char *text) {
-  size_t written = 0;
-  for (const unsigned char *cursor = (const unsigned char *)text;
-       *cursor != 0 && written + 2 < capacity; cursor++) {
-    unsigned char ch = *cursor;
-    if (ch == '\\' || ch == '"') {
-      output[written++] = '\\';
-      output[written++] = (char)ch;
-    } else if (ch == '\n' || ch == '\r' || ch == '\t') {
-      output[written++] = ' ';
-    } else if (ch >= 0x20) {
-      output[written++] = (char)ch;
+static int doctor_context_is_open(const doctor_native_library_t *context) {
+  return doctor_context_is_valid(context) && !context->closed &&
+         context->library != NULL;
+}
+
+static void doctor_mark_context_closed(doctor_native_library_t *context) {
+  context->library = NULL;
+  context->info = NULL;
+  context->probe = NULL;
+  context->last_error = NULL;
+  context->create = NULL;
+  context->destroy = NULL;
+  context->closed = 1;
+}
+
+static void doctor_release_context(doctor_native_library_t *context) {
+  if (!doctor_context_is_valid(context) || context->closed) {
+    return;
+  }
+  if (context->library != NULL) {
+    doctor_close(context->library);
+  }
+  doctor_mark_context_closed(context);
+}
+
+/*
+ * Logically close the MoonBit handle without decrementing the platform loader
+ * reference. This is used only when a runtime could not be destroyed: keeping
+ * the module mapped is safer than unloading code that its threads may still
+ * execute. The operating system reclaims the module when the process exits.
+ */
+static void doctor_abandon_context(doctor_native_library_t *context) {
+  if (!doctor_context_is_valid(context) || context->closed) {
+    return;
+  }
+  doctor_mark_context_closed(context);
+}
+
+static void doctor_native_library_finalize(void *payload) {
+  doctor_native_library_t *context = (doctor_native_library_t *)payload;
+  if (!doctor_context_is_valid(context)) {
+    return;
+  }
+  doctor_release_context(context);
+  /* The external-object container itself is owned and reclaimed by MoonBit. */
+  context->magic = 0;
+}
+
+static doctor_native_library_t *doctor_make_context(void) {
+  doctor_native_library_t *context =
+      (doctor_native_library_t *)moonbit_make_external_object(
+          doctor_native_library_finalize,
+          (uint32_t)sizeof(doctor_native_library_t));
+  memset(context, 0, sizeof(*context));
+  context->magic = DOCTOR_NATIVE_MAGIC;
+  context->closed = 1;
+  return context;
+}
+
+// Copy a diagnostic into caller-owned memory and return its full length.
+static int32_t doctor_copy_text(char *buffer, int32_t buffer_len,
+                                const char *text) {
+  if (text == NULL) {
+    text = "";
+  }
+  size_t required = strlen(text);
+  if (buffer != NULL && buffer_len > 0) {
+    size_t copy_len = required;
+    if (copy_len >= (size_t)buffer_len) {
+      copy_len = (size_t)buffer_len - 1;
     }
+    memcpy(buffer, text, copy_len);
+    buffer[copy_len] = '\0';
   }
-  output[written] = 0;
+  return (int32_t)required;
 }
 
-MOONBIT_FFI_EXPORT moonbit_bytes_t proton_doctor_native_probe(
-    moonbit_bytes_t library_path, moonbit_bytes_t config_json) {
-  char result[4096] = {0};
-  doctor_library_t library = doctor_open((const char *)library_path);
-  if (library == NULL) {
-    char escaped[2048] = {0};
-    doctor_json_escape(escaped, sizeof(escaped), doctor_load_error());
-    snprintf(result, sizeof(result), "{\"load_error\":\"%s\"}", escaped);
-    return doctor_copy_text(result);
+static int32_t doctor_invalid_handle(char *buffer, int32_t buffer_len) {
+  doctor_copy_text(buffer, buffer_len, "invalid native probe handle");
+  return DOCTOR_NATIVE_INVALID_HANDLE;
+}
+
+static int doctor_output_buffer_is_valid(const char *buffer, int32_t length) {
+  return length >= 0 && (length == 0 || buffer != NULL);
+}
+
+MOONBIT_FFI_EXPORT doctor_native_library_t *proton_doctor_native_open(
+    moonbit_bytes_t library_path, int32_t expected_abi_version,
+    int32_t *out_abi_version, int32_t *out_status, char *error_buffer,
+    int32_t error_buffer_len) {
+  doctor_native_library_t *context = doctor_make_context();
+  if (out_abi_version != NULL) {
+    *out_abi_version = 0;
+  }
+  if (out_status != NULL) {
+    *out_status = DOCTOR_NATIVE_INVALID_ARGUMENT;
+  }
+  if (out_abi_version == NULL || out_status == NULL) {
+    doctor_copy_text(error_buffer, error_buffer_len,
+                     "ABI and status output pointers are required");
+    return context;
+  }
+  if (library_path == NULL) {
+    doctor_copy_text(error_buffer, error_buffer_len, "library_path is required");
+    return context;
   }
 
-  doctor_abi_fn abi = (doctor_abi_fn)doctor_symbol(library, "proton_abi_version");
+  doctor_library_t library =
+      doctor_open((const char *)library_path, error_buffer, error_buffer_len);
+  if (library == NULL) {
+    *out_status = DOCTOR_NATIVE_LOAD_ERROR;
+    return context;
+  }
+
+  /* ABI is the only symbol touched before compatibility is established. */
+  doctor_abi_fn abi = (doctor_abi_fn)doctor_symbol(
+      library, "proton_abi_version");
+  if (abi == NULL) {
+    doctor_close(library);
+    *out_status = DOCTOR_NATIVE_SYMBOL_ERROR;
+    doctor_copy_text(error_buffer, error_buffer_len, "proton_abi_version");
+    return context;
+  }
+  int32_t actual_abi_version = abi();
+  *out_abi_version = actual_abi_version;
+  if (actual_abi_version != expected_abi_version) {
+    doctor_close(library);
+    *out_status = DOCTOR_NATIVE_ABI_MISMATCH;
+    doctor_copy_text(error_buffer, error_buffer_len, "");
+    return context;
+  }
+
+  /* Resolve the rest of the ABI only after the version check above. */
   doctor_info_fn info =
       (doctor_info_fn)doctor_symbol(library, "proton_runtime_info_json");
   doctor_probe_fn probe =
       (doctor_probe_fn)doctor_symbol(library, "proton_runtime_probe_json");
   doctor_error_fn last_error =
       (doctor_error_fn)doctor_symbol(library, "proton_last_error_message");
-  doctor_create_fn create =
-      (doctor_create_fn)doctor_symbol(library, "proton_runtime_create_json");
+  doctor_create_fn create = (doctor_create_fn)doctor_symbol(
+      library, "proton_runtime_create_json");
   doctor_destroy_fn destroy =
       (doctor_destroy_fn)doctor_symbol(library, "proton_runtime_destroy");
-  if (abi == NULL || info == NULL || probe == NULL || last_error == NULL ||
-      create == NULL || destroy == NULL) {
-    snprintf(result, sizeof(result),
-             "{\"symbol_error\":\"required proton ABI symbol is missing\"}");
-    doctor_close(library);
-    return doctor_copy_text(result);
-  }
 
-  char info_json[1024] = {0};
-  int32_t required = 0;
-  int32_t info_status = info(info_json, (int32_t)sizeof(info_json), &required);
-  int32_t probe_status = probe((const char *)config_json);
-  char error[1024] = {0};
-  if (probe_status < 0) {
-    last_error(error, (int32_t)sizeof(error));
+  const char *missing_symbol = NULL;
+  if (info == NULL) {
+    missing_symbol = "proton_runtime_info_json";
+  } else if (probe == NULL) {
+    missing_symbol = "proton_runtime_probe_json";
+  } else if (last_error == NULL) {
+    missing_symbol = "proton_last_error_message";
+  } else if (create == NULL) {
+    missing_symbol = "proton_runtime_create_json";
+  } else if (destroy == NULL) {
+    missing_symbol = "proton_runtime_destroy";
   }
-  int32_t smoke_status = probe_status;
-  if (probe_status >= 0) {
-    int64_t runtime = 0;
-    smoke_status = create((const char *)config_json, &runtime);
-    if (smoke_status >= 0) {
-      smoke_status = destroy(runtime);
-    }
-    if (smoke_status < 0) {
-      last_error(error, (int32_t)sizeof(error));
-    }
+  if (missing_symbol != NULL) {
+    doctor_close(library);
+    *out_status = DOCTOR_NATIVE_SYMBOL_ERROR;
+    doctor_copy_text(error_buffer, error_buffer_len, missing_symbol);
+    return context;
   }
-  char escaped_error[2048] = {0};
-  doctor_json_escape(escaped_error, sizeof(escaped_error), error);
-  if (info_status < 0) {
-    snprintf(info_json, sizeof(info_json), "null");
+  context->closed = 0;
+  context->library = library;
+  context->info = info;
+  context->probe = probe;
+  context->last_error = last_error;
+  context->create = create;
+  context->destroy = destroy;
+  *out_status = DOCTOR_NATIVE_OK;
+  doctor_copy_text(error_buffer, error_buffer_len, "");
+  return context;
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_close(
+    doctor_native_library_t *handle) {
+  if (!doctor_context_is_open(handle)) {
+    return DOCTOR_NATIVE_INVALID_HANDLE;
   }
-  snprintf(result, sizeof(result),
-           "{\"abi_version\":%d,\"info_status\":%d,\"info\":%s,"
-           "\"probe_status\":%d,\"smoke_status\":%d,"
-           "\"probe_error\":\"%s\"}",
-           abi(), info_status, info_json, probe_status, smoke_status,
-           escaped_error);
-  doctor_close(library);
-  return doctor_copy_text(result);
+  doctor_release_context(handle);
+  return DOCTOR_NATIVE_OK;
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_abandon(
+    doctor_native_library_t *handle) {
+  if (!doctor_context_is_open(handle)) {
+    return DOCTOR_NATIVE_INVALID_HANDLE;
+  }
+  doctor_abandon_context(handle);
+  return DOCTOR_NATIVE_OK;
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_runtime_info_json(
+    doctor_native_library_t *handle, char *buffer, int32_t buffer_len,
+    int32_t *out_required_len) {
+  if (!doctor_context_is_open(handle)) {
+    return doctor_invalid_handle(buffer, buffer_len);
+  }
+  if (out_required_len == NULL ||
+      !doctor_output_buffer_is_valid(buffer, buffer_len)) {
+    return DOCTOR_NATIVE_INVALID_ARGUMENT;
+  }
+  return handle->info(buffer, buffer_len, out_required_len);
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_runtime_probe_json(
+    doctor_native_library_t *handle, moonbit_bytes_t config_json) {
+  if (!doctor_context_is_open(handle)) {
+    return DOCTOR_NATIVE_INVALID_HANDLE;
+  }
+  if (config_json == NULL) {
+    return DOCTOR_NATIVE_INVALID_ARGUMENT;
+  }
+  return handle->probe((const char *)config_json);
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_last_error_message(
+    doctor_native_library_t *handle, char *buffer, int32_t buffer_len) {
+  if (!doctor_context_is_open(handle)) {
+    return doctor_invalid_handle(buffer, buffer_len);
+  }
+  if (!doctor_output_buffer_is_valid(buffer, buffer_len)) {
+    return DOCTOR_NATIVE_INVALID_ARGUMENT;
+  }
+  return handle->last_error(buffer, buffer_len);
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_runtime_create_json(
+    doctor_native_library_t *handle, moonbit_bytes_t config_json,
+    int64_t *out_runtime) {
+  if (!doctor_context_is_open(handle)) {
+    return DOCTOR_NATIVE_INVALID_HANDLE;
+  }
+  if (config_json == NULL || out_runtime == NULL) {
+    return DOCTOR_NATIVE_INVALID_ARGUMENT;
+  }
+  return handle->create((const char *)config_json, out_runtime);
+}
+
+MOONBIT_FFI_EXPORT int32_t proton_doctor_native_runtime_destroy(
+    doctor_native_library_t *handle, int64_t runtime) {
+  if (!doctor_context_is_open(handle)) {
+    return DOCTOR_NATIVE_INVALID_HANDLE;
+  }
+  return handle->destroy(runtime);
 }

--- a/cli/doctor/doctor_native_probe.c
+++ b/cli/doctor/doctor_native_probe.c
@@ -26,61 +26,31 @@ static void doctor_windows_error(char *buffer, int32_t buffer_len,
     return;
   }
 
-  LPWSTR wide_message = NULL;
+  wchar_t wide_message[512] = {0};
   DWORD wide_length = FormatMessageW(
-      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-          FORMAT_MESSAGE_IGNORE_INSERTS,
-      NULL, error_code, 0, (LPWSTR)&wide_message, 0, NULL);
-  if (wide_length == 0 || wide_message == NULL) {
-    if (wide_message != NULL) {
-      LocalFree(wide_message);
-    }
-    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
-             (unsigned long)error_code);
-    return;
-  }
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+      error_code, 0, wide_message,
+      (DWORD)(sizeof(wide_message) / sizeof(wide_message[0])), NULL);
   while (wide_length > 0 &&
          (wide_message[wide_length - 1] == L'\r' ||
           wide_message[wide_length - 1] == L'\n' ||
           wide_message[wide_length - 1] == L' ')) {
     wide_length--;
   }
-  if (wide_length == 0) {
-    LocalFree(wide_message);
-    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
-             (unsigned long)error_code);
-    return;
+  if (wide_length > 0) {
+    char utf8_message[1024] = {0};
+    int converted = WideCharToMultiByte(
+        CP_UTF8, 0, wide_message, (int)wide_length, utf8_message,
+        (int)sizeof(utf8_message) - 1, NULL, NULL);
+    if (converted > 0) {
+      utf8_message[converted] = '\0';
+      snprintf(buffer, (size_t)buffer_len, "Windows error %lu: %s",
+               (unsigned long)error_code, utf8_message);
+      return;
+    }
   }
-
-  int utf8_required = WideCharToMultiByte(
-      CP_UTF8, 0, wide_message, (int)wide_length, NULL, 0, NULL, NULL);
-  if (utf8_required <= 0) {
-    LocalFree(wide_message);
-    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
-             (unsigned long)error_code);
-    return;
-  }
-  char *utf8_message = (char *)malloc((size_t)utf8_required + 1);
-  if (utf8_message == NULL) {
-    LocalFree(wide_message);
-    doctor_copy_text(buffer, buffer_len,
-                     "out of memory while formatting Windows error");
-    return;
-  }
-  int converted = WideCharToMultiByte(CP_UTF8, 0, wide_message,
-                                      (int)wide_length, utf8_message,
-                                      utf8_required, NULL, NULL);
-  LocalFree(wide_message);
-  if (converted <= 0) {
-    free(utf8_message);
-    snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
-             (unsigned long)error_code);
-    return;
-  }
-  utf8_message[converted] = '\0';
-  snprintf(buffer, (size_t)buffer_len, "Windows error %lu: %s",
-           (unsigned long)error_code, utf8_message);
-  free(utf8_message);
+  snprintf(buffer, (size_t)buffer_len, "Windows error %lu",
+           (unsigned long)error_code);
 }
 
 static doctor_library_t doctor_open(const char *path, char *error_buffer,
@@ -140,8 +110,6 @@ enum {
   DOCTOR_NATIVE_ABI_MISMATCH = -6,
 };
 
-#define DOCTOR_NATIVE_MAGIC UINT32_C(0x50524f42)
-
 typedef int32_t (*doctor_abi_fn)(void);
 typedef int32_t (*doctor_info_fn)(char *, int32_t, int32_t *);
 typedef int32_t (*doctor_probe_fn)(const char *);
@@ -155,8 +123,6 @@ typedef int32_t (*doctor_destroy_fn)(int64_t);
  * the finalizer or by an explicit close.
  */
 typedef struct doctor_native_library {
-  uint32_t magic;
-  int32_t closed;
   doctor_library_t library;
   doctor_info_fn info;
   doctor_probe_fn probe;
@@ -165,32 +131,19 @@ typedef struct doctor_native_library {
   doctor_destroy_fn destroy;
 } doctor_native_library_t;
 
-static int doctor_context_is_valid(const doctor_native_library_t *context) {
-  return context != NULL && context->magic == DOCTOR_NATIVE_MAGIC;
-}
-
 static int doctor_context_is_open(const doctor_native_library_t *context) {
-  return doctor_context_is_valid(context) && !context->closed &&
-         context->library != NULL;
+  return context != NULL && context->library != NULL;
 }
 
 static void doctor_mark_context_closed(doctor_native_library_t *context) {
-  context->library = NULL;
-  context->info = NULL;
-  context->probe = NULL;
-  context->last_error = NULL;
-  context->create = NULL;
-  context->destroy = NULL;
-  context->closed = 1;
+  memset(context, 0, sizeof(*context));
 }
 
 static void doctor_release_context(doctor_native_library_t *context) {
-  if (!doctor_context_is_valid(context) || context->closed) {
+  if (!doctor_context_is_open(context)) {
     return;
   }
-  if (context->library != NULL) {
-    doctor_close(context->library);
-  }
+  doctor_close(context->library);
   doctor_mark_context_closed(context);
 }
 
@@ -201,7 +154,7 @@ static void doctor_release_context(doctor_native_library_t *context) {
  * execute. The operating system reclaims the module when the process exits.
  */
 static void doctor_abandon_context(doctor_native_library_t *context) {
-  if (!doctor_context_is_valid(context) || context->closed) {
+  if (!doctor_context_is_open(context)) {
     return;
   }
   doctor_mark_context_closed(context);
@@ -209,12 +162,7 @@ static void doctor_abandon_context(doctor_native_library_t *context) {
 
 static void doctor_native_library_finalize(void *payload) {
   doctor_native_library_t *context = (doctor_native_library_t *)payload;
-  if (!doctor_context_is_valid(context)) {
-    return;
-  }
   doctor_release_context(context);
-  /* The external-object container itself is owned and reclaimed by MoonBit. */
-  context->magic = 0;
 }
 
 static doctor_native_library_t *doctor_make_context(void) {
@@ -223,8 +171,6 @@ static doctor_native_library_t *doctor_make_context(void) {
           doctor_native_library_finalize,
           (uint32_t)sizeof(doctor_native_library_t));
   memset(context, 0, sizeof(*context));
-  context->magic = DOCTOR_NATIVE_MAGIC;
-  context->closed = 1;
   return context;
 }
 
@@ -243,7 +189,7 @@ static int32_t doctor_copy_text(char *buffer, int32_t buffer_len,
     memcpy(buffer, text, copy_len);
     buffer[copy_len] = '\0';
   }
-  return (int32_t)required;
+  return required > INT32_MAX ? INT32_MAX : (int32_t)required;
 }
 
 static int32_t doctor_invalid_handle(char *buffer, int32_t buffer_len) {
@@ -331,7 +277,6 @@ MOONBIT_FFI_EXPORT doctor_native_library_t *proton_doctor_native_open(
     doctor_copy_text(error_buffer, error_buffer_len, missing_symbol);
     return context;
   }
-  context->closed = 0;
   context->library = library;
   context->info = info;
   context->probe = probe;

--- a/cli/doctor/doctor_native_probe.mbt
+++ b/cli/doctor/doctor_native_probe.mbt
@@ -1,18 +1,359 @@
 ///|
-#borrow(library_path, config_json)
-extern "C" fn proton_doctor_native_probe_ffi(
-  library_path : Bytes,
-  config_json : Bytes,
-) -> Bytes = "proton_doctor_native_probe"
+let doctor_native_expected_abi_version : Int = 1
 
 ///|
-fn doctor_native_probe(library_path : String, config_json : String) -> Json {
-  let result = proton_doctor_native_probe_ffi(
-    @ffi.to_cstr(library_path),
-    @ffi.to_cstr(config_json),
-  )
-  let text = @ffi.from_cstr(result)
-  @json.parse(text) catch {
-    _ => Json::object({ "parse_error": Json::string(text) })
+let doctor_native_ok : Int = 0
+
+///|
+let doctor_native_load_error : Int = -1
+
+///|
+let doctor_native_symbol_error : Int = -2
+
+///|
+let doctor_native_invalid_handle : Int = -5
+
+///|
+let doctor_native_abi_mismatch : Int = -6
+
+///|
+let doctor_native_buffer_too_small : Int = -11
+
+///|
+let doctor_native_max_text_length : Int = 1024 * 1024
+
+///|
+priv enum DoctorNativeProbeError {
+  LoadFailed(String)
+  SymbolsMissing(String)
+  AbiMismatch(Int)
+  OpenFailed(Int, String)
+}
+
+///|
+priv struct DoctorNativeCallError {
+  status : Int
+  message : String
+}
+
+///|
+priv enum DoctorNativeSmokeResult {
+  Skipped
+  Succeeded
+  CreateFailed(DoctorNativeCallError)
+  DestroyFailed(DoctorNativeCallError)
+}
+
+///|
+priv struct DoctorNativeProbeResult {
+  info : Result[String, DoctorNativeCallError]
+  probe : Result[Unit, DoctorNativeCallError]
+  smoke : DoctorNativeSmokeResult
+}
+
+///|
+priv type DoctorNativeLibrary
+
+///|
+#borrow(library_path, out_abi_version, out_status, error_buffer)
+extern "C" fn proton_doctor_native_open_ffi(
+  library_path : Bytes,
+  expected_abi_version : Int,
+  out_abi_version : Ref[Int],
+  out_status : Ref[Int],
+  error_buffer : FixedArray[Byte],
+  error_buffer_len : Int,
+) -> DoctorNativeLibrary = "proton_doctor_native_open"
+
+///|
+#borrow(handle)
+extern "C" fn proton_doctor_native_close_ffi(
+  handle : DoctorNativeLibrary,
+) -> Int = "proton_doctor_native_close"
+
+///|
+#borrow(handle)
+extern "C" fn proton_doctor_native_abandon_ffi(
+  handle : DoctorNativeLibrary,
+) -> Int = "proton_doctor_native_abandon"
+
+///|
+#borrow(handle, buffer, out_required_len)
+extern "C" fn proton_doctor_native_runtime_info_json_ffi(
+  handle : DoctorNativeLibrary,
+  buffer : FixedArray[Byte],
+  buffer_len : Int,
+  out_required_len : Ref[Int],
+) -> Int = "proton_doctor_native_runtime_info_json"
+
+///|
+#borrow(handle, config_json)
+extern "C" fn proton_doctor_native_runtime_probe_json_ffi(
+  handle : DoctorNativeLibrary,
+  config_json : Bytes,
+) -> Int = "proton_doctor_native_runtime_probe_json"
+
+///|
+#borrow(handle, buffer)
+extern "C" fn proton_doctor_native_last_error_message_ffi(
+  handle : DoctorNativeLibrary,
+  buffer : FixedArray[Byte],
+  buffer_len : Int,
+) -> Int = "proton_doctor_native_last_error_message"
+
+///|
+#borrow(handle, config_json, out_runtime)
+extern "C" fn proton_doctor_native_runtime_create_json_ffi(
+  handle : DoctorNativeLibrary,
+  config_json : Bytes,
+  out_runtime : Ref[Int64],
+) -> Int = "proton_doctor_native_runtime_create_json"
+
+///|
+#borrow(handle)
+extern "C" fn proton_doctor_native_runtime_destroy_ffi(
+  handle : DoctorNativeLibrary,
+  runtime : Int64,
+) -> Int = "proton_doctor_native_runtime_destroy"
+
+///|
+fn doctor_native_checked_buffer_length(required : Int) -> Int? {
+  if required < 0 || required > doctor_native_max_text_length {
+    None
+  } else {
+    Some(required + 1)
   }
+}
+
+///|
+fn doctor_native_buffer_text(buffer : FixedArray[Byte]) -> String? {
+  let bytes = Bytes::from_array(buffer)
+  if bytes.length() == 0 {
+    return None
+  }
+  let end = match bytes.find(b"\x00") {
+    Some(index) => index
+    None => return None
+  }
+  Some(@ffi.from_cstr(bytes[0:end + 1].to_owned()))
+}
+
+///|
+fn doctor_native_buffer_text_at_length(
+  buffer : FixedArray[Byte],
+  required : Int,
+) -> String? {
+  if required < 0 || required >= buffer.length() {
+    return None
+  }
+  let bytes = Bytes::from_array(buffer)
+  match bytes.find(b"\x00") {
+    Some(index) if index == required =>
+      Some(@ffi.from_cstr(bytes[0:index + 1].to_owned()))
+    _ => None
+  }
+}
+
+///|
+fn doctor_native_open_with_expected_abi(
+  library_path : String,
+  expected_abi_version : Int,
+) -> Result[DoctorNativeLibrary, DoctorNativeProbeError] {
+  let actual_abi_version = Ref(0)
+  let status = Ref(doctor_native_invalid_handle)
+  let error_buffer = FixedArray::make(4096, b'\x00')
+  let handle = proton_doctor_native_open_ffi(
+    @ffi.to_cstr(library_path),
+    expected_abi_version,
+    actual_abi_version,
+    status,
+    error_buffer,
+    error_buffer.length(),
+  )
+  let message = doctor_native_buffer_text(error_buffer).unwrap_or(
+    "native probe bridge returned unterminated error text",
+  )
+  if status.val == doctor_native_load_error {
+    return Err(LoadFailed(message))
+  }
+  if status.val == doctor_native_symbol_error {
+    return Err(SymbolsMissing(message))
+  }
+  if status.val == doctor_native_abi_mismatch {
+    return Err(AbiMismatch(actual_abi_version.val))
+  }
+  if status.val == doctor_native_ok {
+    return Ok(handle)
+  }
+  Err(OpenFailed(status.val, message))
+}
+
+///|
+fn doctor_native_open(
+  library_path : String,
+) -> Result[DoctorNativeLibrary, DoctorNativeProbeError] {
+  doctor_native_open_with_expected_abi(
+    library_path, doctor_native_expected_abi_version,
+  )
+}
+
+///|
+fn DoctorNativeCallError::hint(
+  self : DoctorNativeCallError,
+  fallback : String,
+) -> String {
+  if self.message == "" {
+    fallback + " with status " + self.status.to_string()
+  } else {
+    self.message
+  }
+}
+
+///|
+fn doctor_native_read_info(
+  handle : DoctorNativeLibrary,
+) -> Result[String, DoctorNativeCallError] {
+  let required = Ref(0)
+  let scratch = FixedArray::make(1, b'\x00')
+  let status = proton_doctor_native_runtime_info_json_ffi(
+    handle, scratch, 0, required,
+  )
+  if status < 0 && status != doctor_native_buffer_too_small {
+    return Err({ status, message: doctor_native_last_error(handle) })
+  }
+  if required.val < 0 {
+    return Err({
+      status,
+      message: "runtime info ABI returned a negative required length",
+    })
+  }
+  let buffer_length = match doctor_native_checked_buffer_length(required.val) {
+    Some(length) => length
+    None =>
+      return Err({
+        status,
+        message: "runtime info ABI required length exceeds the safety limit",
+      })
+  }
+  let first_required = required.val
+  let buffer = FixedArray::make(buffer_length, b'\x00')
+  let second_status = proton_doctor_native_runtime_info_json_ffi(
+    handle,
+    buffer,
+    buffer.length(),
+    required,
+  )
+  if second_status < 0 {
+    Err({ status: second_status, message: doctor_native_last_error(handle) })
+  } else if required.val < 0 {
+    Err({
+      status: second_status,
+      message: "runtime info ABI returned a negative required length",
+    })
+  } else if required.val > first_required {
+    Err({
+      status: second_status,
+      message: "runtime info ABI required length grew while reading",
+    })
+  } else {
+    match doctor_native_buffer_text_at_length(buffer, required.val) {
+      Some(text) => Ok(text)
+      None =>
+        Err({
+          status: second_status,
+          message: "runtime info ABI returned text with an inconsistent length",
+        })
+    }
+  }
+}
+
+///|
+fn doctor_native_last_error(handle : DoctorNativeLibrary) -> String {
+  let scratch = FixedArray::make(1, b'\x00')
+  let required = proton_doctor_native_last_error_message_ffi(handle, scratch, 0)
+  if required < 0 {
+    return "native error message ABI failed with status " + required.to_string()
+  }
+  if required == 0 {
+    return ""
+  }
+  let buffer_length = match doctor_native_checked_buffer_length(required) {
+    Some(length) => length
+    None => return "native error message exceeds the safety limit"
+  }
+  let buffer = FixedArray::make(buffer_length, b'\x00')
+  let second_required = proton_doctor_native_last_error_message_ffi(
+    handle,
+    buffer,
+    buffer.length(),
+  )
+  if second_required < 0 {
+    return "native error message ABI failed with status " +
+      second_required.to_string()
+  }
+  if second_required > required {
+    return "native error message required length grew while reading"
+  }
+  doctor_native_buffer_text_at_length(buffer, second_required).unwrap_or(
+    "native error message ABI returned text with an inconsistent length",
+  )
+}
+
+///|
+fn doctor_native_smoke(
+  handle : DoctorNativeLibrary,
+  config : Bytes,
+) -> DoctorNativeSmokeResult {
+  let runtime = Ref(0L)
+  let create_status = proton_doctor_native_runtime_create_json_ffi(
+    handle, config, runtime,
+  )
+  if create_status < 0 {
+    return CreateFailed({
+      status: create_status,
+      message: doctor_native_last_error(handle),
+    })
+  }
+  let destroy_status = proton_doctor_native_runtime_destroy_ffi(
+    handle,
+    runtime.val,
+  )
+  if destroy_status < 0 {
+    let error = DoctorNativeCallError::{
+      status: destroy_status,
+      message: doctor_native_last_error(handle),
+    }
+    let _ = proton_doctor_native_abandon_ffi(handle)
+    DestroyFailed(error)
+  } else {
+    Succeeded
+  }
+}
+
+///|
+fn doctor_native_probe(
+  library_path : String,
+  config_json : String,
+) -> Result[DoctorNativeProbeResult, DoctorNativeProbeError] {
+  let handle = match doctor_native_open(library_path) {
+    Ok(handle) => handle
+    Err(error) => return Err(error)
+  }
+  defer {
+    let _ = proton_doctor_native_close_ffi(handle)
+  }
+  let info = doctor_native_read_info(handle)
+  let config = @ffi.to_cstr(config_json)
+  let probe_status = proton_doctor_native_runtime_probe_json_ffi(handle, config)
+  let probe = if probe_status < 0 {
+    Err({ status: probe_status, message: doctor_native_last_error(handle) })
+  } else {
+    Ok(())
+  }
+  let smoke = if probe_status < 0 {
+    Skipped
+  } else {
+    doctor_native_smoke(handle, config)
+  }
+  Ok({ info, probe, smoke })
 }

--- a/cli/doctor/doctor_native_probe.mbt
+++ b/cli/doctor/doctor_native_probe.mbt
@@ -323,6 +323,7 @@ fn doctor_native_smoke(
     let _ = proton_doctor_native_abandon_ffi(handle)
     DestroyFailed(error)
   } else {
+    let _ = proton_doctor_native_abandon_ffi(handle)
     Succeeded
   }
 }

--- a/cli/doctor/doctor_native_probe.mbt
+++ b/cli/doctor/doctor_native_probe.mbt
@@ -128,9 +128,6 @@ fn doctor_native_checked_buffer_length(required : Int) -> Int? {
 ///|
 fn doctor_native_buffer_text(buffer : FixedArray[Byte]) -> String? {
   let bytes = Bytes::from_array(buffer)
-  if bytes.length() == 0 {
-    return None
-  }
   let end = match bytes.find(b"\x00") {
     Some(index) => index
     None => return None

--- a/cli/doctor/doctor_paths.mbt
+++ b/cli/doctor/doctor_paths.mbt
@@ -42,6 +42,21 @@ fn find_up(start : String, file_name : String) -> String? {
 }
 
 ///|
+fn find_project_root_marker(start : String) -> (String, String?)? {
+  let moon_mod_path = path_join(start, "moon.mod")
+  if @mbfs.path_exists(moon_mod_path) {
+    return Some((start, Some(moon_mod_path)))
+  }
+  if @mbfs.path_exists(path_join(start, "moon.work")) {
+    return Some((start, None))
+  }
+  match path_parent(start) {
+    Some(parent) => find_project_root_marker(parent)
+    None => None
+  }
+}
+
+///|
 fn path_text_equal(
   left : String,
   right : String,
@@ -107,33 +122,28 @@ fn discover_project(cwd : String) -> ProjectDoctorInfo {
   let cwd = @path.Path(cwd).resolve().to_string()
   let discovered_moon_proton_path = find_up(cwd, "moon.proton")
   let discovered_app_json_path = find_up(cwd, "app.json")
-  let discovered_moon_mod_path = find_up(cwd, "moon.mod")
-  let root = match
-    (
-      discovered_moon_proton_path, discovered_app_json_path, discovered_moon_mod_path,
-    ) {
-    (Some(path), _, _) =>
+  let fallback_root = match
+    (discovered_moon_proton_path, discovered_app_json_path) {
+    (Some(path), _) =>
       match path_parent(path) {
         Some(parent) => parent
         None => cwd
       }
-    (_, Some(path), _) =>
-      match path_parent(path) {
-        Some(parent) => parent
-        None => cwd
-      }
-    (_, _, Some(path)) =>
+    (_, Some(path)) =>
       match path_parent(path) {
         Some(parent) => parent
         None => cwd
       }
     _ => cwd
   }
+  let (root, moon_mod_path) = match find_project_root_marker(cwd) {
+    Some(marker) => marker
+    None => (fallback_root, None)
+  }
   let moon_proton_path = path_option_within_root(
     root, discovered_moon_proton_path,
   )
   let app_json_path = path_option_within_root(root, discovered_app_json_path)
-  let moon_mod_path = path_option_within_root(root, discovered_moon_mod_path)
   let discovered_moon_pkg_path = path_option_within_root(
     root,
     find_up(cwd, "moon.pkg"),

--- a/cli/doctor/doctor_paths.mbt
+++ b/cli/doctor/doctor_paths.mbt
@@ -42,6 +42,54 @@ fn find_up(start : String, file_name : String) -> String? {
 }
 
 ///|
+fn path_text_equal(
+  left : String,
+  right : String,
+  case_sensitive~ : Bool,
+) -> Bool {
+  if case_sensitive {
+    left == right
+  } else {
+    left.equal_ignore_ascii_case(right)
+  }
+}
+
+///|
+fn path_text_has_prefix(
+  value : String,
+  prefix : String,
+  case_sensitive~ : Bool,
+) -> Bool {
+  if value.length() < prefix.length() {
+    return false
+  }
+  path_text_equal(
+    value.unsafe_substring(start=0, end=prefix.length()),
+    prefix,
+    case_sensitive~,
+  )
+}
+
+///|
+fn path_is_within_root(root : String, path : String) -> Bool {
+  let root = @path.Path(root).resolve().to_string()
+  let resolved = @path.Path(path).resolve().to_string()
+  let separator = @path.sep.to_string()
+  let prefix = if root.has_suffix(separator) { root } else { root + separator }
+  let case_sensitive = @path.sep != '\\'
+  path_text_equal(resolved, root, case_sensitive~) ||
+  path_text_has_prefix(resolved, prefix, case_sensitive~)
+}
+
+///|
+fn path_option_within_root(root : String, path : String?) -> String? {
+  match path {
+    Some(path) if path_is_within_root(root, path) => Some(path)
+    _ => None
+  }
+}
+
+///|
 fn project_mode(
   moon_proton_path : String?,
   app_json_path : String?,
@@ -56,11 +104,14 @@ fn project_mode(
 
 ///|
 fn discover_project(cwd : String) -> ProjectDoctorInfo {
-  let moon_proton_path = find_up(cwd, "moon.proton")
-  let app_json_path = find_up(cwd, "app.json")
-  let moon_mod_path = find_up(cwd, "moon.mod")
-  let discovered_moon_pkg_path = find_up(cwd, "moon.pkg")
-  let root = match (moon_proton_path, app_json_path, moon_mod_path) {
+  let cwd = @path.Path(cwd).resolve().to_string()
+  let discovered_moon_proton_path = find_up(cwd, "moon.proton")
+  let discovered_app_json_path = find_up(cwd, "app.json")
+  let discovered_moon_mod_path = find_up(cwd, "moon.mod")
+  let root = match
+    (
+      discovered_moon_proton_path, discovered_app_json_path, discovered_moon_mod_path,
+    ) {
     (Some(path), _, _) =>
       match path_parent(path) {
         Some(parent) => parent
@@ -78,6 +129,15 @@ fn discover_project(cwd : String) -> ProjectDoctorInfo {
       }
     _ => cwd
   }
+  let moon_proton_path = path_option_within_root(
+    root, discovered_moon_proton_path,
+  )
+  let app_json_path = path_option_within_root(root, discovered_app_json_path)
+  let moon_mod_path = path_option_within_root(root, discovered_moon_mod_path)
+  let discovered_moon_pkg_path = path_option_within_root(
+    root,
+    find_up(cwd, "moon.pkg"),
+  )
   let mode = project_mode(moon_proton_path, app_json_path, moon_mod_path)
   let moon_pkg_path = match discovered_moon_pkg_path {
     Some(path) => Some(path)

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -530,6 +530,33 @@ test "doctor renders typed deep runtime probe results" {
     }),
   )
 
+  let inconsistent_info : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(inconsistent_info, {
+    info: Ok(
+      "{\"abi_version\":1,\"runtime_available\":true,\"build_mode\":\"abi-only\",\"platform\":\"darwin\",\"features\":[]}",
+    ),
+    probe: Ok(()),
+    smoke: Succeeded,
+  })
+  assert_true(
+    inconsistent_info.any(fn(line) {
+      line.code == "runtime.deep.info_invalid" &&
+      line.hint ==
+      Some("runtime info runtime_available is inconsistent with build_mode")
+    }),
+  )
+
+  match
+    doctor_native_runtime_info_from_text(
+      "{\"abi_version\":1,\"runtime_available\":true,\"build_mode\":\"unknown\",\"platform\":\"darwin\",\"features\":[]}",
+    ) {
+    Err(message) =>
+      assert_eq(
+        message, "runtime info build_mode must be `runtime` or `abi-only`",
+      )
+    Ok(_) => abort("expected an unsupported runtime build mode error")
+  }
+
   let failed : Array[DoctorLine] = []
   push_deep_runtime_probe_result(failed, {
     info: Err({ status: -7, message: "runtime info unavailable" }),

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -655,6 +655,39 @@ async test "doctor deep native probe succeeds against active runtime" {
 }
 
 ///|
+async test "doctor deep native probe reports invalid runtime config" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_library_path(platform_id) {
+    None => ()
+    Some(library_path) =>
+      match doctor_native_probe(library_path, "{}") {
+        Err(_) => abort("expected the active Proton library to open")
+        Ok(result) => {
+          match result.info {
+            Ok(text) =>
+              match doctor_native_runtime_info_from_text(text) {
+                Ok(_) => ()
+                Err(message) => abort(message)
+              }
+            Err(error) => abort(error.hint("runtime info ABI call failed"))
+          }
+          match result.probe {
+            Ok(_) => abort("expected an invalid runtime config error")
+            Err(error) => {
+              assert_true(error.status < 0)
+              assert_true(error.message.contains("abi_version"))
+            }
+          }
+          match result.smoke {
+            Skipped => ()
+            _ => abort("expected smoke test to be skipped")
+          }
+        }
+      }
+  }
+}
+
+///|
 async test "doctor native loader accepts UTF-8 library paths" {
   let platform_id = @cef.current_platform_id()
   match doctor_test_native_library_path(platform_id) {

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -562,6 +562,8 @@ test "doctor bounds native text buffers and requires termination" {
     doctor_native_checked_buffer_length(doctor_native_max_text_length + 1),
     None,
   )
+  let empty = FixedArray::make(0, b'\x00')
+  assert_eq(doctor_native_buffer_text(empty), None)
   let terminated : FixedArray[Byte] = [b'o', b'k', b'\x00']
   assert_eq(doctor_native_buffer_text(terminated), Some("ok"))
   assert_eq(doctor_native_buffer_text_at_length(terminated, 2), Some("ok"))
@@ -592,7 +594,7 @@ fn doctor_test_workspace_root() -> String {
 }
 
 ///|
-fn doctor_test_native_library_path(platform_id : String) -> String? {
+fn doctor_test_native_dist(platform_id : String) -> String? {
   match runtime_library_relative_path(platform_id) {
     Some(relative) => {
       let project = discover_project(doctor_test_workspace_root())
@@ -617,9 +619,38 @@ fn doctor_test_native_library_path(platform_id : String) -> String? {
           "; run `proton_cli cef setup` and build/install the native runtime",
         )
       }
-      Some(candidate)
+      Some(native_dist)
     }
     None => None
+  }
+}
+
+///|
+fn doctor_test_native_library_path(platform_id : String) -> String? {
+  match doctor_test_native_dist(platform_id) {
+    Some(native_dist) =>
+      match runtime_library_relative_path(platform_id) {
+        Some(relative) => Some(path_join(native_dist, relative))
+        None => None
+      }
+    None => None
+  }
+}
+
+///|
+async test "doctor deep native probe succeeds against active runtime" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_dist(platform_id) {
+    None => ()
+    Some(native_dist) => {
+      let lines : Array[DoctorLine] = []
+      push_deep_runtime_probe(lines, native_dist, platform_id)
+      assert_true(lines.any(fn(line) { line.code == "runtime.deep.info" }))
+      assert_true(lines.any(fn(line) { line.code == "runtime.deep.engine" }))
+      assert_true(lines.any(fn(line) { line.code == "runtime.deep.probe" }))
+      assert_true(lines.any(fn(line) { line.code == "runtime.deep.smoke" }))
+      assert_true(lines.all(fn(line) { line.status == Ok }))
+    }
   }
 }
 

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -9,6 +9,20 @@ fn ensure_test_dir(path : String) -> Unit {
 }
 
 ///|
+fn ensure_test_project_root(path : String) -> String {
+  let root = @path.Path(path).resolve().to_string()
+  ensure_test_dir(root)
+  @mbfs.write_string_to_file(
+    path_join(root, "moon.proton"),
+    "",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  root
+}
+
+///|
 fn assert_test_path_suffix(value : String, suffix : String) -> Unit {
   let normalized = value.replace_all(old="\\", new="/")
   guard normalized.has_suffix(suffix) else {
@@ -23,15 +37,74 @@ test "doctor paths use the host separator" {
 }
 
 ///|
+test "doctor resolves a relative project cwd" {
+  let project = discover_project(".")
+  assert_true(path_is_absolute_like(project.root))
+  assert_true(path_is_absolute_like(development_native_dist(project)))
+}
+
+///|
+test "doctor resolves a relative native dist override" {
+  let previous = @sys.get_env_var("PROTON_NATIVE_DIST")
+  defer (match previous {
+    Some(value) => @sys.set_env_var("PROTON_NATIVE_DIST", value)
+    None => @sys.unset_env_var("PROTON_NATIVE_DIST")
+  })
+  let root = ensure_test_project_root("target/proton-doctor-native-root")
+  let relative = "runtime"
+  @sys.set_env_var("PROTON_NATIVE_DIST", relative)
+  let project = discover_project(root)
+  let (native_dist, manifest) = resolve_native_dist(project)
+  assert_eq(
+    native_dist,
+    @path.Path(path_join(root, relative)).resolve().to_string(),
+  )
+  assert_true(manifest is None)
+
+  @sys.set_env_var("PROTON_NATIVE_DIST", "  ")
+  let (fallback_dist, empty_override_manifest) = resolve_native_dist(project)
+  assert_eq(fallback_dist, development_native_dist(project))
+  assert_true(empty_override_manifest is None)
+}
+
+///|
 test "doctor project boundary rejects parent paths" {
-  let project = discover_project("target/proton-doctor-boundary")
-  assert_true(
+  let root = ensure_test_project_root("target/proton-doctor-boundary")
+  let project = discover_project(root)
+  assert_true(project.moon_mod_path is None)
+  assert_true(project.moon_pkg_path is None)
+  assert_true(path_is_within_project(project, path_join(root, "app.html")))
+  assert_false(
     path_is_within_project(
       project,
-      path_join("target/proton-doctor-boundary", "app.html"),
+      @path.Path("target/outside.html").resolve().to_string(),
     ),
   )
-  assert_false(path_is_within_project(project, "target/outside.html"))
+}
+
+///|
+test "doctor Windows path boundary ignores ASCII case" {
+  assert_true(
+    path_text_has_prefix(
+      "c:\\workspace\\proton\\app",
+      "C:\\Workspace\\Proton\\",
+      case_sensitive=false,
+    ),
+  )
+  assert_true(
+    path_text_equal(
+      "c:\\workspace\\proton",
+      "C:\\Workspace\\Proton",
+      case_sensitive=false,
+    ),
+  )
+  assert_false(
+    path_text_has_prefix(
+      "c:\\workspace\\other",
+      "C:\\Workspace\\Proton\\",
+      case_sensitive=false,
+    ),
+  )
 }
 
 ///|
@@ -175,9 +248,8 @@ async test "frontend run captures build command output" {
 
 ///|
 test "doctor fix regenerates extensions and honors dry run" {
-  let root = "target/proton-doctor-fix"
+  let root = ensure_test_project_root("target/proton-doctor-fix")
   let extension_dir = path_join(root, "sample")
-  ensure_test_dir(root)
   @mbfs.create_dir(extension_dir) catch {
     _ => ()
   }
@@ -304,9 +376,8 @@ test "doctor reports invalid runtime manifests" {
     None => @sys.unset_env_var("PROTON_NATIVE_DIST")
   })
   @sys.unset_env_var("PROTON_NATIVE_DIST")
-  let dir = "target/proton-doctor-invalid-runtime"
+  let dir = ensure_test_project_root("target/proton-doctor-invalid-runtime")
   let proton_dir = path_join(dir, ".proton")
-  ensure_test_dir(dir)
   @mbfs.create_dir(proton_dir) catch {
     _ => ()
   }
@@ -325,9 +396,8 @@ test "doctor reports invalid runtime manifests" {
 
 ///|
 test "doctor validates runtime manifest schema" {
-  let dir = "target/proton-doctor-runtime-schema"
+  let dir = ensure_test_project_root("target/proton-doctor-runtime-schema")
   let proton_dir = path_join(dir, ".proton")
-  ensure_test_dir(dir)
   @mbfs.create_dir(proton_dir) catch {
     _ => ()
   }

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -438,6 +438,333 @@ test "doctor validates runtime manifest schema" {
 }
 
 ///|
+test "doctor renders typed deep runtime probe results" {
+  let lines : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(lines, {
+    info: Ok(
+      "{\"abi_version\":1,\"runtime_available\":true,\"build_mode\":\"runtime\",\"platform\":\"darwin\",\"features\":[]}",
+    ),
+    probe: Ok(()),
+    smoke: Succeeded,
+  })
+  assert_eq(lines.length(), 5)
+  assert_true(lines.any(fn(line) { line.code == "runtime.deep.engine" }))
+  assert_true(lines.any(fn(line) { line.code == "runtime.deep.probe" }))
+  assert_true(lines.any(fn(line) { line.code == "runtime.deep.smoke" }))
+
+  let invalid_info : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(invalid_info, {
+    info: Ok("{"),
+    probe: Ok(()),
+    smoke: Succeeded,
+  })
+  assert_true(
+    invalid_info.any(fn(line) { line.code == "runtime.deep.info_invalid" }),
+  )
+
+  let missing_fields : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(missing_fields, {
+    info: Ok("{}"),
+    probe: Ok(()),
+    smoke: Succeeded,
+  })
+  assert_true(
+    missing_fields.any(fn(line) { line.code == "runtime.deep.info_invalid" }),
+  )
+  assert_false(
+    missing_fields.any(fn(line) {
+      line.code == "runtime.deep.engine_unavailable"
+    }),
+  )
+
+  let mismatched_info : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(mismatched_info, {
+    info: Ok(
+      "{\"abi_version\":7,\"runtime_available\":true,\"build_mode\":\"runtime\",\"platform\":\"darwin\",\"features\":[]}",
+    ),
+    probe: Ok(()),
+    smoke: Succeeded,
+  })
+  assert_true(
+    mismatched_info.any(fn(line) {
+      line.code == "runtime.deep.info_invalid" &&
+      line.hint == Some("runtime info ABI version mismatch: expected 1, got 7")
+    }),
+  )
+
+  let failed : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(failed, {
+    info: Err({ status: -7, message: "runtime info unavailable" }),
+    probe: Err({ status: -1, message: "invalid runtime config" }),
+    smoke: Skipped,
+  })
+  assert_true(
+    failed.any(fn(line) {
+      line.code == "runtime.deep.info_failed" &&
+      line.hint == Some("runtime info unavailable")
+    }),
+  )
+  assert_true(
+    failed.any(fn(line) {
+      line.code == "runtime.deep.probe_failed" &&
+      line.hint == Some("invalid runtime config")
+    }),
+  )
+  assert_true(
+    failed.any(fn(line) {
+      line.code == "runtime.deep.smoke_skipped" && line.status == Neutral
+    }),
+  )
+  assert_false(
+    failed.any(fn(line) { line.code == "runtime.deep.smoke_failed" }),
+  )
+
+  let failed_smoke : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(failed_smoke, {
+    info: Ok(
+      "{\"abi_version\":1,\"runtime_available\":true,\"build_mode\":\"runtime\",\"platform\":\"darwin\",\"features\":[]}",
+    ),
+    probe: Ok(()),
+    smoke: CreateFailed({ status: -7, message: "runtime create failed" }),
+  })
+  assert_true(
+    failed_smoke.any(fn(line) {
+      line.code == "runtime.deep.smoke_failed" &&
+      line.hint == Some("runtime create failed")
+    }),
+  )
+
+  let failed_destroy : Array[DoctorLine] = []
+  push_deep_runtime_probe_result(failed_destroy, {
+    info: Ok(
+      "{\"abi_version\":1,\"runtime_available\":true,\"build_mode\":\"runtime\",\"platform\":\"darwin\",\"features\":[]}",
+    ),
+    probe: Ok(()),
+    smoke: DestroyFailed({ status: -7, message: "" }),
+  })
+  assert_true(
+    failed_destroy.any(fn(line) {
+      line.code == "runtime.deep.smoke_failed" &&
+      line.text == "runtime destruction smoke test failed" &&
+      line.hint == Some("runtime destruction smoke test failed with status -7")
+    }),
+  )
+}
+
+///|
+test "doctor bounds native text buffers and requires termination" {
+  assert_eq(doctor_native_checked_buffer_length(-1), None)
+  assert_eq(
+    doctor_native_checked_buffer_length(doctor_native_max_text_length),
+    Some(doctor_native_max_text_length + 1),
+  )
+  assert_eq(
+    doctor_native_checked_buffer_length(doctor_native_max_text_length + 1),
+    None,
+  )
+  let terminated : FixedArray[Byte] = [b'o', b'k', b'\x00']
+  assert_eq(doctor_native_buffer_text(terminated), Some("ok"))
+  assert_eq(doctor_native_buffer_text_at_length(terminated, 2), Some("ok"))
+  assert_eq(doctor_native_buffer_text_at_length(terminated, 1), None)
+  assert_eq(doctor_native_buffer_text_at_length(terminated, 3), None)
+  let unterminated : FixedArray[Byte] = [b'n', b'o']
+  assert_eq(doctor_native_buffer_text(unterminated), None)
+  assert_eq(doctor_native_buffer_text_at_length(unterminated, 2), None)
+}
+
+///|
+test "doctor renders native open ABI errors" {
+  let lines : Array[DoctorLine] = []
+  push_deep_runtime_probe_error(lines, AbiMismatch(7))
+  assert_eq(lines.length(), 1)
+  assert_eq(lines[0].code, "runtime.deep.abi_mismatch")
+  assert_eq(lines[0].text, "Proton ABI version mismatch: expected 1, got 7")
+  assert_true(lines[0].status == Error)
+}
+
+///|
+fn doctor_test_workspace_root() -> String {
+  let cwd = @path.Path(".").resolve().to_string()
+  match find_up(cwd, "moon.work") {
+    Some(path) => path_parent(path).unwrap_or(cwd)
+    None => abort("expected doctor tests to run inside the Proton workspace")
+  }
+}
+
+///|
+fn doctor_test_native_library_path(platform_id : String) -> String? {
+  match runtime_library_relative_path(platform_id) {
+    Some(relative) => {
+      let project = discover_project(doctor_test_workspace_root())
+      let (native_dist, manifest) = resolve_native_dist(project) catch {
+        error => abort(error.message())
+      }
+      match manifest {
+        Some(manifest) if manifest.platform != platform_id =>
+          abort(
+            "active Proton runtime platform mismatch: expected " +
+            platform_id +
+            ", got " +
+            manifest.platform,
+          )
+        _ => ()
+      }
+      let candidate = path_join(native_dist, relative)
+      guard @mbfs.path_exists(candidate) else {
+        abort(
+          "expected an active Proton runtime library at " +
+          candidate +
+          "; run `proton_cli cef setup` and build/install the native runtime",
+        )
+      }
+      Some(candidate)
+    }
+    None => None
+  }
+}
+
+///|
+async test "doctor native loader accepts UTF-8 library paths" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_library_path(platform_id) {
+    None => ()
+    Some(source_path) => {
+      let unicode_dir = "target/proton-doctor-中文路径"
+      ensure_test_dir(unicode_dir)
+      let relative_source = @path.Path(source_path)
+        .relative(base=@path.Path(".").resolve())
+        .to_string()
+      let library_path = path_join(
+        path_join(path_join(unicode_dir, ".."), ".."),
+        relative_source,
+      )
+      match doctor_native_open(library_path) {
+        Err(_) => abort("expected a Proton library at a UTF-8 path to open")
+        Ok(handle) =>
+          assert_eq(proton_doctor_native_close_ffi(handle), doctor_native_ok)
+      }
+    }
+  }
+}
+
+///|
+async test "doctor native loader closes an external handle safely" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_library_path(platform_id) {
+    None => ()
+    Some(library_path) => {
+      let opened = doctor_native_open(library_path)
+      match opened {
+        Err(_) => abort("expected the repository Proton library to open")
+        Ok(handle) => {
+          assert_eq(proton_doctor_native_close_ffi(handle), doctor_native_ok)
+          assert_eq(
+            proton_doctor_native_close_ffi(handle),
+            doctor_native_invalid_handle,
+          )
+          let required = Ref(0)
+          let scratch = FixedArray::make(1, b'\x00')
+          assert_eq(
+            proton_doctor_native_runtime_info_json_ffi(
+              handle, scratch, 0, required,
+            ),
+            doctor_native_invalid_handle,
+          )
+        }
+      }
+    }
+  }
+}
+
+///|
+async test "doctor native loader can abandon a handle safely" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_library_path(platform_id) {
+    None => ()
+    Some(library_path) =>
+      match doctor_native_open(library_path) {
+        Err(_) => abort("expected the active Proton library to open")
+        Ok(handle) => {
+          assert_eq(proton_doctor_native_abandon_ffi(handle), doctor_native_ok)
+          assert_eq(
+            proton_doctor_native_close_ffi(handle),
+            doctor_native_invalid_handle,
+          )
+          let required = Ref(0)
+          let scratch = FixedArray::make(1, b'\x00')
+          assert_eq(
+            proton_doctor_native_runtime_info_json_ffi(
+              handle, scratch, 0, required,
+            ),
+            doctor_native_invalid_handle,
+          )
+        }
+      }
+  }
+}
+
+///|
+async test "doctor native loader reports ABI mismatch before symbol use" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_native_library_path(platform_id) {
+    None => ()
+    Some(library_path) =>
+      match doctor_native_open_with_expected_abi(library_path, 999) {
+        Err(AbiMismatch(version)) =>
+          assert_eq(version, doctor_native_expected_abi_version)
+        Err(_) =>
+          abort(
+            "expected the repository Proton library to report an ABI mismatch",
+          )
+        Ok(handle) => {
+          let _ = proton_doctor_native_close_ffi(handle)
+          abort("expected ABI mismatch")
+        }
+      }
+  }
+}
+
+///|
+test "doctor native loader reports a missing library" {
+  match doctor_native_open("target/proton-doctor-library-does-not-exist") {
+    Err(LoadFailed(message)) => assert_true(message != "")
+    Err(_) => abort("expected a native library load error")
+    Ok(handle) => {
+      let _ = proton_doctor_native_close_ffi(handle)
+      abort("expected a native library load error")
+    }
+  }
+}
+
+///|
+fn doctor_test_system_library(platform_id : String) -> String? {
+  match platform_id {
+    "win32-x64" => Some("kernel32.dll")
+    "darwin-arm64" | "darwin-x64" => Some("/usr/lib/libSystem.B.dylib")
+    "linux-x64" => Some("libc.so.6")
+    _ => None
+  }
+}
+
+///|
+async test "doctor native loader reports a missing ABI symbol" {
+  let platform_id = @cef.current_platform_id()
+  match doctor_test_system_library(platform_id) {
+    None => ()
+    Some(library_path) =>
+      match doctor_native_open(library_path) {
+        Err(SymbolsMissing(message)) =>
+          assert_true(message.contains("proton_abi_version"))
+        Err(_) => abort("expected a missing proton_abi_version symbol")
+        Ok(handle) => {
+          let _ = proton_doctor_native_close_ffi(handle)
+          abort("expected a missing proton_abi_version symbol")
+        }
+      }
+  }
+}
+
+///|
 test "moon_config adapter reads module deps and package imports" {
   let dir = "target/proton-doctor-config"
   ensure_test_dir(dir)

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -19,6 +19,13 @@ fn ensure_test_project_root(path : String) -> String {
   ) catch {
     err => abort(@debug.render(@debug.to_repr(err)))
   }
+  @mbfs.write_string_to_file(
+    path_join(root, "moon.mod"),
+    "name = \"doctor-test-project\"\n",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
   root
 }
 
@@ -68,10 +75,11 @@ test "doctor resolves a relative native dist override" {
 }
 
 ///|
-test "doctor project boundary rejects parent paths" {
+test "doctor project boundary rejects outside paths" {
   let root = ensure_test_project_root("target/proton-doctor-boundary")
   let project = discover_project(root)
-  assert_true(project.moon_mod_path is None)
+  assert_eq(project.root, root)
+  assert_eq(project.moon_mod_path, Some(path_join(root, "moon.mod")))
   assert_true(project.moon_pkg_path is None)
   assert_true(path_is_within_project(project, path_join(root, "app.html")))
   assert_false(
@@ -80,6 +88,36 @@ test "doctor project boundary rejects parent paths" {
       @path.Path("target/outside.html").resolve().to_string(),
     ),
   )
+}
+
+///|
+test "doctor keeps package-local config in module context" {
+  let root = ensure_test_project_root("target/proton-doctor-package-config")
+  let package_dir = path_join(root, "desktop")
+  ensure_test_dir(package_dir)
+  @mbfs.write_string_to_file(
+    path_join(package_dir, "moon.proton"),
+    "",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  @mbfs.write_string_to_file(
+    path_join(package_dir, "moon.pkg"),
+    "",
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(@debug.to_repr(err)))
+  }
+  let project = discover_project(package_dir)
+  assert_eq(project.root, root)
+  assert_eq(project.moon_mod_path, Some(path_join(root, "moon.mod")))
+  assert_eq(
+    project.moon_proton_path,
+    Some(path_join(package_dir, "moon.proton")),
+  )
+  assert_eq(project.moon_pkg_path, Some(path_join(package_dir, "moon.pkg")))
+  assert_true(path_is_within_project(project, path_join(root, "frontend")))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- move doctor probe sequencing, buffer sizing, typed results, JSON decoding, and diagnostics from C into MoonBit
- keep the C bridge limited to cross-platform dynamic loading, symbol dispatch, and external-object cleanup
- normalize doctor runtime paths and preserve module roots for package-local `moon.proton` and `moon.pkg` files
- harden UTF-8 Windows loading, caller-owned text buffers, ABI mismatch handling, and runtime-info state validation
- add focused unit, integration, and native-loader regression coverage

## Validation

- `moon -C cli test --target native --diagnostic-limit 80` — 302/302
- `moon -C cli test doctor --target native --diagnostic-limit 80` — 37/37
- `moon -C proton test native --target native --diagnostic-limit 80` — 37/37
- `moon -C cli test codegen --target native` — 19/19
- `ctest --test-dir native/build-engine -C Debug --output-on-failure` — 2/2
- `moon check --target native`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C extensions test --target native`
- `moon -C e2e build --target native`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `node native/scripts/verify_link_config.mjs native/dist`
- `node scripts/verify_prebuilt_abi.mjs darwin-arm64`
- Clang warnings-as-errors, Clang static analyzer, and ASan/LSan loader/error-path coverage

## Notes

The runtime create/destroy path is covered by the normal deep-probe smoke test and CTest. CEF intentionally traps in the allocator-disabled ASan harness, so that specific engine path is not treated as an ASan failure.