### PR TITLE
chore: vendor six native binding modules into sys/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,15 @@ developer must perform them.
   design decision.
 - `cli/`: `justjavac/proton_cli`; independent native developer CLI module plus
   `cli/codegen/` and `cli/doctor/` helpers.
+- `extensions/`: `justjavac/proton_ext`; command extensions for examples and
+  applications. Platform capability extensions are backed by the bindings
+  under `sys/`.
+- `sys/<pkg>/`: independently maintained native system capability binding
+  modules (`justjavac/auto_launch`, `justjavac/clipboard`,
+  `justjavac/global_hotkey`, `justjavac/keepawake`, `justjavac/microphone`,
+  `justjavac/tray`). Each keeps its upstream module name, version lineage,
+  and MIT license, and is published from this repository. `justjavac/ffi`
+  remains an external dependency maintained upstream.
 - `examples/`: runnable demos. Keep [examples/Readme.md](examples/Readme.md)
   aligned with the actual examples.
 - `proton/prebuilt/<platform>/`: shipped Proton-only native artifacts. Do not
@@ -74,6 +83,7 @@ developer must perform them.
 - `moon -C cli test codegen --target native`
 - `node scripts/verify_generated.mjs`
 - `moon -C extensions test -p justjavac/proton_ext justjavac/proton_ext/auto_launch justjavac/proton_ext/clipboard justjavac/proton_ext/dialog justjavac/proton_ext/fs justjavac/proton_ext/global_hotkey justjavac/proton_ext/keepawake justjavac/proton_ext/metadata_check justjavac/proton_ext/microphone justjavac/proton_ext/notification justjavac/proton_ext/path justjavac/proton_ext/shell justjavac/proton_ext/tray --target native`
+- `moon test -p justjavac/auto_launch justjavac/clipboard justjavac/global_hotkey justjavac/keepawake justjavac/microphone justjavac/tray --target native`
 - `moon -C examples build --target native`
 - `moon -C e2e build --target native`
 - `moon fmt` or `moon fmt --check`
@@ -105,6 +115,11 @@ native checks before handing off larger refactors.
   `justjavac/proton`, then `justjavac/proton_cli`. For the currently prepared
   release, the chain is `proton_config 0.1.5` -> `proton 0.1.10` ->
   `proton_cli 0.1.7`.
+- The six binding modules under `sys/` keep their upstream module names and
+  are republished from this repository when their sources change. Since the
+  pinned versions already exist on Mooncakes, there is no hard publish-order
+  requirement for them; publish a bumped `sys/<pkg>` module before any
+  `justjavac/proton_ext` release that raises its requirement.
 - Before publishing, keep these values aligned:
   - `config/moon.mod` version;
   - the `justjavac/proton_config@...` requirements in `proton/moon.mod` and

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -12,7 +12,7 @@ import {
   "moonbitlang/async@0.20.1",
   "justjavac/ci@0.1.1",
   "justjavac/template@0.1.1",
-  "justjavac/ffi@0.2.1",
+  "justjavac/ffi@0.2.3",
 }
 
 readme = "codegen/README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -3,7 +3,7 @@ name = "justjavac/proton_ext"
 version = "0.1.7"
 
 import {
-  "justjavac/ffi@0.2.1",
+  "justjavac/ffi@0.2.3",
   "moonbitlang/x@0.4.43",
   "moonbitlang/async@0.20.0",
   "justjavac/clipboard@0.1.5",

--- a/moon.work
+++ b/moon.work
@@ -5,4 +5,10 @@ members = [
   "./examples",
   "./extensions",
   "./e2e",
+  "./sys/auto_launch",
+  "./sys/clipboard",
+  "./sys/global_hotkey",
+  "./sys/keepawake",
+  "./sys/microphone",
+  "./sys/tray",
 ]

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -3,7 +3,7 @@ name = "justjavac/proton"
 version = "0.1.12"
 
 import {
-  "justjavac/ffi@0.2.1",
+  "justjavac/ffi@0.2.3",
   "justjavac/proton_config@0.1.7",
   "moonbitlang/async@0.19.4",
   "moonbitlang/x@0.4.43",

--- a/sys/auto_launch/LICENSE
+++ b/sys/auto_launch/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justjavac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sys/auto_launch/README.mbt.md
+++ b/sys/auto_launch/README.mbt.md
@@ -1,0 +1,40 @@
+# justjavac/auto_launch
+
+[![CI](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+
+Cross-platform auto-launch helpers for MoonBit.
+
+## Example
+
+```mbt check
+///|
+test "public api can be called" {
+  ignore(@auto_launch.current_platform())
+  ignore(@auto_launch.is_supported())
+
+  let launcher = @auto_launch.new(
+    "MoonBit Demo",
+    path=match @auto_launch.current_platform() {
+      Windows => "C:\\Program Files\\MoonBit\\moonbit.exe"
+      Macos => "/Applications/MoonBit.app/Contents/MacOS/MoonBit"
+      Linux => "/usr/bin/moonbit"
+      Unsupported => "/unsupported"
+    },
+    launch_in_background=true,
+    extra_arguments=["--serve"],
+  )
+
+  match launcher {
+    Ok(value) => {
+      ignore(value.name())
+      ignore(value.path())
+      ignore(value.identifier())
+    }
+    Err(_) => ()
+  }
+}
+```

--- a/sys/auto_launch/README.md
+++ b/sys/auto_launch/README.md
@@ -1,0 +1,97 @@
+# justjavac/auto_launch
+
+[![CI](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+
+Cross-platform auto-launch helpers for MoonBit.
+
+This project is inspired by and references [Teamwork/node-auto-launch](https://github.com/Teamwork/node-auto-launch). The API shape, platform choices, and overall package direction in this repository were designed with that project as the main reference and source of inspiration.
+
+## Features
+
+- Windows: stores startup commands in `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
+- macOS: writes a LaunchAgent plist to `~/Library/LaunchAgents`
+- Linux: writes a desktop entry to `~/.config/autostart`
+- Optional hidden/background startup argument support
+- Small synchronous MoonBit API with `Result`-based error handling
+
+## Install
+
+```bash
+moon add justjavac/auto_launch
+```
+
+This package currently supports the `native` target.
+
+## Example
+
+```moonbit
+fn main {
+  let launcher = match @auto_launch.new(
+    "MoonBit Demo",
+    path=match @auto_launch.current_platform() {
+      Windows => "C:\\Program Files\\MoonBit\\moonbit.exe"
+      Macos => "/Applications/MoonBit.app/Contents/MacOS/MoonBit"
+      Linux => "/usr/bin/moonbit"
+      Unsupported => "/unsupported"
+    },
+    launch_in_background=true,
+    extra_arguments=["--serve"],
+  ) {
+    Ok(value) => value
+    Err(error) => fail("failed to create launcher: \{error}")
+  }
+
+  match launcher.enable() {
+    Ok(_) => println("auto-launch enabled")
+    Err(error) => println("enable failed: \{error}")
+  }
+}
+```
+
+## API
+
+- `@auto_launch.current_platform() -> Platform`
+- `@auto_launch.is_supported() -> Bool`
+- `@auto_launch.new(...) -> Result[AutoLaunch, AutoLaunchError]`
+- `AutoLaunch::name() -> String`
+- `AutoLaunch::path() -> String`
+- `AutoLaunch::identifier() -> String`
+- `AutoLaunch::enable() -> Result[Unit, AutoLaunchError]`
+- `AutoLaunch::disable() -> Result[Unit, AutoLaunchError]`
+- `AutoLaunch::is_enabled() -> Result[Bool, AutoLaunchError]`
+
+## Testing
+
+```bash
+moon fmt
+moon check --target native
+moon test --target native
+
+# Coverage for the main package only; excludes src/examples/*
+moon test --target native --enable-coverage
+moon coverage analyze -p justjavac/auto_launch -- -f summary
+moon info --target native
+```
+
+Optional side-effect integration test:
+
+```bash
+$env:MOONBIT_AUTO_LAUNCH_RUN_INTEGRATION_TESTS = "1"
+moon test --target native --filter "integration*"
+```
+
+## Examples
+
+```bash
+moon run src/examples/check_status --target native
+moon run src/examples/enable --target native
+moon run src/examples/disable --target native
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/sys/auto_launch/auto_launch.mbt
+++ b/sys/auto_launch/auto_launch.mbt
@@ -1,0 +1,225 @@
+///|
+/// Normalizes constructor inputs and supports dependency injection in tests.
+fn require_supported_platform(
+  platform : Platform,
+) -> Result[Unit, AutoLaunchError] {
+  if backend_for_platform(platform) == BackendKind::UnsupportedBackend {
+    Err(AutoLaunchError::UnsupportedPlatform(platform))
+  } else {
+    Ok(())
+  }
+}
+
+///|
+/// Trims caller input and rejects empty values with a typed validation error.
+fn require_non_empty_text(
+  text : String,
+  empty_error : AutoLaunchError,
+) -> Result[String, AutoLaunchError] {
+  let trimmed = trim_text(text)
+  if trimmed.is_empty() {
+    Err(empty_error)
+  } else {
+    Ok(trimmed)
+  }
+}
+
+///|
+/// Resolves the executable path from explicit input or the runtime probe.
+fn resolve_executable_path(
+  path : String?,
+  get_current_executable_path~ : () -> Result[String, AutoLaunchError],
+) -> Result[String, AutoLaunchError] {
+  match path {
+    Some(explicit_path) =>
+      require_non_empty_text(
+        explicit_path,
+        AutoLaunchError::EmptyExecutablePath,
+      )
+    None => get_current_executable_path()
+  }
+}
+
+///|
+/// Normalizes constructor inputs and supports dependency injection in tests.
+fn new_with(
+  platform : Platform,
+  name : String,
+  path : String?,
+  launch_in_background : Bool,
+  background_arg : String,
+  extra_arguments : Array[String],
+  identifier : String?,
+  get_current_executable_path~ : () -> Result[String, AutoLaunchError],
+) -> Result[AutoLaunch, AutoLaunchError] {
+  match require_supported_platform(platform) {
+    Ok(_) => ()
+    Err(error) => return Err(error)
+  }
+
+  let trimmed_name = match
+    require_non_empty_text(name, AutoLaunchError::EmptyName) {
+    Ok(value) => value
+    Err(error) => return Err(error)
+  }
+
+  let trimmed_background_arg = trim_text(background_arg)
+  if launch_in_background && trimmed_background_arg.is_empty() {
+    return Err(AutoLaunchError::EmptyBackgroundArgument)
+  }
+
+  let resolved_path = match
+    resolve_executable_path(path, get_current_executable_path~) {
+    Ok(value) => value
+    Err(error) => return Err(error)
+  }
+
+  if !is_absolute_path(platform, resolved_path) {
+    return Err(AutoLaunchError::RelativeExecutablePath(resolved_path))
+  }
+
+  Ok(AutoLaunch::{
+    config: {
+      name: trimmed_name,
+      app_path: resolved_path,
+      identifier: default_identifier(trimmed_name, identifier),
+      launch_in_background,
+      background_arg: trimmed_background_arg,
+      extra_arguments,
+    },
+  })
+}
+
+///|
+/// Create an auto-launch configuration for the current platform.
+///
+/// `name` is the human-readable application name shown in generated desktop
+/// entries. `path` defaults to the current executable path when omitted.
+///
+/// When `launch_in_background` is `true`, the package appends
+/// `background_arg` before any `extra_arguments`. This mirrors the common
+/// `--hidden` startup convention used by desktop applications.
+///
+/// `identifier` controls the stable registry value or file name used by the
+/// backend. When omitted, it is derived from `name`.
+///
+/// Returns `Err(AutoLaunchError)` when validation fails, when the current
+/// platform is unsupported, or when the executable path cannot be discovered.
+///
+/// The resulting value is reusable: you can keep it around and call
+/// `enable()`, `disable()`, and `is_enabled()` multiple times.
+///
+/// # Example
+/// ```mbt nocheck
+/// let launcher = @auto_launch.new(
+///   "MoonBit Demo",
+///   path="/usr/bin/moonbit",
+///   launch_in_background=true,
+///   extra_arguments=["--serve"],
+/// )
+/// ```
+pub fn new(
+  name : String,
+  path? : String,
+  launch_in_background? : Bool = false,
+  background_arg? : String = "--hidden",
+  extra_arguments? : Array[String] = [],
+  identifier? : String,
+) -> Result[AutoLaunch, AutoLaunchError] {
+  new_with(
+    current_platform(),
+    name,
+    path,
+    launch_in_background,
+    background_arg,
+    extra_arguments,
+    identifier,
+    get_current_executable_path=current_executable_path_result,
+  )
+}
+
+///|
+/// Returns the configured human-readable application name.
+///
+/// This is the display name used in generated desktop-entry style metadata. It
+/// may contain spaces and punctuation and is independent from the backend
+/// identifier used for file names or registry keys.
+pub fn AutoLaunch::name(self : AutoLaunch) -> String {
+  self.config.name
+}
+
+///|
+/// Returns the resolved absolute executable path that will be launched.
+///
+/// The value returned here is always the normalized absolute path that passed
+/// constructor validation, either from the explicit `path` argument or from the
+/// current executable path discovered by the native backend.
+pub fn AutoLaunch::path(self : AutoLaunch) -> String {
+  self.config.app_path
+}
+
+///|
+/// Returns the stable backend identifier used for the registry value or file
+/// name.
+///
+/// This value is derived from `name` unless the caller provided `identifier`
+/// explicitly. It is sanitized for backend-safe usage and is what ties
+/// `enable()`, `disable()`, and `is_enabled()` to the same platform entry.
+pub fn AutoLaunch::identifier(self : AutoLaunch) -> String {
+  self.config.identifier
+}
+
+///|
+/// Enable auto-launch for this configuration on the current platform.
+///
+/// On supported platforms this creates or updates the corresponding startup
+/// entry:
+///
+/// - Windows: writes the current-user `Run` registry value
+/// - macOS: writes a LaunchAgent plist under `~/Library/LaunchAgents`
+/// - Linux: writes an XDG autostart desktop entry under
+///   `~/.config/autostart`
+///
+/// Returns `Ok(())` when the entry was written successfully.
+pub fn AutoLaunch::enable(self : AutoLaunch) -> Result[Unit, AutoLaunchError] {
+  enable_with(
+    self,
+    current_platform(),
+    home_directory_result,
+    windows_set_run_entry_result,
+    write_text_file_result,
+  )
+}
+
+///|
+/// Disable auto-launch for this configuration on the current platform.
+///
+/// Missing entries are treated as already-disabled and therefore do not produce
+/// an error in the native backend.
+pub fn AutoLaunch::disable(self : AutoLaunch) -> Result[Unit, AutoLaunchError] {
+  disable_with(
+    self,
+    current_platform(),
+    home_directory_result,
+    windows_delete_run_entry_result,
+    remove_file_result,
+  )
+}
+
+///|
+/// Check whether the auto-launch entry currently exists for this configuration.
+///
+/// This is an existence check against the backend entry identified by
+/// `identifier()`. It does not attempt to prove that the entry still contains
+/// the exact expected command line beyond the backend's own lookup semantics.
+pub fn AutoLaunch::is_enabled(
+  self : AutoLaunch,
+) -> Result[Bool, AutoLaunchError] {
+  is_enabled_with(
+    self,
+    current_platform(),
+    home_directory_result,
+    windows_run_entry_exists_result,
+    file_exists_result,
+  )
+}

--- a/sys/auto_launch/auto_launch_integration_test.mbt
+++ b/sys/auto_launch/auto_launch_integration_test.mbt
@@ -1,0 +1,85 @@
+///|
+/// Returns whether `value` should enable integration-test execution.
+fn is_truthy_env_value(value : String?) -> Bool {
+  match value {
+    Some("1") => true
+    Some("true") => true
+    Some("yes") => true
+    Some("on") => true
+    _ => false
+  }
+}
+
+///|
+/// Reads the integration-test toggle from the process environment.
+fn integration_tests_enabled() -> Bool {
+  is_truthy_env_value(
+    @env.get_env_var("MOONBIT_AUTO_LAUNCH_RUN_INTEGRATION_TESTS"),
+  )
+}
+
+///|
+/// Returns a safe, platform-specific executable path for integration tests.
+fn stable_test_path(platform : Platform) -> String {
+  match platform {
+    Platform::Windows => "C:\\Windows\\System32\\notepad.exe"
+    Platform::Macos => "/usr/bin/true"
+    Platform::Linux => "/bin/true"
+    Platform::Unsupported => "/unsupported"
+  }
+}
+
+///|
+/// Builds the launcher instance shared by the integration roundtrip test.
+fn new_integration_test_launcher() -> Result[AutoLaunch, AutoLaunchError] {
+  let platform = @auto_launch.current_platform()
+  @auto_launch.new(
+    "MoonBit Auto Launch Integration Test",
+    path=stable_test_path(platform),
+    identifier="moonbit-auto-launch-integration-test",
+  )
+}
+
+///|
+/// Verifies the real backend can enable, query, and disable one launcher entry.
+test "integration enable disable roundtrip" {
+  guard integration_tests_enabled() else { return }
+  guard @auto_launch.is_supported() else {
+    fail("integration tests were enabled on an unsupported platform")
+  }
+
+  let launcher = match new_integration_test_launcher() {
+    Ok(value) => value
+    Err(error) => fail("failed to build launcher: \{error}")
+  }
+
+  ignore(launcher.disable())
+
+  match launcher.is_enabled() {
+    Ok(false) => ()
+    Ok(true) => fail("launcher should be disabled after cleanup")
+    Err(error) => fail("failed to query initial auto-launch state: \{error}")
+  }
+
+  match launcher.enable() {
+    Ok(_) => ()
+    Err(error) => fail("failed to enable auto-launch: \{error}")
+  }
+
+  match launcher.is_enabled() {
+    Ok(true) => ()
+    Ok(false) => fail("launcher should be enabled after enable()")
+    Err(error) => fail("failed to query enabled auto-launch state: \{error}")
+  }
+
+  match launcher.disable() {
+    Ok(_) => ()
+    Err(error) => fail("failed to disable auto-launch: \{error}")
+  }
+
+  match launcher.is_enabled() {
+    Ok(false) => ()
+    Ok(true) => fail("launcher should be disabled after disable()")
+    Err(error) => fail("failed to query disabled auto-launch state: \{error}")
+  }
+}

--- a/sys/auto_launch/auto_launch_native.c
+++ b/sys/auto_launch/auto_launch_native.c
@@ -1,0 +1,615 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "moonbit.h"
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "advapi32.lib")
+#endif
+#else
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define MB_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define MB_THREAD_LOCAL _Thread_local
+#else
+#define MB_THREAD_LOCAL
+#endif
+
+#define MB_STATUS_OK 0
+#define MB_STATUS_ERROR -1
+
+static MB_THREAD_LOCAL int32_t mb_last_error_code = 0;
+static MB_THREAD_LOCAL char mb_last_error_message[1024] = "";
+
+static void mb_set_error(int32_t code, const char *message) {
+  mb_last_error_code = code;
+  if (message == NULL) {
+    mb_last_error_message[0] = '\0';
+    return;
+  }
+  snprintf(mb_last_error_message, sizeof(mb_last_error_message), "%s", message);
+}
+
+static void mb_clear_error(void) {
+  mb_set_error(0, "");
+}
+
+static moonbit_bytes_t mb_make_bytes_from_buffer(const char *buf, size_t len) {
+  moonbit_bytes_t out = moonbit_make_bytes((int32_t)len, 0);
+  if (len > 0) {
+    memcpy(out, buf, len);
+  }
+  return out;
+}
+
+static char *mb_bytes_to_c_string(moonbit_bytes_t bytes) {
+  size_t len = (size_t)Moonbit_array_length(bytes);
+  char *buffer = (char *)malloc(len + 1);
+  if (buffer == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memcpy(buffer, bytes, len);
+  }
+  buffer[len] = '\0';
+  return buffer;
+}
+
+#ifdef _WIN32
+static void mb_set_windows_error(DWORD code, const char *fallback) {
+  char message[512] = "";
+  DWORD flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
+  DWORD len = FormatMessageA(
+    flags,
+    NULL,
+    code,
+    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    message,
+    (DWORD)sizeof(message),
+    NULL
+  );
+  if (len == 0) {
+    mb_set_error((int32_t)code, fallback);
+    return;
+  }
+
+  while (len > 0 &&
+         (message[len - 1] == '\r' || message[len - 1] == '\n' || message[len - 1] == ' ')) {
+    message[len - 1] = '\0';
+    len--;
+  }
+  mb_set_error((int32_t)code, message);
+}
+
+static wchar_t *mb_utf8_to_wide(const char *value) {
+  if (value == NULL) {
+    return NULL;
+  }
+  int length = MultiByteToWideChar(CP_UTF8, 0, value, -1, NULL, 0);
+  if (length <= 0) {
+    return NULL;
+  }
+  wchar_t *wide = (wchar_t *)malloc((size_t)length * sizeof(wchar_t));
+  if (wide == NULL) {
+    return NULL;
+  }
+  if (MultiByteToWideChar(CP_UTF8, 0, value, -1, wide, length) <= 0) {
+    free(wide);
+    return NULL;
+  }
+  return wide;
+}
+
+static wchar_t *mb_bytes_to_wide_string(
+  moonbit_bytes_t bytes,
+  const char *allocation_error,
+  const char *conversion_error
+) {
+  char *utf8_value = mb_bytes_to_c_string(bytes);
+  wchar_t *wide_value = NULL;
+
+  if (utf8_value == NULL) {
+    mb_set_error(ENOMEM, allocation_error);
+    return NULL;
+  }
+
+  wide_value = mb_utf8_to_wide(utf8_value);
+  free(utf8_value);
+
+  if (wide_value == NULL) {
+    mb_set_error(ERROR_INVALID_DATA, conversion_error);
+    return NULL;
+  }
+
+  return wide_value;
+}
+
+static moonbit_bytes_t mb_wide_to_bytes(const wchar_t *value) {
+  if (value == NULL) {
+    return moonbit_make_bytes(0, 0);
+  }
+  int length = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
+  if (length <= 0) {
+    return moonbit_make_bytes(0, 0);
+  }
+  char *buffer = (char *)malloc((size_t)length);
+  if (buffer == NULL) {
+    return moonbit_make_bytes(0, 0);
+  }
+  if (WideCharToMultiByte(CP_UTF8, 0, value, -1, buffer, length, NULL, NULL) <= 0) {
+    free(buffer);
+    return moonbit_make_bytes(0, 0);
+  }
+  moonbit_bytes_t out = mb_make_bytes_from_buffer(buffer, (size_t)(length - 1));
+  free(buffer);
+  return out;
+}
+
+static HKEY mb_open_run_key(REGSAM access) {
+  static const wchar_t subkey[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+  HKEY key = NULL;
+  LONG status = RegCreateKeyExW(
+    HKEY_CURRENT_USER,
+    subkey,
+    0,
+    NULL,
+    REG_OPTION_NON_VOLATILE,
+    access,
+    NULL,
+    &key,
+    NULL
+  );
+  if (status != ERROR_SUCCESS) {
+    mb_set_windows_error((DWORD)status, "Failed to open Windows Run registry key");
+    return NULL;
+  }
+  return key;
+}
+#endif
+
+static int mb_ensure_parent_directory(const char *path) {
+  char *copy = NULL;
+  size_t len = 0;
+  size_t i = 0;
+
+  if (path == NULL) {
+    return MB_STATUS_ERROR;
+  }
+
+  len = strlen(path);
+  copy = (char *)malloc(len + 1);
+  if (copy == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate directory buffer");
+    return MB_STATUS_ERROR;
+  }
+
+  memcpy(copy, path, len + 1);
+
+  for (i = 1; i < len; i++) {
+    if (copy[i] != '/' && copy[i] != '\\') {
+      continue;
+    }
+
+    if (i == 2 && copy[1] == ':') {
+      continue;
+    }
+
+    copy[i] = '\0';
+    if (copy[0] != '\0') {
+#ifdef _WIN32
+      if (_mkdir(copy) != 0 && errno != EEXIST) {
+#else
+      if (mkdir(copy, 0777) != 0 && errno != EEXIST) {
+#endif
+        mb_set_error(errno, "Failed to create parent directory");
+        free(copy);
+        return MB_STATUS_ERROR;
+      }
+    }
+    copy[i] = path[i];
+  }
+
+  free(copy);
+  return MB_STATUS_OK;
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_platform_code(void) {
+#ifdef _WIN32
+  return 1;
+#elif defined(__APPLE__)
+  return 2;
+#elif defined(__linux__)
+  return 3;
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_auto_launch_current_executable_path(void) {
+#ifdef _WIN32
+  DWORD size = MAX_PATH;
+  wchar_t *buffer = NULL;
+
+  while (1) {
+    buffer = (wchar_t *)malloc((size_t)size * sizeof(wchar_t));
+    if (buffer == NULL) {
+      mb_set_error(ENOMEM, "Failed to allocate executable path buffer");
+      return moonbit_make_bytes(0, 0);
+    }
+
+    DWORD written = GetModuleFileNameW(NULL, buffer, size);
+    if (written == 0) {
+      free(buffer);
+      mb_set_windows_error(GetLastError(), "Failed to get current executable path");
+      return moonbit_make_bytes(0, 0);
+    }
+
+    if (written < size - 1) {
+      moonbit_bytes_t out = mb_wide_to_bytes(buffer);
+      free(buffer);
+      mb_clear_error();
+      return out;
+    }
+
+    free(buffer);
+    size *= 2;
+  }
+#elif defined(__APPLE__)
+  uint32_t size = 0;
+  _NSGetExecutablePath(NULL, &size);
+  char *buffer = (char *)malloc((size_t)size + 1);
+  if (buffer == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate executable path buffer");
+    return moonbit_make_bytes(0, 0);
+  }
+  if (_NSGetExecutablePath(buffer, &size) != 0) {
+    free(buffer);
+    mb_set_error(errno, "Failed to get current executable path");
+    return moonbit_make_bytes(0, 0);
+  }
+  buffer[size] = '\0';
+  mb_clear_error();
+  moonbit_bytes_t out = mb_make_bytes_from_buffer(buffer, strlen(buffer));
+  free(buffer);
+  return out;
+#elif defined(__linux__)
+  char buffer[PATH_MAX];
+  ssize_t length = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+  if (length < 0) {
+    mb_set_error(errno, "Failed to get current executable path");
+    return moonbit_make_bytes(0, 0);
+  }
+  buffer[length] = '\0';
+  mb_clear_error();
+  return mb_make_bytes_from_buffer(buffer, (size_t)length);
+#else
+  mb_set_error(ENOSYS, "Executable path lookup is unsupported on this platform");
+  return moonbit_make_bytes(0, 0);
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_auto_launch_home_directory(void) {
+#ifdef _WIN32
+  DWORD size = GetEnvironmentVariableW(L"USERPROFILE", NULL, 0);
+  if (size == 0) {
+    mb_set_windows_error(GetLastError(), "Failed to read USERPROFILE");
+    return moonbit_make_bytes(0, 0);
+  }
+
+  wchar_t *buffer = (wchar_t *)malloc((size_t)size * sizeof(wchar_t));
+  if (buffer == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate home directory buffer");
+    return moonbit_make_bytes(0, 0);
+  }
+
+  if (GetEnvironmentVariableW(L"USERPROFILE", buffer, size) == 0) {
+    free(buffer);
+    mb_set_windows_error(GetLastError(), "Failed to read USERPROFILE");
+    return moonbit_make_bytes(0, 0);
+  }
+
+  moonbit_bytes_t out = mb_wide_to_bytes(buffer);
+  free(buffer);
+  mb_clear_error();
+  return out;
+#else
+  const char *home = getenv("HOME");
+  if (home == NULL || *home == '\0') {
+    mb_set_error(errno == 0 ? ENOENT : errno, "Failed to read HOME");
+    return moonbit_make_bytes(0, 0);
+  }
+  mb_clear_error();
+  return mb_make_bytes_from_buffer(home, strlen(home));
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_write_text_file(moonbit_bytes_t path, moonbit_bytes_t contents) {
+  char *file_path = mb_bytes_to_c_string(path);
+  char *text = NULL;
+  size_t length = (size_t)Moonbit_array_length(contents);
+  FILE *file = NULL;
+
+  if (file_path == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate file path buffer");
+    return MB_STATUS_ERROR;
+  }
+
+  text = (char *)malloc(length + 1);
+  if (text == NULL) {
+    free(file_path);
+    mb_set_error(ENOMEM, "Failed to allocate file contents buffer");
+    return MB_STATUS_ERROR;
+  }
+  if (length > 0) {
+    memcpy(text, contents, length);
+  }
+  text[length] = '\0';
+
+  if (mb_ensure_parent_directory(file_path) != MB_STATUS_OK) {
+    free(text);
+    free(file_path);
+    return MB_STATUS_ERROR;
+  }
+
+  file = fopen(file_path, "wb");
+  if (file == NULL) {
+    mb_set_error(errno, "Failed to open output file");
+    free(text);
+    free(file_path);
+    return MB_STATUS_ERROR;
+  }
+
+  if (length > 0 && fwrite(text, 1, length, file) != length) {
+    mb_set_error(errno, "Failed to write output file");
+    fclose(file);
+    free(text);
+    free(file_path);
+    return MB_STATUS_ERROR;
+  }
+
+  fclose(file);
+  free(text);
+  free(file_path);
+  mb_clear_error();
+  return MB_STATUS_OK;
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_remove_file(moonbit_bytes_t path) {
+  char *file_path = mb_bytes_to_c_string(path);
+  if (file_path == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate file path buffer");
+    return MB_STATUS_ERROR;
+  }
+
+  if (remove(file_path) != 0) {
+    if (errno == ENOENT) {
+      free(file_path);
+      mb_clear_error();
+      return MB_STATUS_OK;
+    }
+    mb_set_error(errno, "Failed to remove file");
+    free(file_path);
+    return MB_STATUS_ERROR;
+  }
+
+  free(file_path);
+  mb_clear_error();
+  return MB_STATUS_OK;
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_file_exists(moonbit_bytes_t path) {
+  char *file_path = mb_bytes_to_c_string(path);
+  FILE *file = NULL;
+
+  if (file_path == NULL) {
+    mb_set_error(ENOMEM, "Failed to allocate file path buffer");
+    return MB_STATUS_ERROR;
+  }
+
+  file = fopen(file_path, "rb");
+  if (file == NULL) {
+    if (errno == ENOENT) {
+      free(file_path);
+      mb_clear_error();
+      return 0;
+    }
+    mb_set_error(errno, "Failed to check file existence");
+    free(file_path);
+    return MB_STATUS_ERROR;
+  }
+
+  fclose(file);
+  free(file_path);
+  mb_clear_error();
+  return 1;
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_windows_set_run_entry(moonbit_bytes_t name, moonbit_bytes_t command) {
+#ifdef _WIN32
+  wchar_t *wide_name = NULL;
+  wchar_t *wide_command = NULL;
+  HKEY key = NULL;
+  LONG status = ERROR_SUCCESS;
+
+  wide_name = mb_bytes_to_wide_string(
+    name,
+    "Failed to allocate registry entry name",
+    "Failed to convert registry entry name to UTF-16"
+  );
+  wide_command = mb_bytes_to_wide_string(
+    command,
+    "Failed to allocate registry entry command",
+    "Failed to convert registry entry command to UTF-16"
+  );
+
+  if (wide_name == NULL || wide_command == NULL) {
+    free(wide_name);
+    free(wide_command);
+    return MB_STATUS_ERROR;
+  }
+
+  key = mb_open_run_key(KEY_SET_VALUE);
+  if (key == NULL) {
+    free(wide_name);
+    free(wide_command);
+    return MB_STATUS_ERROR;
+  }
+
+  status = RegSetValueExW(
+    key,
+    wide_name,
+    0,
+    REG_SZ,
+    (const BYTE *)wide_command,
+    (DWORD)((wcslen(wide_command) + 1) * sizeof(wchar_t))
+  );
+
+  RegCloseKey(key);
+  free(wide_name);
+  free(wide_command);
+
+  if (status != ERROR_SUCCESS) {
+    mb_set_windows_error((DWORD)status, "Failed to write Windows Run registry value");
+    return MB_STATUS_ERROR;
+  }
+
+  mb_clear_error();
+  return MB_STATUS_OK;
+#else
+  (void)name;
+  (void)command;
+  mb_set_error(ENOSYS, "Windows Run registry is unavailable on this platform");
+  return MB_STATUS_ERROR;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_windows_delete_run_entry(moonbit_bytes_t name) {
+#ifdef _WIN32
+  wchar_t *wide_name = mb_bytes_to_wide_string(
+    name,
+    "Failed to allocate registry entry name",
+    "Failed to convert registry entry name to UTF-16"
+  );
+  HKEY key = NULL;
+  LONG status = ERROR_SUCCESS;
+
+  if (wide_name == NULL) {
+    return MB_STATUS_ERROR;
+  }
+
+  key = mb_open_run_key(KEY_SET_VALUE);
+  if (key == NULL) {
+    free(wide_name);
+    return MB_STATUS_ERROR;
+  }
+
+  status = RegDeleteValueW(key, wide_name);
+  RegCloseKey(key);
+  free(wide_name);
+
+  if (status == ERROR_FILE_NOT_FOUND) {
+    mb_clear_error();
+    return MB_STATUS_OK;
+  }
+  if (status != ERROR_SUCCESS) {
+    mb_set_windows_error((DWORD)status, "Failed to delete Windows Run registry value");
+    return MB_STATUS_ERROR;
+  }
+
+  mb_clear_error();
+  return MB_STATUS_OK;
+#else
+  (void)name;
+  mb_set_error(ENOSYS, "Windows Run registry is unavailable on this platform");
+  return MB_STATUS_ERROR;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_windows_run_entry_exists(moonbit_bytes_t name) {
+#ifdef _WIN32
+  wchar_t *wide_name = mb_bytes_to_wide_string(
+    name,
+    "Failed to allocate registry entry name",
+    "Failed to convert registry entry name to UTF-16"
+  );
+  HKEY key = NULL;
+  DWORD type = 0;
+  DWORD size = 0;
+  LONG status = ERROR_SUCCESS;
+
+  if (wide_name == NULL) {
+    return MB_STATUS_ERROR;
+  }
+
+  key = mb_open_run_key(KEY_QUERY_VALUE);
+  if (key == NULL) {
+    free(wide_name);
+    return MB_STATUS_ERROR;
+  }
+
+  status = RegQueryValueExW(key, wide_name, NULL, &type, NULL, &size);
+  RegCloseKey(key);
+  free(wide_name);
+
+  if (status == ERROR_FILE_NOT_FOUND) {
+    mb_clear_error();
+    return 0;
+  }
+  if (status != ERROR_SUCCESS) {
+    mb_set_windows_error((DWORD)status, "Failed to query Windows Run registry value");
+    return MB_STATUS_ERROR;
+  }
+  if (type != REG_SZ && type != REG_EXPAND_SZ) {
+    mb_clear_error();
+    return 0;
+  }
+
+  mb_clear_error();
+  return 1;
+#else
+  (void)name;
+  mb_set_error(ENOSYS, "Windows Run registry is unavailable on this platform");
+  return MB_STATUS_ERROR;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_auto_launch_last_error_code(void) {
+  return mb_last_error_code;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_auto_launch_last_error_message(void) {
+  return mb_make_bytes_from_buffer(mb_last_error_message, strlen(mb_last_error_message));
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_auto_launch_test_getenv(moonbit_bytes_t name) {
+  char *key = mb_bytes_to_c_string(name);
+  const char *value = NULL;
+
+  if (key == NULL) {
+    return moonbit_make_bytes(0, 0);
+  }
+
+  value = getenv(key);
+  free(key);
+
+  if (value == NULL) {
+    return moonbit_make_bytes(0, 0);
+  }
+
+  return mb_make_bytes_from_buffer(value, strlen(value));
+}

--- a/sys/auto_launch/auto_launch_test.mbt
+++ b/sys/auto_launch/auto_launch_test.mbt
@@ -1,0 +1,137 @@
+///|
+/// Verifies that the public library symbols remain available to downstream callers.
+test "public api symbols are exported" {
+  ignore(@auto_launch.current_platform)
+  ignore(@auto_launch.is_supported)
+  ignore(@auto_launch.AutoLaunch::name)
+  ignore(@auto_launch.AutoLaunch::path)
+  ignore(@auto_launch.AutoLaunch::identifier)
+  ignore(@auto_launch.AutoLaunch::enable)
+  ignore(@auto_launch.AutoLaunch::disable)
+  ignore(@auto_launch.AutoLaunch::is_enabled)
+}
+
+///|
+/// Returns a stable sample executable path for public API tests on `platform`.
+fn sample_public_app_path(platform : Platform) -> String {
+  match platform {
+    Windows => "C:\\Program Files\\MoonBit\\moonbit.exe"
+    Macos => "/Applications/MoonBit.app/Contents/MacOS/MoonBit"
+    Linux => "/usr/bin/moonbit"
+    Unsupported => "/unsupported"
+  }
+}
+
+///|
+/// Builds a launcher with predictable defaults for black-box API tests.
+fn new_public_test_launcher(
+  identifier : String,
+  name? : String = "MoonBit Auto Launch",
+  path? : String,
+  launch_in_background? : Bool = false,
+  extra_arguments? : Array[String] = [],
+) -> Result[AutoLaunch, AutoLaunchError] {
+  let platform = @auto_launch.current_platform()
+  let resolved_path = match path {
+    Some(value) => value
+    None => sample_public_app_path(platform)
+  }
+  @auto_launch.new(
+    name,
+    path=resolved_path,
+    launch_in_background~,
+    extra_arguments~,
+    identifier~,
+  )
+}
+
+///|
+/// Ensures the public constructor rejects empty application names.
+test "new validates empty names" {
+  match @auto_launch.new("") {
+    Err(EmptyName) => ()
+    _ => fail("expected EmptyName")
+  }
+  match @auto_launch.new("   ") {
+    Err(EmptyName) => ()
+    _ => fail("expected EmptyName")
+  }
+}
+
+///|
+/// Ensures the public constructor rejects relative explicit executable paths.
+test "new validates relative explicit paths" {
+  match @auto_launch.new("Auto Launch", path="relative/path") {
+    Err(RelativeExecutablePath(path)) => assert_eq(path, "relative/path")
+    _ => fail("expected RelativeExecutablePath")
+  }
+}
+
+///|
+/// Ensures launcher creation succeeds on supported platforms with valid input.
+test "new creates a launcher on supported platforms" {
+  guard @auto_launch.is_supported() else { return }
+
+  let launcher = match
+    new_public_test_launcher("moonbit-auto-launch", launch_in_background=true, extra_arguments=[
+      "--verbose",
+    ]) {
+    Ok(value) => value
+    Err(error) => fail("expected launcher creation to succeed: \{error}")
+  }
+
+  assert_eq(launcher.name(), "MoonBit Auto Launch")
+  assert_eq(launcher.identifier(), "moonbit-auto-launch")
+}
+
+///|
+/// Ensures runtime platform detection and support reporting stay consistent.
+test "current platform and support flag stay in sync" {
+  match (@auto_launch.current_platform(), @auto_launch.is_supported()) {
+    (Unsupported, false) => ()
+    (Windows, true) => ()
+    (Macos, true) => ()
+    (Linux, true) => ()
+    _ => fail("platform support detection should stay consistent")
+  }
+}
+
+///|
+/// Exercises the public enable-disable roundtrip on Windows startup entries.
+test "public methods can roundtrip a windows startup entry" {
+  guard @auto_launch.current_platform() is Windows else { return }
+
+  let launcher = match
+    new_public_test_launcher(
+      "moonbit-auto-launch-public-roundtrip-test",
+      name="MoonBit Auto Launch Public Roundtrip Test",
+      path="C:\\Windows\\System32\\notepad.exe",
+    ) {
+    Ok(value) => value
+    Err(error) => fail("expected launcher creation to succeed: \{error}")
+  }
+
+  ignore(launcher.disable())
+
+  match launcher.enable() {
+    Ok(_) => ()
+    Err(error) => fail("failed to enable auto-launch: \{error}")
+  }
+
+  match launcher.is_enabled() {
+    Ok(true) => ()
+    Ok(false) => fail("launcher should be enabled after enable()")
+    Err(error) => fail("failed to query enabled state: \{error}")
+  }
+
+  match launcher.disable() {
+    Ok(_) => ()
+    Err(error) => fail("failed to disable auto-launch: \{error}")
+  }
+
+  match launcher.is_enabled() {
+    Ok(false) => ()
+    Ok(true) => fail("launcher should be disabled after disable()")
+    Err(error) => fail("failed to query disabled state: \{error}")
+  }
+}

--- a/sys/auto_launch/auto_launch_wbtest.mbt
+++ b/sys/auto_launch/auto_launch_wbtest.mbt
@@ -1,0 +1,683 @@
+///|
+/// Builds a reusable configuration record for white-box rendering and dispatch tests.
+fn sample_config(
+  name? : String = "MoonBit App",
+  app_path? : String = "/usr/bin/moonbit",
+  identifier? : String = "moonbit-app",
+  launch_in_background? : Bool = false,
+  background_arg? : String = "--hidden",
+  extra_arguments? : Array[String] = [],
+) -> AutoLaunchConfig {
+  {
+    name,
+    app_path,
+    identifier,
+    launch_in_background,
+    background_arg,
+    extra_arguments,
+  }
+}
+
+///|
+/// Builds a reusable launcher value for white-box behavior tests.
+fn sample_launcher(
+  name? : String = "MoonBit App",
+  app_path? : String = "/usr/bin/moonbit",
+  identifier? : String = "moonbit-app",
+  launch_in_background? : Bool = false,
+  background_arg? : String = "--hidden",
+  extra_arguments? : Array[String] = [],
+) -> AutoLaunch {
+  AutoLaunch::{
+    config: sample_config(
+      name~,
+      app_path~,
+      identifier~,
+      launch_in_background~,
+      background_arg~,
+      extra_arguments~,
+    ),
+  }
+}
+
+///|
+/// Returns the expected file-backed startup entry path for `platform`.
+fn expected_entry_path(
+  platform : Platform,
+  home_directory : String,
+  identifier : String,
+) -> String {
+  match platform {
+    Platform::Macos => launch_agent_path(home_directory, identifier)
+    Platform::Linux => linux_desktop_path(home_directory, identifier)
+    _ => ""
+  }
+}
+
+///|
+/// Verifies platform codes map to the expected runtime backends.
+test "platform mapping and backend selection" {
+  assert_eq(platform_from_code(0), Platform::Unsupported)
+  assert_eq(platform_from_code(1), Platform::Windows)
+  assert_eq(platform_from_code(2), Platform::Macos)
+  assert_eq(platform_from_code(3), Platform::Linux)
+  assert_eq(
+    backend_for_platform(Platform::Windows),
+    BackendKind::WindowsRegistry,
+  )
+  assert_eq(backend_for_platform(Platform::Macos), BackendKind::MacLaunchAgent)
+  assert_eq(
+    backend_for_platform(Platform::Linux),
+    BackendKind::LinuxDesktopEntry,
+  )
+  assert_eq(
+    backend_for_platform(Platform::Unsupported),
+    BackendKind::UnsupportedBackend,
+  )
+}
+
+///|
+/// Verifies identifier sanitization remains stable for typical caller input.
+test "identifier sanitization is stable" {
+  assert_eq(sanitize_identifier("MoonBit Auto Launch"), "moonbit-auto-launch")
+  assert_eq(sanitize_identifier("  Hello__World  "), "hello__world")
+  assert_eq(sanitize_identifier("%%%"), "")
+  assert_eq(default_identifier("MoonBit App", None), "moonbit-app")
+  assert_eq(default_identifier("MoonBit App", Some("Custom ID")), "custom-id")
+  assert_eq(default_identifier("%%%", None), "auto-launch")
+}
+
+///|
+/// Verifies absolute-path detection covers the supported Windows and Unix forms.
+test "absolute path detection covers windows and unix styles" {
+  assert_true(is_absolute_path(Platform::Windows, "C:\\Windows\\notepad.exe"))
+  assert_true(is_absolute_path(Platform::Windows, "C:/Windows/notepad.exe"))
+  assert_true(is_absolute_path(Platform::Windows, "\\\\server\\share\\app.exe"))
+  assert_false(is_absolute_path(Platform::Windows, "app.exe"))
+  assert_true(is_absolute_path(Platform::Linux, "/usr/bin/app"))
+  assert_true(is_absolute_path(Platform::Macos, "/Applications/App"))
+  assert_false(is_absolute_path(Platform::Unsupported, "/unsupported"))
+  assert_false(is_absolute_path(Platform::Linux, "./app"))
+}
+
+///|
+/// Verifies background and extra arguments are assembled in the expected order.
+test "program arguments include background switch when requested" {
+  let visible = sample_config(
+    name="Visible App",
+    app_path="/usr/bin/app",
+    identifier="visible-app",
+    extra_arguments=["--flag"],
+  )
+  let hidden = sample_config(
+    name="Hidden App",
+    app_path="/usr/bin/app",
+    identifier="hidden-app",
+    launch_in_background=true,
+    background_arg="--background",
+    extra_arguments=["--flag", "value"],
+  )
+
+  assert_eq(build_program_arguments(visible), ["/usr/bin/app", "--flag"])
+  assert_eq(build_program_arguments(hidden), [
+    "/usr/bin/app", "--background", "--flag", "value",
+  ])
+}
+
+///|
+/// Verifies Windows command-line quoting handles common escaping edge cases.
+test "windows quoting escapes spaces quotes and trailing backslashes" {
+  assert_eq(
+    windows_quote_argument("C:\\Program Files\\App\\app.exe"),
+    "\"C:\\Program Files\\App\\app.exe\"",
+  )
+  assert_eq(windows_quote_argument("say \"hello\""), "\"say \\\"hello\\\"\"")
+  assert_eq(windows_quote_argument("C:\\temp\\"), "\"C:\\temp\\\\\"")
+}
+
+///|
+/// Verifies desktop-entry quoting and plist XML escaping stay deterministic.
+test "desktop quoting and xml escaping are deterministic" {
+  assert_eq(
+    desktop_quote_argument("/opt/My App/app \"$HOME\""),
+    "\"/opt/My App/app \\\"\\$HOME\\\"\"",
+  )
+  assert_eq(
+    xml_escape("MoonBit & <Launch> \"App\""),
+    "MoonBit &amp; &lt;Launch&gt; &quot;App&quot;",
+  )
+}
+
+///|
+/// Verifies Linux desktop-entry paths and file contents render correctly.
+test "join paths and render linux desktop entries" {
+  let config = sample_config(
+    app_path="/usr/bin/moonbit",
+    launch_in_background=true,
+    extra_arguments=["--profile", "work"],
+  )
+  assert_eq(
+    linux_desktop_path("/home/moonbit", "moonbit-app"),
+    "/home/moonbit/.config/autostart/moonbit-app.desktop",
+  )
+  assert_eq(join_unix_path("/home/moonbit/", "child"), "/home/moonbit/child")
+  let contents = linux_desktop_contents(config)
+  assert_true(contents.contains("Name=MoonBit App"))
+  assert_true(
+    contents.contains(
+      "Exec=\"/usr/bin/moonbit\" \"--hidden\" \"--profile\" \"work\"",
+    ),
+  )
+
+  let simple_contents = linux_desktop_contents(
+    sample_config(
+      name="Simple App",
+      app_path="/usr/bin/simple",
+      identifier="simple-app",
+    ),
+  )
+  assert_true(simple_contents.contains("Exec=\"/usr/bin/simple\""))
+}
+
+///|
+/// Verifies macOS LaunchAgent paths and plist contents render correctly.
+test "render mac launch agents" {
+  let config = sample_config(
+    app_path="/Applications/MoonBit.app/Contents/MacOS/MoonBit",
+    extra_arguments=["--agent"],
+  )
+  assert_eq(
+    launch_agent_path("/Users/moonbit", "moonbit-app"),
+    "/Users/moonbit/Library/LaunchAgents/moonbit-app.plist",
+  )
+  let contents = mac_launch_agent_contents(config)
+  assert_true(contents.contains("<string>moonbit-app</string>"))
+  assert_true(
+    contents.contains(
+      "<string>/Applications/MoonBit.app/Contents/MacOS/MoonBit</string>",
+    ),
+  )
+  assert_true(contents.contains("<string>--agent</string>"))
+
+  match file_entry_result(config, Platform::Macos, "/Users/moonbit") {
+    Ok(entry) => {
+      assert_eq(
+        entry.file_path,
+        "/Users/moonbit/Library/LaunchAgents/moonbit-app.plist",
+      )
+      assert_true(entry.contents.contains("<key>RunAtLoad</key>"))
+    }
+    _ => fail("expected macOS file entry")
+  }
+}
+
+///|
+/// Verifies supported and unsupported backends resolve the expected entry specs.
+test "entry specs cover supported and unsupported branches" {
+  let windows_config = sample_config(
+    app_path="C:\\Program Files\\MoonBit\\moonbit.exe",
+    launch_in_background=true,
+    extra_arguments=["--trace"],
+  )
+
+  let command = windows_command(windows_config)
+  assert_true(command.contains("\"C:\\Program Files\\MoonBit\\moonbit.exe\""))
+  assert_true(command.contains("\"--hidden\""))
+  assert_true(command.contains("\"--trace\""))
+
+  match file_entry_result(windows_config, Platform::Unsupported, "/tmp") {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected UnsupportedPlatform")
+  }
+}
+
+///|
+/// Verifies platform dispatch routes enable, disable, and lookup calls correctly.
+test "enable disable and is_enabled cover platform dispatch" {
+  let launcher = sample_launcher()
+
+  let mut observed_path = ""
+  let mut observed_windows_name = ""
+  let mut observed_windows_command = ""
+
+  let enable_linux = enable_with(
+    launcher,
+    Platform::Linux,
+    fn() { Ok("/home/moonbit") },
+    fn(name, _command) {
+      observed_windows_name = name
+      Ok(())
+    },
+    fn(path, _contents) {
+      observed_path = path
+      Ok(())
+    },
+  )
+  assert_eq(enable_linux, Ok(()))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Linux, "/home/moonbit", "moonbit-app"),
+  )
+  assert_eq(observed_windows_name, "")
+
+  let disable_linux = disable_with(
+    launcher,
+    Platform::Linux,
+    fn() { Ok("/home/moonbit") },
+    fn(name) {
+      observed_windows_name = name
+      Ok(())
+    },
+    fn(path) {
+      observed_path = path
+      Ok(())
+    },
+  )
+  assert_eq(disable_linux, Ok(()))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Linux, "/home/moonbit", "moonbit-app"),
+  )
+
+  let enabled_windows = is_enabled_with(
+    launcher,
+    Platform::Windows,
+    fn() { Ok("/ignored") },
+    fn(name) {
+      observed_windows_name = name
+      Ok(true)
+    },
+    fn(_path) { Ok(false) },
+  )
+  assert_eq(enabled_windows, Ok(true))
+  assert_eq(observed_windows_name, "moonbit-app")
+
+  let enable_windows = enable_with(
+    launcher,
+    Platform::Windows,
+    fn() { Ok("/ignored") },
+    fn(name, command) {
+      observed_windows_name = name
+      observed_windows_command = command
+      Ok(())
+    },
+    fn(_path, _contents) { Ok(()) },
+  )
+  assert_eq(enable_windows, Ok(()))
+  assert_eq(observed_windows_name, "moonbit-app")
+  assert_true(observed_windows_command.contains("/usr/bin/moonbit"))
+
+  let disable_windows = disable_with(
+    launcher,
+    Platform::Windows,
+    fn() { Ok("/ignored") },
+    fn(name) {
+      observed_windows_name = name
+      Ok(())
+    },
+    fn(_path) { Ok(()) },
+  )
+  assert_eq(disable_windows, Ok(()))
+  assert_eq(observed_windows_name, "moonbit-app")
+
+  let disable_macos = disable_with(
+    launcher,
+    Platform::Macos,
+    fn() { Ok("/Users/moonbit") },
+    fn(_name) { Ok(()) },
+    fn(path) {
+      observed_path = path
+      Ok(())
+    },
+  )
+  assert_eq(disable_macos, Ok(()))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Macos, "/Users/moonbit", "moonbit-app"),
+  )
+
+  let enable_macos = enable_with(
+    launcher,
+    Platform::Macos,
+    fn() { Ok("/Users/moonbit") },
+    fn(_name, _command) { Ok(()) },
+    fn(path, _contents) {
+      observed_path = path
+      Ok(())
+    },
+  )
+  assert_eq(enable_macos, Ok(()))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Macos, "/Users/moonbit", "moonbit-app"),
+  )
+
+  match
+    enable_with(
+      launcher,
+      Platform::Linux,
+      fn() { Err(HomeDirectoryUnavailable) },
+      fn(_name, _command) { Ok(()) },
+      fn(_path, _contents) { Ok(()) },
+    ) {
+    Err(HomeDirectoryUnavailable) => ()
+    _ => fail("expected home directory failure")
+  }
+
+  match
+    enable_with(
+      launcher,
+      Platform::Unsupported,
+      fn() { Ok("/ignored") },
+      fn(_name, _command) { Ok(()) },
+      fn(_path, _contents) { Ok(()) },
+    ) {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected unsupported enable result")
+  }
+
+  match
+    disable_with(
+      launcher,
+      Platform::Macos,
+      fn() { Err(HomeDirectoryUnavailable) },
+      fn(_name) { Ok(()) },
+      fn(_path) { Ok(()) },
+    ) {
+    Err(HomeDirectoryUnavailable) => ()
+    _ => fail("expected home directory failure")
+  }
+
+  match
+    is_enabled_with(
+      launcher,
+      Platform::Linux,
+      fn() { Err(HomeDirectoryUnavailable) },
+      fn(_name) { Ok(false) },
+      fn(_path) { Ok(false) },
+    ) {
+    Err(HomeDirectoryUnavailable) => ()
+    _ => fail("expected home directory failure")
+  }
+
+  let enabled_linux = is_enabled_with(
+    launcher,
+    Platform::Linux,
+    fn() { Ok("/home/moonbit") },
+    fn(_name) { Ok(false) },
+    fn(path) {
+      observed_path = path
+      Ok(true)
+    },
+  )
+  assert_eq(enabled_linux, Ok(true))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Linux, "/home/moonbit", "moonbit-app"),
+  )
+
+  let enabled_macos = is_enabled_with(
+    launcher,
+    Platform::Macos,
+    fn() { Ok("/Users/moonbit") },
+    fn(_name) { Ok(false) },
+    fn(path) {
+      observed_path = path
+      Ok(true)
+    },
+  )
+  assert_eq(enabled_macos, Ok(true))
+  assert_eq(
+    observed_path,
+    expected_entry_path(Platform::Macos, "/Users/moonbit", "moonbit-app"),
+  )
+
+  match
+    disable_with(
+      launcher,
+      Platform::Unsupported,
+      fn() { Ok("/ignored") },
+      fn(_name) { Ok(()) },
+      fn(_path) { Ok(()) },
+    ) {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected unsupported disable result")
+  }
+
+  match
+    is_enabled_with(
+      launcher,
+      Platform::Unsupported,
+      fn() { Ok("/ignored") },
+      fn(_name) { Ok(false) },
+      fn(_path) { Ok(false) },
+    ) {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected unsupported is_enabled result")
+  }
+}
+
+///|
+/// Verifies constructor validation branches beyond the public black-box cases.
+test "new covers additional validation branches" {
+  guard is_supported() else { return }
+
+  match new("MoonBit", path="", launch_in_background=false) {
+    Err(EmptyExecutablePath) => ()
+    _ => fail("expected EmptyExecutablePath")
+  }
+
+  match
+    new(
+      "MoonBit",
+      path=match current_platform() {
+        Windows => "C:\\Windows\\System32\\notepad.exe"
+        Macos => "/usr/bin/true"
+        Linux => "/bin/true"
+        Unsupported => "/unsupported"
+      },
+      launch_in_background=true,
+      background_arg="",
+    ) {
+    Err(EmptyBackgroundArgument) => ()
+    _ => fail("expected EmptyBackgroundArgument")
+  }
+
+  match new("MoonBit Current Executable") {
+    Ok(launcher) => assert_true(!launcher.path().is_empty())
+    Err(error) =>
+      fail("expected current executable path to be detected: \{error}")
+  }
+}
+
+///|
+/// Verifies injected constructor dependencies surface unsupported and probe failures.
+test "new_with covers unsupported and executable path failures" {
+  match
+    new_with(
+      Platform::Unsupported,
+      "MoonBit",
+      None,
+      false,
+      "--hidden",
+      [],
+      None,
+      get_current_executable_path=fn() { Ok("/bin/true") },
+    ) {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected UnsupportedPlatform")
+  }
+
+  match
+    new_with(Platform::Linux, "MoonBit", None, false, "--hidden", [], None, get_current_executable_path=fn() {
+      Err(ExecutablePathUnavailable)
+    }) {
+    Err(ExecutablePathUnavailable) => ()
+    _ => fail("expected ExecutablePathUnavailable")
+  }
+}
+
+///|
+/// Returns a temporary file path suitable for native FFI file-system tests.
+fn temp_file_path() -> String {
+  match current_platform() {
+    Windows => "C:\\Users\\Public\\moonbit-auto-launch-ffi-test.txt"
+    Macos => "/tmp/moonbit-auto-launch-ffi-test.txt"
+    Linux => "/tmp/moonbit-auto-launch-ffi-test.txt"
+    Unsupported => "/tmp/moonbit-auto-launch-ffi-test.txt"
+  }
+}
+
+///|
+/// Returns a path whose removal should fail in native FFI error-handling tests.
+fn invalid_remove_path() -> String {
+  match current_platform() {
+    Windows => "C:\\Windows"
+    Macos => "/tmp"
+    Linux => "/tmp"
+    Unsupported => "/tmp"
+  }
+}
+
+///|
+/// Verifies the native FFI helpers succeed on normal discovery and file operations.
+test "ffi helpers cover success paths" {
+  match current_executable_path_result() {
+    Ok(path) => assert_true(!path.is_empty())
+    Err(error) => fail("expected executable path: \{error}")
+  }
+
+  match home_directory_result() {
+    Ok(path) => assert_true(!path.is_empty())
+    Err(error) => fail("expected home directory: \{error}")
+  }
+
+  let file_path = temp_file_path()
+  assert_eq(remove_file_result(file_path), Ok(()))
+  assert_eq(file_exists_result(file_path), Ok(false))
+  assert_eq(write_text_file_result(file_path, "MoonBit"), Ok(()))
+  assert_eq(file_exists_result(file_path), Ok(true))
+  assert_eq(remove_file_result(file_path), Ok(()))
+  assert_eq(file_exists_result(file_path), Ok(false))
+}
+
+///|
+/// Verifies the native FFI helpers surface fallback error messages when needed.
+test "ffi helpers cover fallback error messages" {
+  assert_eq(decode_optional_text(@utf8.encode("")), None)
+  assert_eq(decode_optional_text(@utf8.encode("MoonBit")), Some("MoonBit"))
+  assert_eq(decode_error_message(@utf8.encode(""), "fallback"), "fallback")
+  assert_eq(
+    decode_error_message(@utf8.encode("native error"), "fallback"),
+    "native error",
+  )
+  assert_eq(last_error_message_or("fallback"), "fallback")
+  match native_failure("probe", "fallback") {
+    NativeFailure(action="probe", message="fallback") => ()
+    _ => fail("expected NativeFailure")
+  }
+
+  match write_text_file_result("", "MoonBit") {
+    Err(NativeFailure(action="write file", ..)) => ()
+    _ => fail("expected write file failure")
+  }
+
+  match remove_file_result("") {
+    Ok(_) =>
+      match remove_file_result(invalid_remove_path()) {
+        Err(NativeFailure(action="remove file", ..)) => ()
+        _ => fail("expected remove file failure")
+      }
+    Err(NativeFailure(action="remove file", ..)) => ()
+    _ => fail("expected remove file failure")
+  }
+
+  match file_exists_result("") {
+    Ok(false) => ()
+    Err(NativeFailure(action="file exists", ..)) => ()
+    _ => fail("expected missing file or file exists failure")
+  }
+}
+
+///|
+/// Verifies pure helper functions map native status codes into typed results.
+test "pure ffi result helpers cover success and error mappings" {
+  assert_eq(
+    optional_path_result(Some("/bin/true"), ExecutablePathUnavailable),
+    Ok("/bin/true"),
+  )
+  match optional_path_result(None, HomeDirectoryUnavailable) {
+    Err(HomeDirectoryUnavailable) => ()
+    _ => fail("expected HomeDirectoryUnavailable")
+  }
+
+  assert_eq(unit_result_from_status(0, "action", "fallback"), Ok(()))
+  match unit_result_from_status(1, "action", "fallback") {
+    Err(NativeFailure(action="action", ..)) => ()
+    _ => fail("expected NativeFailure")
+  }
+
+  assert_eq(bool_result_from_status(0, "action", "fallback"), Ok(false))
+  assert_eq(bool_result_from_status(1, "action", "fallback"), Ok(true))
+  match bool_result_from_status(2, "action", "fallback") {
+    Err(NativeFailure(action="action", ..)) => ()
+    _ => fail("expected NativeFailure")
+  }
+}
+
+///|
+/// Verifies file-entry resolution forwards home-directory failures unchanged.
+test "resolve_file_entry forwards home lookup failures" {
+  let launcher = sample_launcher()
+
+  match
+    resolve_file_entry(launcher, Platform::Linux, fn() {
+      Err(HomeDirectoryUnavailable)
+    }) {
+    Err(HomeDirectoryUnavailable) => ()
+    _ => fail("expected HomeDirectoryUnavailable")
+  }
+
+  match
+    resolve_file_entry(launcher, Platform::Macos, fn() { Ok("/Users/moonbit") }) {
+    Ok(entry) =>
+      assert_eq(
+        entry.file_path,
+        expected_entry_path(Platform::Macos, "/Users/moonbit", "moonbit-app"),
+      )
+    _ => fail("expected macOS file entry")
+  }
+
+  match
+    resolve_file_entry(launcher, Platform::Unsupported, fn() { Ok("/tmp") }) {
+    Err(UnsupportedPlatform(Unsupported)) => ()
+    _ => fail("expected UnsupportedPlatform")
+  }
+
+  match
+    resolve_file_entry(launcher, Platform::Linux, fn() { Ok("/home/moonbit") }) {
+    Ok(entry) =>
+      assert_eq(
+        entry.file_path,
+        expected_entry_path(Platform::Linux, "/home/moonbit", "moonbit-app"),
+      )
+    _ => fail("expected Linux file entry")
+  }
+}
+
+///|
+/// Verifies the Windows registry wrappers can create and remove a test entry.
+test "windows registry ffi wrappers work on windows" {
+  guard current_platform() == Platform::Windows else { return }
+
+  let name = "moonbit-auto-launch-whitebox-registry-test"
+  assert_eq(windows_delete_run_entry_result(name), Ok(()))
+  assert_eq(windows_run_entry_exists_result(name), Ok(false))
+  assert_eq(
+    windows_set_run_entry_result(name, "\"C:\\Windows\\System32\\notepad.exe\""),
+    Ok(()),
+  )
+  assert_eq(windows_run_entry_exists_result(name), Ok(true))
+  assert_eq(windows_delete_run_entry_result(name), Ok(()))
+  assert_eq(windows_run_entry_exists_result(name), Ok(false))
+}

--- a/sys/auto_launch/errors.mbt
+++ b/sys/auto_launch/errors.mbt
@@ -9,8 +9,8 @@
 /// - `NativeFailure` reports a backend-specific failure message produced by the
 ///   underlying platform API
 ///
-/// This enum derives `Eq` and `Show`, which makes it convenient to inspect in
-/// tests and to print in user-facing diagnostics.
+/// This enum derives `Eq` and implements `Show`, which makes it convenient to
+/// inspect in tests and to print in user-facing diagnostics.
 pub enum AutoLaunchError {
   EmptyName
   EmptyExecutablePath
@@ -20,4 +20,33 @@ pub enum AutoLaunchError {
   RelativeExecutablePath(String)
   UnsupportedPlatform(Platform)
   NativeFailure(action~ : String, message~ : String)
-} derive(Debug, Eq, Show)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for AutoLaunchError with fn output(self : AutoLaunchError, logger) {
+  match self {
+    EmptyName => logger.write_string("EmptyName")
+    EmptyExecutablePath => logger.write_string("EmptyExecutablePath")
+    EmptyBackgroundArgument => logger.write_string("EmptyBackgroundArgument")
+    ExecutablePathUnavailable =>
+      logger.write_string("ExecutablePathUnavailable")
+    HomeDirectoryUnavailable => logger.write_string("HomeDirectoryUnavailable")
+    RelativeExecutablePath(path) => {
+      logger.write_string("RelativeExecutablePath(")
+      logger.write_object(path)
+      logger.write_string(")")
+    }
+    UnsupportedPlatform(platform) => {
+      logger.write_string("UnsupportedPlatform(")
+      logger.write_object(platform)
+      logger.write_string(")")
+    }
+    NativeFailure(action~, message~) => {
+      logger.write_string("NativeFailure(action=")
+      logger.write_object(action)
+      logger.write_string(", message=")
+      logger.write_object(message)
+      logger.write_string(")")
+    }
+  }
+}

--- a/sys/auto_launch/errors.mbt
+++ b/sys/auto_launch/errors.mbt
@@ -1,0 +1,23 @@
+///|
+/// Errors returned by `auto_launch` operations.
+///
+/// The error model is intentionally small and stable:
+///
+/// - validation errors describe incorrect input supplied by the caller
+/// - discovery errors describe missing runtime information such as the current
+///   executable path or home directory
+/// - `NativeFailure` reports a backend-specific failure message produced by the
+///   underlying platform API
+///
+/// This enum derives `Eq` and `Show`, which makes it convenient to inspect in
+/// tests and to print in user-facing diagnostics.
+pub enum AutoLaunchError {
+  EmptyName
+  EmptyExecutablePath
+  EmptyBackgroundArgument
+  ExecutablePathUnavailable
+  HomeDirectoryUnavailable
+  RelativeExecutablePath(String)
+  UnsupportedPlatform(Platform)
+  NativeFailure(action~ : String, message~ : String)
+} derive(Debug, Eq, Show)

--- a/sys/auto_launch/ffi.mbt
+++ b/sys/auto_launch/ffi.mbt
@@ -1,0 +1,226 @@
+///|
+/// Returns the native platform code for the current process.
+extern "C" fn platform_code_ffi() -> Int = "mb_auto_launch_platform_code"
+
+///|
+/// Returns the current executable path as UTF-8 bytes, or an empty value.
+extern "C" fn current_executable_path_ffi() -> Bytes = "mb_auto_launch_current_executable_path"
+
+///|
+/// Returns the current user's home directory as UTF-8 bytes, or an empty value.
+extern "C" fn home_directory_ffi() -> Bytes = "mb_auto_launch_home_directory"
+
+///|
+/// Writes a UTF-8 text file and returns a native status code.
+#borrow(path)
+#owned(contents)
+extern "C" fn write_text_file_ffi(path : Bytes, contents : Bytes) -> Int = "mb_auto_launch_write_text_file"
+
+///|
+/// Removes the file at `path` and returns a native status code.
+#borrow(path)
+extern "C" fn remove_file_ffi(path : Bytes) -> Int = "mb_auto_launch_remove_file"
+
+///|
+/// Checks whether the file at `path` exists.
+#borrow(path)
+extern "C" fn file_exists_ffi(path : Bytes) -> Int = "mb_auto_launch_file_exists"
+
+///|
+/// Creates or updates a current-user Windows `Run` registry value.
+#borrow(name)
+#owned(command)
+extern "C" fn windows_set_run_entry_ffi(name : Bytes, command : Bytes) -> Int = "mb_auto_launch_windows_set_run_entry"
+
+///|
+/// Deletes a current-user Windows `Run` registry value.
+#borrow(name)
+extern "C" fn windows_delete_run_entry_ffi(name : Bytes) -> Int = "mb_auto_launch_windows_delete_run_entry"
+
+///|
+/// Queries whether a current-user Windows `Run` registry value exists.
+#borrow(name)
+extern "C" fn windows_run_entry_exists_ffi(name : Bytes) -> Int = "mb_auto_launch_windows_run_entry_exists"
+
+///|
+/// Returns the last native error code observed by the C shim.
+extern "C" fn last_error_code_ffi() -> Int = "mb_auto_launch_last_error_code"
+
+///|
+/// Returns the last native error message as UTF-8 bytes.
+extern "C" fn last_error_message_ffi() -> Bytes = "mb_auto_launch_last_error_message"
+
+///|
+/// Decodes UTF-8 bytes into a MoonBit string with lossy fallback.
+fn decode_utf8(bytes : Bytes) -> String {
+  @utf8.decode_lossy(bytes[:])
+}
+
+///|
+/// Decodes optional text returned by the native layer.
+fn decode_optional_text(bytes : Bytes) -> String? {
+  let value = decode_utf8(bytes)
+  if value.is_empty() {
+    None
+  } else {
+    Some(value)
+  }
+}
+
+///|
+/// Decodes a native error message and falls back to `default_message`.
+fn decode_error_message(bytes : Bytes, default_message : String) -> String {
+  let message = decode_utf8(bytes)
+  if message.is_empty() {
+    default_message
+  } else {
+    message
+  }
+}
+
+///|
+/// Returns the last native error message or `default_message`.
+fn last_error_message_or(default_message : String) -> String {
+  decode_error_message(last_error_message_ffi(), default_message)
+}
+
+///|
+/// Converts the last native failure into `AutoLaunchError`.
+fn native_failure(
+  action : String,
+  fallback_message : String,
+) -> AutoLaunchError {
+  ignore(last_error_code_ffi())
+  AutoLaunchError::NativeFailure(
+    action~,
+    message=last_error_message_or(fallback_message),
+  )
+}
+
+///|
+/// Converts an optional path into a `Result`.
+fn optional_path_result(
+  path : String?,
+  missing_error : AutoLaunchError,
+) -> Result[String, AutoLaunchError] {
+  match path {
+    Some(value) => Ok(value)
+    None => Err(missing_error)
+  }
+}
+
+///|
+/// Converts a native "0 means success" status code into `Result[Unit, _]`.
+fn unit_result_from_status(
+  status : Int,
+  action : String,
+  fallback_message : String,
+) -> Result[Unit, AutoLaunchError] {
+  if status == 0 {
+    Ok(())
+  } else {
+    Err(native_failure(action, fallback_message))
+  }
+}
+
+///|
+/// Converts a native tri-state existence status into `Result[Bool, _]`.
+fn bool_result_from_status(
+  status : Int,
+  action : String,
+  fallback_message : String,
+) -> Result[Bool, AutoLaunchError] {
+  match status {
+    0 => Ok(false)
+    1 => Ok(true)
+    _ => Err(native_failure(action, fallback_message))
+  }
+}
+
+///|
+/// Returns the current executable path or a typed discovery error.
+fn current_executable_path_result() -> Result[String, AutoLaunchError] {
+  optional_path_result(
+    decode_optional_text(current_executable_path_ffi()),
+    AutoLaunchError::ExecutablePathUnavailable,
+  )
+}
+
+///|
+/// Returns the current home directory or a typed discovery error.
+fn home_directory_result() -> Result[String, AutoLaunchError] {
+  optional_path_result(
+    decode_optional_text(home_directory_ffi()),
+    AutoLaunchError::HomeDirectoryUnavailable,
+  )
+}
+
+///|
+/// Writes a text file through the native layer.
+fn write_text_file_result(
+  path : String,
+  contents : String,
+) -> Result[Unit, AutoLaunchError] {
+  unit_result_from_status(
+    write_text_file_ffi(@utf8.encode(path), @utf8.encode(contents)),
+    "write file",
+    "Failed to write auto-launch entry file",
+  )
+}
+
+///|
+/// Removes a file through the native layer.
+fn remove_file_result(path : String) -> Result[Unit, AutoLaunchError] {
+  unit_result_from_status(
+    remove_file_ffi(@utf8.encode(path)),
+    "remove file",
+    "Failed to remove auto-launch entry file",
+  )
+}
+
+///|
+/// Checks file existence through the native layer.
+fn file_exists_result(path : String) -> Result[Bool, AutoLaunchError] {
+  bool_result_from_status(
+    file_exists_ffi(@utf8.encode(path)),
+    "file exists",
+    "Failed to check auto-launch entry file",
+  )
+}
+
+///|
+/// Creates or updates a Windows `Run` registry entry.
+fn windows_set_run_entry_result(
+  name : String,
+  command : String,
+) -> Result[Unit, AutoLaunchError] {
+  unit_result_from_status(
+    windows_set_run_entry_ffi(@utf8.encode(name), @utf8.encode(command)),
+    "set windows run entry",
+    "Failed to write Windows Run registry value",
+  )
+}
+
+///|
+/// Deletes a Windows `Run` registry entry.
+fn windows_delete_run_entry_result(
+  name : String,
+) -> Result[Unit, AutoLaunchError] {
+  unit_result_from_status(
+    windows_delete_run_entry_ffi(@utf8.encode(name)),
+    "delete windows run entry",
+    "Failed to delete Windows Run registry value",
+  )
+}
+
+///|
+/// Checks whether a Windows `Run` registry entry exists.
+fn windows_run_entry_exists_result(
+  name : String,
+) -> Result[Bool, AutoLaunchError] {
+  bool_result_from_status(
+    windows_run_entry_exists_ffi(@utf8.encode(name)),
+    "windows run entry exists",
+    "Failed to query Windows Run registry value",
+  )
+}

--- a/sys/auto_launch/model_core.mbt
+++ b/sys/auto_launch/model_core.mbt
@@ -1,0 +1,204 @@
+///|
+/// Canonical auto-launch settings shared by all platform backends.
+struct AutoLaunchConfig {
+  name : String
+  app_path : String
+  identifier : String
+  launch_in_background : Bool
+  background_arg : String
+  extra_arguments : Array[String]
+}
+
+///|
+/// A rendered file-based auto-launch entry ready to be written to disk.
+struct FileEntry {
+  file_path : String
+  contents : String
+} derive(Eq, Show)
+
+///|
+/// Stores the normalized auto-launch configuration for one application.
+///
+/// `AutoLaunch` values are created through [`new`](../auto_launch.mbt) after
+/// validation and normalization have already completed. Callers therefore get a
+/// stable, reusable handle that can be queried or applied multiple times
+/// without having to repeat path validation or identifier generation.
+pub struct AutoLaunch {
+  config : AutoLaunchConfig
+}
+
+///|
+/// Trims leading and trailing whitespace from `text`.
+fn trim_text(text : String) -> String {
+  text.trim().to_string()
+}
+
+///|
+/// Returns whether `ch` is an ASCII lowercase letter.
+fn is_ascii_lower_letter(ch : Char) -> Bool {
+  ch >= 'a' && ch <= 'z'
+}
+
+///|
+/// Returns whether `ch` is an ASCII uppercase letter.
+fn is_ascii_upper_letter(ch : Char) -> Bool {
+  ch >= 'A' && ch <= 'Z'
+}
+
+///|
+/// Returns whether `ch` is an ASCII digit.
+fn is_ascii_digit(ch : Char) -> Bool {
+  ch >= '0' && ch <= '9'
+}
+
+///|
+/// Returns whether `ch` is any ASCII alphabetic character.
+fn is_ascii_letter(ch : Char) -> Bool {
+  is_ascii_lower_letter(ch) || is_ascii_upper_letter(ch)
+}
+
+///|
+/// Returns whether `ch` is allowed punctuation in sanitized identifiers.
+fn is_identifier_punctuation(ch : Char) -> Bool {
+  ch == '-' || ch == '_' || ch == '.'
+}
+
+///|
+/// Converts free-form text into a backend-safe identifier fragment.
+fn sanitize_identifier(text : String) -> String {
+  let lowered = text.to_lower()
+  let builder = StringBuilder::new()
+  let mut last_was_separator = true
+  for ch in lowered {
+    if is_ascii_letter(ch) ||
+      is_ascii_digit(ch) ||
+      is_identifier_punctuation(ch) {
+      builder.write_char(ch)
+      last_was_separator = false
+    } else if !last_was_separator {
+      builder.write_char('-')
+      last_was_separator = true
+    }
+  }
+  builder.to_string().trim(chars="-._").to_string()
+}
+
+///|
+/// Chooses the final identifier for a launcher configuration.
+fn default_identifier(name : String, explicit_identifier : String?) -> String {
+  let source = match explicit_identifier {
+    Some(identifier) => trim_text(identifier)
+    None => trim_text(name)
+  }
+  let sanitized = sanitize_identifier(source)
+  if sanitized.is_empty() {
+    "auto-launch"
+  } else {
+    sanitized
+  }
+}
+
+///|
+/// Returns whether `path` looks like an absolute Windows drive path.
+fn is_windows_drive_path(path : String) -> Bool {
+  match (path.get_char(0), path.get_char(1), path.get_char(2)) {
+    (Some(drive), Some(':'), Some('\\')) if is_ascii_letter(drive) => true
+    (Some(drive), Some(':'), Some('/')) if is_ascii_letter(drive) => true
+    _ => false
+  }
+}
+
+///|
+/// Returns whether `path` uses the Windows UNC form.
+fn is_windows_unc_path(path : String) -> Bool {
+  path.has_prefix("\\\\") || path.has_prefix("//")
+}
+
+///|
+/// Performs platform-aware absolute-path detection.
+fn is_absolute_path(platform : Platform, path : String) -> Bool {
+  match platform {
+    Platform::Windows =>
+      is_windows_drive_path(path) || is_windows_unc_path(path)
+    Platform::Macos => path.has_prefix("/")
+    Platform::Linux => path.has_prefix("/")
+    Platform::Unsupported => false
+  }
+}
+
+///|
+/// Builds the ordered program argument vector used by every backend.
+fn build_program_arguments(config : AutoLaunchConfig) -> Array[String] {
+  let arguments : Array[String] = [config.app_path]
+  if config.launch_in_background {
+    arguments.push(config.background_arg)
+  }
+  for argument in config.extra_arguments {
+    arguments.push(argument)
+  }
+  arguments
+}
+
+///|
+/// Appends `count` copies of `ch` into `builder`.
+fn write_repeated_char(builder : StringBuilder, ch : Char, count : Int) -> Unit {
+  for _ in 0..<count {
+    builder.write_char(ch)
+  }
+}
+
+///|
+/// Quotes one argument using Windows command-line escaping rules.
+fn windows_quote_argument(argument : String) -> String {
+  let builder = StringBuilder::new()
+  builder.write_char('"')
+  let mut backslash_count = 0
+  for ch in argument {
+    if ch == '\\' {
+      backslash_count += 1
+    } else if ch == '"' {
+      write_repeated_char(builder, '\\', backslash_count * 2 + 1)
+      builder.write_char('"')
+      backslash_count = 0
+    } else {
+      write_repeated_char(builder, '\\', backslash_count)
+      builder.write_char(ch)
+      backslash_count = 0
+    }
+  }
+  write_repeated_char(builder, '\\', backslash_count * 2)
+  builder.write_char('"')
+  builder.to_string()
+}
+
+///|
+/// Quotes one argument for file-based Unix desktop launchers.
+fn desktop_quote_argument(argument : String) -> String {
+  let escaped = argument
+    .replace_all(old="\\", new="\\\\")
+    .replace_all(old="\"", new="\\\"")
+    .replace_all(old="$", new="\\$")
+    .replace_all(old="`", new="\\`")
+  "\"" + escaped + "\""
+}
+
+///|
+/// Escapes XML-special characters for LaunchAgent plist output.
+fn xml_escape(text : String) -> String {
+  text
+  .replace_all(old="&", new="&amp;")
+  .replace_all(old="<", new="&lt;")
+  .replace_all(old=">", new="&gt;")
+  .replace_all(old="\"", new="&quot;")
+  .replace_all(old="'", new="&apos;")
+}
+
+///|
+/// Joins `base` and `child` using a single `/` separator.
+fn join_unix_path(base : String, child : String) -> String {
+  if base.has_suffix("/") {
+    base + child
+  } else {
+    base + "/" + child
+  }
+}

--- a/sys/auto_launch/model_core.mbt
+++ b/sys/auto_launch/model_core.mbt
@@ -14,7 +14,7 @@ struct AutoLaunchConfig {
 struct FileEntry {
   file_path : String
   contents : String
-} derive(Eq, Show)
+} derive(Debug, Eq)
 
 ///|
 /// Stores the normalized auto-launch configuration for one application.
@@ -30,7 +30,7 @@ pub struct AutoLaunch {
 ///|
 /// Trims leading and trailing whitespace from `text`.
 fn trim_text(text : String) -> String {
-  text.trim().to_string()
+  text.trim().to_owned()
 }
 
 ///|
@@ -80,7 +80,7 @@ fn sanitize_identifier(text : String) -> String {
       last_was_separator = true
     }
   }
-  builder.to_string().trim(chars="-._").to_string()
+  builder.to_string().trim(chars="-._").to_owned()
 }
 
 ///|

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,0 +1,32 @@
+name = "justjavac/auto_launch"
+
+version = "0.1.3"
+
+readme = "README.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/auto_launch"
+
+license = "MIT"
+
+keywords = [
+  "desktop",
+  "autostart",
+  "startup",
+  "auto-launch",
+  "native",
+  "windows",
+  "macos",
+  "linux",
+]
+
+description = "Cross-platform auto-launch helpers for MoonBit, inspired by Teamwork/node-auto-launch."
+
+warnings = ""
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "+native",
+)

--- a/sys/auto_launch/moon.pkg
+++ b/sys/auto_launch/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/core/env",
+  "moonbitlang/core/encoding/utf8",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "auto_launch_native.c" ],
+  targets: { "auto_launch.mbt": [ "native" ] },
+)

--- a/sys/auto_launch/pkg.generated.mbti
+++ b/sys/auto_launch/pkg.generated.mbti
@@ -36,18 +36,20 @@ pub enum AutoLaunchError {
   RelativeExecutablePath(String)
   UnsupportedPlatform(Platform)
   NativeFailure(action~ : String, message~ : String)
-} derive(Eq, Show, @debug.Debug)
+} derive(Eq, @debug.Debug)
+pub impl Show for AutoLaunchError
 
-type BackendKind derive(Eq, Show, @debug.Debug)
+type BackendKind derive(Eq, @debug.Debug)
 
-type FileEntry derive(Eq, Show)
+type FileEntry derive(Eq, @debug.Debug)
 
 pub enum Platform {
   Windows
   Macos
   Linux
   Unsupported
-} derive(Eq, Show, @debug.Debug)
+} derive(Eq, @debug.Debug)
+pub impl Show for Platform
 
 // Type aliases
 

--- a/sys/auto_launch/pkg.generated.mbti
+++ b/sys/auto_launch/pkg.generated.mbti
@@ -1,0 +1,55 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/auto_launch"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn current_platform() -> Platform
+
+pub fn is_supported() -> Bool
+
+pub fn new(String, path? : String, launch_in_background? : Bool, background_arg? : String, extra_arguments? : Array[String], identifier? : String) -> Result[AutoLaunch, AutoLaunchError]
+
+// Errors
+
+// Types and methods
+pub struct AutoLaunch {
+  config : AutoLaunchConfig
+}
+pub fn AutoLaunch::disable(Self) -> Result[Unit, AutoLaunchError]
+pub fn AutoLaunch::enable(Self) -> Result[Unit, AutoLaunchError]
+pub fn AutoLaunch::identifier(Self) -> String
+pub fn AutoLaunch::is_enabled(Self) -> Result[Bool, AutoLaunchError]
+pub fn AutoLaunch::name(Self) -> String
+pub fn AutoLaunch::path(Self) -> String
+
+type AutoLaunchConfig
+
+pub enum AutoLaunchError {
+  EmptyName
+  EmptyExecutablePath
+  EmptyBackgroundArgument
+  ExecutablePathUnavailable
+  HomeDirectoryUnavailable
+  RelativeExecutablePath(String)
+  UnsupportedPlatform(Platform)
+  NativeFailure(action~ : String, message~ : String)
+} derive(Eq, Show, @debug.Debug)
+
+type BackendKind derive(Eq, Show, @debug.Debug)
+
+type FileEntry derive(Eq, Show)
+
+pub enum Platform {
+  Windows
+  Macos
+  Linux
+  Unsupported
+} derive(Eq, Show, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/sys/auto_launch/platform.mbt
+++ b/sys/auto_launch/platform.mbt
@@ -1,0 +1,69 @@
+///|
+/// Enumerates the operating systems that this package can detect at runtime.
+///
+/// The value is derived from the active native backend rather than from
+/// build-time configuration alone, so it reflects the platform that the
+/// current executable is actually running on.
+pub enum Platform {
+  Windows
+  Macos
+  Linux
+  Unsupported
+} derive(Debug, Eq, Show)
+
+///|
+/// Internal backend categories for supported startup mechanisms.
+enum BackendKind {
+  WindowsRegistry
+  MacLaunchAgent
+  LinuxDesktopEntry
+  UnsupportedBackend
+} derive(Debug, Eq, Show)
+
+///|
+/// Decodes the numeric platform code returned by the native layer.
+fn platform_from_code(code : Int) -> Platform {
+  match code {
+    1 => Platform::Windows
+    2 => Platform::Macos
+    3 => Platform::Linux
+    _ => Platform::Unsupported
+  }
+}
+
+///|
+/// Returns the auto-launch backend used for `platform`.
+fn backend_for_platform(platform : Platform) -> BackendKind {
+  match platform {
+    Platform::Windows => BackendKind::WindowsRegistry
+    Platform::Macos => BackendKind::MacLaunchAgent
+    Platform::Linux => BackendKind::LinuxDesktopEntry
+    Platform::Unsupported => BackendKind::UnsupportedBackend
+  }
+}
+
+///|
+/// Detects the current runtime platform for the active native build.
+///
+/// This function is a lightweight probe over the native FFI layer. It is safe
+/// to call repeatedly and is primarily useful for platform-specific setup,
+/// conditional logging, or selecting example paths in applications and tests.
+pub fn current_platform() -> Platform {
+  platform_from_code(platform_code_ffi())
+}
+
+///|
+/// Returns `true` when the current runtime platform has a supported auto-launch
+/// backend in this package.
+///
+/// Supported platforms currently map to these backends:
+///
+/// - `Windows`: current-user `Run` registry value
+/// - `Macos`: per-user LaunchAgent plist
+/// - `Linux`: XDG autostart desktop entry
+///
+/// `Unsupported` means the package was compiled or executed in an environment
+/// for which no native backend is implemented.
+pub fn is_supported() -> Bool {
+  backend_for_platform(current_platform()) != BackendKind::UnsupportedBackend
+}

--- a/sys/auto_launch/platform.mbt
+++ b/sys/auto_launch/platform.mbt
@@ -9,7 +9,19 @@ pub enum Platform {
   Macos
   Linux
   Unsupported
-} derive(Debug, Eq, Show)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for Platform with fn output(self : Platform, logger) {
+  logger.write_string(
+    match self {
+      Windows => "Windows"
+      Macos => "Macos"
+      Linux => "Linux"
+      Unsupported => "Unsupported"
+    },
+  )
+}
 
 ///|
 /// Internal backend categories for supported startup mechanisms.
@@ -18,7 +30,7 @@ enum BackendKind {
   MacLaunchAgent
   LinuxDesktopEntry
   UnsupportedBackend
-} derive(Debug, Eq, Show)
+} derive(Debug, Eq)
 
 ///|
 /// Decodes the numeric platform code returned by the native layer.

--- a/sys/auto_launch/rendering.mbt
+++ b/sys/auto_launch/rendering.mbt
@@ -1,0 +1,227 @@
+///|
+/// Returns the per-user LaunchAgent plist path for `identifier`.
+fn launch_agent_path(home_directory : String, identifier : String) -> String {
+  join_unix_path(
+    join_unix_path(home_directory, "Library"),
+    "LaunchAgents/" + identifier + ".plist",
+  )
+}
+
+///|
+/// Returns the XDG autostart desktop-entry path for `identifier`.
+fn linux_desktop_path(home_directory : String, identifier : String) -> String {
+  join_unix_path(
+    join_unix_path(join_unix_path(home_directory, ".config"), "autostart"),
+    identifier + ".desktop",
+  )
+}
+
+///|
+/// Renders the command string stored in the Windows `Run` registry value.
+fn render_command_line(
+  config : AutoLaunchConfig,
+  quote_argument : (String) -> String,
+) -> String {
+  let quoted : Array[String] = []
+  for argument in build_program_arguments(config) {
+    quoted.push(quote_argument(argument))
+  }
+  quoted.join(" ")
+}
+
+///|
+/// Renders the command string stored in the Windows `Run` registry value.
+fn windows_command(config : AutoLaunchConfig) -> String {
+  render_command_line(config, windows_quote_argument)
+}
+
+///|
+/// Renders a freedesktop.org desktop-entry file for Linux auto-start.
+fn linux_desktop_contents(config : AutoLaunchConfig) -> String {
+  let exec_line = render_command_line(config, desktop_quote_argument)
+  (
+    $|[Desktop Entry]
+    $|Type=Application
+    $|Version=1.0
+    $|Name=\{config.name}
+    $|Comment=Launch \{config.name} automatically at login
+    $|Exec=\{exec_line}
+    $|Terminal=false
+    $|StartupNotify=false
+    $|
+  )
+}
+
+///|
+/// Renders the `<string>` items for a LaunchAgent `ProgramArguments` array.
+fn plist_program_arguments(arguments : Array[String]) -> String {
+  let builder = StringBuilder::new()
+  for argument in arguments {
+    builder.write_string("    <string>")
+    builder.write_string(xml_escape(argument))
+    builder.write_string("</string>\n")
+  }
+  builder.to_string()
+}
+
+///|
+/// Renders a macOS LaunchAgent plist.
+fn mac_launch_agent_contents(config : AutoLaunchConfig) -> String {
+  let arguments = build_program_arguments(config)
+  let argument_items = plist_program_arguments(arguments)
+  (
+    $|<?xml version="1.0" encoding="UTF-8"?>
+    $|<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    $|<plist version="1.0">
+    $|<dict>
+    $|  <key>Label</key>
+    $|  <string>\{xml_escape(config.identifier)}</string>
+    $|  <key>ProgramArguments</key>
+    $|  <array>
+    $|\{argument_items}  </array>
+    $|  <key>RunAtLoad</key>
+    $|  <true/>
+    $|</dict>
+    $|</plist>
+    $|
+  )
+}
+
+///|
+/// Produces the file-backed entry for macOS or Linux.
+fn file_entry_result(
+  config : AutoLaunchConfig,
+  platform : Platform,
+  home_directory : String,
+) -> Result[FileEntry, AutoLaunchError] {
+  match platform {
+    Platform::Macos =>
+      Ok(FileEntry::{
+        file_path: launch_agent_path(home_directory, config.identifier),
+        contents: mac_launch_agent_contents(config),
+      })
+    Platform::Linux =>
+      Ok(FileEntry::{
+        file_path: linux_desktop_path(home_directory, config.identifier),
+        contents: linux_desktop_contents(config),
+      })
+    _ => Err(AutoLaunchError::UnsupportedPlatform(platform))
+  }
+}
+
+///|
+/// Resolves the concrete file entry for a launcher.
+fn resolve_file_entry(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+) -> Result[FileEntry, AutoLaunchError] {
+  match get_home_directory() {
+    Ok(home_directory) =>
+      file_entry_result(launcher.config, platform, home_directory)
+    Err(error) => Err(error)
+  }
+}
+
+///|
+/// Writes a resolved file-backed launcher entry.
+fn write_resolved_file_entry(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  write_file : (String, String) -> Result[Unit, AutoLaunchError],
+) -> Result[Unit, AutoLaunchError] {
+  match resolve_file_entry(launcher, platform, get_home_directory) {
+    Ok(entry) => write_file(entry.file_path, entry.contents)
+    Err(error) => Err(error)
+  }
+}
+
+///|
+/// Removes a resolved file-backed launcher entry.
+fn remove_resolved_file_entry(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  remove_file : (String) -> Result[Unit, AutoLaunchError],
+) -> Result[Unit, AutoLaunchError] {
+  match resolve_file_entry(launcher, platform, get_home_directory) {
+    Ok(entry) => remove_file(entry.file_path)
+    Err(error) => Err(error)
+  }
+}
+
+///|
+/// Checks whether a resolved file-backed launcher entry exists.
+fn resolved_file_entry_exists(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  file_exists : (String) -> Result[Bool, AutoLaunchError],
+) -> Result[Bool, AutoLaunchError] {
+  match resolve_file_entry(launcher, platform, get_home_directory) {
+    Ok(entry) => file_exists(entry.file_path)
+    Err(error) => Err(error)
+  }
+}
+
+///|
+/// Enables auto-launch using injected side-effect functions.
+fn enable_with(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  set_windows_entry : (String, String) -> Result[Unit, AutoLaunchError],
+  write_file : (String, String) -> Result[Unit, AutoLaunchError],
+) -> Result[Unit, AutoLaunchError] {
+  match platform {
+    Platform::Windows =>
+      set_windows_entry(
+        launcher.config.identifier,
+        windows_command(launcher.config),
+      )
+    Platform::Macos | Platform::Linux =>
+      write_resolved_file_entry(
+        launcher, platform, get_home_directory, write_file,
+      )
+    Platform::Unsupported => Err(AutoLaunchError::UnsupportedPlatform(platform))
+  }
+}
+
+///|
+/// Disables auto-launch using injected side-effect functions.
+fn disable_with(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  delete_windows_entry : (String) -> Result[Unit, AutoLaunchError],
+  remove_file : (String) -> Result[Unit, AutoLaunchError],
+) -> Result[Unit, AutoLaunchError] {
+  match platform {
+    Platform::Windows => delete_windows_entry(launcher.config.identifier)
+    Platform::Macos | Platform::Linux =>
+      remove_resolved_file_entry(
+        launcher, platform, get_home_directory, remove_file,
+      )
+    Platform::Unsupported => Err(AutoLaunchError::UnsupportedPlatform(platform))
+  }
+}
+
+///|
+/// Checks whether auto-launch is enabled using injected lookup functions.
+fn is_enabled_with(
+  launcher : AutoLaunch,
+  platform : Platform,
+  get_home_directory : () -> Result[String, AutoLaunchError],
+  windows_entry_exists : (String) -> Result[Bool, AutoLaunchError],
+  file_exists : (String) -> Result[Bool, AutoLaunchError],
+) -> Result[Bool, AutoLaunchError] {
+  match platform {
+    Platform::Windows => windows_entry_exists(launcher.config.identifier)
+    Platform::Macos | Platform::Linux =>
+      resolved_file_entry_exists(
+        launcher, platform, get_home_directory, file_exists,
+      )
+    Platform::Unsupported => Err(AutoLaunchError::UnsupportedPlatform(platform))
+  }
+}

--- a/sys/clipboard/LICENSE
+++ b/sys/clipboard/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 justjavac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sys/clipboard/README.mbt.md
+++ b/sys/clipboard/README.mbt.md
@@ -1,0 +1,37 @@
+# justjavac/clipboard
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+
+Cross-platform native clipboard helpers for MoonBit `native` builds.
+
+This package reads and writes UTF-8 text on Windows, macOS, and Linux with a
+small synchronous API.
+
+## Quick Start
+
+```mbt check
+///|
+test "probe clipboard support and read text" {
+  match @clipboard.ensure_supported() {
+    Ok(_) => ()
+    Err(message) => assert_true(!message.is_empty())
+  }
+
+  match @clipboard.read_text() {
+    Ok(Some(_text)) => ()
+    Ok(None) => ()
+    Err(message) => assert_true(!message.is_empty())
+  }
+}
+```
+
+## Platform Backends
+
+- Windows: Win32 clipboard API
+- macOS: `pbcopy` and `pbpaste`
+- Linux: `wl-copy` / `wl-paste`, then `xclip`, then `xsel`
+
+On Linux, at least one supported clipboard tool must be available on `PATH`.

--- a/sys/clipboard/README.md
+++ b/sys/clipboard/README.md
@@ -1,0 +1,72 @@
+# justjavac/clipboard
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+
+Cross-platform native clipboard helpers for MoonBit `native` builds.
+
+This package reads and writes UTF-8 text on Windows, macOS, and Linux with a
+small synchronous API.
+
+## Install
+
+```bash
+moon add justjavac/clipboard
+```
+
+## Quick Start
+
+```mbt check
+///|
+test "probe clipboard support and read text" {
+  match @clipboard.ensure_supported() {
+    Ok(_) => ()
+    Err(message) => assert_true(!message.is_empty())
+  }
+
+  match @clipboard.read_text() {
+    Ok(Some(_text)) => ()
+    Ok(None) => ()
+    Err(message) => assert_true(!message.is_empty())
+  }
+}
+```
+
+## API
+
+- `is_supported()`: Returns whether a supported backend is available.
+- `ensure_supported()`: Returns `Ok(())` or an explanatory `Err(String)`.
+- `read_text()`: Returns `Ok(Some(text))`, `Ok(None)`, or `Err(String)`.
+- `write_text(text)`: Writes UTF-8 text and returns `Ok(())` or `Err(String)`.
+
+## Platform Backends
+
+- Windows: Win32 clipboard API
+- macOS: `pbcopy` and `pbpaste`
+- Linux: `wl-copy` / `wl-paste`, then `xclip`, then `xsel`
+
+On Linux, at least one supported clipboard tool must be available on `PATH`.
+
+## Examples
+
+```bash
+moon run --manifest-path examples/moon.mod.json check_support
+moon run --manifest-path examples/moon.mod.json read_text
+moon run --manifest-path examples/moon.mod.json write_text
+```
+
+## Test
+
+```bash
+moon test --target native
+moon check --manifest-path examples/moon.mod.json --target native
+```
+
+Integration test:
+
+```bash
+$env:MOONBIT_CLIPBOARD_RUN_INTEGRATION_TESTS = "1"
+moon test --target native --filter "integration*"
+```

--- a/sys/clipboard/clipboard.mbt
+++ b/sys/clipboard/clipboard.mbt
@@ -1,0 +1,223 @@
+///|
+/// Returns whether the native backend is available on the current target.
+extern "C" fn platform_supported_ffi() -> Bool = "mb_clipboard_platform_supported"
+
+///|
+/// Reads raw clipboard text bytes from the native backend.
+extern "C" fn read_text_ffi() -> Bytes = "mb_clipboard_read_text"
+
+///|
+/// Writes UTF-8 encoded text bytes to the native backend.
+#borrow(text)
+extern "C" fn write_text_ffi(text : Bytes) -> Int = "mb_clipboard_write_text"
+
+///|
+/// Returns the last backend error code.
+extern "C" fn last_error_code_ffi() -> Int = "mb_clipboard_last_error_code"
+
+///|
+/// Returns the last backend error message.
+extern "C" fn last_error_message_ffi() -> Bytes = "mb_clipboard_last_error_message"
+
+///|
+/// Decodes clipboard bytes and maps an empty string to `None`.
+fn decode_optional_text(bytes : Bytes) -> String? {
+  let value = @utf8.decode_lossy(bytes[:])
+  if value.is_empty() {
+    None
+  } else {
+    Some(value)
+  }
+}
+
+///|
+/// Decodes an error message or falls back to a default string.
+fn decode_error_message(bytes : Bytes, default : String) -> String {
+  let value = @utf8.decode_lossy(bytes[:])
+  if value.is_empty() {
+    default
+  } else {
+    value
+  }
+}
+
+///|
+/// Returns the shared unsupported-platform error message.
+fn unsupported_error_message() -> String {
+  "clipboard package currently supports Windows, macOS, and Linux native builds only"
+}
+
+///|
+/// Converts a support probe into the public result form.
+fn ensure_supported_result(supported : Bool) -> Result[Unit, String] {
+  if supported {
+    Ok(())
+  } else {
+    Err(unsupported_error_message())
+  }
+}
+
+///|
+/// Converts raw read outputs into the public read result.
+fn read_text_result(
+  supported : Bool,
+  bytes : Bytes,
+  error_code : Int,
+  error_message : Bytes,
+) -> Result[String?, String] {
+  if !supported {
+    Err(unsupported_error_message())
+  } else if error_code == 0 {
+    Ok(decode_optional_text(bytes))
+  } else {
+    Err(decode_error_message(error_message, "clipboard read failed"))
+  }
+}
+
+///|
+/// Converts raw write outputs into the public write result.
+fn write_text_result(
+  supported : Bool,
+  status : Int,
+  error_message : Bytes,
+) -> Result[Unit, String] {
+  if !supported {
+    Err(unsupported_error_message())
+  } else if status == 0 {
+    Ok(())
+  } else {
+    Err(decode_error_message(error_message, "clipboard write failed"))
+  }
+}
+
+///|
+/// Runs a read through injectable callbacks for testing.
+fn read_text_with(
+  supported : Bool,
+  read : () -> Bytes,
+  get_error_code : () -> Int,
+  get_error_message : () -> Bytes,
+) -> Result[String?, String] {
+  if supported {
+    read_text_result(true, read(), get_error_code(), get_error_message())
+  } else {
+    Err(unsupported_error_message())
+  }
+}
+
+///|
+/// Runs a write through injectable callbacks for testing.
+fn write_text_with(
+  supported : Bool,
+  text : String,
+  write : (Bytes) -> Int,
+  get_error_message : () -> Bytes,
+) -> Result[Unit, String] {
+  if supported {
+    write_text_result(true, write(@utf8.encode(text)), get_error_message())
+  } else {
+    Err(unsupported_error_message())
+  }
+}
+
+///|
+/// Returns `true` when the current native target has a clipboard backend that
+/// this package knows how to call.
+///
+/// On Unix-like systems this also checks whether a supported clipboard backend
+/// is available on `PATH`, so the result reflects both platform support and
+/// runtime tool availability.
+///
+/// This function performs only a capability probe. It does not read or modify
+/// clipboard contents.
+///
+/// # Example
+/// ```mbt check
+/// test "is_supported reports capability without touching clipboard" {
+///   let supported = is_supported()
+///   match supported {
+///     true => ()
+///     false => ()
+///   }
+/// }
+/// ```
+pub fn is_supported() -> Bool {
+  platform_supported_ffi()
+}
+
+///|
+/// Verifies that the current native platform is supported by this package.
+///
+/// Returns `Ok(())` on supported platforms and an explanatory `Err(String)` on
+/// unsupported targets. Use this when you want to fail fast before attempting a
+/// clipboard read or write.
+///
+/// This is a convenience wrapper around `is_supported()` for callers that
+/// prefer `Result`-based control flow.
+///
+/// # Example
+/// ```mbt check
+/// test "ensure_supported gives a result-oriented capability check" {
+///   match ensure_supported() {
+///     Ok(_) => ()
+///     Err(message) => assert_true(!message.is_empty())
+///   }
+/// }
+/// ```
+pub fn ensure_supported() -> Result[Unit, String] {
+  ensure_supported_result(is_supported())
+}
+
+///|
+/// Reads the current clipboard text decoded from UTF-8.
+///
+/// The underlying implementation uses `@utf8.decode_lossy`, so any invalid
+/// UTF-8 byte sequences are replaced with the Unicode replacement character
+/// (U+FFFD) instead of causing an error.
+///
+/// Successful reads return `Ok(Some(text))`. If the clipboard currently has no
+/// text content, this returns `Ok(None)`. Unsupported platforms and backend
+/// failures are reported as `Err(String)`.
+///
+/// This function is synchronous and only works on the `native` target.
+///
+/// # Example
+/// ```mbt check
+/// test "read_text returns text, emptiness, or an error" {
+///   match read_text() {
+///     Ok(Some(text)) => assert_true(text.length() >= 0)
+///     Ok(None) => ()
+///     Err(message) => assert_true(!message.is_empty())
+///   }
+/// }
+/// ```
+pub fn read_text() -> Result[String?, String] {
+  read_text_with(
+    is_supported(),
+    read_text_ffi,
+    last_error_code_ffi,
+    last_error_message_ffi,
+  )
+}
+
+///|
+/// Replaces the current clipboard text with `text`.
+///
+/// Returns `Ok(())` when the write succeeds. Unsupported platforms and backend
+/// failures are reported as `Err(String)`. Passing an empty string clears the
+/// clipboard text for backends that model an empty clipboard as empty text.
+///
+/// The string is encoded as UTF-8 before it is passed to the native backend.
+///
+/// # Example
+/// ```mbt check
+/// test "write_text accepts a string and reports success or failure" {
+///   match write_text("") {
+///     Ok(_) => ()
+///     Err(message) => assert_true(!message.is_empty())
+///   }
+/// }
+/// ```
+pub fn write_text(text : String) -> Result[Unit, String] {
+  write_text_with(is_supported(), text, write_text_ffi, last_error_message_ffi)
+}

--- a/sys/clipboard/clipboard_integration_test.mbt
+++ b/sys/clipboard/clipboard_integration_test.mbt
@@ -1,0 +1,53 @@
+///|
+/// Returns whether clipboard integration tests are explicitly enabled.
+fn integration_tests_enabled() -> Bool {
+  match @env.get_env_var("MOONBIT_CLIPBOARD_RUN_INTEGRATION_TESTS") {
+    Some("1") => true
+    Some("true") => true
+    Some("yes") => true
+    Some("on") => true
+    _ => false
+  }
+}
+
+///|
+/// Restores the clipboard text captured before an integration test ran.
+fn restore_clipboard_text(original : String?) -> Result[Unit, String] {
+  match original {
+    Some(text) => @clipboard.write_text(text)
+    None => @clipboard.write_text("")
+  }
+}
+
+///|
+test "integration write and read roundtrip" {
+  guard integration_tests_enabled() else { return }
+
+  guard @clipboard.is_supported() else {
+    fail("integration tests were enabled on an unsupported platform")
+  }
+
+  let original = match @clipboard.read_text() {
+    Ok(value) => value
+    Err(error) => fail("failed to read clipboard before test: " + error)
+  }
+
+  let probe = "justjavac/clipboard integration probe"
+
+  match @clipboard.write_text(probe) {
+    Ok(_) => ()
+    Err(error) => fail("failed to write clipboard probe text: " + error)
+  }
+
+  let roundtrip_result = @clipboard.read_text()
+
+  match restore_clipboard_text(original) {
+    Ok(_) => ()
+    Err(error) => fail("failed to restore original clipboard text: " + error)
+  }
+
+  match roundtrip_result {
+    Ok(value) => assert_eq(value, Some(probe))
+    Err(error) => fail("failed to read clipboard probe text: " + error)
+  }
+}

--- a/sys/clipboard/clipboard_native.c
+++ b/sys/clipboard/clipboard_native.c
@@ -1,0 +1,476 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "moonbit.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "user32.lib")
+#endif
+#else
+#include <sys/wait.h>
+#include <unistd.h>
+#define MB_POPEN popen
+#define MB_PCLOSE pclose
+#endif
+
+#define MB_STATUS_OK 0
+#define MB_STATUS_NOT_AVAILABLE 1
+#define MB_STATUS_PERMISSION_DENIED 2
+#define MB_STATUS_BACKEND_FAILURE 3
+
+#if defined(_MSC_VER)
+#define MB_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define MB_THREAD_LOCAL _Thread_local
+#else
+#define MB_THREAD_LOCAL
+#endif
+
+static MB_THREAD_LOCAL int32_t mb_last_error_code = MB_STATUS_OK;
+static MB_THREAD_LOCAL char mb_last_error_message[512] = "";
+
+static void mb_set_error(int32_t code, const char *message) {
+  mb_last_error_code = code;
+  if (message == NULL) {
+    mb_last_error_message[0] = '\0';
+    return;
+  }
+  snprintf(mb_last_error_message, sizeof(mb_last_error_message), "%s", message);
+}
+
+static moonbit_bytes_t mb_make_bytes_from_buffer(const char *buf, size_t len) {
+  moonbit_bytes_t out = moonbit_make_bytes((int32_t)len, 0);
+  if (len > 0) {
+    memcpy(out, buf, len);
+  }
+  return out;
+}
+
+#ifndef _WIN32
+static int mb_command_exists(const char *name) {
+  const char *path = getenv("PATH");
+  if (path == NULL || *path == '\0') {
+    return 0;
+  }
+
+  size_t name_len = strlen(name);
+  const char *segment = path;
+
+  while (1) {
+    const char *separator = strchr(segment, ':');
+    size_t segment_len =
+      separator == NULL ? strlen(segment) : (size_t)(separator - segment);
+    size_t candidate_len = segment_len + 1 + name_len + 1;
+    char *candidate = (char *)malloc(candidate_len);
+    if (candidate == NULL) {
+      return 0;
+    }
+
+    if (segment_len > 0) {
+      memcpy(candidate, segment, segment_len);
+      candidate[segment_len] = '/';
+      memcpy(candidate + segment_len + 1, name, name_len + 1);
+    } else {
+      memcpy(candidate, name, name_len + 1);
+    }
+
+    int found = access(candidate, X_OK) == 0;
+    free(candidate);
+    if (found) {
+      return 1;
+    }
+
+    if (separator == NULL) {
+      break;
+    }
+    segment = separator + 1;
+  }
+
+  return 0;
+}
+
+static int mb_unix_clipboard_backend_available(void) {
+#if defined(__APPLE__)
+  return mb_command_exists("pbcopy") && mb_command_exists("pbpaste");
+#elif defined(__linux__)
+  if (mb_command_exists("wl-copy") && mb_command_exists("wl-paste")) {
+    return 1;
+  }
+  if (mb_command_exists("xclip")) {
+    return 1;
+  }
+  if (mb_command_exists("xsel")) {
+    return 1;
+  }
+  return 0;
+#else
+  return 0;
+#endif
+}
+#endif
+
+#ifdef _WIN32
+static int mb_win32_error_to_status(DWORD err) {
+  if (err == ERROR_ACCESS_DENIED || err == ERROR_CLIPBOARD_NOT_OPEN) {
+    return MB_STATUS_PERMISSION_DENIED;
+  }
+  return MB_STATUS_BACKEND_FAILURE;
+}
+
+static int mb_win_read_clipboard(char **out_buf, size_t *out_len) {
+  *out_buf = NULL;
+  *out_len = 0;
+
+  if (!OpenClipboard(NULL)) {
+    return mb_win32_error_to_status(GetLastError());
+  }
+
+  if (!IsClipboardFormatAvailable(CF_UNICODETEXT)) {
+    CloseClipboard();
+    *out_buf = (char *)malloc(1);
+    if (*out_buf == NULL) {
+      return MB_STATUS_BACKEND_FAILURE;
+    }
+    (*out_buf)[0] = '\0';
+    return MB_STATUS_OK;
+  }
+
+  HANDLE handle = GetClipboardData(CF_UNICODETEXT);
+  if (handle == NULL) {
+    DWORD err = GetLastError();
+    CloseClipboard();
+    return mb_win32_error_to_status(err);
+  }
+
+  const wchar_t *value = (const wchar_t *)GlobalLock(handle);
+  if (value == NULL) {
+    DWORD err = GetLastError();
+    CloseClipboard();
+    return mb_win32_error_to_status(err);
+  }
+
+  int utf8_len_with_nul = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
+  if (utf8_len_with_nul <= 0) {
+    GlobalUnlock(handle);
+    CloseClipboard();
+    return MB_STATUS_BACKEND_FAILURE;
+  }
+
+  int utf8_len = utf8_len_with_nul - 1;
+  char *buf = (char *)malloc((size_t)utf8_len + 1);
+  if (buf == NULL) {
+    GlobalUnlock(handle);
+    CloseClipboard();
+    return MB_STATUS_BACKEND_FAILURE;
+  }
+
+  int converted =
+    WideCharToMultiByte(CP_UTF8, 0, value, -1, buf, utf8_len_with_nul, NULL, NULL);
+  GlobalUnlock(handle);
+  CloseClipboard();
+  if (converted <= 0) {
+    free(buf);
+    return MB_STATUS_BACKEND_FAILURE;
+  }
+
+  *out_buf = buf;
+  *out_len = (size_t)utf8_len;
+  return MB_STATUS_OK;
+}
+
+static int mb_win_write_clipboard(const char *utf8_text, size_t utf8_len) {
+  int wide_len = 0;
+  if (utf8_len > 0) {
+    wide_len = MultiByteToWideChar(CP_UTF8, 0, utf8_text, (int)utf8_len, NULL, 0);
+    if (wide_len <= 0) {
+      return MB_STATUS_BACKEND_FAILURE;
+    }
+  }
+
+  HGLOBAL handle = GlobalAlloc(GMEM_MOVEABLE, (size_t)(wide_len + 1) * sizeof(wchar_t));
+  if (handle == NULL) {
+    return MB_STATUS_BACKEND_FAILURE;
+  }
+
+  wchar_t *buffer = (wchar_t *)GlobalLock(handle);
+  if (buffer == NULL) {
+    GlobalFree(handle);
+    return MB_STATUS_BACKEND_FAILURE;
+  }
+
+  if (wide_len > 0) {
+    int converted =
+      MultiByteToWideChar(CP_UTF8, 0, utf8_text, (int)utf8_len, buffer, wide_len);
+    if (converted <= 0) {
+      GlobalUnlock(handle);
+      GlobalFree(handle);
+      return MB_STATUS_BACKEND_FAILURE;
+    }
+  }
+  buffer[wide_len] = L'\0';
+  GlobalUnlock(handle);
+
+  if (!OpenClipboard(NULL)) {
+    GlobalFree(handle);
+    return mb_win32_error_to_status(GetLastError());
+  }
+
+  if (!EmptyClipboard()) {
+    DWORD err = GetLastError();
+    CloseClipboard();
+    GlobalFree(handle);
+    return mb_win32_error_to_status(err);
+  }
+
+  if (SetClipboardData(CF_UNICODETEXT, handle) == NULL) {
+    DWORD err = GetLastError();
+    CloseClipboard();
+    GlobalFree(handle);
+    return mb_win32_error_to_status(err);
+  }
+
+  CloseClipboard();
+  return MB_STATUS_OK;
+}
+#endif
+
+#ifndef _WIN32
+static int mb_exit_code_from_pclose(int pclose_rc) {
+  if (pclose_rc == -1) {
+    return -1;
+  }
+  if (WIFEXITED(pclose_rc)) {
+    return WEXITSTATUS(pclose_rc);
+  }
+  return -1;
+}
+
+static int mb_run_read_command(const char *command, char **out_buf, size_t *out_len) {
+  FILE *pipe = MB_POPEN(command, "r");
+  if (pipe == NULL) {
+    return -1;
+  }
+
+  size_t cap = 1024;
+  size_t len = 0;
+  char *buf = (char *)malloc(cap);
+  if (buf == NULL) {
+    MB_PCLOSE(pipe);
+    return -1;
+  }
+
+  while (1) {
+    if (len == cap) {
+      cap *= 2;
+      char *next = (char *)realloc(buf, cap);
+      if (next == NULL) {
+        free(buf);
+        MB_PCLOSE(pipe);
+        return -1;
+      }
+      buf = next;
+    }
+
+    size_t n = fread(buf + len, 1, cap - len, pipe);
+    len += n;
+    if (n == 0) {
+      if (feof(pipe)) {
+        break;
+      }
+      free(buf);
+      MB_PCLOSE(pipe);
+      return -1;
+    }
+  }
+
+  int exit_code = mb_exit_code_from_pclose(MB_PCLOSE(pipe));
+  if (exit_code != 0) {
+    free(buf);
+    return exit_code;
+  }
+
+  *out_buf = buf;
+  *out_len = len;
+  return 0;
+}
+
+static int mb_run_write_command(const char *command, const char *text, size_t len) {
+  FILE *pipe = MB_POPEN(command, "w");
+  if (pipe == NULL) {
+    return -1;
+  }
+
+  if (len > 0 && fwrite(text, 1, len, pipe) != len) {
+    MB_PCLOSE(pipe);
+    return -1;
+  }
+
+  return mb_exit_code_from_pclose(MB_PCLOSE(pipe));
+}
+
+static int mb_try_read_commands(const char *const *commands, size_t command_count,
+                                char **out_buf, size_t *out_len) {
+  int saw_not_available = 0;
+  int saw_permission_denied = 0;
+
+  for (size_t i = 0; i < command_count; i++) {
+    int rc = mb_run_read_command(commands[i], out_buf, out_len);
+    if (rc == 0) {
+      return MB_STATUS_OK;
+    }
+    if (rc == 127) {
+      saw_not_available = 1;
+      continue;
+    }
+    if (rc == 126) {
+      saw_permission_denied = 1;
+      continue;
+    }
+  }
+
+  if (saw_permission_denied) {
+    return MB_STATUS_PERMISSION_DENIED;
+  }
+  if (saw_not_available) {
+    return MB_STATUS_NOT_AVAILABLE;
+  }
+  return MB_STATUS_BACKEND_FAILURE;
+}
+
+static int mb_try_write_commands(const char *const *commands, size_t command_count,
+                                 const char *text, size_t len) {
+  int saw_not_available = 0;
+  int saw_permission_denied = 0;
+
+  for (size_t i = 0; i < command_count; i++) {
+    int rc = mb_run_write_command(commands[i], text, len);
+    if (rc == 0) {
+      return MB_STATUS_OK;
+    }
+    if (rc == 127) {
+      saw_not_available = 1;
+      continue;
+    }
+    if (rc == 126) {
+      saw_permission_denied = 1;
+      continue;
+    }
+  }
+
+  if (saw_permission_denied) {
+    return MB_STATUS_PERMISSION_DENIED;
+  }
+  if (saw_not_available) {
+    return MB_STATUS_NOT_AVAILABLE;
+  }
+  return MB_STATUS_BACKEND_FAILURE;
+}
+#endif
+
+static int mb_try_read_clipboard(char **out_buf, size_t *out_len) {
+#ifdef _WIN32
+  return mb_win_read_clipboard(out_buf, out_len);
+#elif __APPLE__
+  static const char *const commands[] = { "pbpaste" };
+  return mb_try_read_commands(commands, sizeof(commands) / sizeof(commands[0]), out_buf, out_len);
+#elif __linux__
+  static const char *const commands[] = {
+    "wl-paste -n 2>/dev/null",
+    "xclip -selection clipboard -o 2>/dev/null",
+    "xsel --clipboard --output 2>/dev/null",
+  };
+  return mb_try_read_commands(commands, sizeof(commands) / sizeof(commands[0]), out_buf, out_len);
+#else
+  (void)out_buf;
+  (void)out_len;
+  return MB_STATUS_NOT_AVAILABLE;
+#endif
+}
+
+static int mb_try_write_clipboard(const char *text, size_t len) {
+#ifdef _WIN32
+  return mb_win_write_clipboard(text, len);
+#elif __APPLE__
+  static const char *const commands[] = { "pbcopy" };
+  return mb_try_write_commands(commands, sizeof(commands) / sizeof(commands[0]), text, len);
+#elif __linux__
+  static const char *const commands[] = {
+    "wl-copy 2>/dev/null",
+    "xclip -selection clipboard 2>/dev/null",
+    "xsel --clipboard --input 2>/dev/null",
+  };
+  return mb_try_write_commands(commands, sizeof(commands) / sizeof(commands[0]), text, len);
+#else
+  (void)text;
+  (void)len;
+  return MB_STATUS_NOT_AVAILABLE;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_clipboard_platform_supported(void) {
+#if defined(_WIN32)
+  return 1;
+#elif defined(__APPLE__) || defined(__linux__)
+  return mb_unix_clipboard_backend_available();
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_clipboard_read_text(void) {
+  char *buffer = NULL;
+  size_t len = 0;
+  int rc = mb_try_read_clipboard(&buffer, &len);
+
+  if (rc == MB_STATUS_OK) {
+    mb_set_error(MB_STATUS_OK, "");
+    moonbit_bytes_t result = mb_make_bytes_from_buffer(buffer, len);
+    free(buffer);
+    return result;
+  }
+
+  if (rc == MB_STATUS_NOT_AVAILABLE) {
+    mb_set_error(MB_STATUS_NOT_AVAILABLE, "Clipboard backend is unavailable on this system");
+  } else if (rc == MB_STATUS_PERMISSION_DENIED) {
+    mb_set_error(MB_STATUS_PERMISSION_DENIED, "Clipboard permission denied");
+  } else {
+    mb_set_error(MB_STATUS_BACKEND_FAILURE, "Failed to read clipboard");
+  }
+
+  return moonbit_make_bytes(0, 0);
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_clipboard_write_text(moonbit_bytes_t text) {
+  size_t len = (size_t)Moonbit_array_length(text);
+  int rc = mb_try_write_clipboard((const char *)text, len);
+
+  if (rc == MB_STATUS_OK) {
+    mb_set_error(MB_STATUS_OK, "");
+    return MB_STATUS_OK;
+  }
+
+  if (rc == MB_STATUS_NOT_AVAILABLE) {
+    mb_set_error(MB_STATUS_NOT_AVAILABLE, "Clipboard backend is unavailable on this system");
+    return MB_STATUS_NOT_AVAILABLE;
+  }
+  if (rc == MB_STATUS_PERMISSION_DENIED) {
+    mb_set_error(MB_STATUS_PERMISSION_DENIED, "Clipboard permission denied");
+    return MB_STATUS_PERMISSION_DENIED;
+  }
+
+  mb_set_error(MB_STATUS_BACKEND_FAILURE, "Failed to write clipboard");
+  return MB_STATUS_BACKEND_FAILURE;
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_clipboard_last_error_code(void) {
+  return mb_last_error_code;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_clipboard_last_error_message(void) {
+  return mb_make_bytes_from_buffer(mb_last_error_message, strlen(mb_last_error_message));
+}

--- a/sys/clipboard/clipboard_test.mbt
+++ b/sys/clipboard/clipboard_test.mbt
@@ -1,0 +1,16 @@
+///|
+test "public api symbols are exported" {
+  ignore(@clipboard.is_supported)
+  ignore(@clipboard.ensure_supported)
+  ignore(@clipboard.read_text)
+  ignore(@clipboard.write_text)
+}
+
+///|
+test "ensure_supported matches platform probe" {
+  match (@clipboard.is_supported(), @clipboard.ensure_supported()) {
+    (true, Ok(_)) => ()
+    (false, Err(_)) => ()
+    _ => fail("ensure_supported should agree with is_supported")
+  }
+}

--- a/sys/clipboard/clipboard_wbtest.mbt
+++ b/sys/clipboard/clipboard_wbtest.mbt
@@ -1,0 +1,143 @@
+///|
+test "empty clipboard text decodes to None" {
+  assert_eq(decode_optional_text(@utf8.encode("")), None)
+}
+
+///|
+test "utf8 clipboard text decodes to Some" {
+  assert_eq(decode_optional_text(@utf8.encode("hello")), Some("hello"))
+  assert_eq(
+    decode_optional_text(@utf8.encode("hello world")),
+    Some("hello world"),
+  )
+}
+
+///|
+test "error message falls back when ffi message is empty" {
+  assert_eq(decode_error_message(@utf8.encode(""), "fallback"), "fallback")
+  assert_eq(
+    decode_error_message(@utf8.encode("clipboard unavailable"), "fallback"),
+    "clipboard unavailable",
+  )
+}
+
+///|
+test "ensure_supported_result covers both outcomes" {
+  assert_eq(ensure_supported_result(true), Ok(()))
+  assert_eq(ensure_supported_result(false), Err(unsupported_error_message()))
+}
+
+///|
+test "read_text_result handles unsupported clipboard" {
+  assert_eq(
+    read_text_result(false, @utf8.encode("ignored"), 0, @utf8.encode("ignored")),
+    Err(unsupported_error_message()),
+  )
+}
+
+///|
+test "read_text_result handles success cases" {
+  assert_eq(
+    read_text_result(true, @utf8.encode(""), 0, @utf8.encode("")),
+    Ok(None),
+  )
+  assert_eq(
+    read_text_result(true, @utf8.encode("hello"), 0, @utf8.encode("")),
+    Ok(Some("hello")),
+  )
+}
+
+///|
+test "read_text_result handles explicit and fallback errors" {
+  assert_eq(
+    read_text_result(
+      true,
+      @utf8.encode("ignored"),
+      1,
+      @utf8.encode("backend failed"),
+    ),
+    Err("backend failed"),
+  )
+  assert_eq(
+    read_text_result(true, @utf8.encode("ignored"), 1, @utf8.encode("")),
+    Err("clipboard read failed"),
+  )
+}
+
+///|
+test "write_text_result handles unsupported clipboard" {
+  assert_eq(
+    write_text_result(false, 1, @utf8.encode("ignored")),
+    Err(unsupported_error_message()),
+  )
+}
+
+///|
+test "write_text_result handles success and error cases" {
+  assert_eq(write_text_result(true, 0, @utf8.encode("")), Ok(()))
+  assert_eq(
+    write_text_result(true, 1, @utf8.encode("permission denied")),
+    Err("permission denied"),
+  )
+  assert_eq(
+    write_text_result(true, 1, @utf8.encode("")),
+    Err("clipboard write failed"),
+  )
+}
+
+///|
+test "read_text_with covers supported and unsupported wrapper paths" {
+  assert_eq(
+    read_text_with(true, fn() { @utf8.encode("wrapped") }, fn() { 0 }, fn() {
+      @utf8.encode("")
+    }),
+    Ok(Some("wrapped")),
+  )
+  assert_eq(
+    read_text_with(false, fn() { @utf8.encode("ignored") }, fn() { 1 }, fn() {
+      @utf8.encode("ignored")
+    }),
+    Err(unsupported_error_message()),
+  )
+}
+
+///|
+test "write_text_with covers supported and unsupported wrapper paths" {
+  assert_eq(
+    write_text_with(
+      true,
+      "wrapped",
+      fn(bytes) {
+        if @utf8.decode_lossy(bytes[:]) == "wrapped" {
+          0
+        } else {
+          1
+        }
+      },
+      fn() { @utf8.encode("") },
+    ),
+    Ok(()),
+  )
+  assert_eq(
+    write_text_with(false, "ignored", fn(_bytes) { 1 }, fn() {
+      @utf8.encode("ignored")
+    }),
+    Err(unsupported_error_message()),
+  )
+}
+
+///|
+test "public read_text can be invoked without mutating clipboard" {
+  match read_text() {
+    Ok(_) => ()
+    Err(_) => ()
+  }
+}
+
+///|
+test "public write_text can be invoked with a harmless payload" {
+  match write_text("") {
+    Ok(_) => ()
+    Err(_) => ()
+  }
+}

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,0 +1,23 @@
+name = "justjavac/clipboard"
+
+version = "0.1.5"
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/clipboard"
+
+license = "MIT"
+
+keywords = [ "desktop", "clipboard", "native", "windows", "macos", "linux" ]
+
+description = "Cross-platform native clipboard helpers for MoonBit."
+
+warnings = ""
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "+native",
+)

--- a/sys/clipboard/moon.pkg
+++ b/sys/clipboard/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/core/encoding/utf8",
+}
+
+import {
+  "moonbitlang/core/env",
+} for "test"
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "clipboard_native.c" ],
+  targets: { "clipboard.mbt": [ "native" ] },
+)

--- a/sys/clipboard/pkg.generated.mbti
+++ b/sys/clipboard/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/clipboard"
+
+// Values
+pub fn ensure_supported() -> Result[Unit, String]
+
+pub fn is_supported() -> Bool
+
+pub fn read_text() -> Result[String?, String]
+
+pub fn write_text(String) -> Result[Unit, String]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/sys/global_hotkey/LICENSE
+++ b/sys/global_hotkey/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justjavac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sys/global_hotkey/README.mbt.md
+++ b/sys/global_hotkey/README.mbt.md
@@ -1,0 +1,24 @@
+# justjavac/global_hotkey
+
+[![CI](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+
+Cross-platform native global hotkey helpers for MoonBit.
+
+This package targets `native` and supports Windows, macOS, and Linux X11 sessions.
+
+## Example
+
+```mbt check
+///|
+test "global_hotkey can be probed safely" {
+  ignore(@global_hotkey.is_supported())
+  match @global_hotkey.create() {
+    Ok(manager) => manager.destroy()
+    Err(_) => ()
+  }
+}
+```

--- a/sys/global_hotkey/README.md
+++ b/sys/global_hotkey/README.md
@@ -1,0 +1,120 @@
+# justjavac/global_hotkey
+
+[![CI](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/justjavac/global_hotkey)
+
+Cross-platform native global hotkey helpers for MoonBit.
+
+This package targets `native` and supports Windows, macOS, and Linux X11 sessions, and exposes a small polling-friendly API for registering, unregistering, and draining global shortcut events.
+
+## Platform support
+
+| Platform | Backend | Notes |
+| --- | --- | --- |
+| Windows | `RegisterHotKey` | No extra permission prompt is expected for ordinary desktop apps. |
+| macOS | global event tap | Input Monitoring permission may be required before `create()` succeeds. |
+| Linux | X11 via `libX11` | Requires an X11 session or XWayland-compatible `DISPLAY`. Native Wayland-only sessions are out of scope. |
+
+## Install
+
+```bash
+moon add justjavac/global_hotkey
+```
+
+## Quick start
+
+Minimal checked example:
+
+```mbt check
+test "global_hotkey support can be queried" {
+  ignore(@global_hotkey.is_supported())
+  ignore(@global_hotkey.ensure_supported())
+}
+```
+
+Typical polling loop:
+
+```mbt nocheck
+let manager = match @global_hotkey.create() {
+  Ok(manager) => manager
+  Err(error) => fail(error)
+}
+
+ignore(manager.register("Ctrl+Shift+K"))
+ignore(manager.register("Meta+Space"))
+
+while true {
+  for accelerator in manager.drain_triggered() {
+    println("triggered: \{accelerator}")
+  }
+}
+```
+
+## Accelerator syntax
+
+Accelerators are normalized before they are stored or returned from the API.
+
+- Modifier order is always `Ctrl+Shift+Alt+Meta+Key`.
+- Supported modifier aliases:
+  `Ctrl`, `Control`, `Ctl`
+  `Alt`, `Option`
+  `Meta`, `Cmd`, `Command`, `Win`, `Windows`, `Super`
+- Supported key groups:
+  letters `A-Z`
+  digits `0-9`
+  function keys `F1-F24`
+  navigation keys such as `Left`, `Right`, `Up`, `Down`, `Home`, `End`, `PageUp`, `PageDown`
+  text keys such as `Space`, `Tab`, `Enter`, `Escape`, `Backspace`, `Delete`, `Insert`
+  punctuation keys such as `Minus`, `Equal`, `Plus`, `Comma`, `Period`, `Slash`, `Backslash`, `Semicolon`, `Quote`, `Backquote`, `LeftBracket`, `RightBracket`
+
+Examples:
+
+- `ctrl + shift + k` -> `Ctrl+Shift+K`
+- `cmd+option+space` -> `Alt+Meta+Space`
+- `ctrl+-` -> `Ctrl+Minus`
+- `meta+page-up` -> `Meta+PageUp`
+
+## Public API
+
+- `is_supported() -> Bool`
+- `ensure_supported() -> Result[Unit, String]`
+- `create() -> Result[GlobalHotkeyManager, String]`
+- `GlobalHotkeyManager::register(String) -> Result[Bool, String]`
+- `GlobalHotkeyManager::unregister(String) -> Result[Bool, String]`
+- `GlobalHotkeyManager::list() -> Array[String]`
+- `GlobalHotkeyManager::take_triggered() -> String?`
+- `GlobalHotkeyManager::drain_triggered() -> Array[String]`
+- `GlobalHotkeyManager::destroy() -> Unit`
+
+Operational notes:
+
+- `register()` returns `Ok(true)` when the backend accepted the accelerator.
+- `unregister()` returns `Ok(true)` when something was removed and `Ok(false)` when nothing matched.
+- `take_triggered()` and `drain_triggered()` never block.
+- `destroy()` is idempotent. After destruction, mutating methods return an error and polling returns `None` or an empty array.
+
+## Build requirements
+
+- Windows: ordinary Visual Studio native toolchain is enough.
+- macOS: the system SDK must provide `ApplicationServices`, `Carbon`, and `CoreFoundation`.
+- Linux: install the X11 development headers to build, for example `libx11-dev` on Debian or Ubuntu.
+
+## Development
+
+Key commands:
+
+```bash
+moon check --target native
+moon test --target native
+moon coverage analyze -p justjavac/global_hotkey -- -f summary
+moon info
+moon fmt
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/sys/global_hotkey/errors.mbt
+++ b/sys/global_hotkey/errors.mbt
@@ -1,0 +1,40 @@
+///|
+/// Declares shared error message helpers for the public API.
+fn decode_error_message(bytes : Bytes, default : String) -> String {
+  let value = @utf8.decode_lossy(bytes[:])
+  if value.is_empty() {
+    default
+  } else {
+    value
+  }
+}
+
+///|
+/// Returns the generic unsupported-platform message for this package.
+fn unsupported_error_message() -> String {
+  "global_hotkey supports Windows and macOS native builds, plus Linux native builds running on X11."
+}
+
+///|
+/// Builds a fallback message for native initialization failures.
+fn create_error_message() -> String {
+  "global_hotkey failed to initialize the native backend"
+}
+
+///|
+/// Builds a fallback message for native registration failures.
+fn register_error_message(accelerator : String) -> String {
+  "global_hotkey failed to register: " + accelerator
+}
+
+///|
+/// Builds a fallback message for native unregistration failures.
+fn unregister_error_message(accelerator : String) -> String {
+  "global_hotkey failed to unregister: " + accelerator
+}
+
+///|
+/// Builds a fallback message for operations attempted after destroy.
+fn destroyed_error_message() -> String {
+  "global_hotkey manager has already been destroyed"
+}

--- a/sys/global_hotkey/ffi.mbt
+++ b/sys/global_hotkey/ffi.mbt
@@ -1,0 +1,45 @@
+///|
+/// Represents the opaque native backend handle owned by `GlobalHotkeyManager`.
+///
+/// Package users do not inspect values of this type directly. It exists so the
+/// manager can retain the foreign state returned by the platform backend.
+#external
+pub type GlobalHotkeyState
+
+///|
+/// Queries whether a backend is currently available on this native target.
+extern "C" fn platform_supported_ffi() -> Bool = "mb_global_hotkey_platform_supported"
+
+///|
+/// Allocates a backend state object for polling global hotkeys.
+extern "C" fn create_state_ffi() -> GlobalHotkeyState = "mb_global_hotkey_create"
+
+///|
+/// Releases every native resource associated with a backend state.
+extern "C" fn destroy_state_ffi(state : GlobalHotkeyState) -> Unit = "mb_global_hotkey_destroy"
+
+///|
+/// Checks whether an external state pointer is null.
+extern "C" fn state_is_null_ffi(state : GlobalHotkeyState) -> Bool = "moonbit_is_null"
+
+///|
+/// Registers a parsed hotkey against the backend.
+#borrow(key_name)
+extern "C" fn register_hotkey_ffi(
+  state : GlobalHotkeyState,
+  id : Int,
+  modifiers : Int,
+  key_name : Bytes,
+) -> Int = "mb_global_hotkey_register"
+
+///|
+/// Unregisters a previously registered hotkey id from the backend.
+extern "C" fn unregister_hotkey_ffi(state : GlobalHotkeyState, id : Int) -> Int = "mb_global_hotkey_unregister"
+
+///|
+/// Pops the next triggered hotkey id from the backend queue.
+extern "C" fn take_triggered_id_ffi(state : GlobalHotkeyState) -> Int = "mb_global_hotkey_take_triggered_id"
+
+///|
+/// Returns the last backend error message as UTF-8 bytes.
+extern "C" fn last_error_message_ffi() -> Bytes = "mb_global_hotkey_last_error_message"

--- a/sys/global_hotkey/global_hotkey.mbt
+++ b/sys/global_hotkey/global_hotkey.mbt
@@ -1,0 +1,391 @@
+///|
+/// Owns one native backend instance and the normalized registration index for it.
+///
+/// Create a value with `create()`, use its methods to manage global shortcuts,
+/// and call `destroy()` when you are finished so the native resources are
+/// released promptly.
+pub struct GlobalHotkeyManager {
+  state : GlobalHotkeyState
+  store : RegistrationStore
+}
+
+///|
+/// Resolves the backend state unless the manager has already been destroyed.
+fn GlobalHotkeyManager::resolve_state(
+  self : GlobalHotkeyManager,
+) -> Result[GlobalHotkeyState, String] {
+  if self.store.destroyed {
+    Err(destroyed_error_message())
+  } else if state_is_null_ffi(self.state) {
+    Err(create_error_message())
+  } else {
+    Ok(self.state)
+  }
+}
+
+///|
+/// Converts the support probe into the package's public result shape.
+fn ensure_supported_result(
+  supported : Bool,
+  error_message : Bytes,
+) -> Result[Unit, String] {
+  if supported {
+    Ok(())
+  } else {
+    Err(decode_error_message(error_message, unsupported_error_message()))
+  }
+}
+
+///|
+/// Converts a native create failure into the package's public result shape.
+fn create_status_result(
+  is_null : Bool,
+  error_message : Bytes,
+) -> Result[Unit, String] {
+  if is_null {
+    Err(decode_error_message(error_message, create_error_message()))
+  } else {
+    Ok(())
+  }
+}
+
+///|
+/// Converts a native register status code into the package's public result shape.
+fn register_status_result(
+  status : Int,
+  error_message : Bytes,
+  accelerator : String,
+) -> Result[Bool, String] {
+  if status == 0 {
+    Ok(true)
+  } else {
+    Err(
+      decode_error_message(error_message, register_error_message(accelerator)),
+    )
+  }
+}
+
+///|
+/// Converts a native unregister status code into the package's public result shape.
+fn unregister_status_result(
+  status : Int,
+  error_message : Bytes,
+  accelerator : String,
+) -> Result[Bool, String] {
+  if status == 0 {
+    Ok(true)
+  } else {
+    Err(
+      decode_error_message(error_message, unregister_error_message(accelerator)),
+    )
+  }
+}
+
+///|
+/// Drains repeated trigger reads into one array.
+fn drain_with(take : () -> String?) -> Array[String] {
+  let accelerators : Array[String] = []
+  while true {
+    match take() {
+      Some(accelerator) => accelerators.push(accelerator)
+      None => break
+    }
+  }
+  accelerators
+}
+
+///|
+/// Returns `true` when the current native target exposes a usable global hotkey backend.
+///
+/// This is a lightweight capability probe that does not allocate a manager, so
+/// it is safe to call repeatedly during startup. On Linux it checks for an X11
+/// session and an X11 backend that can be opened at runtime. On macOS a later
+/// `create()` call may still fail until the process has Input Monitoring
+/// permission.
+///
+/// Use this when you only need a boolean answer. If you also want a
+/// human-readable failure reason, call `ensure_supported()` instead.
+///
+/// # Returns
+///
+/// Returns `true` when this package can open a native backend on the current
+/// machine. Returns `false` when the target is unsupported, when Linux lacks an
+/// X11 session, or when the runtime backend cannot currently be loaded.
+///
+/// ```mbt check
+/// test "support detection can be queried" {
+///   ignore(@global_hotkey.is_supported())
+/// }
+/// ```
+pub fn is_supported() -> Bool {
+  platform_supported_ffi()
+}
+
+///|
+/// Verifies that the current native target has a backend this package can use.
+///
+/// This is useful for fast-fail checks before building a polling loop. Unlike
+/// `create()`, it only reports capability and does not retain any native state.
+/// When the probe can provide a concrete reason, the returned `Err(String)`
+/// contains it; otherwise a generic compatibility message is used.
+///
+/// Call this when you want an actionable error message for logs or setup flows
+/// before attempting real registration work.
+///
+/// # Returns
+///
+/// Returns `Ok(())` when a backend is available right now. Returns `Err(String)`
+/// with a human-readable reason when the current target cannot provide global
+/// hotkeys.
+///
+/// ```mbt check
+/// test "support can be checked without registering anything" {
+///   ignore(@global_hotkey.ensure_supported())
+/// }
+/// ```
+pub fn ensure_supported() -> Result[Unit, String] {
+  ensure_supported_result(is_supported(), last_error_message_ffi())
+}
+
+///|
+/// Creates a manager that can register, unregister, and poll global hotkeys.
+///
+/// This allocates the native backend state and initializes the package's
+/// normalized registration store. The returned manager owns native resources
+/// until `destroy()` is called, so long-lived applications will usually create
+/// one manager and reuse it for their polling loop.
+///
+/// Returns `Err(String)` when the backend cannot be initialized on the current
+/// machine, including unsupported platforms, missing Linux X11 support, or
+/// missing macOS Input Monitoring permission.
+///
+/// # Returns
+///
+/// Returns `Ok(GlobalHotkeyManager)` when the native backend starts
+/// successfully. The returned manager is ready to register accelerators, poll
+/// for triggered shortcuts, and later release its resources with `destroy()`.
+///
+/// # Lifecycle
+///
+/// Each successful call creates an independent manager with its own MoonBit-side
+/// registration store. Most applications should create one manager during
+/// startup and keep it alive for the duration of their event loop.
+///
+/// ```mbt check
+/// test "manager creation can be attempted safely" {
+///   match @global_hotkey.create() {
+///     Ok(manager) => manager.destroy()
+///     Err(_) => ()
+///   }
+/// }
+/// ```
+pub fn create() -> Result[GlobalHotkeyManager, String] {
+  let state = create_state_ffi()
+  match
+    create_status_result(state_is_null_ffi(state), last_error_message_ffi()) {
+    Err(error) => Err(error)
+    Ok(_) => Ok({ state, store: new_registration_store() })
+  }
+}
+
+///|
+/// Registers one global accelerator like `Ctrl+Shift+K` or `Meta+Space`.
+///
+/// Supported modifier aliases include `Ctrl` / `Control`, `Alt` / `Option`,
+/// and `Meta` / `Cmd` / `Command` / `Win` / `Super`. The accelerator is
+/// normalized before registration, so `ctrl + shift + k` is stored as
+/// `Ctrl+Shift+K`.
+///
+/// Every accelerator must contain exactly one non-modifier key. Duplicate
+/// modifiers such as `Ctrl+Control+K` and malformed segments such as
+/// `Ctrl++K` are rejected before the native backend is called.
+///
+/// Returns `Ok(true)` when the native backend accepted the registration.
+/// Returns `Err(String)` when the accelerator is malformed, the normalized
+/// shortcut is already registered by this manager, the manager has already been
+/// destroyed, or the native backend rejects the request.
+///
+/// Successful registrations become visible immediately through `list()`,
+/// `take_triggered()`, and `drain_triggered()`.
+///
+/// # Parameters
+///
+/// `accelerator` is a user-facing shortcut string such as `Ctrl+Shift+K`,
+/// `Meta+Space`, or `Alt+F12`.
+///
+/// # Returns
+///
+/// Returns `Ok(true)` when the registration is now active for this manager.
+/// Returns `Err(String)` when parsing fails, the normalized shortcut is already
+/// present in this manager, the manager has been destroyed, or the OS backend
+/// refuses the registration.
+///
+/// ```mbt check
+/// test "register may be attempted on a live manager" {
+///   match @global_hotkey.create() {
+///     Ok(manager) => {
+///       ignore(manager.register("Ctrl+Shift+F24"))
+///       ignore(manager.unregister("Ctrl+Shift+F24"))
+///       manager.destroy()
+///     }
+///     Err(_) => ()
+///   }
+/// }
+/// ```
+pub fn GlobalHotkeyManager::register(
+  self : GlobalHotkeyManager,
+  accelerator : String,
+) -> Result[Bool, String] {
+  match self.resolve_state() {
+    Err(error) => Err(error)
+    Ok(state) =>
+      match self.store.plan_register(accelerator) {
+        Err(error) => Err(error)
+        Ok(plan) =>
+          match
+            register_status_result(
+              register_hotkey_ffi(
+                state,
+                plan.id,
+                plan.parsed.modifiers,
+                @utf8.encode(plan.parsed.key_name),
+              ),
+              last_error_message_ffi(),
+              plan.parsed.normalized,
+            ) {
+            Err(error) => Err(error)
+            Ok(result) => {
+              self.store.commit_register(plan)
+              Ok(result)
+            }
+          }
+      }
+  }
+}
+
+///|
+/// Unregisters one previously registered accelerator.
+///
+/// The accelerator string is normalized with the same rules as `register()`.
+/// Callers may therefore use any supported alias or spacing style.
+///
+/// Returns `Ok(true)` when a registration existed and was removed, `Ok(false)`
+/// when nothing matched in this manager, and `Err(String)` when the accelerator
+/// is malformed, the manager was destroyed, or the backend refuses the
+/// unregistration.
+///
+/// # Parameters
+///
+/// `accelerator` may use any supported alias or spacing style. It is normalized
+/// before lookup, so `ctrl + k` and `Ctrl+K` refer to the same registration.
+///
+/// # Returns
+///
+/// Returns `Ok(true)` when a matching registration existed and has been removed.
+/// Returns `Ok(false)` when the manager was alive but no normalized shortcut
+/// matched. Returns `Err(String)` when parsing fails, the manager has already
+/// been destroyed, or the native backend reports an unregistration error.
+pub fn GlobalHotkeyManager::unregister(
+  self : GlobalHotkeyManager,
+  accelerator : String,
+) -> Result[Bool, String] {
+  match self.resolve_state() {
+    Err(error) => Err(error)
+    Ok(state) =>
+      match self.store.plan_unregister(accelerator) {
+        Err(error) => Err(error)
+        Ok(None) => Ok(false)
+        Ok(Some(plan)) =>
+          match
+            unregister_status_result(
+              unregister_hotkey_ffi(state, plan.id),
+              last_error_message_ffi(),
+              plan.normalized,
+            ) {
+            Err(error) => Err(error)
+            Ok(result) => {
+              self.store.commit_unregister(plan)
+              Ok(result)
+            }
+          }
+      }
+  }
+}
+
+///|
+/// Returns a snapshot of every accelerator currently registered in this manager.
+///
+/// Each entry uses the canonical normalized form produced by `register()`. This
+/// only reads the MoonBit-side registry, so it does not block on the native
+/// backend and remains available even when no triggers are pending.
+///
+/// # Returns
+///
+/// Returns an array of normalized accelerators in registration order. The
+/// returned array is a snapshot, so later `register()` or `unregister()` calls
+/// do not mutate previously returned arrays.
+pub fn GlobalHotkeyManager::list(self : GlobalHotkeyManager) -> Array[String] {
+  self.store.list()
+}
+
+///|
+/// Pops the next triggered accelerator from the native queue, if any.
+///
+/// This call never blocks. It returns `Some(String)` for the next queued
+/// trigger in normalized form and `None` when the queue is empty or when the
+/// manager has already been destroyed.
+///
+/// Poll this method from your application's main loop when you want to react to
+/// global shortcuts one event at a time.
+///
+/// # Returns
+///
+/// Returns `Some(String)` with the next queued normalized accelerator when one
+/// is available. Returns `None` when no trigger is pending or when polling is
+/// no longer possible because the manager has been destroyed.
+pub fn GlobalHotkeyManager::take_triggered(
+  self : GlobalHotkeyManager,
+) -> String? {
+  match self.resolve_state() {
+    Err(_) => None
+    Ok(state) => self.store.lookup_trigger(take_triggered_id_ffi(state))
+  }
+}
+
+///|
+/// Drains every currently queued trigger in the order reported by the backend.
+///
+/// This is a convenience wrapper over repeated `take_triggered()` calls and is
+/// useful when you poll infrequently or want to batch-handle pending shortcuts.
+/// It returns an empty array when nothing is queued, and it also becomes empty
+/// after `destroy()` because polling is no longer possible.
+///
+/// # Returns
+///
+/// Returns an array containing every currently queued normalized accelerator in
+/// FIFO order. The queue is empty after this call returns, because all pending
+/// trigger ids have been consumed.
+pub fn GlobalHotkeyManager::drain_triggered(
+  self : GlobalHotkeyManager,
+) -> Array[String] {
+  drain_with(fn() { self.take_triggered() })
+}
+
+///|
+/// Releases every native resource owned by this manager and clears its registry.
+///
+/// Calling `destroy()` more than once is harmless. After destruction,
+/// `register()` and `unregister()` return `Err(String)`, `take_triggered()`
+/// returns `None`, and `drain_triggered()` returns `[]`.
+///
+/// # Lifecycle
+///
+/// Call this once you no longer need the manager, typically during application
+/// shutdown. After destruction, the value may still exist as a MoonBit object,
+/// but it no longer owns a usable native backend.
+pub fn GlobalHotkeyManager::destroy(self : GlobalHotkeyManager) -> Unit {
+  if !self.store.destroyed {
+    destroy_state_ffi(self.state)
+    self.store.destroy()
+  }
+}

--- a/sys/global_hotkey/global_hotkey_native.c
+++ b/sys/global_hotkey/global_hotkey_native.c
@@ -1,0 +1,1811 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "moonbit.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "user32.lib")
+#endif
+#else
+#include <dlfcn.h>
+#include <pthread.h>
+#endif
+
+#ifdef __linux__
+#include <sys/select.h>
+#include <unistd.h>
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+#endif
+
+#ifdef __APPLE__
+#include <ApplicationServices/ApplicationServices.h>
+#include <Carbon/Carbon.h>
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
+#define MB_MOD_ALT 0x0001u
+#define MB_MOD_CONTROL 0x0002u
+#define MB_MOD_SHIFT 0x0004u
+#define MB_MOD_META 0x0008u
+
+#if defined(_MSC_VER)
+#define MB_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define MB_THREAD_LOCAL _Thread_local
+#else
+#define MB_THREAD_LOCAL
+#endif
+
+typedef struct mb_registration {
+  int32_t id;
+  uint32_t modifiers;
+  uint32_t keycode;
+  struct mb_registration *next;
+} mb_registration_t;
+
+typedef struct mb_trigger {
+  int32_t id;
+  struct mb_trigger *next;
+} mb_trigger_t;
+
+typedef struct mb_global_hotkey_state {
+  mb_registration_t *registrations;
+  mb_trigger_t *triggered_head;
+  mb_trigger_t *triggered_tail;
+  int32_t startup_status;
+  char startup_error[512];
+#ifdef _WIN32
+  HANDLE thread;
+  HANDLE ready_event;
+  DWORD thread_id;
+  CRITICAL_SECTION lock;
+#elif defined(__linux__)
+  pthread_t thread;
+  pthread_mutex_t lock;
+  pthread_cond_t ready_cond;
+  int ready;
+  int running;
+  int thread_started;
+  int wake_pipe[2];
+  Display *display;
+  Window root_window;
+  unsigned int lock_mask;
+  unsigned int numlock_mask;
+#elif defined(__APPLE__)
+  pthread_t thread;
+  pthread_mutex_t lock;
+  pthread_cond_t ready_cond;
+  int ready;
+  int running;
+  int thread_started;
+  CFMachPortRef event_tap;
+  CFRunLoopRef run_loop;
+#endif
+} mb_global_hotkey_state_t;
+
+static int mb_name_is_function_key(const char *name);
+static int mb_keycode_from_name_common(
+    const char *name,
+    uint32_t *out_alpha_numeric);
+static void mb_state_set_startup_error(
+    mb_global_hotkey_state_t *state,
+    const char *message);
+static void mb_push_trigger_locked(
+    mb_global_hotkey_state_t *state,
+    int32_t id);
+
+#ifdef __APPLE__
+typedef struct mb_macos_api {
+  void *app_services;
+  void *core_foundation;
+  int loaded;
+  int initialized;
+  CFMachPortRef (*CGEventTapCreate)(CGEventTapLocation, CGEventTapPlacement,
+                                    CGEventTapOptions, CGEventMask,
+                                    CGEventTapCallBack, void *);
+  void (*CGEventTapEnable)(CFMachPortRef, bool);
+  CGEventFlags (*CGEventGetFlags)(CGEventRef);
+  int64_t (*CGEventGetIntegerValueField)(CGEventRef, CGEventField);
+  CFRunLoopSourceRef (*CFMachPortCreateRunLoopSource)(CFAllocatorRef,
+                                                      CFMachPortRef, CFIndex);
+  CFRunLoopObserverRef (*CFRunLoopObserverCreate)(
+      CFAllocatorRef,
+      CFOptionFlags,
+      Boolean,
+      CFIndex,
+      CFRunLoopObserverCallBack,
+      CFRunLoopObserverContext *);
+  CFRunLoopRef (*CFRunLoopGetCurrent)(void);
+  void (*CFRunLoopAddSource)(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef);
+  void (*CFRunLoopAddObserver)(CFRunLoopRef, CFRunLoopObserverRef, CFStringRef);
+  void (*CFRunLoopRun)(void);
+  void (*CFRunLoopStop)(CFRunLoopRef);
+  void (*CFRunLoopWakeUp)(CFRunLoopRef);
+  CFTypeRef (*CFRetain)(CFTypeRef);
+  void (*CFRelease)(CFTypeRef);
+  CFStringRef (*CFStringCreateWithCString)(CFAllocatorRef, const char *,
+                                          CFStringEncoding);
+} mb_macos_api_t;
+
+static mb_macos_api_t mb_macos_api;
+
+static int mb_macos_load_api(void) {
+  if (mb_macos_api.initialized) {
+    return mb_macos_api.loaded;
+  }
+
+  memset(&mb_macos_api, 0, sizeof(mb_macos_api));
+  mb_macos_api.initialized = 1;
+  mb_macos_api.app_services = dlopen(
+      "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices",
+      RTLD_LAZY | RTLD_LOCAL);
+  mb_macos_api.core_foundation = dlopen(
+      "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+      RTLD_LAZY | RTLD_LOCAL);
+  if (mb_macos_api.app_services == NULL || mb_macos_api.core_foundation == NULL) {
+    return 0;
+  }
+
+  mb_macos_api.CGEventTapCreate =
+      (CFMachPortRef(*)(CGEventTapLocation, CGEventTapPlacement,
+                        CGEventTapOptions, CGEventMask, CGEventTapCallBack,
+                        void *))dlsym(mb_macos_api.app_services, "CGEventTapCreate");
+  mb_macos_api.CGEventTapEnable =
+      (void (*)(CFMachPortRef, bool))dlsym(mb_macos_api.app_services, "CGEventTapEnable");
+  mb_macos_api.CGEventGetFlags =
+      (CGEventFlags(*)(CGEventRef))dlsym(mb_macos_api.app_services, "CGEventGetFlags");
+  mb_macos_api.CGEventGetIntegerValueField =
+      (int64_t(*)(CGEventRef, CGEventField))dlsym(
+          mb_macos_api.app_services, "CGEventGetIntegerValueField");
+  mb_macos_api.CFMachPortCreateRunLoopSource =
+      (CFRunLoopSourceRef(*)(CFAllocatorRef, CFMachPortRef, CFIndex))dlsym(
+          mb_macos_api.core_foundation, "CFMachPortCreateRunLoopSource");
+  mb_macos_api.CFRunLoopObserverCreate =
+      (CFRunLoopObserverRef(*)(CFAllocatorRef, CFOptionFlags, Boolean, CFIndex,
+                               CFRunLoopObserverCallBack,
+                               CFRunLoopObserverContext *))dlsym(
+          mb_macos_api.core_foundation, "CFRunLoopObserverCreate");
+  mb_macos_api.CFRunLoopGetCurrent =
+      (CFRunLoopRef(*)(void))dlsym(mb_macos_api.core_foundation, "CFRunLoopGetCurrent");
+  mb_macos_api.CFRunLoopAddSource =
+      (void (*)(CFRunLoopRef, CFRunLoopSourceRef, CFStringRef))dlsym(
+          mb_macos_api.core_foundation, "CFRunLoopAddSource");
+  mb_macos_api.CFRunLoopAddObserver =
+      (void (*)(CFRunLoopRef, CFRunLoopObserverRef, CFStringRef))dlsym(
+          mb_macos_api.core_foundation, "CFRunLoopAddObserver");
+  mb_macos_api.CFRunLoopRun =
+      (void (*)(void))dlsym(mb_macos_api.core_foundation, "CFRunLoopRun");
+  mb_macos_api.CFRunLoopStop =
+      (void (*)(CFRunLoopRef))dlsym(mb_macos_api.core_foundation, "CFRunLoopStop");
+  mb_macos_api.CFRunLoopWakeUp =
+      (void (*)(CFRunLoopRef))dlsym(mb_macos_api.core_foundation, "CFRunLoopWakeUp");
+  mb_macos_api.CFRetain =
+      (CFTypeRef(*)(CFTypeRef))dlsym(mb_macos_api.core_foundation, "CFRetain");
+  mb_macos_api.CFRelease =
+      (void (*)(CFTypeRef))dlsym(mb_macos_api.core_foundation, "CFRelease");
+  mb_macos_api.CFStringCreateWithCString =
+      (CFStringRef(*)(CFAllocatorRef, const char *, CFStringEncoding))dlsym(
+          mb_macos_api.core_foundation, "CFStringCreateWithCString");
+
+  if (mb_macos_api.CGEventTapCreate == NULL ||
+      mb_macos_api.CGEventTapEnable == NULL ||
+      mb_macos_api.CGEventGetFlags == NULL ||
+      mb_macos_api.CGEventGetIntegerValueField == NULL ||
+      mb_macos_api.CFMachPortCreateRunLoopSource == NULL ||
+      mb_macos_api.CFRunLoopObserverCreate == NULL ||
+      mb_macos_api.CFRunLoopGetCurrent == NULL ||
+      mb_macos_api.CFRunLoopAddSource == NULL ||
+      mb_macos_api.CFRunLoopAddObserver == NULL ||
+      mb_macos_api.CFRunLoopRun == NULL ||
+      mb_macos_api.CFRunLoopStop == NULL ||
+      mb_macos_api.CFRunLoopWakeUp == NULL ||
+      mb_macos_api.CFRetain == NULL || mb_macos_api.CFRelease == NULL ||
+      mb_macos_api.CFStringCreateWithCString == NULL) {
+    return 0;
+  }
+
+  mb_macos_api.loaded = 1;
+  return 1;
+}
+
+static uint32_t mb_macos_modifiers_from_flags(CGEventFlags flags) {
+  uint32_t mask = 0;
+  if ((flags & kCGEventFlagMaskAlternate) != 0) {
+    mask |= MB_MOD_ALT;
+  }
+  if ((flags & kCGEventFlagMaskControl) != 0) {
+    mask |= MB_MOD_CONTROL;
+  }
+  if ((flags & kCGEventFlagMaskShift) != 0) {
+    mask |= MB_MOD_SHIFT;
+  }
+  if ((flags & kCGEventFlagMaskCommand) != 0) {
+    mask |= MB_MOD_META;
+  }
+  return mask;
+}
+
+static int mb_macos_keycode_from_name(const char *name, uint32_t *out_keycode) {
+  uint32_t alpha_numeric = 0;
+
+  if (mb_keycode_from_name_common(name, &alpha_numeric)) {
+    if (alpha_numeric >= 'A' && alpha_numeric <= 'Z') {
+      *out_keycode = (uint32_t)(kVK_ANSI_A + (alpha_numeric - 'A'));
+      return 1;
+    }
+    switch (alpha_numeric) {
+    case '0':
+      *out_keycode = kVK_ANSI_0;
+      return 1;
+    case '1':
+      *out_keycode = kVK_ANSI_1;
+      return 1;
+    case '2':
+      *out_keycode = kVK_ANSI_2;
+      return 1;
+    case '3':
+      *out_keycode = kVK_ANSI_3;
+      return 1;
+    case '4':
+      *out_keycode = kVK_ANSI_4;
+      return 1;
+    case '5':
+      *out_keycode = kVK_ANSI_5;
+      return 1;
+    case '6':
+      *out_keycode = kVK_ANSI_6;
+      return 1;
+    case '7':
+      *out_keycode = kVK_ANSI_7;
+      return 1;
+    case '8':
+      *out_keycode = kVK_ANSI_8;
+      return 1;
+    case '9':
+      *out_keycode = kVK_ANSI_9;
+      return 1;
+    default:
+      break;
+    }
+  }
+
+  if (strcmp(name, "Space") == 0) {
+    *out_keycode = kVK_Space;
+    return 1;
+  }
+  if (strcmp(name, "Tab") == 0) {
+    *out_keycode = kVK_Tab;
+    return 1;
+  }
+  if (strcmp(name, "Enter") == 0) {
+    *out_keycode = kVK_Return;
+    return 1;
+  }
+  if (strcmp(name, "Escape") == 0) {
+    *out_keycode = kVK_Escape;
+    return 1;
+  }
+  if (strcmp(name, "Backspace") == 0) {
+    *out_keycode = kVK_Delete;
+    return 1;
+  }
+  if (strcmp(name, "Delete") == 0) {
+    *out_keycode = kVK_ForwardDelete;
+    return 1;
+  }
+  if (strcmp(name, "Home") == 0) {
+    *out_keycode = kVK_Home;
+    return 1;
+  }
+  if (strcmp(name, "End") == 0) {
+    *out_keycode = kVK_End;
+    return 1;
+  }
+  if (strcmp(name, "PageUp") == 0) {
+    *out_keycode = kVK_PageUp;
+    return 1;
+  }
+  if (strcmp(name, "PageDown") == 0) {
+    *out_keycode = kVK_PageDown;
+    return 1;
+  }
+  if (strcmp(name, "Left") == 0) {
+    *out_keycode = kVK_LeftArrow;
+    return 1;
+  }
+  if (strcmp(name, "Right") == 0) {
+    *out_keycode = kVK_RightArrow;
+    return 1;
+  }
+  if (strcmp(name, "Up") == 0) {
+    *out_keycode = kVK_UpArrow;
+    return 1;
+  }
+  if (strcmp(name, "Down") == 0) {
+    *out_keycode = kVK_DownArrow;
+    return 1;
+  }
+  if (strcmp(name, "Minus") == 0) {
+    *out_keycode = kVK_ANSI_Minus;
+    return 1;
+  }
+  if (strcmp(name, "Equal") == 0 || strcmp(name, "Plus") == 0) {
+    *out_keycode = kVK_ANSI_Equal;
+    return 1;
+  }
+  if (strcmp(name, "Comma") == 0) {
+    *out_keycode = kVK_ANSI_Comma;
+    return 1;
+  }
+  if (strcmp(name, "Period") == 0) {
+    *out_keycode = kVK_ANSI_Period;
+    return 1;
+  }
+  if (strcmp(name, "Slash") == 0) {
+    *out_keycode = kVK_ANSI_Slash;
+    return 1;
+  }
+  if (strcmp(name, "Backslash") == 0) {
+    *out_keycode = kVK_ANSI_Backslash;
+    return 1;
+  }
+  if (strcmp(name, "Semicolon") == 0) {
+    *out_keycode = kVK_ANSI_Semicolon;
+    return 1;
+  }
+  if (strcmp(name, "Quote") == 0) {
+    *out_keycode = kVK_ANSI_Quote;
+    return 1;
+  }
+  if (strcmp(name, "Backquote") == 0) {
+    *out_keycode = kVK_ANSI_Grave;
+    return 1;
+  }
+  if (strcmp(name, "LeftBracket") == 0) {
+    *out_keycode = kVK_ANSI_LeftBracket;
+    return 1;
+  }
+  if (strcmp(name, "RightBracket") == 0) {
+    *out_keycode = kVK_ANSI_RightBracket;
+    return 1;
+  }
+  if (mb_name_is_function_key(name)) {
+    int number = atoi(name + 1);
+    switch (number) {
+    case 1:
+      *out_keycode = kVK_F1;
+      return 1;
+    case 2:
+      *out_keycode = kVK_F2;
+      return 1;
+    case 3:
+      *out_keycode = kVK_F3;
+      return 1;
+    case 4:
+      *out_keycode = kVK_F4;
+      return 1;
+    case 5:
+      *out_keycode = kVK_F5;
+      return 1;
+    case 6:
+      *out_keycode = kVK_F6;
+      return 1;
+    case 7:
+      *out_keycode = kVK_F7;
+      return 1;
+    case 8:
+      *out_keycode = kVK_F8;
+      return 1;
+    case 9:
+      *out_keycode = kVK_F9;
+      return 1;
+    case 10:
+      *out_keycode = kVK_F10;
+      return 1;
+    case 11:
+      *out_keycode = kVK_F11;
+      return 1;
+    case 12:
+      *out_keycode = kVK_F12;
+      return 1;
+    case 13:
+      *out_keycode = kVK_F13;
+      return 1;
+    case 14:
+      *out_keycode = kVK_F14;
+      return 1;
+    case 15:
+      *out_keycode = kVK_F15;
+      return 1;
+    case 16:
+      *out_keycode = kVK_F16;
+      return 1;
+    case 17:
+      *out_keycode = kVK_F17;
+      return 1;
+    case 18:
+      *out_keycode = kVK_F18;
+      return 1;
+    case 19:
+      *out_keycode = kVK_F19;
+      return 1;
+    case 20:
+      *out_keycode = kVK_F20;
+      return 1;
+    default:
+      break;
+    }
+  }
+  return 0;
+}
+
+static CGEventRef mb_macos_event_callback(CGEventTapProxy proxy,
+                                          CGEventType type,
+                                          CGEventRef event,
+                                          void *user_info) {
+  mb_global_hotkey_state_t *state = (mb_global_hotkey_state_t *)user_info;
+  (void)proxy;
+
+  if (type == kCGEventTapDisabledByTimeout ||
+      type == kCGEventTapDisabledByUserInput) {
+    if (state->event_tap != NULL) {
+      mb_macos_api.CGEventTapEnable(state->event_tap, true);
+    }
+    return event;
+  }
+
+  if (type != kCGEventKeyDown) {
+    return event;
+  }
+
+  if (mb_macos_api.CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat) != 0) {
+    return event;
+  }
+
+  pthread_mutex_lock(&state->lock);
+  {
+    uint32_t keycode = (uint32_t)mb_macos_api.CGEventGetIntegerValueField(
+        event, kCGKeyboardEventKeycode);
+    uint32_t modifiers =
+        mb_macos_modifiers_from_flags(mb_macos_api.CGEventGetFlags(event));
+    mb_registration_t *cursor = state->registrations;
+    while (cursor != NULL) {
+      if (cursor->keycode == keycode && cursor->modifiers == modifiers) {
+        mb_push_trigger_locked(state, cursor->id);
+        break;
+      }
+      cursor = cursor->next;
+    }
+  }
+  pthread_mutex_unlock(&state->lock);
+  return event;
+}
+
+static void mb_macos_run_loop_ready_callback(CFRunLoopObserverRef observer,
+                                             CFRunLoopActivity activity,
+                                             void *user_info) {
+  mb_global_hotkey_state_t *state = (mb_global_hotkey_state_t *)user_info;
+  (void)observer;
+  (void)activity;
+
+  pthread_mutex_lock(&state->lock);
+  state->ready = 1;
+  state->running = 1;
+  pthread_cond_signal(&state->ready_cond);
+  pthread_mutex_unlock(&state->lock);
+}
+
+static void *mb_macos_thread_main(void *raw_state) {
+  mb_global_hotkey_state_t *state = (mb_global_hotkey_state_t *)raw_state;
+  CFMachPortRef event_tap = NULL;
+  CFRunLoopSourceRef source = NULL;
+  CFRunLoopObserverRef startup_observer = NULL;
+  CFRunLoopRef run_loop = NULL;
+  CFStringRef mode = NULL;
+
+  if (!mb_macos_load_api()) {
+    pthread_mutex_lock(&state->lock);
+    mb_state_set_startup_error(state, "failed to load macOS event frameworks");
+    state->ready = 1;
+    pthread_cond_signal(&state->ready_cond);
+    pthread_mutex_unlock(&state->lock);
+    return NULL;
+  }
+
+  event_tap = mb_macos_api.CGEventTapCreate(
+      kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly,
+      (((CGEventMask)1) << kCGEventKeyDown) |
+          (((CGEventMask)1) << kCGEventTapDisabledByTimeout) |
+          (((CGEventMask)1) << kCGEventTapDisabledByUserInput),
+      mb_macos_event_callback, state);
+  if (event_tap == NULL) {
+    pthread_mutex_lock(&state->lock);
+    mb_state_set_startup_error(
+        state,
+        "failed to create a macOS event tap; grant Input Monitoring permission if needed");
+    state->ready = 1;
+    pthread_cond_signal(&state->ready_cond);
+    pthread_mutex_unlock(&state->lock);
+    return NULL;
+  }
+
+  source = mb_macos_api.CFMachPortCreateRunLoopSource(NULL, event_tap, 0);
+  if (source == NULL) {
+    pthread_mutex_lock(&state->lock);
+    mb_state_set_startup_error(state, "failed to create the macOS run loop source");
+    state->ready = 1;
+    pthread_cond_signal(&state->ready_cond);
+    pthread_mutex_unlock(&state->lock);
+    mb_macos_api.CFRelease(event_tap);
+    return NULL;
+  }
+
+  mode = mb_macos_api.CFStringCreateWithCString(NULL, "kCFRunLoopDefaultMode",
+                                                kCFStringEncodingUTF8);
+  if (mode == NULL) {
+    pthread_mutex_lock(&state->lock);
+    mb_state_set_startup_error(state, "failed to create the macOS run loop mode");
+    state->ready = 1;
+    pthread_cond_signal(&state->ready_cond);
+    pthread_mutex_unlock(&state->lock);
+    mb_macos_api.CFRelease(source);
+    mb_macos_api.CFRelease(event_tap);
+    return NULL;
+  }
+
+  run_loop = mb_macos_api.CFRunLoopGetCurrent();
+  mb_macos_api.CFRetain(run_loop);
+
+  {
+    CFRunLoopObserverContext observer_context = {0, state, NULL, NULL, NULL};
+    startup_observer = mb_macos_api.CFRunLoopObserverCreate(
+        NULL, kCFRunLoopEntry, false, 0, mb_macos_run_loop_ready_callback,
+        &observer_context);
+  }
+  if (startup_observer == NULL) {
+    pthread_mutex_lock(&state->lock);
+    mb_state_set_startup_error(state, "failed to create the macOS run loop observer");
+    state->ready = 1;
+    pthread_cond_signal(&state->ready_cond);
+    pthread_mutex_unlock(&state->lock);
+    mb_macos_api.CFRelease(run_loop);
+    mb_macos_api.CFRelease(mode);
+    mb_macos_api.CFRelease(source);
+    mb_macos_api.CFRelease(event_tap);
+    return NULL;
+  }
+
+  pthread_mutex_lock(&state->lock);
+  state->event_tap = event_tap;
+  state->run_loop = run_loop;
+  pthread_mutex_unlock(&state->lock);
+
+  mb_macos_api.CFRunLoopAddSource(run_loop, source, mode);
+  mb_macos_api.CFRunLoopAddObserver(run_loop, startup_observer, mode);
+  mb_macos_api.CGEventTapEnable(event_tap, true);
+  mb_macos_api.CFRelease(startup_observer);
+  startup_observer = NULL;
+  mb_macos_api.CFRelease(source);
+  mb_macos_api.CFRunLoopRun();
+
+  pthread_mutex_lock(&state->lock);
+  state->running = 0;
+  state->event_tap = NULL;
+  state->run_loop = NULL;
+  pthread_mutex_unlock(&state->lock);
+
+  mb_macos_api.CFRelease(mode);
+  mb_macos_api.CFRelease(run_loop);
+  mb_macos_api.CFRelease(event_tap);
+  return NULL;
+}
+#endif
+
+#ifdef __linux__
+typedef struct mb_x11_api {
+  void *handle;
+  int loaded;
+  int initialized;
+  Status (*XInitThreads)(void);
+  Display *(*XOpenDisplay)(const char *);
+  int (*XCloseDisplay)(Display *);
+  int (*XPending)(Display *);
+  int (*XNextEvent)(Display *, XEvent *);
+  int (*XGrabKey)(Display *, int, unsigned int, Window, Bool, int, int);
+  int (*XUngrabKey)(Display *, int, unsigned int, Window);
+  int (*XFlush)(Display *);
+  int (*XSync)(Display *, Bool);
+  KeySym (*XStringToKeysym)(const char *);
+  KeyCode (*XKeysymToKeycode)(Display *, KeySym);
+  int (*XSetErrorHandler)(int (*handler)(Display *, XErrorEvent *));
+  XModifierKeymap *(*XGetModifierMapping)(Display *);
+  int (*XFreeModifiermap)(XModifierKeymap *);
+} mb_x11_api_t;
+
+static mb_x11_api_t mb_x11_api;
+static MB_THREAD_LOCAL int mb_linux_x11_error_code = 0;
+
+static int mb_linux_x11_error_handler(Display *display, XErrorEvent *event) {
+  (void)display;
+  mb_linux_x11_error_code = event->error_code;
+  return 0;
+}
+
+static int mb_linux_load_x11(void) {
+  if (mb_x11_api.initialized) {
+    return mb_x11_api.loaded;
+  }
+
+  memset(&mb_x11_api, 0, sizeof(mb_x11_api));
+  mb_x11_api.initialized = 1;
+  mb_x11_api.handle = dlopen("libX11.so.6", RTLD_LAZY | RTLD_LOCAL);
+  if (mb_x11_api.handle == NULL) {
+    mb_x11_api.handle = dlopen("libX11.so", RTLD_LAZY | RTLD_LOCAL);
+  }
+  if (mb_x11_api.handle == NULL) {
+    return 0;
+  }
+
+  mb_x11_api.XInitThreads =
+      (Status(*)(void))dlsym(mb_x11_api.handle, "XInitThreads");
+  mb_x11_api.XOpenDisplay =
+      (Display * (*)(const char *))dlsym(mb_x11_api.handle, "XOpenDisplay");
+  mb_x11_api.XCloseDisplay =
+      (int (*)(Display *))dlsym(mb_x11_api.handle, "XCloseDisplay");
+  mb_x11_api.XPending =
+      (int (*)(Display *))dlsym(mb_x11_api.handle, "XPending");
+  mb_x11_api.XNextEvent =
+      (int (*)(Display *, XEvent *))dlsym(mb_x11_api.handle, "XNextEvent");
+  mb_x11_api.XGrabKey = (int (*)(Display *, int, unsigned int, Window, Bool,
+                                  int, int))dlsym(mb_x11_api.handle, "XGrabKey");
+  mb_x11_api.XUngrabKey = (int (*)(Display *, int, unsigned int, Window))
+      dlsym(mb_x11_api.handle, "XUngrabKey");
+  mb_x11_api.XFlush =
+      (int (*)(Display *))dlsym(mb_x11_api.handle, "XFlush");
+  mb_x11_api.XSync =
+      (int (*)(Display *, Bool))dlsym(mb_x11_api.handle, "XSync");
+  mb_x11_api.XStringToKeysym = (KeySym(*)(const char *))
+      dlsym(mb_x11_api.handle, "XStringToKeysym");
+  mb_x11_api.XKeysymToKeycode = (KeyCode(*)(Display *, KeySym))
+      dlsym(mb_x11_api.handle, "XKeysymToKeycode");
+  mb_x11_api.XSetErrorHandler = (int (*)(int (*)(Display *, XErrorEvent *)))
+      dlsym(mb_x11_api.handle, "XSetErrorHandler");
+  mb_x11_api.XGetModifierMapping = (XModifierKeymap * (*)(Display *))
+      dlsym(mb_x11_api.handle, "XGetModifierMapping");
+  mb_x11_api.XFreeModifiermap = (int (*)(XModifierKeymap *))
+      dlsym(mb_x11_api.handle, "XFreeModifiermap");
+
+  if (mb_x11_api.XInitThreads == NULL || mb_x11_api.XOpenDisplay == NULL ||
+      mb_x11_api.XCloseDisplay == NULL || mb_x11_api.XPending == NULL ||
+      mb_x11_api.XNextEvent == NULL || mb_x11_api.XGrabKey == NULL ||
+      mb_x11_api.XUngrabKey == NULL || mb_x11_api.XFlush == NULL ||
+      mb_x11_api.XSync == NULL || mb_x11_api.XStringToKeysym == NULL ||
+      mb_x11_api.XKeysymToKeycode == NULL ||
+      mb_x11_api.XSetErrorHandler == NULL ||
+      mb_x11_api.XGetModifierMapping == NULL ||
+      mb_x11_api.XFreeModifiermap == NULL) {
+    dlclose(mb_x11_api.handle);
+    memset(&mb_x11_api, 0, sizeof(mb_x11_api));
+    mb_x11_api.initialized = 1;
+    return 0;
+  }
+
+  if (mb_x11_api.XInitThreads() == 0) {
+    dlclose(mb_x11_api.handle);
+    memset(&mb_x11_api, 0, sizeof(mb_x11_api));
+    mb_x11_api.initialized = 1;
+    return 0;
+  }
+
+  mb_x11_api.loaded = 1;
+  return 1;
+}
+
+static unsigned int mb_linux_modifiers(uint32_t modifiers) {
+  unsigned int mask = 0;
+  if ((modifiers & MB_MOD_ALT) != 0) {
+    mask |= Mod1Mask;
+  }
+  if ((modifiers & MB_MOD_CONTROL) != 0) {
+    mask |= ControlMask;
+  }
+  if ((modifiers & MB_MOD_SHIFT) != 0) {
+    mask |= ShiftMask;
+  }
+  if ((modifiers & MB_MOD_META) != 0) {
+    mask |= Mod4Mask;
+  }
+  return mask;
+}
+
+static unsigned int mb_linux_clean_event_modifiers(
+    mb_global_hotkey_state_t *state,
+    unsigned int modifiers) {
+  unsigned int clean = modifiers;
+  clean &= ~(state->lock_mask | state->numlock_mask);
+  clean &= (ShiftMask | ControlMask | Mod1Mask | Mod4Mask);
+  return clean;
+}
+
+static unsigned int mb_linux_detect_numlock_mask(Display *display) {
+  unsigned int mask = 0;
+  XModifierKeymap *modifier_map = mb_x11_api.XGetModifierMapping(display);
+  KeyCode numlock_keycode;
+  int modifier_index;
+  int key_index;
+
+  if (modifier_map == NULL) {
+    return 0;
+  }
+
+  numlock_keycode = mb_x11_api.XKeysymToKeycode(display, XK_Num_Lock);
+  for (modifier_index = 0; modifier_index < 8; modifier_index++) {
+    for (key_index = 0; key_index < modifier_map->max_keypermod; key_index++) {
+      KeyCode keycode =
+          modifier_map->modifiermap[modifier_index * modifier_map->max_keypermod +
+                                    key_index];
+      if (keycode == numlock_keycode) {
+        mask = (unsigned int)(1u << modifier_index);
+        break;
+      }
+    }
+    if (mask != 0) {
+      break;
+    }
+  }
+
+  mb_x11_api.XFreeModifiermap(modifier_map);
+  return mask;
+}
+
+static const char *mb_linux_keysym_name(const char *name) {
+  if (strcmp(name, "Space") == 0) {
+    return "space";
+  }
+  if (strcmp(name, "Tab") == 0) {
+    return "Tab";
+  }
+  if (strcmp(name, "Enter") == 0) {
+    return "Return";
+  }
+  if (strcmp(name, "Escape") == 0) {
+    return "Escape";
+  }
+  if (strcmp(name, "Backspace") == 0) {
+    return "BackSpace";
+  }
+  if (strcmp(name, "Delete") == 0) {
+    return "Delete";
+  }
+  if (strcmp(name, "Insert") == 0) {
+    return "Insert";
+  }
+  if (strcmp(name, "Home") == 0) {
+    return "Home";
+  }
+  if (strcmp(name, "End") == 0) {
+    return "End";
+  }
+  if (strcmp(name, "PageUp") == 0) {
+    return "Page_Up";
+  }
+  if (strcmp(name, "PageDown") == 0) {
+    return "Page_Down";
+  }
+  if (strcmp(name, "Left") == 0) {
+    return "Left";
+  }
+  if (strcmp(name, "Right") == 0) {
+    return "Right";
+  }
+  if (strcmp(name, "Up") == 0) {
+    return "Up";
+  }
+  if (strcmp(name, "Down") == 0) {
+    return "Down";
+  }
+  if (strcmp(name, "Minus") == 0) {
+    return "minus";
+  }
+  if (strcmp(name, "Equal") == 0) {
+    return "equal";
+  }
+  if (strcmp(name, "Plus") == 0) {
+    return "plus";
+  }
+  if (strcmp(name, "Comma") == 0) {
+    return "comma";
+  }
+  if (strcmp(name, "Period") == 0) {
+    return "period";
+  }
+  if (strcmp(name, "Slash") == 0) {
+    return "slash";
+  }
+  if (strcmp(name, "Backslash") == 0) {
+    return "backslash";
+  }
+  if (strcmp(name, "Semicolon") == 0) {
+    return "semicolon";
+  }
+  if (strcmp(name, "Quote") == 0) {
+    return "apostrophe";
+  }
+  if (strcmp(name, "Backquote") == 0) {
+    return "grave";
+  }
+  if (strcmp(name, "LeftBracket") == 0) {
+    return "bracketleft";
+  }
+  if (strcmp(name, "RightBracket") == 0) {
+    return "bracketright";
+  }
+  return name;
+}
+
+static int mb_linux_keycode_from_name(
+    Display *display,
+    const char *name,
+    KeyCode *out_keycode) {
+  uint32_t alpha_numeric = 0;
+  const char *keysym_name;
+  KeySym keysym;
+
+  if (mb_keycode_from_name_common(name, &alpha_numeric)) {
+    keysym = mb_x11_api.XStringToKeysym(name);
+    if (keysym == NoSymbol) {
+      return 0;
+    }
+    *out_keycode = mb_x11_api.XKeysymToKeycode(display, keysym);
+    return *out_keycode != 0;
+  }
+
+  keysym_name = mb_linux_keysym_name(name);
+  keysym = mb_x11_api.XStringToKeysym(keysym_name);
+  if (keysym == NoSymbol) {
+    return 0;
+  }
+  *out_keycode = mb_x11_api.XKeysymToKeycode(display, keysym);
+  return *out_keycode != 0;
+}
+
+static void *mb_linux_thread_main(void *raw_state) {
+  mb_global_hotkey_state_t *state = (mb_global_hotkey_state_t *)raw_state;
+  int display_fd = ConnectionNumber(state->display);
+
+  pthread_mutex_lock(&state->lock);
+  state->ready = 1;
+  state->running = 1;
+  pthread_cond_signal(&state->ready_cond);
+  pthread_mutex_unlock(&state->lock);
+
+  while (1) {
+    fd_set read_fds;
+    int max_fd = display_fd > state->wake_pipe[0] ? display_fd : state->wake_pipe[0];
+    int select_result;
+
+    FD_ZERO(&read_fds);
+    FD_SET(display_fd, &read_fds);
+    FD_SET(state->wake_pipe[0], &read_fds);
+
+    select_result = select(max_fd + 1, &read_fds, NULL, NULL, NULL);
+    if (select_result <= 0) {
+      continue;
+    }
+
+    if (FD_ISSET(state->wake_pipe[0], &read_fds)) {
+      char byte = 0;
+      (void)read(state->wake_pipe[0], &byte, 1);
+      pthread_mutex_lock(&state->lock);
+      if (!state->running) {
+        pthread_mutex_unlock(&state->lock);
+        break;
+      }
+      pthread_mutex_unlock(&state->lock);
+    }
+
+    if (FD_ISSET(display_fd, &read_fds)) {
+      while (mb_x11_api.XPending(state->display) > 0) {
+        XEvent event;
+        mb_x11_api.XNextEvent(state->display, &event);
+        if (event.type == KeyPress) {
+          unsigned int clean_modifiers =
+              mb_linux_clean_event_modifiers(state, event.xkey.state);
+          pthread_mutex_lock(&state->lock);
+          {
+            mb_registration_t *cursor = state->registrations;
+            while (cursor != NULL) {
+              if (cursor->keycode == (uint32_t)event.xkey.keycode &&
+                  cursor->modifiers == clean_modifiers) {
+                mb_push_trigger_locked(state, cursor->id);
+                break;
+              }
+              cursor = cursor->next;
+            }
+          }
+          pthread_mutex_unlock(&state->lock);
+        }
+      }
+    }
+  }
+
+  pthread_mutex_lock(&state->lock);
+  state->running = 0;
+  pthread_mutex_unlock(&state->lock);
+  return NULL;
+}
+#endif
+
+static MB_THREAD_LOCAL char mb_last_error_message[512] = "";
+
+static void mb_set_error_message(const char *message) {
+  if (message == NULL) {
+    mb_last_error_message[0] = '\0';
+    return;
+  }
+  snprintf(mb_last_error_message, sizeof(mb_last_error_message), "%s", message);
+}
+
+static moonbit_bytes_t mb_make_bytes_from_buffer(const char *buffer, size_t len) {
+  moonbit_bytes_t out = moonbit_make_bytes((int32_t)len, 0);
+  if (len > 0) {
+    memcpy(out, buffer, len);
+  }
+  return out;
+}
+
+static char *mb_copy_bytes_to_c_string(moonbit_bytes_t bytes) {
+  size_t len = (size_t)Moonbit_array_length(bytes);
+  char *copy = (char *)malloc(len + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memcpy(copy, bytes, len);
+  }
+  copy[len] = '\0';
+  return copy;
+}
+
+#if defined(__linux__) || defined(__APPLE__)
+static int mb_init_sync_primitives(
+    pthread_mutex_t *lock,
+    pthread_cond_t *ready_cond) {
+  if (pthread_mutex_init(lock, NULL) != 0) {
+    return 0;
+  }
+  if (pthread_cond_init(ready_cond, NULL) != 0) {
+    pthread_mutex_destroy(lock);
+    return 0;
+  }
+  return 1;
+}
+
+static void mb_destroy_sync_primitives(
+    pthread_mutex_t *lock,
+    pthread_cond_t *ready_cond) {
+  pthread_cond_destroy(ready_cond);
+  pthread_mutex_destroy(lock);
+}
+#endif
+
+static void mb_state_set_startup_error(
+    mb_global_hotkey_state_t *state,
+    const char *message) {
+  state->startup_status = 1;
+  snprintf(state->startup_error, sizeof(state->startup_error), "%s",
+           message == NULL ? "" : message);
+}
+
+static void mb_free_registrations(mb_registration_t *registration) {
+  while (registration != NULL) {
+    mb_registration_t *next = registration->next;
+    free(registration);
+    registration = next;
+  }
+}
+
+static void mb_free_triggers(mb_trigger_t *trigger) {
+  while (trigger != NULL) {
+    mb_trigger_t *next = trigger->next;
+    free(trigger);
+    trigger = next;
+  }
+}
+
+static void mb_clear_runtime_state_locked(mb_global_hotkey_state_t *state) {
+  mb_free_registrations(state->registrations);
+  mb_free_triggers(state->triggered_head);
+  state->registrations = NULL;
+  state->triggered_head = NULL;
+  state->triggered_tail = NULL;
+}
+
+static void mb_push_trigger_locked(
+    mb_global_hotkey_state_t *state,
+    int32_t id) {
+  mb_trigger_t *node = (mb_trigger_t *)calloc(1, sizeof(*node));
+  if (node == NULL) {
+    return;
+  }
+  node->id = id;
+  if (state->triggered_tail == NULL) {
+    state->triggered_head = node;
+    state->triggered_tail = node;
+  } else {
+    state->triggered_tail->next = node;
+    state->triggered_tail = node;
+  }
+}
+
+static int32_t mb_take_triggered_id_locked(mb_global_hotkey_state_t *state) {
+  int32_t id = 0;
+  mb_trigger_t *node = state->triggered_head;
+  if (node == NULL) {
+    return 0;
+  }
+  id = node->id;
+  state->triggered_head = node->next;
+  if (state->triggered_head == NULL) {
+    state->triggered_tail = NULL;
+  }
+  free(node);
+  return id;
+}
+
+static mb_registration_t *mb_find_registration_locked(
+    mb_global_hotkey_state_t *state,
+    int32_t id) {
+  mb_registration_t *cursor = state->registrations;
+  while (cursor != NULL) {
+    if (cursor->id == id) {
+      return cursor;
+    }
+    cursor = cursor->next;
+  }
+  return NULL;
+}
+
+static void mb_add_registration_locked(
+    mb_global_hotkey_state_t *state,
+    int32_t id,
+    uint32_t modifiers,
+    uint32_t keycode) {
+  mb_registration_t *node = (mb_registration_t *)calloc(1, sizeof(*node));
+  if (node == NULL) {
+    return;
+  }
+  node->id = id;
+  node->modifiers = modifiers;
+  node->keycode = keycode;
+  node->next = state->registrations;
+  state->registrations = node;
+}
+
+static int mb_remove_registration_locked(
+    mb_global_hotkey_state_t *state,
+    int32_t id,
+    uint32_t *out_modifiers,
+    uint32_t *out_keycode) {
+  mb_registration_t *cursor = state->registrations;
+  mb_registration_t *previous = NULL;
+  while (cursor != NULL) {
+    if (cursor->id == id) {
+      if (out_modifiers != NULL) {
+        *out_modifiers = cursor->modifiers;
+      }
+      if (out_keycode != NULL) {
+        *out_keycode = cursor->keycode;
+      }
+      if (previous == NULL) {
+        state->registrations = cursor->next;
+      } else {
+        previous->next = cursor->next;
+      }
+      free(cursor);
+      return 1;
+    }
+    previous = cursor;
+    cursor = cursor->next;
+  }
+  return 0;
+}
+
+static int mb_name_is_function_key(const char *name) {
+  return name[0] == 'F' && name[1] >= '1' && name[1] <= '9';
+}
+
+static int mb_keycode_from_name_common(
+    const char *name,
+    uint32_t *out_alpha_numeric) {
+  size_t len = strlen(name);
+  if (len == 1) {
+    unsigned char ch = (unsigned char)name[0];
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')) {
+      *out_alpha_numeric = (uint32_t)ch;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+#ifdef _WIN32
+#define MB_WIN_MSG_REGISTER (WM_APP + 401)
+#define MB_WIN_MSG_UNREGISTER (WM_APP + 402)
+#define MB_WIN_MSG_QUIT (WM_APP + 403)
+
+typedef struct mb_win_command {
+  HANDLE done_event;
+  int32_t status;
+  int32_t id;
+  UINT modifiers;
+  UINT keycode;
+} mb_win_command_t;
+
+static UINT mb_windows_modifiers(uint32_t modifiers) {
+  UINT mask = 0;
+  if ((modifiers & MB_MOD_ALT) != 0) {
+    mask |= MOD_ALT;
+  }
+  if ((modifiers & MB_MOD_CONTROL) != 0) {
+    mask |= MOD_CONTROL;
+  }
+  if ((modifiers & MB_MOD_SHIFT) != 0) {
+    mask |= MOD_SHIFT;
+  }
+  if ((modifiers & MB_MOD_META) != 0) {
+    mask |= MOD_WIN;
+  }
+  return mask;
+}
+
+static int mb_windows_keycode_from_name(const char *name, UINT *out_keycode) {
+  uint32_t alpha_numeric = 0;
+  if (mb_keycode_from_name_common(name, &alpha_numeric)) {
+    *out_keycode = (UINT)alpha_numeric;
+    return 1;
+  }
+
+  if (strcmp(name, "Space") == 0) {
+    *out_keycode = VK_SPACE;
+    return 1;
+  }
+  if (strcmp(name, "Tab") == 0) {
+    *out_keycode = VK_TAB;
+    return 1;
+  }
+  if (strcmp(name, "Enter") == 0) {
+    *out_keycode = VK_RETURN;
+    return 1;
+  }
+  if (strcmp(name, "Escape") == 0) {
+    *out_keycode = VK_ESCAPE;
+    return 1;
+  }
+  if (strcmp(name, "Backspace") == 0) {
+    *out_keycode = VK_BACK;
+    return 1;
+  }
+  if (strcmp(name, "Delete") == 0) {
+    *out_keycode = VK_DELETE;
+    return 1;
+  }
+  if (strcmp(name, "Insert") == 0) {
+    *out_keycode = VK_INSERT;
+    return 1;
+  }
+  if (strcmp(name, "Home") == 0) {
+    *out_keycode = VK_HOME;
+    return 1;
+  }
+  if (strcmp(name, "End") == 0) {
+    *out_keycode = VK_END;
+    return 1;
+  }
+  if (strcmp(name, "PageUp") == 0) {
+    *out_keycode = VK_PRIOR;
+    return 1;
+  }
+  if (strcmp(name, "PageDown") == 0) {
+    *out_keycode = VK_NEXT;
+    return 1;
+  }
+  if (strcmp(name, "Left") == 0) {
+    *out_keycode = VK_LEFT;
+    return 1;
+  }
+  if (strcmp(name, "Right") == 0) {
+    *out_keycode = VK_RIGHT;
+    return 1;
+  }
+  if (strcmp(name, "Up") == 0) {
+    *out_keycode = VK_UP;
+    return 1;
+  }
+  if (strcmp(name, "Down") == 0) {
+    *out_keycode = VK_DOWN;
+    return 1;
+  }
+  if (strcmp(name, "Minus") == 0) {
+    *out_keycode = VK_OEM_MINUS;
+    return 1;
+  }
+  if (strcmp(name, "Equal") == 0 || strcmp(name, "Plus") == 0) {
+    *out_keycode = VK_OEM_PLUS;
+    return 1;
+  }
+  if (strcmp(name, "Comma") == 0) {
+    *out_keycode = VK_OEM_COMMA;
+    return 1;
+  }
+  if (strcmp(name, "Period") == 0) {
+    *out_keycode = VK_OEM_PERIOD;
+    return 1;
+  }
+  if (strcmp(name, "Slash") == 0) {
+    *out_keycode = VK_OEM_2;
+    return 1;
+  }
+  if (strcmp(name, "Backslash") == 0) {
+    *out_keycode = VK_OEM_5;
+    return 1;
+  }
+  if (strcmp(name, "Semicolon") == 0) {
+    *out_keycode = VK_OEM_1;
+    return 1;
+  }
+  if (strcmp(name, "Quote") == 0) {
+    *out_keycode = VK_OEM_7;
+    return 1;
+  }
+  if (strcmp(name, "Backquote") == 0) {
+    *out_keycode = VK_OEM_3;
+    return 1;
+  }
+  if (strcmp(name, "LeftBracket") == 0) {
+    *out_keycode = VK_OEM_4;
+    return 1;
+  }
+  if (strcmp(name, "RightBracket") == 0) {
+    *out_keycode = VK_OEM_6;
+    return 1;
+  }
+  if (mb_name_is_function_key(name)) {
+    int number = atoi(name + 1);
+    if (number >= 1 && number <= 24) {
+      *out_keycode = (UINT)(VK_F1 + (number - 1));
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static DWORD WINAPI mb_windows_thread_main(void *raw_state) {
+  MSG message;
+  mb_global_hotkey_state_t *state = (mb_global_hotkey_state_t *)raw_state;
+
+  PeekMessage(&message, NULL, WM_USER, WM_USER, PM_NOREMOVE);
+  SetEvent(state->ready_event);
+
+  while (GetMessage(&message, NULL, 0, 0) > 0) {
+    if (message.message == MB_WIN_MSG_REGISTER) {
+      mb_win_command_t *command = (mb_win_command_t *)message.lParam;
+      if (RegisterHotKey(NULL, command->id, command->modifiers, command->keycode)) {
+        EnterCriticalSection(&state->lock);
+        mb_add_registration_locked(state, command->id, 0, 0);
+        LeaveCriticalSection(&state->lock);
+        command->status = 0;
+      } else {
+        command->status = 1;
+      }
+      SetEvent(command->done_event);
+      continue;
+    }
+
+    if (message.message == MB_WIN_MSG_UNREGISTER) {
+      mb_win_command_t *command = (mb_win_command_t *)message.lParam;
+      if (UnregisterHotKey(NULL, command->id)) {
+        EnterCriticalSection(&state->lock);
+        mb_remove_registration_locked(state, command->id, NULL, NULL);
+        LeaveCriticalSection(&state->lock);
+        command->status = 0;
+      } else {
+        command->status = 1;
+      }
+      SetEvent(command->done_event);
+      continue;
+    }
+
+    if (message.message == MB_WIN_MSG_QUIT) {
+      PostQuitMessage(0);
+      continue;
+    }
+
+    if (message.message == WM_HOTKEY) {
+      EnterCriticalSection(&state->lock);
+      mb_push_trigger_locked(state, (int32_t)message.wParam);
+      LeaveCriticalSection(&state->lock);
+    }
+  }
+
+  EnterCriticalSection(&state->lock);
+  {
+    mb_registration_t *cursor = state->registrations;
+    while (cursor != NULL) {
+      UnregisterHotKey(NULL, cursor->id);
+      cursor = cursor->next;
+    }
+    mb_clear_runtime_state_locked(state);
+  }
+  LeaveCriticalSection(&state->lock);
+  return 0;
+}
+#endif
+
+MOONBIT_FFI_EXPORT int32_t mb_global_hotkey_platform_supported(void) {
+#ifdef _WIN32
+  mb_set_error_message("");
+  return 1;
+#elif defined(__linux__)
+  Display *display;
+  if (!mb_linux_load_x11()) {
+    mb_set_error_message(
+        "libX11 could not be loaded; install the X11 runtime and headers");
+    return 0;
+  }
+  display = mb_x11_api.XOpenDisplay(NULL);
+  if (display == NULL) {
+    mb_set_error_message(
+        "an X11 display is required; ensure DISPLAY is set or use XWayland");
+    return 0;
+  }
+  mb_x11_api.XCloseDisplay(display);
+  mb_set_error_message("");
+  return 1;
+#elif defined(__APPLE__)
+  if (!mb_macos_load_api()) {
+    mb_set_error_message("failed to load the macOS event frameworks");
+    return 0;
+  }
+  mb_set_error_message("");
+  return 1;
+#else
+  mb_set_error_message("this target does not provide a native global hotkey backend");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT mb_global_hotkey_state_t *mb_global_hotkey_create(void) {
+  mb_global_hotkey_state_t *state;
+
+  state = (mb_global_hotkey_state_t *)calloc(1, sizeof(*state));
+  if (state == NULL) {
+    mb_set_error_message("failed to allocate the native global hotkey state");
+    return NULL;
+  }
+
+#ifdef _WIN32
+  state->ready_event = CreateEventW(NULL, TRUE, FALSE, NULL);
+  if (state->ready_event == NULL) {
+    free(state);
+    mb_set_error_message("failed to create the Windows readiness event");
+    return NULL;
+  }
+  InitializeCriticalSection(&state->lock);
+  state->thread = CreateThread(NULL, 0, mb_windows_thread_main, state, 0,
+                               &state->thread_id);
+  if (state->thread == NULL) {
+    DeleteCriticalSection(&state->lock);
+    CloseHandle(state->ready_event);
+    free(state);
+    mb_set_error_message("failed to create the Windows hotkey thread");
+    return NULL;
+  }
+  WaitForSingleObject(state->ready_event, INFINITE);
+  mb_set_error_message("");
+  return state;
+#elif defined(__linux__)
+  if (!mb_linux_load_x11()) {
+    free(state);
+    mb_set_error_message(
+        "libX11 could not be loaded; install the X11 runtime and headers");
+    return NULL;
+  }
+  state->display = mb_x11_api.XOpenDisplay(NULL);
+  if (state->display == NULL) {
+    free(state);
+    mb_set_error_message(
+        "an X11 display is required; ensure DISPLAY is set or use XWayland");
+    return NULL;
+  }
+  state->root_window = DefaultRootWindow(state->display);
+  state->lock_mask = LockMask;
+  state->numlock_mask = mb_linux_detect_numlock_mask(state->display);
+  if (!mb_init_sync_primitives(&state->lock, &state->ready_cond)) {
+    mb_x11_api.XCloseDisplay(state->display);
+    free(state);
+    mb_set_error_message("failed to initialize Linux synchronization primitives");
+    return NULL;
+  }
+  if (pipe(state->wake_pipe) != 0) {
+    mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+    mb_x11_api.XCloseDisplay(state->display);
+    free(state);
+    mb_set_error_message("failed to create the Linux wake pipe");
+    return NULL;
+  }
+  if (pthread_create(&state->thread, NULL, mb_linux_thread_main, state) != 0) {
+    close(state->wake_pipe[0]);
+    close(state->wake_pipe[1]);
+    mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+    mb_x11_api.XCloseDisplay(state->display);
+    free(state);
+    mb_set_error_message("failed to create the Linux hotkey thread");
+    return NULL;
+  }
+  state->thread_started = 1;
+  pthread_mutex_lock(&state->lock);
+  while (!state->ready) {
+    pthread_cond_wait(&state->ready_cond, &state->lock);
+  }
+  pthread_mutex_unlock(&state->lock);
+  mb_set_error_message("");
+  return state;
+#elif defined(__APPLE__)
+  if (!mb_macos_load_api()) {
+    free(state);
+    mb_set_error_message("failed to load the macOS event frameworks");
+    return NULL;
+  }
+  if (!mb_init_sync_primitives(&state->lock, &state->ready_cond)) {
+    free(state);
+    mb_set_error_message("failed to initialize macOS synchronization primitives");
+    return NULL;
+  }
+  if (pthread_create(&state->thread, NULL, mb_macos_thread_main, state) != 0) {
+    mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+    free(state);
+    mb_set_error_message("failed to create the macOS hotkey thread");
+    return NULL;
+  }
+  state->thread_started = 1;
+  pthread_mutex_lock(&state->lock);
+  while (!state->ready) {
+    pthread_cond_wait(&state->ready_cond, &state->lock);
+  }
+  pthread_mutex_unlock(&state->lock);
+  if (!state->running) {
+    pthread_join(state->thread, NULL);
+    mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+    mb_set_error_message(state->startup_error);
+    free(state);
+    return NULL;
+  }
+  mb_set_error_message("");
+  return state;
+#else
+  free(state);
+  mb_set_error_message("this target does not provide a native global hotkey backend");
+  return NULL;
+#endif
+}
+
+MOONBIT_FFI_EXPORT void mb_global_hotkey_destroy(
+    mb_global_hotkey_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+
+#ifdef _WIN32
+  PostThreadMessage(state->thread_id, MB_WIN_MSG_QUIT, 0, 0);
+  WaitForSingleObject(state->thread, INFINITE);
+  DeleteCriticalSection(&state->lock);
+  CloseHandle(state->thread);
+  CloseHandle(state->ready_event);
+  free(state);
+#elif defined(__linux__)
+  if (state->thread_started) {
+    pthread_mutex_lock(&state->lock);
+    state->running = 0;
+    pthread_mutex_unlock(&state->lock);
+    (void)write(state->wake_pipe[1], "q", 1);
+    pthread_join(state->thread, NULL);
+  }
+  pthread_mutex_lock(&state->lock);
+  {
+    mb_registration_t *cursor = state->registrations;
+    while (cursor != NULL) {
+      unsigned int base_modifiers = cursor->modifiers;
+      unsigned int variants[4] = {
+          base_modifiers,
+          base_modifiers | state->lock_mask,
+          base_modifiers | state->numlock_mask,
+          base_modifiers | state->lock_mask | state->numlock_mask,
+      };
+      size_t index;
+      for (index = 0; index < 4; index++) {
+        mb_x11_api.XUngrabKey(state->display, (int)cursor->keycode, variants[index],
+                              state->root_window);
+      }
+      cursor = cursor->next;
+    }
+    mb_x11_api.XFlush(state->display);
+    mb_clear_runtime_state_locked(state);
+  }
+  pthread_mutex_unlock(&state->lock);
+  close(state->wake_pipe[0]);
+  close(state->wake_pipe[1]);
+  mb_x11_api.XCloseDisplay(state->display);
+  mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+  free(state);
+#elif defined(__APPLE__)
+  if (state->thread_started) {
+    CFRunLoopRef run_loop = NULL;
+    pthread_mutex_lock(&state->lock);
+    if (state->run_loop != NULL) {
+      run_loop = (CFRunLoopRef)mb_macos_api.CFRetain(state->run_loop);
+    }
+    pthread_mutex_unlock(&state->lock);
+    if (run_loop != NULL) {
+      mb_macos_api.CFRunLoopStop(run_loop);
+      mb_macos_api.CFRunLoopWakeUp(run_loop);
+      mb_macos_api.CFRelease(run_loop);
+    }
+    pthread_join(state->thread, NULL);
+  }
+  pthread_mutex_lock(&state->lock);
+  mb_clear_runtime_state_locked(state);
+  pthread_mutex_unlock(&state->lock);
+  mb_destroy_sync_primitives(&state->lock, &state->ready_cond);
+  free(state);
+#else
+  free(state);
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_global_hotkey_register(
+    mb_global_hotkey_state_t *state,
+    int32_t id,
+    int32_t modifiers,
+    moonbit_bytes_t key_name) {
+  char *name;
+
+  if (state == NULL) {
+    mb_set_error_message("the native global hotkey state is null");
+    return 1;
+  }
+  name = mb_copy_bytes_to_c_string(key_name);
+  if (name == NULL) {
+    mb_set_error_message("failed to copy the key name for registration");
+    return 1;
+  }
+
+#ifdef _WIN32
+  {
+    mb_win_command_t command;
+    UINT keycode = 0;
+    if (!mb_windows_keycode_from_name(name, &keycode)) {
+      free(name);
+      mb_set_error_message("unsupported Windows hotkey key");
+      return 1;
+    }
+    memset(&command, 0, sizeof(command));
+    command.done_event = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (command.done_event == NULL) {
+      free(name);
+      mb_set_error_message("failed to create the Windows registration event");
+      return 1;
+    }
+    command.id = id;
+    command.modifiers = mb_windows_modifiers((uint32_t)modifiers);
+    command.keycode = keycode;
+    if (!PostThreadMessage(state->thread_id, MB_WIN_MSG_REGISTER, 0,
+                           (LPARAM)&command)) {
+      CloseHandle(command.done_event);
+      free(name);
+      mb_set_error_message("failed to post the Windows registration command");
+      return 1;
+    }
+    WaitForSingleObject(command.done_event, INFINITE);
+    CloseHandle(command.done_event);
+    free(name);
+    if (command.status == 0) {
+      mb_set_error_message("");
+      return 0;
+    }
+    mb_set_error_message("the Windows hotkey is unavailable or already in use");
+    return 1;
+  }
+#elif defined(__linux__)
+  {
+    KeyCode keycode = 0;
+    unsigned int base_modifiers = mb_linux_modifiers((uint32_t)modifiers);
+    unsigned int variants[4];
+    size_t index;
+    if (!mb_linux_keycode_from_name(state->display, name, &keycode)) {
+      free(name);
+      mb_set_error_message("unsupported X11 hotkey key");
+      return 1;
+    }
+    variants[0] = base_modifiers;
+    variants[1] = base_modifiers | state->lock_mask;
+    variants[2] = base_modifiers | state->numlock_mask;
+    variants[3] = base_modifiers | state->lock_mask | state->numlock_mask;
+
+    mb_linux_x11_error_code = 0;
+    mb_x11_api.XSetErrorHandler(mb_linux_x11_error_handler);
+    for (index = 0; index < 4; index++) {
+      mb_x11_api.XGrabKey(state->display, keycode, variants[index], state->root_window,
+                          True, GrabModeAsync, GrabModeAsync);
+    }
+    mb_x11_api.XSync(state->display, False);
+    mb_x11_api.XSetErrorHandler(NULL);
+    if (mb_linux_x11_error_code != 0) {
+      for (index = 0; index < 4; index++) {
+        mb_x11_api.XUngrabKey(state->display, keycode, variants[index],
+                              state->root_window);
+      }
+      mb_x11_api.XFlush(state->display);
+      free(name);
+      mb_set_error_message("the X11 hotkey is unavailable or already in use");
+      return 1;
+    }
+
+    pthread_mutex_lock(&state->lock);
+    mb_add_registration_locked(state, id, base_modifiers, keycode);
+    pthread_mutex_unlock(&state->lock);
+    mb_x11_api.XFlush(state->display);
+    free(name);
+    mb_set_error_message("");
+    return 0;
+  }
+#elif defined(__APPLE__)
+  {
+    uint32_t keycode = 0;
+    if (!mb_macos_keycode_from_name(name, &keycode)) {
+      free(name);
+      mb_set_error_message("unsupported macOS hotkey key");
+      return 1;
+    }
+    pthread_mutex_lock(&state->lock);
+    mb_add_registration_locked(state, id, (uint32_t)modifiers, keycode);
+    pthread_mutex_unlock(&state->lock);
+    free(name);
+    mb_set_error_message("");
+    return 0;
+  }
+#else
+  free(name);
+  mb_set_error_message("this target does not provide a native global hotkey backend");
+  return 1;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_global_hotkey_unregister(
+    mb_global_hotkey_state_t *state,
+    int32_t id) {
+  if (state == NULL) {
+    mb_set_error_message("the native global hotkey state is null");
+    return 1;
+  }
+
+#ifdef _WIN32
+  {
+    mb_win_command_t command;
+    memset(&command, 0, sizeof(command));
+    command.done_event = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (command.done_event == NULL) {
+      mb_set_error_message("failed to create the Windows unregistration event");
+      return 1;
+    }
+    command.id = id;
+    if (!PostThreadMessage(state->thread_id, MB_WIN_MSG_UNREGISTER, 0,
+                           (LPARAM)&command)) {
+      CloseHandle(command.done_event);
+      mb_set_error_message("failed to post the Windows unregistration command");
+      return 1;
+    }
+    WaitForSingleObject(command.done_event, INFINITE);
+    CloseHandle(command.done_event);
+    if (command.status == 0) {
+      mb_set_error_message("");
+      return 0;
+    }
+    mb_set_error_message("the Windows hotkey could not be unregistered");
+    return 1;
+  }
+#elif defined(__linux__)
+  {
+    unsigned int base_modifiers = 0;
+    unsigned int keycode = 0;
+    unsigned int variants[4];
+    size_t index;
+
+    pthread_mutex_lock(&state->lock);
+    {
+      mb_registration_t *registration = mb_find_registration_locked(state, id);
+      if (registration == NULL) {
+        pthread_mutex_unlock(&state->lock);
+        mb_set_error_message("the X11 hotkey id was not found");
+        return 1;
+      }
+      base_modifiers = registration->modifiers;
+      keycode = registration->keycode;
+    }
+    pthread_mutex_unlock(&state->lock);
+
+    variants[0] = base_modifiers;
+    variants[1] = base_modifiers | state->lock_mask;
+    variants[2] = base_modifiers | state->numlock_mask;
+    variants[3] = base_modifiers | state->lock_mask | state->numlock_mask;
+
+    mb_linux_x11_error_code = 0;
+    mb_x11_api.XSetErrorHandler(mb_linux_x11_error_handler);
+    for (index = 0; index < 4; index++) {
+      mb_x11_api.XUngrabKey(state->display, (int)keycode, variants[index],
+                            state->root_window);
+    }
+    mb_x11_api.XSync(state->display, False);
+    mb_x11_api.XSetErrorHandler(NULL);
+    if (mb_linux_x11_error_code != 0) {
+      mb_set_error_message("the X11 hotkey could not be unregistered");
+      return 1;
+    }
+
+    pthread_mutex_lock(&state->lock);
+    mb_remove_registration_locked(state, id, NULL, NULL);
+    pthread_mutex_unlock(&state->lock);
+    mb_x11_api.XFlush(state->display);
+    mb_set_error_message("");
+    return 0;
+  }
+#elif defined(__APPLE__)
+  pthread_mutex_lock(&state->lock);
+  if (!mb_remove_registration_locked(state, id, NULL, NULL)) {
+    pthread_mutex_unlock(&state->lock);
+    mb_set_error_message("the macOS hotkey id was not found");
+    return 1;
+  }
+  pthread_mutex_unlock(&state->lock);
+  mb_set_error_message("");
+  return 0;
+#else
+  mb_set_error_message("this target does not provide a native global hotkey backend");
+  return 1;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t mb_global_hotkey_take_triggered_id(
+    mb_global_hotkey_state_t *state) {
+  if (state == NULL) {
+    return 0;
+  }
+
+#ifdef _WIN32
+  EnterCriticalSection(&state->lock);
+  {
+    int32_t id = mb_take_triggered_id_locked(state);
+    LeaveCriticalSection(&state->lock);
+    return id;
+  }
+#elif defined(__linux__) || defined(__APPLE__)
+  pthread_mutex_lock(&state->lock);
+  {
+    int32_t id = mb_take_triggered_id_locked(state);
+    pthread_mutex_unlock(&state->lock);
+    return id;
+  }
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t mb_global_hotkey_last_error_message(void) {
+  return mb_make_bytes_from_buffer(mb_last_error_message,
+                                   strlen(mb_last_error_message));
+}

--- a/sys/global_hotkey/global_hotkey_test.mbt
+++ b/sys/global_hotkey/global_hotkey_test.mbt
@@ -1,0 +1,95 @@
+///|
+/// Attempts candidate accelerators until one registers successfully.
+fn register_first_available(
+  manager : @global_hotkey.GlobalHotkeyManager,
+  candidates : Array[String],
+) -> String? {
+  for candidate in candidates {
+    match manager.register(candidate) {
+      Ok(true) => return Some(candidate)
+      _ => ()
+    }
+  }
+  None
+}
+
+///|
+test "support checks are callable" {
+  ignore(@global_hotkey.is_supported())
+  ignore(@global_hotkey.ensure_supported())
+}
+
+///|
+test "manager lifecycle can be exercised on the current machine" {
+  match @global_hotkey.create() {
+    Err(_) => ()
+    Ok(manager) => {
+      assert_eq(manager.list().length(), 0)
+      let candidates = ["Shift+F24", "Ctrl+Shift+F23", "Alt+Shift+F22"]
+      match register_first_available(manager, candidates) {
+        None => manager.destroy()
+        Some(accelerator) => {
+          assert_eq(manager.list().length(), 1)
+          assert_true(manager.unregister(accelerator) == Ok(true))
+          assert_true(manager.unregister(accelerator) == Ok(false))
+          manager.destroy()
+        }
+      }
+    }
+  }
+}
+
+///|
+test "native registration conflict surfaces as an error" {
+  match (@global_hotkey.create(), @global_hotkey.create()) {
+    (Ok(first), Ok(second)) => {
+      let candidates = ["Ctrl+Shift+F24", "Alt+Shift+F23"]
+      match register_first_available(first, candidates) {
+        None => {
+          first.destroy()
+          second.destroy()
+        }
+        Some(accelerator) => {
+          match second.register(accelerator) {
+            Ok(_) => fail("expected second manager registration to fail")
+            Err(_) => ()
+          }
+          ignore(first.unregister(accelerator))
+          first.destroy()
+          second.destroy()
+        }
+      }
+    }
+    (Ok(first), Err(_)) => first.destroy()
+    (Err(_), Ok(second)) => second.destroy()
+    (Err(_), Err(_)) => ()
+  }
+}
+
+///|
+test "destroy makes future operations inert" {
+  match @global_hotkey.create() {
+    Err(_) => ()
+    Ok(manager) => {
+      match manager.register("ctrl") {
+        Ok(_) => fail("expected invalid accelerator registration to fail")
+        Err(_) => ()
+      }
+      match manager.unregister("ctrl") {
+        Ok(_) => fail("expected invalid accelerator unregistration to fail")
+        Err(_) => ()
+      }
+      manager.destroy()
+      match manager.register("Ctrl+F24") {
+        Ok(_) => fail("expected destroyed manager registration to fail")
+        Err(_) => ()
+      }
+      match manager.unregister("Ctrl+F24") {
+        Ok(_) => fail("expected destroyed manager unregistration to fail")
+        Err(_) => ()
+      }
+      assert_true(manager.take_triggered() == None)
+      assert_true(manager.drain_triggered() is [])
+    }
+  }
+}

--- a/sys/global_hotkey/global_hotkey_wbtest.mbt
+++ b/sys/global_hotkey/global_hotkey_wbtest.mbt
@@ -1,0 +1,311 @@
+///|
+test "decode_error_message falls back when ffi output is empty" {
+  assert_eq(decode_error_message(@utf8.encode(""), "fallback"), "fallback")
+  assert_eq(
+    decode_error_message(@utf8.encode("native failure"), "fallback"),
+    "native failure",
+  )
+}
+
+///|
+test "error message helpers stay stable" {
+  assert_eq(
+    unsupported_error_message(),
+    "global_hotkey supports Windows and macOS native builds, plus Linux native builds running on X11.",
+  )
+  assert_eq(
+    create_error_message(),
+    "global_hotkey failed to initialize the native backend",
+  )
+  assert_eq(
+    register_error_message("Ctrl+K"),
+    "global_hotkey failed to register: Ctrl+K",
+  )
+  assert_eq(
+    unregister_error_message("Ctrl+K"),
+    "global_hotkey failed to unregister: Ctrl+K",
+  )
+}
+
+///|
+test "decode_key_name accepts aliases and punctuation" {
+  assert_true(decode_key_name("a") == Ok("A"))
+  assert_true(decode_key_name("page-up") == Ok("PageUp"))
+  assert_true(decode_key_name("apostrophe") == Ok("Quote"))
+  assert_true(decode_key_name("[") == Ok("LeftBracket"))
+  assert_true(decode_key_name("plus") == Ok("Plus"))
+}
+
+///|
+test "decode_key_name covers named key aliases" {
+  assert_true(decode_key_name("=") == Ok("Equal"))
+  assert_true(decode_key_name(",") == Ok("Comma"))
+  assert_true(decode_key_name(".") == Ok("Period"))
+  assert_true(decode_key_name("/") == Ok("Slash"))
+  assert_true(decode_key_name("\\") == Ok("Backslash"))
+  assert_true(decode_key_name(";") == Ok("Semicolon"))
+  assert_true(decode_key_name("'") == Ok("Quote"))
+  assert_true(decode_key_name("`") == Ok("Backquote"))
+  assert_true(decode_key_name("]") == Ok("RightBracket"))
+  assert_true(decode_key_name("tab") == Ok("Tab"))
+  assert_true(decode_key_name("enter") == Ok("Enter"))
+  assert_true(decode_key_name("return") == Ok("Enter"))
+  assert_true(decode_key_name("escape") == Ok("Escape"))
+  assert_true(decode_key_name("esc") == Ok("Escape"))
+  assert_true(decode_key_name("backspace") == Ok("Backspace"))
+  assert_true(decode_key_name("delete") == Ok("Delete"))
+  assert_true(decode_key_name("del") == Ok("Delete"))
+  assert_true(decode_key_name("insert") == Ok("Insert"))
+  assert_true(decode_key_name("ins") == Ok("Insert"))
+  assert_true(decode_key_name("home") == Ok("Home"))
+  assert_true(decode_key_name("end") == Ok("End"))
+  assert_true(decode_key_name("pgup") == Ok("PageUp"))
+  assert_true(decode_key_name("pagedown") == Ok("PageDown"))
+  assert_true(decode_key_name("pgdown") == Ok("PageDown"))
+  assert_true(decode_key_name("left") == Ok("Left"))
+  assert_true(decode_key_name("right") == Ok("Right"))
+  assert_true(decode_key_name("up") == Ok("Up"))
+  assert_true(decode_key_name("down") == Ok("Down"))
+  assert_true(decode_key_name("minus") == Ok("Minus"))
+  assert_true(decode_key_name("hyphen") == Ok("Minus"))
+  assert_true(decode_key_name("equal") == Ok("Equal"))
+  assert_true(decode_key_name("equals") == Ok("Equal"))
+  assert_true(decode_key_name("comma") == Ok("Comma"))
+  assert_true(decode_key_name("period") == Ok("Period"))
+  assert_true(decode_key_name("dot") == Ok("Period"))
+  assert_true(decode_key_name("slash") == Ok("Slash"))
+  assert_true(decode_key_name("backslash") == Ok("Backslash"))
+  assert_true(decode_key_name("semicolon") == Ok("Semicolon"))
+  assert_true(decode_key_name("quote") == Ok("Quote"))
+  assert_true(decode_key_name("backquote") == Ok("Backquote"))
+  assert_true(decode_key_name("grave") == Ok("Backquote"))
+  assert_true(decode_key_name("tilde") == Ok("Backquote"))
+  assert_true(decode_key_name("leftbracket") == Ok("LeftBracket"))
+  assert_true(decode_key_name("lbracket") == Ok("LeftBracket"))
+  assert_true(decode_key_name("bracketleft") == Ok("LeftBracket"))
+  assert_true(decode_key_name("rightbracket") == Ok("RightBracket"))
+  assert_true(decode_key_name("rbracket") == Ok("RightBracket"))
+  assert_true(decode_key_name("bracketright") == Ok("RightBracket"))
+  assert_true(decode_key_name("f1") == Ok("F1"))
+  assert_true(decode_key_name("f2") == Ok("F2"))
+  assert_true(decode_key_name("f3") == Ok("F3"))
+  assert_true(decode_key_name("f10") == Ok("F10"))
+  assert_true(decode_key_name("f11") == Ok("F11"))
+  assert_true(decode_key_name("f13") == Ok("F13"))
+  assert_true(decode_key_name("f14") == Ok("F14"))
+  assert_true(decode_key_name("f15") == Ok("F15"))
+  assert_true(decode_key_name("f16") == Ok("F16"))
+  assert_true(decode_key_name("f17") == Ok("F17"))
+  assert_true(decode_key_name("f18") == Ok("F18"))
+  assert_true(decode_key_name("f19") == Ok("F19"))
+  assert_true(decode_key_name("f20") == Ok("F20"))
+  assert_true(decode_key_name("f21") == Ok("F21"))
+  assert_true(decode_key_name("f22") == Ok("F22"))
+  assert_true(decode_key_name("f23") == Ok("F23"))
+  assert_true(decode_key_name("f24") == Ok("F24"))
+  match decode_key_name("?") {
+    Ok(_) => fail("expected unsupported punctuation to fail")
+    Err(_) => ()
+  }
+}
+
+///|
+test "parse_accelerator normalizes modifiers and keys" {
+  assert_true(
+    parse_accelerator("cmd + option + k") ==
+    Ok({ normalized: "Alt+Meta+K", modifiers: 9, key_name: "K" }),
+  )
+  assert_true(
+    parse_accelerator("ctrl+shift+page-down") ==
+    Ok({ normalized: "Ctrl+Shift+PageDown", modifiers: 6, key_name: "PageDown" }),
+  )
+  assert_true(
+    parse_accelerator("ctrl+-") ==
+    Ok({ normalized: "Ctrl+Minus", modifiers: 2, key_name: "Minus" }),
+  )
+}
+
+///|
+test "parse_accelerator accepts modifier aliases" {
+  assert_true(
+    parse_accelerator("ctl+quote") ==
+    Ok({ normalized: "Ctrl+Quote", modifiers: 2, key_name: "Quote" }),
+  )
+  assert_true(
+    parse_accelerator("control+super+grave") ==
+    Ok({
+      normalized: "Ctrl+Meta+Backquote",
+      modifiers: 10,
+      key_name: "Backquote",
+    }),
+  )
+  assert_true(
+    parse_accelerator("windows+pageup") ==
+    Ok({ normalized: "Meta+PageUp", modifiers: 8, key_name: "PageUp" }),
+  )
+}
+
+///|
+test "parse_accelerator rejects malformed inputs" {
+  assert_true(
+    parse_accelerator("ctrl++k") ==
+    Err("global_hotkey accelerator contains an empty segment"),
+  )
+  assert_true(
+    parse_accelerator("ctrl+control+k") ==
+    Err("global_hotkey accelerator repeats Ctrl"),
+  )
+  assert_true(
+    parse_accelerator("k+j") ==
+    Err("global_hotkey accelerator must contain exactly one key"),
+  )
+  assert_true(
+    parse_accelerator("ctrl") ==
+    Err("global_hotkey accelerator must include a key"),
+  )
+  assert_true(
+    parse_accelerator("ctrl+ctl+k") ==
+    Err("global_hotkey accelerator repeats Ctrl"),
+  )
+  assert_true(
+    parse_accelerator("shift+shift+k") ==
+    Err("global_hotkey accelerator repeats Shift"),
+  )
+  assert_true(
+    parse_accelerator("alt+option+k") ==
+    Err("global_hotkey accelerator repeats Alt"),
+  )
+  assert_true(
+    parse_accelerator("meta+cmd+k") ==
+    Err("global_hotkey accelerator repeats Meta"),
+  )
+  assert_true(
+    parse_accelerator("meta+command+k") ==
+    Err("global_hotkey accelerator repeats Meta"),
+  )
+  assert_true(
+    parse_accelerator("meta+super+k") ==
+    Err("global_hotkey accelerator repeats Meta"),
+  )
+  assert_true(
+    parse_accelerator("meta+win+k") ==
+    Err("global_hotkey accelerator repeats Meta"),
+  )
+  assert_true(
+    parse_accelerator("meta+windows+k") ==
+    Err("global_hotkey accelerator repeats Meta"),
+  )
+  match parse_accelerator("ctrl+unknown") {
+    Ok(_) => fail("expected unknown key to fail")
+    Err(_) => ()
+  }
+}
+
+///|
+test "key and support status helpers cover both outcomes" {
+  assert_true(ensure_supported_result(true, @utf8.encode("ignored")) == Ok(()))
+  assert_true(
+    ensure_supported_result(false, @utf8.encode("reason")) == Err("reason"),
+  )
+  assert_true(
+    create_status_result(true, @utf8.encode("init failed")) ==
+    Err("init failed"),
+  )
+  assert_true(create_status_result(false, @utf8.encode("ignored")) == Ok(()))
+  assert_true(
+    register_status_result(1, @utf8.encode("busy"), "Ctrl+K") == Err("busy"),
+  )
+  assert_true(
+    unregister_status_result(1, @utf8.encode("missing"), "Ctrl+K") ==
+    Err("missing"),
+  )
+  assert_true(
+    register_status_result(0, @utf8.encode("ignored"), "Ctrl+K") == Ok(true),
+  )
+  assert_true(
+    unregister_status_result(0, @utf8.encode("ignored"), "Ctrl+K") == Ok(true),
+  )
+}
+
+///|
+test "drain_with collects until the producer returns None" {
+  let mut remaining = ["Ctrl+K", "Alt+F12"]
+  assert_true(
+    drain_with(fn() {
+      if remaining is [head, .. rest] {
+        remaining = rest.to_owned()
+        Some(head)
+      } else {
+        None
+      }
+    })
+    is ["Ctrl+K", "Alt+F12"],
+  )
+}
+
+///|
+test "registration store tracks ids and normalization" {
+  let store = new_registration_store()
+  let first = match store.plan_register("ctrl+k") {
+    Ok(plan) => plan
+    Err(error) => fail(error)
+  }
+  assert_eq(first.id, 1)
+  assert_eq(first.parsed.normalized, "Ctrl+K")
+  store.commit_register(first)
+  assert_true(store.list() is ["Ctrl+K"])
+
+  match store.plan_register("Ctrl+K") {
+    Ok(_) => fail("expected duplicate registration to fail")
+    Err(error) => assert_eq(error, "global_hotkey already registered: Ctrl+K")
+  }
+
+  let second = match store.plan_register("alt+f12") {
+    Ok(plan) => plan
+    Err(error) => fail(error)
+  }
+  assert_eq(second.id, 2)
+
+  match store.plan_register("ctrl") {
+    Ok(_) => fail("expected invalid accelerator to fail")
+    Err(error) =>
+      assert_eq(error, "global_hotkey accelerator must include a key")
+  }
+}
+
+///|
+test "registration store unregisters and destroys cleanly" {
+  let store = new_registration_store()
+  let plan = match store.plan_register("ctrl+shift+f24") {
+    Ok(plan) => plan
+    Err(error) => fail(error)
+  }
+  store.commit_register(plan)
+
+  let unregister_plan = match store.plan_unregister("Ctrl+Shift+F24") {
+    Ok(Some(plan)) => plan
+    Ok(None) => fail("expected unregister plan")
+    Err(error) => fail(error)
+  }
+  assert_eq(unregister_plan.id, 1)
+  store.commit_unregister(unregister_plan)
+  assert_true(store.plan_unregister("Ctrl+Shift+F24") == Ok(None))
+
+  let plan_after_gap = match store.plan_register("meta+space") {
+    Ok(plan) => plan
+    Err(error) => fail(error)
+  }
+  assert_eq(plan_after_gap.id, 2)
+  store.commit_register(plan_after_gap)
+  assert_true(store.lookup_trigger(2) == Some("Meta+Space"))
+
+  store.destroy()
+  match store.plan_register("Ctrl+F24") {
+    Ok(_) => fail("expected destroyed store to reject registration")
+    Err(error) => assert_eq(error, destroyed_error_message())
+  }
+  match store.plan_unregister("Ctrl+F24") {
+    Ok(_) => fail("expected destroyed store to reject unregistration")
+    Err(error) => assert_eq(error, destroyed_error_message())
+  }
+}

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,0 +1,29 @@
+name = "justjavac/global_hotkey"
+
+version = "0.1.4"
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/global_hotkey"
+
+license = "MIT"
+
+keywords = [
+  "desktop",
+  "shortcut",
+  "hotkey",
+  "native",
+  "windows",
+  "macos",
+  "linux",
+]
+
+description = "Cross-platform native global hotkey helpers for MoonBit."
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "+native",
+)

--- a/sys/global_hotkey/moon.pkg
+++ b/sys/global_hotkey/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/core/encoding/utf8",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "global_hotkey_native.c" ],
+)

--- a/sys/global_hotkey/parser.mbt
+++ b/sys/global_hotkey/parser.mbt
@@ -1,0 +1,307 @@
+///|
+/// Stores the normalized shortcut data passed into the native backend.
+struct ParsedGlobalHotkey {
+  normalized : String
+  modifiers : Int
+  key_name : String
+} derive(Debug, Eq)
+
+///|
+/// Tracks which modifier families have already been seen while parsing.
+priv struct ModifierSet {
+  mut control : Bool
+  mut shift : Bool
+  mut alt : Bool
+  mut meta : Bool
+}
+
+///|
+/// Represents the canonical modifier families supported by this package.
+priv enum ModifierKind {
+  Control
+  Shift
+  Alt
+  Meta
+}
+
+///|
+/// Creates an empty modifier set for one accelerator parse.
+fn new_modifier_set() -> ModifierSet {
+  { control: false, shift: false, alt: false, meta: false }
+}
+
+///|
+/// Normalizes a single modifier or key token for case-insensitive matching.
+fn normalize_keyword(raw : String) -> String {
+  raw.trim().to_owned().to_lower()
+}
+
+///|
+/// Returns the user-facing duplicate-modifier error for one modifier family.
+fn ModifierKind::duplicate_error(self : ModifierKind) -> String {
+  match self {
+    Control => "global_hotkey accelerator repeats Ctrl"
+    Shift => "global_hotkey accelerator repeats Shift"
+    Alt => "global_hotkey accelerator repeats Alt"
+    Meta => "global_hotkey accelerator repeats Meta"
+  }
+}
+
+///|
+/// Parses modifier aliases into their canonical modifier family.
+fn parse_modifier_kind(token : String) -> ModifierKind? {
+  match normalize_keyword(token) {
+    "ctrl" | "control" | "ctl" => Some(Control)
+    "shift" => Some(Shift)
+    "alt" | "option" => Some(Alt)
+    "meta" | "cmd" | "command" | "super" | "win" | "windows" => Some(Meta)
+    _ => None
+  }
+}
+
+///|
+/// Marks one modifier family as seen, rejecting duplicate aliases.
+fn ModifierSet::enable(
+  self : ModifierSet,
+  modifier : ModifierKind,
+) -> Result[Unit, String] {
+  match modifier {
+    Control =>
+      if self.control {
+        Err(modifier.duplicate_error())
+      } else {
+        self.control = true
+        Ok(())
+      }
+    Shift =>
+      if self.shift {
+        Err(modifier.duplicate_error())
+      } else {
+        self.shift = true
+        Ok(())
+      }
+    Alt =>
+      if self.alt {
+        Err(modifier.duplicate_error())
+      } else {
+        self.alt = true
+        Ok(())
+      }
+    Meta =>
+      if self.meta {
+        Err(modifier.duplicate_error())
+      } else {
+        self.meta = true
+        Ok(())
+      }
+  }
+}
+
+///|
+/// Converts modifier booleans into the backend's logical modifier bitset.
+fn ModifierSet::mask(self : ModifierSet) -> Int {
+  let mut mask = 0
+  if self.alt {
+    mask += 0x0001
+  }
+  if self.control {
+    mask += 0x0002
+  }
+  if self.shift {
+    mask += 0x0004
+  }
+  if self.meta {
+    mask += 0x0008
+  }
+  mask
+}
+
+///|
+/// Renders a normalized accelerator string in a stable modifier order.
+fn ModifierSet::normalize_accelerator_name(
+  self : ModifierSet,
+  key_name : String,
+) -> String {
+  let builder = StringBuilder::new()
+  let mut wrote_modifier = false
+  if self.control {
+    builder.write_string("Ctrl")
+    wrote_modifier = true
+  }
+  if self.shift {
+    if wrote_modifier {
+      builder.write_char('+')
+    }
+    builder.write_string("Shift")
+    wrote_modifier = true
+  }
+  if self.alt {
+    if wrote_modifier {
+      builder.write_char('+')
+    }
+    builder.write_string("Alt")
+    wrote_modifier = true
+  }
+  if self.meta {
+    if wrote_modifier {
+      builder.write_char('+')
+    }
+    builder.write_string("Meta")
+    wrote_modifier = true
+  }
+  if wrote_modifier {
+    builder.write_char('+')
+  }
+  builder.write_string(key_name)
+  builder.to_string()
+}
+
+///|
+/// Builds the unsupported-key error shared by all key decoders.
+fn unsupported_key_error(raw : String) -> String {
+  "unsupported global_hotkey key: " + raw
+}
+
+///|
+/// Decodes a key token into the canonical key name used by all backends.
+fn decode_key_name(raw : String) -> Result[String, String] {
+  let token = raw.trim().to_owned()
+  let upper = token.to_upper()
+  if upper.length() == 1 {
+    match upper.get_char(0) {
+      Some(ch) =>
+        if (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+          Ok(upper)
+        } else {
+          match ch {
+            '-' => Ok("Minus")
+            '=' => Ok("Equal")
+            ',' => Ok("Comma")
+            '.' => Ok("Period")
+            '/' => Ok("Slash")
+            '\\' => Ok("Backslash")
+            ';' => Ok("Semicolon")
+            '\'' => Ok("Quote")
+            '`' => Ok("Backquote")
+            '[' => Ok("LeftBracket")
+            ']' => Ok("RightBracket")
+            _ => Err(unsupported_key_error(raw))
+          }
+        }
+      None => Err(unsupported_key_error(raw))
+    }
+  } else {
+    match normalize_keyword(token) {
+      "space" => Ok("Space")
+      "tab" => Ok("Tab")
+      "enter" => Ok("Enter")
+      "return" => Ok("Enter")
+      "escape" => Ok("Escape")
+      "esc" => Ok("Escape")
+      "backspace" => Ok("Backspace")
+      "delete" => Ok("Delete")
+      "del" => Ok("Delete")
+      "insert" => Ok("Insert")
+      "ins" => Ok("Insert")
+      "home" => Ok("Home")
+      "end" => Ok("End")
+      "pageup" => Ok("PageUp")
+      "page-up" => Ok("PageUp")
+      "pgup" => Ok("PageUp")
+      "pagedown" => Ok("PageDown")
+      "page-down" => Ok("PageDown")
+      "pgdown" => Ok("PageDown")
+      "left" => Ok("Left")
+      "right" => Ok("Right")
+      "up" => Ok("Up")
+      "down" => Ok("Down")
+      "minus" => Ok("Minus")
+      "hyphen" => Ok("Minus")
+      "equal" => Ok("Equal")
+      "equals" => Ok("Equal")
+      "plus" => Ok("Plus")
+      "comma" => Ok("Comma")
+      "period" => Ok("Period")
+      "dot" => Ok("Period")
+      "slash" => Ok("Slash")
+      "backslash" => Ok("Backslash")
+      "semicolon" => Ok("Semicolon")
+      "quote" => Ok("Quote")
+      "apostrophe" => Ok("Quote")
+      "backquote" => Ok("Backquote")
+      "grave" => Ok("Backquote")
+      "tilde" => Ok("Backquote")
+      "leftbracket" => Ok("LeftBracket")
+      "lbracket" => Ok("LeftBracket")
+      "bracketleft" => Ok("LeftBracket")
+      "rightbracket" => Ok("RightBracket")
+      "rbracket" => Ok("RightBracket")
+      "bracketright" => Ok("RightBracket")
+      "f1" => Ok("F1")
+      "f2" => Ok("F2")
+      "f3" => Ok("F3")
+      "f4" => Ok("F4")
+      "f5" => Ok("F5")
+      "f6" => Ok("F6")
+      "f7" => Ok("F7")
+      "f8" => Ok("F8")
+      "f9" => Ok("F9")
+      "f10" => Ok("F10")
+      "f11" => Ok("F11")
+      "f12" => Ok("F12")
+      "f13" => Ok("F13")
+      "f14" => Ok("F14")
+      "f15" => Ok("F15")
+      "f16" => Ok("F16")
+      "f17" => Ok("F17")
+      "f18" => Ok("F18")
+      "f19" => Ok("F19")
+      "f20" => Ok("F20")
+      "f21" => Ok("F21")
+      "f22" => Ok("F22")
+      "f23" => Ok("F23")
+      "f24" => Ok("F24")
+      _ => Err(unsupported_key_error(raw))
+    }
+  }
+}
+
+///|
+/// Parses a user-facing accelerator string into canonical backend data.
+fn parse_accelerator(raw : String) -> Result[ParsedGlobalHotkey, String] {
+  let parts = raw.split("+").to_array()
+  let modifiers = new_modifier_set()
+  let mut key_name : String? = None
+
+  for part in parts {
+    let token = part.to_owned().trim().to_owned()
+    if token.is_empty() {
+      return Err("global_hotkey accelerator contains an empty segment")
+    }
+    match parse_modifier_kind(token) {
+      Some(modifier) =>
+        match modifiers.enable(modifier) {
+          Ok(_) => ()
+          Err(error) => return Err(error)
+        }
+      None =>
+        match key_name {
+          Some(_) =>
+            return Err("global_hotkey accelerator must contain exactly one key")
+          None =>
+            match decode_key_name(token) {
+              Ok(name) => key_name = Some(name)
+              Err(error) => return Err(error)
+            }
+        }
+    }
+  }
+
+  match key_name {
+    Some(key_name) => {
+      let normalized = modifiers.normalize_accelerator_name(key_name)
+      Ok({ normalized, modifiers: modifiers.mask(), key_name })
+    }
+    None => Err("global_hotkey accelerator must include a key")
+  }
+}

--- a/sys/global_hotkey/pkg.generated.mbti
+++ b/sys/global_hotkey/pkg.generated.mbti
@@ -1,0 +1,43 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/global_hotkey"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn create() -> Result[GlobalHotkeyManager, String]
+
+pub fn ensure_supported() -> Result[Unit, String]
+
+pub fn is_supported() -> Bool
+
+// Errors
+
+// Types and methods
+pub struct GlobalHotkeyManager {
+  state : GlobalHotkeyState
+  store : RegistrationStore
+}
+pub fn GlobalHotkeyManager::destroy(Self) -> Unit
+pub fn GlobalHotkeyManager::drain_triggered(Self) -> Array[String]
+pub fn GlobalHotkeyManager::list(Self) -> Array[String]
+pub fn GlobalHotkeyManager::register(Self, String) -> Result[Bool, String]
+pub fn GlobalHotkeyManager::take_triggered(Self) -> String?
+pub fn GlobalHotkeyManager::unregister(Self, String) -> Result[Bool, String]
+
+#external
+pub type GlobalHotkeyState
+
+type ParsedGlobalHotkey derive(Eq, @debug.Debug)
+
+type RegisterPlan derive(Eq, @debug.Debug)
+
+type RegistrationStore
+
+type UnregisterPlan derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/sys/global_hotkey/registry.mbt
+++ b/sys/global_hotkey/registry.mbt
@@ -1,0 +1,142 @@
+///|
+/// Captures the work needed to register one new normalized shortcut.
+struct RegisterPlan {
+  id : Int
+  parsed : ParsedGlobalHotkey
+} derive(Debug, Eq)
+
+///|
+/// Captures the work needed to unregister one previously normalized shortcut.
+struct UnregisterPlan {
+  id : Int
+  normalized : String
+} derive(Debug, Eq)
+
+///|
+/// Stores the MoonBit-side registration bookkeeping that mirrors the native backend.
+struct RegistrationStore {
+  registrations : Map[String, Int]
+  registration_names : Map[Int, String]
+  mut next_id : Int
+  mut destroyed : Bool
+}
+
+///|
+/// Creates an empty registration store ready for a fresh manager.
+fn new_registration_store() -> RegistrationStore {
+  { registrations: {}, registration_names: {}, next_id: 1, destroyed: false }
+}
+
+///|
+/// Rejects mutations after the manager has been destroyed.
+fn RegistrationStore::ensure_alive(
+  self : RegistrationStore,
+) -> Result[Unit, String] {
+  if self.destroyed {
+    Err(destroyed_error_message())
+  } else {
+    Ok(())
+  }
+}
+
+///|
+/// Parses an accelerator only when the store is still active.
+fn RegistrationStore::parse_active_accelerator(
+  self : RegistrationStore,
+  accelerator : String,
+) -> Result[ParsedGlobalHotkey, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) => parse_accelerator(accelerator)
+  }
+}
+
+///|
+/// Reserves and returns the next registration id.
+fn RegistrationStore::take_next_id(self : RegistrationStore) -> Int {
+  let id = self.next_id
+  self.next_id += 1
+  id
+}
+
+///|
+/// Validates a registration request and reserves the next id for it.
+fn RegistrationStore::plan_register(
+  self : RegistrationStore,
+  accelerator : String,
+) -> Result[RegisterPlan, String] {
+  match self.parse_active_accelerator(accelerator) {
+    Err(error) => Err(error)
+    Ok(parsed) =>
+      match self.registrations.get(parsed.normalized) {
+        Some(_) => Err("global_hotkey already registered: " + parsed.normalized)
+        None => {
+          let id = self.take_next_id()
+          Ok({ id, parsed })
+        }
+      }
+  }
+}
+
+///|
+/// Records a native registration that has already succeeded.
+fn RegistrationStore::commit_register(
+  self : RegistrationStore,
+  plan : RegisterPlan,
+) -> Unit {
+  self.registrations.set(plan.parsed.normalized, plan.id)
+  self.registration_names.set(plan.id, plan.parsed.normalized)
+}
+
+///|
+/// Validates an unregistration request and resolves it to a native id.
+fn RegistrationStore::plan_unregister(
+  self : RegistrationStore,
+  accelerator : String,
+) -> Result[UnregisterPlan?, String] {
+  match self.parse_active_accelerator(accelerator) {
+    Err(error) => Err(error)
+    Ok(parsed) =>
+      match self.registrations.get(parsed.normalized) {
+        Some(id) => Ok(Some({ id, normalized: parsed.normalized }))
+        None => Ok(None)
+      }
+  }
+}
+
+///|
+/// Removes the MoonBit-side bookkeeping for a successful unregistration.
+fn RegistrationStore::commit_unregister(
+  self : RegistrationStore,
+  plan : UnregisterPlan,
+) -> Unit {
+  self.registrations.remove(plan.normalized)
+  self.registration_names.remove(plan.id)
+}
+
+///|
+/// Returns the normalized registrations in insertion order.
+fn RegistrationStore::list(self : RegistrationStore) -> Array[String] {
+  let accelerators : Array[String] = []
+  for accelerator, _ in self.registrations {
+    accelerators.push(accelerator)
+  }
+  accelerators
+}
+
+///|
+/// Resolves a triggered id back to the normalized accelerator string.
+fn RegistrationStore::lookup_trigger(
+  self : RegistrationStore,
+  id : Int,
+) -> String? {
+  self.registration_names.get(id)
+}
+
+///|
+/// Clears all bookkeeping and marks the store as destroyed.
+fn RegistrationStore::destroy(self : RegistrationStore) -> Unit {
+  self.destroyed = true
+  self.registrations.clear()
+  self.registration_names.clear()
+}

--- a/sys/keepawake/LICENSE
+++ b/sys/keepawake/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justjavac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sys/keepawake/README.mbt.md
+++ b/sys/keepawake/README.mbt.md
@@ -1,0 +1,24 @@
+# keepawake
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+
+Native-only keep-awake guards for MoonBit on Windows, Linux, and macOS.
+
+```mbt check
+///|
+test {
+  assert_eq(Scope::PreventSystemSleep.to_string(), "PreventSystemSleep")
+}
+```
+
+```mbt nocheck
+let guard = @keepawake.acquire(
+  reason="Rendering a large animation",
+  scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+)
+
+guard.release()
+```

--- a/sys/keepawake/README.md
+++ b/sys/keepawake/README.md
@@ -1,0 +1,100 @@
+# keepawake
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+
+`keepawake` is a native-only MoonBit module that exposes a small, readable API
+for keeping a machine awake while long-running work is in progress.
+
+This first iteration focuses on a minimal public surface that is easy to
+maintain and easy to extend:
+
+- `acquire` returns a guard that starts the native keep-awake request.
+- `Guard::release` ends the request and is safe to call more than once.
+- `with_keepawake` wraps scoped work and releases automatically.
+- `Scope` keeps the policy choice explicit without exposing backend details.
+
+## Install
+
+Add the module to your project, then import `justjavac/keepawake`.
+
+```bash
+moon add justjavac/keepawake
+```
+
+Package configuration:
+
+```moonbit
+import {
+  "justjavac/keepawake",
+}
+```
+
+## API Overview
+
+```moonbit
+let guard = @keepawake.acquire(
+  reason="Rendering a long animation",
+  scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+)
+
+// ... perform the long-running work ...
+
+guard.release()
+```
+
+Use the scoped helper when you want automatic cleanup:
+
+```moonbit
+let result = @keepawake.with_keepawake(
+  () => {
+    // ... perform the long-running work ...
+    "done"
+  },
+  reason="Syncing a large local cache",
+  scope=@keepawake.Scope::PreventSystemSleep,
+)
+```
+
+## Platform Notes
+
+### Windows
+
+The Windows backend uses `SetThreadExecutionState`, which is the standard API
+for declaring thread-level execution requirements.
+
+### macOS
+
+The macOS backend creates IOKit power assertions. The implementation loads the
+required frameworks dynamically so the package does not need platform-specific
+linker flags for this minimal version.
+
+### Linux
+
+The Linux backend uses `systemd-inhibit` as the smallest maintainable
+cross-distribution starting point for this first version.
+
+- `PreventSystemSleep` maps to `sleep`
+- `PreventDisplaySleep` maps to `idle`
+- `PreventSystemAndDisplaySleep` maps to `idle:sleep`
+
+In headless or non-systemd environments the module may raise
+`BackendUnavailable` with a descriptive message instead of pretending the
+request succeeded.
+
+## Examples
+
+Run the example module from the repository root:
+
+```bash
+moon -C examples run basic
+```
+
+The example acquires a guard, keeps the machine awake for roughly five seconds,
+and then releases it.
+
+## License
+
+MIT

--- a/sys/keepawake/errors.mbt
+++ b/sys/keepawake/errors.mbt
@@ -1,0 +1,43 @@
+///|
+/// Describes failures raised by the native keep-awake backends.
+///
+/// `BackendUnavailable` means the current environment cannot offer the
+/// requested inhibition mechanism, while `OperationFailed` means a supported
+/// backend was found but the requested operation still failed.
+///
+/// Use the variant payloads to surface actionable diagnostics to callers or end
+/// users:
+///
+/// - `BackendUnavailable(detail~)` reports that the current environment does
+///   not expose a usable keep-awake mechanism, for example because
+///   `systemd-inhibit` is missing or the expected macOS framework cannot be
+///   loaded.
+/// - `OperationFailed(operation~, detail~)` reports that the selected backend
+///   exists but could not complete the requested lifecycle action such as
+///   acquire or release.
+///
+/// The detail strings are intentionally human-readable, so they can be logged
+/// directly or attached to higher-level application errors without extra
+/// translation.
+pub(all) suberror KeepAwakeError {
+  BackendUnavailable(detail~ : String)
+  OperationFailed(operation~ : String, detail~ : String)
+} derive(Eq)
+
+///|
+/// Formats a keep-awake error into a stable diagnostic string.
+///
+/// The output is designed for logs, test assertions, and user-facing fallback
+/// diagnostics where a structured payload is not convenient to carry around.
+/// Each variant includes its labeled fields so the rendered text remains easy
+/// to scan when attached to higher-level error reports.
+pub impl Show for KeepAwakeError with fn output(self : KeepAwakeError, logger) {
+  match self {
+    BackendUnavailable(detail~) =>
+      logger.write_string("BackendUnavailable(detail=\"\{detail}\")")
+    OperationFailed(operation~, detail~) =>
+      logger.write_string(
+        "OperationFailed(operation=\"\{operation}\", detail=\"\{detail}\")",
+      )
+  }
+}

--- a/sys/keepawake/guard.mbt
+++ b/sys/keepawake/guard.mbt
@@ -1,0 +1,142 @@
+///|
+/// The fallback reason used when callers pass an empty or whitespace-only
+/// reason.
+///
+/// This value is intentionally readable because some native backends expose the
+/// reason in system diagnostics or activity monitors. Applications can override
+/// it per call when they want more task-specific text, but keeping a default
+/// reason makes the simple API path ergonomic.
+pub let default_reason : String = "MoonBit keepawake request"
+
+///|
+/// Acquires a keep-awake guard for the current operating system.
+///
+/// The returned guard activates the native inhibition immediately and keeps it
+/// alive until `Guard::release` is called or the guard is reclaimed by the
+/// runtime. Blank reasons are normalized to `default_reason` so callers can
+/// keep call sites simple without losing readable backend diagnostics.
+///
+/// `reason` should describe the user-visible work being protected, such as
+/// `"Exporting a large report"` or `"Downloading offline assets"`. `scope`
+/// controls whether the request blocks system sleep, display sleep, or both.
+///
+/// Prefer `acquire` when your code naturally manages a long-lived handle. If
+/// the work is already scoped to a single callback, `with_keepawake` is usually
+/// more convenient because it guarantees structured release.
+///
+/// # Errors
+///
+/// Raises `KeepAwakeError::BackendUnavailable` when the current environment
+/// cannot provide a usable keep-awake backend, and raises
+/// `KeepAwakeError::OperationFailed` when a backend exists but the native
+/// acquire step still fails.
+///
+/// # Example
+/// ```mbt nocheck
+/// let guard = @keepawake.acquire(
+///   reason="Encoding a large video",
+///   scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+/// )
+///
+/// // ... perform the long-running work ...
+///
+/// guard.release()
+/// ```
+pub fn acquire(
+  reason? : String = default_reason,
+  scope? : Scope = Scope::PreventSystemSleep,
+) -> Guard raise KeepAwakeError {
+  let handle = native_guard_create(
+    @ffi.to_cstr(normalize_reason(reason)),
+    scope.native_code(),
+  )
+  finish_acquire(handle)
+}
+
+///|
+/// Runs an action while a keep-awake guard is held.
+///
+/// This is the most ergonomic API for scoped work such as file exports, build
+/// steps, or long-running synchronization tasks. The guard is released after
+/// `action` finishes. If `action` raises, release is still attempted and any
+/// release failure is suppressed in favor of the original error.
+///
+/// This helper is the best default when the keep-awake lifetime should exactly
+/// match one operation. It keeps the call site small, avoids leaking a guard in
+/// early-return branches, and preserves the original application error if both
+/// the action and the release step fail.
+///
+/// `reason` and `scope` behave the same way as in `acquire`. The return value
+/// of `action` is passed through unchanged.
+///
+/// # Errors
+///
+/// Raises the same `KeepAwakeError` values as `acquire`, plus any error raised
+/// by `action`.
+///
+/// # Example
+/// ```mbt nocheck
+/// let summary = @keepawake.with_keepawake(
+///   () => "done",
+///   reason="Syncing local cache",
+///   // ... perform long-running work ...
+///   scope=@keepawake.Scope::PreventSystemSleep,
+/// )
+/// ```
+pub fn[T] with_keepawake(
+  action : () -> T raise?,
+  reason? : String = default_reason,
+  scope? : Scope = Scope::PreventSystemSleep,
+) -> T raise {
+  let handle = acquire(reason~, scope~)
+  run_with_cleanup(fn() -> T raise { action() }, fn() -> Unit raise {
+    handle.release()
+  })
+}
+
+///|
+/// Returns whether the underlying native inhibition is still active.
+///
+/// This becomes `false` after a successful call to `Guard::release`, and it is
+/// also `false` for guards returned by a failed acquire attempt before the
+/// error is raised to the caller.
+///
+/// Use this method for diagnostics, assertions, or defensive checks around
+/// cleanup-heavy workflows. Most callers do not need to poll it during normal
+/// operation because the guard exposes only a single lifecycle boundary:
+/// active versus released.
+pub fn Guard::active(self : Guard) -> Bool {
+  native_guard_is_active(self)
+}
+
+///|
+/// Returns the scope that was requested when the guard was created.
+///
+/// This is the semantic scope originally passed to `acquire` or
+/// `with_keepawake`, not a platform-specific low-level flag set. It is useful
+/// when code stores guards in higher-level abstractions and later wants to
+/// inspect or report what kind of inhibition is currently in effect.
+pub fn Guard::scope(self : Guard) -> Scope {
+  scope_from_native_code(native_guard_scope_code(self))
+}
+
+///|
+/// Releases the native keep-awake request.
+///
+/// Releasing a guard is idempotent. Calling `release` on an inactive guard is a
+/// no-op. If the backend reports an unexpected release failure, this method
+/// raises `KeepAwakeError::OperationFailed`.
+///
+/// Call this as soon as the protected work finishes when you acquired the guard
+/// manually. Releasing early is preferred over waiting for runtime cleanup,
+/// because explicit release makes the lifetime obvious and avoids depending on
+/// garbage collection timing.
+///
+/// # Errors
+///
+/// Raises `KeepAwakeError::OperationFailed` if the backend reports that the
+/// native release operation did not complete successfully.
+pub fn Guard::release(self : Guard) -> Unit raise KeepAwakeError {
+  let status = native_guard_release(self)
+  finish_release(status, native_guard_last_error(self))
+}

--- a/sys/keepawake/guard_internal.mbt
+++ b/sys/keepawake/guard_internal.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Normalizes caller-supplied reasons before they cross the FFI boundary.
 fn normalize_reason(reason : String) -> String {
-  let trimmed = reason.trim().to_string()
+  let trimmed = reason.trim().to_owned()
   if trimmed is "" {
     default_reason
   } else {
@@ -65,7 +65,9 @@ fn[T] run_with_cleanup(
 ) -> T raise {
   try action() catch {
     err => {
-      let _ : Result[Unit, Error] = try? cleanup()
+      cleanup() catch {
+        _ => ()
+      }
       raise err
     }
   } noraise {

--- a/sys/keepawake/guard_internal.mbt
+++ b/sys/keepawake/guard_internal.mbt
@@ -1,0 +1,93 @@
+///|
+/// Normalizes caller-supplied reasons before they cross the FFI boundary.
+fn normalize_reason(reason : String) -> String {
+  let trimmed = reason.trim().to_string()
+  if trimmed is "" {
+    default_reason
+  } else {
+    trimmed
+  }
+}
+
+///|
+/// Decodes a backend error payload into a readable string.
+fn decode_native_detail(detail : Bytes) -> String {
+  if detail.is_empty() {
+    "The native backend did not provide extra details."
+  } else {
+    @utf8.decode_lossy(detail)
+  }
+}
+
+///|
+/// Raises a public keep-awake error from raw native status and detail bytes.
+fn[T] raise_native_error(
+  status~ : Int,
+  operation~ : String,
+  detail~ : Bytes,
+) -> T raise KeepAwakeError {
+  raise classify_native_error(
+    status~,
+    operation~,
+    detail=decode_native_detail(detail),
+  )
+}
+
+///|
+/// Resolves a newly-created native guard into either a live handle or an error.
+fn finish_acquire(handle : Guard) -> Guard raise KeepAwakeError {
+  if handle.active() {
+    handle
+  } else {
+    raise_native_error(
+      status=native_guard_status(handle),
+      operation="acquire",
+      detail=native_guard_last_error(handle),
+    )
+  }
+}
+
+///|
+/// Raises a release failure if the native backend did not report success.
+fn finish_release(status : Int, detail : Bytes) -> Unit raise KeepAwakeError {
+  if status == native_status_ok {
+    ()
+  } else {
+    raise_native_error(status~, operation="release", detail~)
+  }
+}
+
+///|
+/// Runs an action and always attempts cleanup before returning or re-raising.
+fn[T] run_with_cleanup(
+  action : () -> T raise,
+  cleanup : () -> Unit raise,
+) -> T raise {
+  try action() catch {
+    err => {
+      let _ : Result[Unit, Error] = try? cleanup()
+      raise err
+    }
+  } noraise {
+    value => {
+      cleanup()
+      value
+    }
+  }
+}
+
+///|
+/// Maps native backend status codes into public MoonBit errors.
+fn classify_native_error(
+  status~ : Int,
+  operation~ : String,
+  detail~ : String,
+) -> KeepAwakeError {
+  if status == native_status_backend_unavailable {
+    BackendUnavailable(detail~)
+  } else if status == native_status_operation_failed {
+    OperationFailed(operation~, detail~)
+  } else {
+    OperationFailed(operation~, detail~)
+  }
+}

--- a/sys/keepawake/keepawake_test.mbt
+++ b/sys/keepawake/keepawake_test.mbt
@@ -1,0 +1,59 @@
+///|
+test "scope names stay stable" {
+  inspect(
+    [
+      @keepawake.Scope::PreventSystemSleep.to_string(),
+      @keepawake.Scope::PreventDisplaySleep.to_string(),
+      @keepawake.Scope::PreventSystemAndDisplaySleep.to_string(),
+    ],
+    content="[PreventSystemSleep, PreventDisplaySleep, PreventSystemAndDisplaySleep]",
+  )
+}
+
+///|
+test "acquire and release smoke test" {
+  let result = try? @keepawake.acquire(
+    reason="blackbox smoke test",
+    scope=@keepawake.Scope::PreventSystemSleep,
+  )
+  match result {
+    Ok(handle) => {
+      assert_true(handle.active())
+      assert_eq(handle.scope(), @keepawake.Scope::PreventSystemSleep)
+      handle.release()
+      assert_true(handle.active() == false)
+      handle.release()
+      assert_true(handle.active() == false)
+    }
+    Err(@keepawake.BackendUnavailable(detail~)) =>
+      assert_true(
+        detail.contains("systemd-inhibit") ||
+        detail.contains("unsupported") ||
+        detail.contains("framework") ||
+        detail.contains("inhibit"),
+        msg=detail,
+      )
+    Err(err) => fail("\{err}")
+  }
+}
+
+///|
+test "with_keepawake returns the action result" {
+  let result : Result[String, Error] = try? @keepawake.with_keepawake(
+    fn() { "kept awake" },
+    reason="scoped smoke test",
+    scope=@keepawake.Scope::PreventSystemSleep,
+  )
+  match result {
+    Ok(value) => assert_eq(value, "kept awake")
+    Err(@keepawake.BackendUnavailable(detail~)) =>
+      assert_true(
+        detail.contains("systemd-inhibit") ||
+        detail.contains("unsupported") ||
+        detail.contains("framework") ||
+        detail.contains("inhibit"),
+        msg=detail,
+      )
+    Err(err) => fail("\{err}")
+  }
+}

--- a/sys/keepawake/keepawake_test.mbt
+++ b/sys/keepawake/keepawake_test.mbt
@@ -1,21 +1,31 @@
 ///|
 test "scope names stay stable" {
-  inspect(
+  debug_inspect(
     [
       @keepawake.Scope::PreventSystemSleep.to_string(),
       @keepawake.Scope::PreventDisplaySleep.to_string(),
       @keepawake.Scope::PreventSystemAndDisplaySleep.to_string(),
     ],
-    content="[PreventSystemSleep, PreventDisplaySleep, PreventSystemAndDisplaySleep]",
+    content=(
+      #|[
+      #|  "PreventSystemSleep",
+      #|  "PreventDisplaySleep",
+      #|  "PreventSystemAndDisplaySleep",
+      #|]
+    ),
   )
 }
 
 ///|
 test "acquire and release smoke test" {
-  let result = try? @keepawake.acquire(
-    reason="blackbox smoke test",
-    scope=@keepawake.Scope::PreventSystemSleep,
-  )
+  let result = Ok(
+    @keepawake.acquire(
+      reason="blackbox smoke test",
+      scope=@keepawake.Scope::PreventSystemSleep,
+    ),
+  ) catch {
+    e => Err(e)
+  }
   match result {
     Ok(handle) => {
       assert_true(handle.active())
@@ -39,11 +49,15 @@ test "acquire and release smoke test" {
 
 ///|
 test "with_keepawake returns the action result" {
-  let result : Result[String, Error] = try? @keepawake.with_keepawake(
-    fn() { "kept awake" },
-    reason="scoped smoke test",
-    scope=@keepawake.Scope::PreventSystemSleep,
-  )
+  let result : Result[String, Error] = Ok(
+    @keepawake.with_keepawake(
+      fn() { "kept awake" },
+      reason="scoped smoke test",
+      scope=@keepawake.Scope::PreventSystemSleep,
+    ),
+  ) catch {
+    e => Err(e)
+  }
   match result {
     Ok(value) => assert_eq(value, "kept awake")
     Err(@keepawake.BackendUnavailable(detail~)) =>

--- a/sys/keepawake/keepawake_wbtest.mbt
+++ b/sys/keepawake/keepawake_wbtest.mbt
@@ -23,11 +23,15 @@ test "normalized reasons convert to null-terminated c strings" {
 
 ///|
 test "raise_native_error decodes backend-unavailable details" {
-  let result : Result[Unit, Error] = try? raise_native_error(
-    status=native_status_backend_unavailable,
-    operation="acquire",
-    detail=@utf8.encode("systemd-inhibit was not found"),
-  )
+  let result : Result[Unit, Error] = Ok(
+    raise_native_error(
+      status=native_status_backend_unavailable,
+      operation="acquire",
+      detail=@utf8.encode("systemd-inhibit was not found"),
+    ),
+  ) catch {
+    e => Err(e)
+  }
   guard result
     is Err(BackendUnavailable(detail="systemd-inhibit was not found")) else {
     fail("expected a decoded backend-unavailable error")
@@ -36,11 +40,11 @@ test "raise_native_error decodes backend-unavailable details" {
 
 ///|
 test "raise_native_error uses fallback detail for empty payloads" {
-  let result : Result[Unit, Error] = try? raise_native_error(
-    status=999,
-    operation="release",
-    detail=b"",
-  )
+  let result : Result[Unit, Error] = Ok(
+    raise_native_error(status=999, operation="release", detail=b""),
+  ) catch {
+    e => Err(e)
+  }
   guard result
     is Err(
       OperationFailed(
@@ -60,7 +64,9 @@ test "finish_acquire raises synthetic backend failures" {
     @ffi.to_cstr("synthetic acquire failure"),
     Scope::PreventSystemSleep.native_code(),
   )
-  let result : Result[Guard, Error] = try? finish_acquire(handle)
+  let result : Result[Guard, Error] = Ok(finish_acquire(handle)) catch {
+    e => Err(e)
+  }
   guard result is Err(BackendUnavailable(detail="synthetic acquire failure")) else {
     fail("expected the synthetic acquire failure to surface")
   }
@@ -68,10 +74,14 @@ test "finish_acquire raises synthetic backend failures" {
 
 ///|
 test "finish_release raises release failures" {
-  let result : Result[Unit, Error] = try? finish_release(
-    native_status_operation_failed,
-    @utf8.encode("synthetic release failure"),
-  )
+  let result : Result[Unit, Error] = Ok(
+    finish_release(
+      native_status_operation_failed,
+      @utf8.encode("synthetic release failure"),
+    ),
+  ) catch {
+    e => Err(e)
+  }
   guard result
     is Err(
       OperationFailed(operation="release", detail="synthetic release failure")
@@ -83,10 +93,11 @@ test "finish_release raises release failures" {
 ///|
 test "run_with_cleanup returns action result after cleanup" {
   let mut cleanup_calls = 0
-  let result : Result[String, Error] = try? run_with_cleanup(
-    () => "kept awake",
-    () => cleanup_calls += 1,
-  )
+  let result : Result[String, Error] = Ok(
+    run_with_cleanup(() => "kept awake", () => cleanup_calls += 1),
+  ) catch {
+    e => Err(e)
+  }
   assert_eq(cleanup_calls, 1)
   guard result is Ok("kept awake") else {
     fail("expected the action result to be returned")
@@ -96,13 +107,17 @@ test "run_with_cleanup returns action result after cleanup" {
 ///|
 test "run_with_cleanup preserves action error and suppresses cleanup error" {
   let mut cleanup_calls = 0
-  let result : Result[Int, Error] = try? run_with_cleanup(
-    fn() -> Int raise { raise BackendUnavailable(detail="action failed") },
-    fn() -> Unit raise {
-      cleanup_calls += 1
-      raise OperationFailed(operation="release", detail="cleanup failed")
-    },
-  )
+  let result : Result[Int, Error] = Ok(
+    run_with_cleanup(
+      fn() -> Int raise { raise BackendUnavailable(detail="action failed") },
+      fn() -> Unit raise {
+        cleanup_calls += 1
+        raise OperationFailed(operation="release", detail="cleanup failed")
+      },
+    ),
+  ) catch {
+    e => Err(e)
+  }
   assert_eq(cleanup_calls, 1)
   guard result is Err(BackendUnavailable(detail="action failed")) else {
     fail("expected the original action error")

--- a/sys/keepawake/keepawake_wbtest.mbt
+++ b/sys/keepawake/keepawake_wbtest.mbt
@@ -1,0 +1,158 @@
+///|
+/// Creates a synthetic guard for white-box testing of MoonBit-side error paths.
+#borrow(last_error)
+extern "C" fn native_test_guard_make(
+  active : Bool,
+  status : Int,
+  last_error : Bytes,
+  scope : Int,
+) -> Guard = "moonbit_keepawake_test_guard_make"
+
+///|
+test "normalize_reason trims surrounding whitespace" {
+  assert_eq(normalize_reason("  writing backups  "), "writing backups")
+  assert_eq(normalize_reason("   "), default_reason)
+}
+
+///|
+test "normalized reasons convert to null-terminated c strings" {
+  let c_reason = @ffi.to_cstr(normalize_reason("  writing backups  "))
+  assert_eq(@ffi.from_cstr(c_reason), "writing backups")
+  assert_eq(c_reason[c_reason.length() - 1], 0)
+}
+
+///|
+test "raise_native_error decodes backend-unavailable details" {
+  let result : Result[Unit, Error] = try? raise_native_error(
+    status=native_status_backend_unavailable,
+    operation="acquire",
+    detail=@utf8.encode("systemd-inhibit was not found"),
+  )
+  guard result
+    is Err(BackendUnavailable(detail="systemd-inhibit was not found")) else {
+    fail("expected a decoded backend-unavailable error")
+  }
+}
+
+///|
+test "raise_native_error uses fallback detail for empty payloads" {
+  let result : Result[Unit, Error] = try? raise_native_error(
+    status=999,
+    operation="release",
+    detail=b"",
+  )
+  guard result
+    is Err(
+      OperationFailed(
+        operation="release",
+        detail="The native backend did not provide extra details."
+      )
+    ) else {
+    fail("expected an operation failure with fallback detail")
+  }
+}
+
+///|
+test "finish_acquire raises synthetic backend failures" {
+  let handle = native_test_guard_make(
+    false,
+    native_status_backend_unavailable,
+    @ffi.to_cstr("synthetic acquire failure"),
+    Scope::PreventSystemSleep.native_code(),
+  )
+  let result : Result[Guard, Error] = try? finish_acquire(handle)
+  guard result is Err(BackendUnavailable(detail="synthetic acquire failure")) else {
+    fail("expected the synthetic acquire failure to surface")
+  }
+}
+
+///|
+test "finish_release raises release failures" {
+  let result : Result[Unit, Error] = try? finish_release(
+    native_status_operation_failed,
+    @utf8.encode("synthetic release failure"),
+  )
+  guard result
+    is Err(
+      OperationFailed(operation="release", detail="synthetic release failure")
+    ) else {
+    fail("expected the release failure to surface")
+  }
+}
+
+///|
+test "run_with_cleanup returns action result after cleanup" {
+  let mut cleanup_calls = 0
+  let result : Result[String, Error] = try? run_with_cleanup(
+    () => "kept awake",
+    () => cleanup_calls += 1,
+  )
+  assert_eq(cleanup_calls, 1)
+  guard result is Ok("kept awake") else {
+    fail("expected the action result to be returned")
+  }
+}
+
+///|
+test "run_with_cleanup preserves action error and suppresses cleanup error" {
+  let mut cleanup_calls = 0
+  let result : Result[Int, Error] = try? run_with_cleanup(
+    fn() -> Int raise { raise BackendUnavailable(detail="action failed") },
+    fn() -> Unit raise {
+      cleanup_calls += 1
+      raise OperationFailed(operation="release", detail="cleanup failed")
+    },
+  )
+  assert_eq(cleanup_calls, 1)
+  guard result is Err(BackendUnavailable(detail="action failed")) else {
+    fail("expected the original action error")
+  }
+}
+
+///|
+test "scope codes round-trip" {
+  let scopes : Array[Scope] = [
+    Scope::PreventSystemSleep,
+    Scope::PreventDisplaySleep,
+    Scope::PreventSystemAndDisplaySleep,
+  ]
+  for scope in scopes {
+    assert_eq(scope_from_native_code(scope.native_code()), scope)
+  }
+}
+
+///|
+test "classify_native_error keeps backend-unavailable distinct" {
+  guard classify_native_error(
+      status=native_status_backend_unavailable,
+      operation="acquire",
+      detail="systemd-inhibit was not found",
+    )
+    is BackendUnavailable(detail="systemd-inhibit was not found") else {
+    fail("expected a backend-unavailable error")
+  }
+}
+
+///|
+test "classify_native_error maps operational failures" {
+  guard classify_native_error(
+      status=native_status_operation_failed,
+      operation="release",
+      detail="release failed",
+    )
+    is OperationFailed(operation="release", detail="release failed") else {
+    fail("expected an operation-failed error")
+  }
+}
+
+///|
+test "error show output stays readable" {
+  assert_eq(
+    BackendUnavailable(detail="missing backend").to_string(),
+    "BackendUnavailable(detail=\"missing backend\")",
+  )
+  assert_eq(
+    OperationFailed(operation="release", detail="failed").to_string(),
+    "OperationFailed(operation=\"release\", detail=\"failed\")",
+  )
+}

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -3,7 +3,7 @@ name = "justjavac/keepawake"
 version = "0.1.0"
 
 import {
-  "justjavac/ffi@0.2.1",
+  "justjavac/ffi@0.2.3",
 }
 
 readme = "README.mbt.md"

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,0 +1,32 @@
+name = "justjavac/keepawake"
+
+version = "0.1.0"
+
+import {
+  "justjavac/ffi@0.2.1",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/keepawake"
+
+license = "MIT"
+
+keywords = [
+  "keepawake",
+  "native",
+  "windows",
+  "linux",
+  "macos",
+  "power-management",
+]
+
+description = "Native keep-awake guards for MoonBit on Windows, Linux, and macOS."
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "native",
+)

--- a/sys/keepawake/moon.pkg
+++ b/sys/keepawake/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "justjavac/ffi",
+  "moonbitlang/core/encoding/utf8",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [
+    "native_common.c",
+    "native_windows.c",
+    "native_macos.c",
+    "native_linux.c",
+  ],
+)

--- a/sys/keepawake/native_common.c
+++ b/sys/keepawake/native_common.c
@@ -1,0 +1,114 @@
+#include "native_stub.h"
+
+static char *keepawake_duplicate_string(const char *text) {
+  size_t len = strlen(text);
+  char *copy = (char *)malloc(len + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  memcpy(copy, text, len + 1);
+  return copy;
+}
+
+void keepawake_clear_error(keepawake_guard_t *guard) {
+  if (guard->last_error != NULL) {
+    free(guard->last_error);
+    guard->last_error = NULL;
+  }
+}
+
+void keepawake_set_error(
+  keepawake_guard_t *guard,
+  int32_t status,
+  const char *format,
+  ...
+) {
+  char stack_buffer[1024];
+  va_list args;
+  keepawake_clear_error(guard);
+  va_start(args, format);
+  vsnprintf(stack_buffer, sizeof(stack_buffer), format, args);
+  va_end(args);
+  guard->last_error = keepawake_duplicate_string(stack_buffer);
+  guard->status = status;
+}
+
+moonbit_bytes_t keepawake_make_error_bytes(const char *text) {
+  if (text == NULL || text[0] == '\0') {
+    return moonbit_make_bytes(0, 0);
+  }
+  int32_t len = (int32_t)strlen(text);
+  moonbit_bytes_t bytes = moonbit_make_bytes(len, 0);
+  memcpy(bytes, text, (size_t)len);
+  return bytes;
+}
+
+static void keepawake_guard_finalize(void *payload) {
+  keepawake_guard_t *guard = (keepawake_guard_t *)payload;
+  keepawake_platform_release(guard);
+  keepawake_clear_error(guard);
+}
+
+MOONBIT_FFI_EXPORT
+keepawake_guard_t *moonbit_keepawake_guard_create(
+  moonbit_bytes_t reason,
+  int32_t scope
+) {
+  keepawake_guard_t *guard =
+    (keepawake_guard_t *)moonbit_make_external_object(
+      keepawake_guard_finalize,
+      (uint32_t)sizeof(keepawake_guard_t)
+    );
+  memset(guard, 0, sizeof(*guard));
+  guard->scope = scope;
+  keepawake_platform_start(guard, (const char *)reason, scope);
+  return guard;
+}
+
+MOONBIT_FFI_EXPORT
+keepawake_guard_t *moonbit_keepawake_test_guard_make(
+  int32_t active,
+  int32_t status,
+  moonbit_bytes_t last_error,
+  int32_t scope
+) {
+  keepawake_guard_t *guard =
+    (keepawake_guard_t *)moonbit_make_external_object(
+      keepawake_guard_finalize,
+      (uint32_t)sizeof(keepawake_guard_t)
+    );
+  memset(guard, 0, sizeof(*guard));
+  guard->active = active;
+  guard->status = status;
+  guard->scope = scope;
+  if (last_error != NULL && last_error[0] != '\0') {
+    guard->last_error = keepawake_duplicate_string((const char *)last_error);
+  }
+  return guard;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbit_keepawake_guard_is_active(keepawake_guard_t *guard) {
+  return guard->active;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbit_keepawake_guard_status(keepawake_guard_t *guard) {
+  return guard->status;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbit_keepawake_guard_scope_code(keepawake_guard_t *guard) {
+  return guard->scope;
+}
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbit_keepawake_guard_last_error(keepawake_guard_t *guard) {
+  return keepawake_make_error_bytes(guard->last_error);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbit_keepawake_guard_release(keepawake_guard_t *guard) {
+  keepawake_platform_release(guard);
+  return guard->status;
+}

--- a/sys/keepawake/native_ffi.mbt
+++ b/sys/keepawake/native_ffi.mbt
@@ -1,0 +1,50 @@
+///|
+/// Represents a native keep-awake request managed by the current platform.
+///
+/// A `Guard` is created by `acquire` and released explicitly through
+/// `Guard::release` or implicitly when the runtime reclaims it. The type is
+/// intentionally opaque so callers interact only through the safe public API
+/// instead of depending on backend-specific state layout.
+pub type Guard
+
+///|
+/// Creates a native keep-awake guard.
+#borrow(reason)
+extern "C" fn native_guard_create(reason : Bytes, scope : Int) -> Guard = "moonbit_keepawake_guard_create"
+
+///|
+/// Returns whether a native guard is still active.
+#borrow(handle)
+extern "C" fn native_guard_is_active(handle : Guard) -> Bool = "moonbit_keepawake_guard_is_active"
+
+///|
+/// Returns the latest backend status code recorded on the guard.
+#borrow(handle)
+extern "C" fn native_guard_status(handle : Guard) -> Int = "moonbit_keepawake_guard_status"
+
+///|
+/// Returns the scope code associated with the guard.
+#borrow(handle)
+extern "C" fn native_guard_scope_code(handle : Guard) -> Int = "moonbit_keepawake_guard_scope_code"
+
+///|
+/// Returns the latest backend error message.
+#borrow(handle)
+extern "C" fn native_guard_last_error(handle : Guard) -> Bytes = "moonbit_keepawake_guard_last_error"
+
+///|
+/// Releases the native keep-awake request if it is still active.
+#borrow(handle)
+extern "C" fn native_guard_release(handle : Guard) -> Int = "moonbit_keepawake_guard_release"
+
+///|
+/// Indicates a successful native backend operation.
+let native_status_ok : Int = 0
+
+///|
+/// Indicates that the backend is unavailable in the current environment.
+let native_status_backend_unavailable : Int = 1
+
+///|
+/// Indicates that the backend exists but the operation still failed.
+let native_status_operation_failed : Int = 2

--- a/sys/keepawake/native_linux.c
+++ b/sys/keepawake/native_linux.c
@@ -1,0 +1,154 @@
+#include "native_stub.h"
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static const char *keepawake_linux_scope_to_what(int32_t scope) {
+  switch (scope) {
+  case keepawake_SCOPE_DISPLAY:
+    return "idle";
+  case keepawake_SCOPE_SYSTEM_AND_DISPLAY:
+    return "idle:sleep";
+  case keepawake_SCOPE_SYSTEM:
+  default:
+    return "sleep";
+  }
+}
+
+void keepawake_platform_release(keepawake_guard_t *guard) {
+  if (!guard->active) {
+    return;
+  }
+
+  if (guard->child_pid > 0) {
+    if (kill(-guard->child_pid, SIGTERM) != 0 && errno != ESRCH) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_OPERATION_FAILED,
+        "Failed to terminate the Linux keep-awake helper: %s",
+        strerror(errno)
+      );
+      return;
+    }
+    waitpid(guard->child_pid, NULL, 0);
+  }
+
+  guard->child_pid = 0;
+  guard->active = 0;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+}
+
+void keepawake_platform_start(
+  keepawake_guard_t *guard,
+  const char *reason,
+  int32_t scope
+) {
+  int exec_error_pipe[2];
+  pid_t pid;
+  const char *what = keepawake_linux_scope_to_what(scope);
+  char error_buffer[64];
+
+  if (pipe(exec_error_pipe) != 0) {
+    keepawake_set_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to create the Linux startup pipe: %s",
+      strerror(errno)
+    );
+    return;
+  }
+
+  pid = fork();
+  if (pid < 0) {
+    close(exec_error_pipe[0]);
+    close(exec_error_pipe[1]);
+    keepawake_set_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to fork the Linux keep-awake helper: %s",
+      strerror(errno)
+    );
+    return;
+  }
+
+  if (pid == 0) {
+    char *const argv[] = {
+      "systemd-inhibit",
+      "--what",
+      (char *)what,
+      "--mode",
+      "block",
+      "--why",
+      (char *)reason,
+      "/bin/sh",
+      "-c",
+      "while :; do sleep 3600; done",
+      NULL,
+    };
+    close(exec_error_pipe[0]);
+    setpgid(0, 0);
+    execvp("systemd-inhibit", argv);
+    snprintf(error_buffer, sizeof(error_buffer), "%d", errno);
+    write(exec_error_pipe[1], error_buffer, strlen(error_buffer));
+    _exit(127);
+  }
+
+  close(exec_error_pipe[1]);
+
+  {
+    ssize_t read_len = read(
+      exec_error_pipe[0],
+      error_buffer,
+      sizeof(error_buffer) - 1
+    );
+    close(exec_error_pipe[0]);
+    if (read_len > 0) {
+      int child_errno = 0;
+      error_buffer[read_len] = '\0';
+      child_errno = atoi(error_buffer);
+      waitpid(pid, NULL, 0);
+      if (child_errno == ENOENT) {
+        keepawake_set_error(
+          guard,
+          keepawake_STATUS_BACKEND_UNAVAILABLE,
+          "systemd-inhibit was not found in PATH"
+        );
+      } else {
+        keepawake_set_error(
+          guard,
+          keepawake_STATUS_OPERATION_FAILED,
+          "Failed to launch systemd-inhibit: %s",
+          strerror(child_errno)
+        );
+      }
+      return;
+    }
+  }
+
+  usleep(100000);
+  {
+    int child_status = 0;
+    pid_t wait_result = waitpid(pid, &child_status, WNOHANG);
+    if (wait_result == pid) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_BACKEND_UNAVAILABLE,
+        "systemd-inhibit exited immediately; ensure logind is available"
+      );
+      return;
+    }
+  }
+
+  guard->child_pid = (int32_t)pid;
+  guard->active = 1;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+}
+
+#endif

--- a/sys/keepawake/native_macos.c
+++ b/sys/keepawake/native_macos.c
@@ -1,0 +1,219 @@
+#include "native_stub.h"
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+
+typedef int32_t IOReturn;
+typedef uint32_t IOPMAssertionID;
+typedef const void *CFStringRef;
+typedef const void *CFAllocatorRef;
+typedef uint32_t CFStringEncoding;
+
+typedef IOReturn (*keepawake_iopm_assertion_create_with_name_fn)(
+  CFStringRef,
+  uint32_t,
+  CFStringRef,
+  IOPMAssertionID *
+);
+typedef IOReturn (*keepawake_iopm_assertion_release_fn)(IOPMAssertionID);
+typedef CFStringRef (*keepawake_cfstring_create_with_cstring_fn)(
+  CFAllocatorRef,
+  const char *,
+  CFStringEncoding
+);
+typedef void (*keepawake_cfrelease_fn)(const void *);
+
+static const CFStringEncoding keepawake_k_cfstring_encoding_utf8 = 0x08000100U;
+
+void keepawake_platform_release(keepawake_guard_t *guard) {
+  void *core_foundation = dlopen(
+    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  void *iokit = dlopen(
+    "/System/Library/Frameworks/IOKit.framework/IOKit",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  keepawake_iopm_assertion_release_fn release_assertion =
+    iokit == NULL ? NULL :
+    (keepawake_iopm_assertion_release_fn)dlsym(iokit, "IOPMAssertionRelease");
+  if (release_assertion == NULL) {
+    if (core_foundation != NULL) {
+      dlclose(core_foundation);
+    }
+    if (iokit != NULL) {
+      dlclose(iokit);
+    }
+    keepawake_set_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to load macOS power management release symbols"
+    );
+    return;
+  }
+
+  if (guard->has_system_assertion) {
+    if (release_assertion(guard->system_assertion_id) != 0) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_OPERATION_FAILED,
+        "Failed to release the macOS system sleep assertion"
+      );
+      goto cleanup;
+    }
+    guard->has_system_assertion = 0;
+  }
+  if (guard->has_display_assertion) {
+    if (release_assertion(guard->display_assertion_id) != 0) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_OPERATION_FAILED,
+        "Failed to release the macOS display sleep assertion"
+      );
+      goto cleanup;
+    }
+    guard->has_display_assertion = 0;
+  }
+
+  guard->active = 0;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+
+cleanup:
+  if (core_foundation != NULL) {
+    dlclose(core_foundation);
+  }
+  if (iokit != NULL) {
+    dlclose(iokit);
+  }
+}
+
+void keepawake_platform_start(
+  keepawake_guard_t *guard,
+  const char *reason,
+  int32_t scope
+) {
+  void *core_foundation = dlopen(
+    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  void *iokit = dlopen(
+    "/System/Library/Frameworks/IOKit.framework/IOKit",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  keepawake_cfstring_create_with_cstring_fn make_cfstring =
+    core_foundation == NULL ? NULL :
+    (keepawake_cfstring_create_with_cstring_fn)dlsym(
+      core_foundation,
+      "CFStringCreateWithCString"
+    );
+  keepawake_cfrelease_fn cfrelease =
+    core_foundation == NULL ? NULL :
+    (keepawake_cfrelease_fn)dlsym(core_foundation, "CFRelease");
+  keepawake_iopm_assertion_create_with_name_fn create_assertion =
+    iokit == NULL ? NULL :
+    (keepawake_iopm_assertion_create_with_name_fn)dlsym(
+      iokit,
+      "IOPMAssertionCreateWithName"
+    );
+  CFStringRef reason_string = NULL;
+  CFStringRef system_type = NULL;
+  CFStringRef display_type = NULL;
+
+  if (make_cfstring == NULL || cfrelease == NULL || create_assertion == NULL) {
+    keepawake_set_error(
+      guard,
+      keepawake_STATUS_BACKEND_UNAVAILABLE,
+      "Failed to load macOS power management frameworks"
+    );
+    goto cleanup;
+  }
+
+  reason_string = make_cfstring(
+    NULL,
+    reason,
+    keepawake_k_cfstring_encoding_utf8
+  );
+  if (reason_string == NULL) {
+    keepawake_set_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to create the macOS reason string"
+    );
+    goto cleanup;
+  }
+
+  if (scope == keepawake_SCOPE_SYSTEM ||
+      scope == keepawake_SCOPE_SYSTEM_AND_DISPLAY) {
+    system_type = make_cfstring(
+      NULL,
+      "PreventUserIdleSystemSleep",
+      keepawake_k_cfstring_encoding_utf8
+    );
+    if (system_type == NULL ||
+        create_assertion(
+          system_type,
+          255,
+          reason_string,
+          &guard->system_assertion_id
+        ) != 0) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_OPERATION_FAILED,
+        "Failed to create the macOS system sleep assertion"
+      );
+      goto cleanup;
+    }
+    guard->has_system_assertion = 1;
+  }
+
+  if (scope == keepawake_SCOPE_DISPLAY ||
+      scope == keepawake_SCOPE_SYSTEM_AND_DISPLAY) {
+    display_type = make_cfstring(
+      NULL,
+      "PreventUserIdleDisplaySleep",
+      keepawake_k_cfstring_encoding_utf8
+    );
+    if (display_type == NULL ||
+        create_assertion(
+          display_type,
+          255,
+          reason_string,
+          &guard->display_assertion_id
+        ) != 0) {
+      keepawake_set_error(
+        guard,
+        keepawake_STATUS_OPERATION_FAILED,
+        "Failed to create the macOS display sleep assertion"
+      );
+      if (guard->has_system_assertion) {
+        keepawake_platform_release(guard);
+      }
+      goto cleanup;
+    }
+    guard->has_display_assertion = 1;
+  }
+
+  guard->active = 1;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+
+cleanup:
+  if (reason_string != NULL && cfrelease != NULL) {
+    cfrelease(reason_string);
+  }
+  if (system_type != NULL && cfrelease != NULL) {
+    cfrelease(system_type);
+  }
+  if (display_type != NULL && cfrelease != NULL) {
+    cfrelease(display_type);
+  }
+  if (core_foundation != NULL) {
+    dlclose(core_foundation);
+  }
+  if (iokit != NULL) {
+    dlclose(iokit);
+  }
+}
+
+#endif

--- a/sys/keepawake/native_stub.h
+++ b/sys/keepawake/native_stub.h
@@ -1,0 +1,57 @@
+#ifndef KEEP_AWAKE_NATIVE_STUB_H
+#define KEEP_AWAKE_NATIVE_STUB_H
+
+#include "moonbit.h"
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum keepawake_scope {
+  keepawake_SCOPE_SYSTEM = 1,
+  keepawake_SCOPE_DISPLAY = 2,
+  keepawake_SCOPE_SYSTEM_AND_DISPLAY = 3
+};
+
+enum keepawake_status {
+  keepawake_STATUS_OK = 0,
+  keepawake_STATUS_BACKEND_UNAVAILABLE = 1,
+  keepawake_STATUS_OPERATION_FAILED = 2
+};
+
+typedef struct keepawake_guard {
+  int32_t status;
+  int32_t scope;
+  int32_t active;
+  char *last_error;
+#ifdef _WIN32
+  uint32_t requested_state;
+#elif defined(__APPLE__)
+  uint32_t system_assertion_id;
+  uint32_t display_assertion_id;
+  int32_t has_system_assertion;
+  int32_t has_display_assertion;
+#else
+  int32_t child_pid;
+#endif
+} keepawake_guard_t;
+
+void keepawake_clear_error(keepawake_guard_t *guard);
+void keepawake_set_error(
+  keepawake_guard_t *guard,
+  int32_t status,
+  const char *format,
+  ...
+);
+moonbit_bytes_t keepawake_make_error_bytes(const char *text);
+
+void keepawake_platform_start(
+  keepawake_guard_t *guard,
+  const char *reason,
+  int32_t scope
+);
+void keepawake_platform_release(keepawake_guard_t *guard);
+
+#endif

--- a/sys/keepawake/native_windows.c
+++ b/sys/keepawake/native_windows.c
@@ -1,0 +1,95 @@
+#include "native_stub.h"
+
+#ifdef _WIN32
+#include <windows.h>
+
+static void keepawake_set_windows_error(
+  keepawake_guard_t *guard,
+  int32_t status,
+  const char *prefix
+) {
+  DWORD error_code = GetLastError();
+  char *system_message = NULL;
+  DWORD message_len = FormatMessageA(
+    FORMAT_MESSAGE_ALLOCATE_BUFFER |
+      FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    error_code,
+    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    (LPSTR)&system_message,
+    0,
+    NULL
+  );
+  if (message_len == 0 || system_message == NULL) {
+    keepawake_set_error(
+      guard,
+      status,
+      "%s (GetLastError=%lu)",
+      prefix,
+      (unsigned long)error_code
+    );
+    return;
+  }
+  keepawake_set_error(
+    guard,
+    status,
+    "%s: %s",
+    prefix,
+    system_message
+  );
+  LocalFree(system_message);
+}
+
+static uint32_t keepawake_windows_state_for_scope(int32_t scope) {
+  uint32_t state = ES_CONTINUOUS;
+  if (scope == keepawake_SCOPE_SYSTEM ||
+      scope == keepawake_SCOPE_SYSTEM_AND_DISPLAY) {
+    state |= ES_SYSTEM_REQUIRED;
+  }
+  if (scope == keepawake_SCOPE_DISPLAY ||
+      scope == keepawake_SCOPE_SYSTEM_AND_DISPLAY) {
+    state |= ES_DISPLAY_REQUIRED;
+  }
+  return state;
+}
+
+void keepawake_platform_release(keepawake_guard_t *guard) {
+  if (!guard->active) {
+    return;
+  }
+  if (SetThreadExecutionState(ES_CONTINUOUS) == 0) {
+    keepawake_set_windows_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to release SetThreadExecutionState"
+    );
+    return;
+  }
+  guard->active = 0;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+}
+
+void keepawake_platform_start(
+  keepawake_guard_t *guard,
+  const char *reason,
+  int32_t scope
+) {
+  (void)reason;
+  uint32_t requested_state = keepawake_windows_state_for_scope(scope);
+  if (SetThreadExecutionState(requested_state) == 0) {
+    keepawake_set_windows_error(
+      guard,
+      keepawake_STATUS_OPERATION_FAILED,
+      "Failed to activate SetThreadExecutionState"
+    );
+    return;
+  }
+  guard->requested_state = requested_state;
+  guard->active = 1;
+  guard->status = keepawake_STATUS_OK;
+  keepawake_clear_error(guard);
+}
+
+#endif

--- a/sys/keepawake/pkg.generated.mbti
+++ b/sys/keepawake/pkg.generated.mbti
@@ -1,0 +1,38 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/keepawake"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn acquire(reason? : String, scope? : Scope) -> Guard raise KeepAwakeError
+
+pub let default_reason : String
+
+pub fn[T] with_keepawake(() -> T raise?, reason? : String, scope? : Scope) -> T raise
+
+// Errors
+pub(all) suberror KeepAwakeError {
+  BackendUnavailable(detail~ : String)
+  OperationFailed(operation~ : String, detail~ : String)
+} derive(Eq)
+pub impl Show for KeepAwakeError
+
+// Types and methods
+pub type Guard
+pub fn Guard::active(Self) -> Bool
+pub fn Guard::release(Self) -> Unit raise KeepAwakeError
+pub fn Guard::scope(Self) -> Scope
+
+pub(all) enum Scope {
+  PreventSystemSleep
+  PreventDisplaySleep
+  PreventSystemAndDisplaySleep
+} derive(Eq, @debug.Debug)
+pub impl Show for Scope
+
+// Type aliases
+
+// Traits
+

--- a/sys/keepawake/scope.mbt
+++ b/sys/keepawake/scope.mbt
@@ -1,0 +1,70 @@
+///|
+/// Describes which kind of idle policy should be inhibited while a guard is
+/// alive.
+///
+/// `PreventSystemSleep` asks the operating system to keep the machine awake.
+/// `PreventDisplaySleep` asks the operating system to keep the display awake.
+/// `PreventSystemAndDisplaySleep` requests both when the backend supports both
+/// concepts directly.
+///
+/// Choose the smallest scope that matches the protected work:
+///
+/// - use `PreventSystemSleep` for background work such as builds, exports, or
+///   downloads where the display may still turn off
+/// - use `PreventDisplaySleep` for presentation-style tasks where the screen
+///   must remain visible
+/// - use `PreventSystemAndDisplaySleep` when both machine sleep and display
+///   sleep would interrupt the task
+///
+/// Backends may map these variants to different native APIs, but the semantic
+/// meaning of each variant stays stable across operating systems.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   assert_eq(
+///     Scope::PreventSystemAndDisplaySleep.to_string(),
+///     "PreventSystemAndDisplaySleep",
+///   )
+/// }
+/// ```
+pub(all) enum Scope {
+  PreventSystemSleep
+  PreventDisplaySleep
+  PreventSystemAndDisplaySleep
+} derive(Debug, Eq)
+
+///|
+/// Formats a scope using the stable public variant name.
+///
+/// The rendered form is intentionally identical to the enum case name so logs,
+/// examples, and snapshot tests can refer to the same terminology that callers
+/// use at the API boundary.
+pub impl Show for Scope with fn output(self : Scope, logger) {
+  match self {
+    PreventSystemSleep => logger.write_string("PreventSystemSleep")
+    PreventDisplaySleep => logger.write_string("PreventDisplaySleep")
+    PreventSystemAndDisplaySleep =>
+      logger.write_string("PreventSystemAndDisplaySleep")
+  }
+}
+
+///|
+/// Converts a public scope into the compact code used by the C backend.
+fn Scope::native_code(self : Scope) -> Int {
+  match self {
+    PreventSystemSleep => 1
+    PreventDisplaySleep => 2
+    PreventSystemAndDisplaySleep => 3
+  }
+}
+
+///|
+/// Converts a native scope code back into the public enum.
+fn scope_from_native_code(code : Int) -> Scope {
+  match code {
+    2 => Scope::PreventDisplaySleep
+    3 => Scope::PreventSystemAndDisplaySleep
+    _ => Scope::PreventSystemSleep
+  }
+}

--- a/sys/microphone/LICENSE
+++ b/sys/microphone/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justjavac contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sys/microphone/README.mbt.md
+++ b/sys/microphone/README.mbt.md
@@ -1,0 +1,35 @@
+# justjavac/microphone
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-microphone)
+
+Native-only microphone discovery and capture-session helpers.
+
+```mbt nocheck
+///|
+fn main {
+  let devices = @microphone.MicrophoneDevice::list()
+  for device in devices {
+    println(device.session_label())
+  }
+}
+```
+
+```mbt nocheck
+///|
+fn example_label {
+  let device = @microphone.MicrophoneDevice::{
+    id: "mic-1",
+    name: "Built-in Mic",
+    state: Idle,
+    default_config: @microphone.CaptureConfig::new(
+      echo_cancellation=true,
+      noise_suppression=true,
+    ),
+    monitor_supported: true,
+  }
+  println(device.session_label())
+}
+```

--- a/sys/microphone/README.md
+++ b/sys/microphone/README.md
@@ -1,0 +1,95 @@
+# justjavac/microphone
+
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-microphone)
+
+`justjavac/microphone` is a native-only MoonBit package for microphone
+device discovery and capture-session metadata. It uses small C native stubs for host integration, and exposes a focused MoonBit API that works on Windows, Linux, and macOS.
+
+## Platform Support
+
+The package is intentionally native-only. `moon.mod.json` sets
+`"preferred-target": "native"`, and `src/moon.pkg` limits the package to the
+native backend.
+
+Discovery uses one platform audio API per operating system:
+
+| Platform | Discovery API |
+| --- | --- |
+| Windows | Core Audio endpoint enumeration |
+| Linux | ALSA device hints, loaded dynamically when available |
+| macOS | Core Audio device properties |
+
+The native stub returns an empty listing when the host API is unavailable.
+`MicrophoneDevice::list()` therefore returns `[]` instead of raising in minimal CI images,
+containers, or machines without audio services.
+
+## Usage
+
+List visible microphone-like devices:
+
+```mbt
+///|
+fn main {
+  let devices = @microphone.MicrophoneDevice::list()
+  if devices.length() == 0 {
+    println("No microphones found.")
+  } else {
+    for device in devices {
+      println(device.session_label())
+    }
+  }
+}
+```
+
+Normalize capture settings before using them to size buffers:
+
+```mbt
+///|
+fn chunk_bytes(config : @microphone.CaptureConfig) -> Int {
+  let normalized = config.normalized()
+  normalized.recommended_chunk_frames() *
+  normalized.channels *
+  normalized.sample_format.bytes_per_sample()
+}
+```
+
+Create a configuration by overriding only the fields that matter:
+
+```mbt
+///|
+let config = @microphone.CaptureConfig::new(
+  channels=2,
+  sample_rate_hz=48_000,
+  echo_cancellation=true,
+).normalized()
+```
+
+Parse a known listing in tests:
+
+```mbt
+///|
+test "parse listing" {
+  let devices = @microphone.MicrophoneDevice::parse_listing(
+    "Built-in Microphone\nmonitor-source\nUSB Studio Mic\n",
+  )
+  inspect(devices.length(), content="2")
+  inspect(devices[0].session_label(), content="mic-0:idle:Built-in Microphone")
+}
+```
+
+## Examples
+
+Runnable examples live under `src/examples` so the repository keeps MoonBit
+source in the configured source tree.
+
+```bash
+moon run src/examples/list_devices --target native
+moon run src/examples/parse_listing --target native
+```
+
+## License
+
+MIT.

--- a/sys/microphone/config.mbt
+++ b/sys/microphone/config.mbt
@@ -1,0 +1,140 @@
+///|
+/// Clamp a channel count to the minimum usable value.
+fn min_channels(value : Int) -> Int {
+  if value < 1 {
+    1
+  } else {
+    value
+  }
+}
+
+///|
+/// Clamp a sample rate to the minimum supported voice-capture rate.
+fn min_sample_rate(value : Int) -> Int {
+  if value < 8_000 {
+    8_000
+  } else {
+    value
+  }
+}
+
+///|
+/// Create a capture configuration.
+///
+/// Every argument has a conservative default: mono, 48 kHz, floating-point
+/// audio with voice-processing flags disabled. Callers can override only the
+/// fields they care about, then call `normalized` before sizing buffers or
+/// opening a native capture stream. This keeps common code short while still
+/// making platform-sensitive options explicit at the call site.
+///
+/// # Example
+/// ```mbt check
+/// test "CaptureConfig::new applies conservative defaults" {
+///   let config = CaptureConfig::new(sample_rate_hz=44_100)
+///   assert_eq(config.channels, 1)
+///   assert_eq(config.sample_rate_hz, 44_100)
+/// }
+/// ```
+pub fn CaptureConfig::new(
+  channels? : Int = 1,
+  sample_rate_hz? : Int = 48_000,
+  sample_format? : SampleFormat = F32,
+  echo_cancellation? : Bool = false,
+  noise_suppression? : Bool = false,
+) -> CaptureConfig {
+  {
+    channels,
+    sample_rate_hz,
+    sample_format,
+    echo_cancellation,
+    noise_suppression,
+  }
+}
+
+///|
+/// Return the number of bytes occupied by one sample.
+///
+/// This is useful when translating frame counts into byte sizes for native
+/// buffers. `I16` and `U16` occupy two bytes per channel, while `F32` occupies
+/// four bytes per channel.
+///
+/// # Example
+/// ```mbt check
+/// test "bytes_per_sample reflects the format width" {
+///   assert_eq(SampleFormat::I16.bytes_per_sample(), 2)
+///   assert_eq(SampleFormat::F32.bytes_per_sample(), 4)
+/// }
+/// ```
+pub fn SampleFormat::bytes_per_sample(self : SampleFormat) -> Int {
+  match self {
+    I16 => 2
+    U16 => 2
+    F32 => 4
+  }
+}
+
+///|
+/// Normalize a capture configuration into safe runtime bounds.
+///
+/// A configuration with fewer than one channel is clamped to mono, and a sample
+/// rate below 8 kHz is clamped to 8 kHz. The sample format and
+/// voice-processing flags are preserved so callers do not lose intent when
+/// normalizing user-provided settings.
+///
+/// # Example
+/// ```mbt check
+/// test "normalized clamps channels and sample rate to safe bounds" {
+///   let config = CaptureConfig::new(channels=0, sample_rate_hz=4_000).normalized()
+///   assert_eq(config.channels, 1)
+///   assert_eq(config.sample_rate_hz, 8_000)
+/// }
+/// ```
+pub fn CaptureConfig::normalized(self : CaptureConfig) -> CaptureConfig {
+  {
+    channels: min_channels(self.channels),
+    sample_rate_hz: min_sample_rate(self.sample_rate_hz),
+    sample_format: self.sample_format,
+    echo_cancellation: self.echo_cancellation,
+    noise_suppression: self.noise_suppression,
+  }
+}
+
+///|
+/// Return the preferred frame count for one responsive capture chunk.
+///
+/// The recommendation is ten milliseconds of audio after normalization. For
+/// example, 48 kHz audio yields 480 frames, while an invalid 4 kHz input first
+/// normalizes to 8 kHz and then yields 80 frames.
+///
+/// # Example
+/// ```mbt check
+/// test "recommended_chunk_frames is ten milliseconds of audio" {
+///   assert_eq(
+///     CaptureConfig::new(sample_rate_hz=48_000).recommended_chunk_frames(),
+///     480,
+///   )
+/// }
+/// ```
+pub fn CaptureConfig::recommended_chunk_frames(self : CaptureConfig) -> Int {
+  self.normalized().sample_rate_hz / 100
+}
+
+///|
+/// Whether a config requests voice-processing behavior.
+///
+/// This helper only checks caller intent. It does not promise that the current
+/// operating system or selected device can actually provide echo cancellation
+/// or noise suppression.
+///
+/// # Example
+/// ```mbt check
+/// test "uses_voice_processing reflects requested flags" {
+///   assert_false(CaptureConfig::new().uses_voice_processing())
+///   assert_true(
+///     CaptureConfig::new(noise_suppression=true).uses_voice_processing(),
+///   )
+/// }
+/// ```
+pub fn CaptureConfig::uses_voice_processing(self : CaptureConfig) -> Bool {
+  self.echo_cancellation || self.noise_suppression
+}

--- a/sys/microphone/discovery.mbt
+++ b/sys/microphone/discovery.mbt
@@ -1,0 +1,71 @@
+///|
+/// Check whether a native source name describes a monitor device.
+fn is_monitor_name(name : String) -> Bool {
+  name.to_lower().contains("monitor")
+}
+
+///|
+/// Build a parsed microphone device with the next stable listing id.
+fn parsed_device(name : String, id_number : Int) -> MicrophoneDevice {
+  {
+    id: "mic-\{id_number}",
+    name,
+    state: Idle,
+    default_config: CaptureConfig::new(),
+    monitor_supported: false,
+  }
+}
+
+///|
+/// Parse a native microphone listing into device descriptors.
+///
+/// The parser expects one device name per line after the private FFI layer has
+/// decoded the native string encoding. Empty lines are ignored, Linux
+/// monitor/source-loopback names are filtered out, and parsed ids are assigned
+/// densely as `mic-0`, `mic-1`, and so on. Each parsed device receives
+/// `CaptureConfig::new()` defaults and starts in `Idle`, which keeps tests
+/// deterministic even when the host platform reports devices in a different
+/// order.
+///
+/// # Example
+/// ```mbt check
+/// test "parse_listing assigns dense ids and drops monitors" {
+///   let devices = MicrophoneDevice::parse_listing(
+///     "Built-in Mic\nMonitor of Output\nUSB Mic\n",
+///   )
+///   assert_eq(devices.length(), 2)
+///   assert_eq(devices[0].id, "mic-0")
+///   assert_eq(devices[1].name, "USB Mic")
+/// }
+/// ```
+pub fn MicrophoneDevice::parse_listing(
+  output : String,
+) -> Array[MicrophoneDevice] {
+  let devices : Array[MicrophoneDevice] = []
+  for line in output.split("\n").to_array() {
+    let name = line.trim().to_owned()
+    if name != "" && !is_monitor_name(name) {
+      devices.push(parsed_device(name, devices.length()))
+    }
+  }
+  devices
+}
+
+///|
+/// List microphone-like capture devices visible to the current platform.
+///
+/// Discovery is best-effort and uses the host audio API directly: Windows uses
+/// Core Audio capture endpoints, Linux uses ALSA device hints when available,
+/// and macOS uses Core Audio device properties. If the platform API is
+/// unavailable, blocked, or returns no capture devices, the function returns an
+/// empty array instead of raising.
+///
+/// # Example
+/// ```mbt nocheck
+/// for device in @microphone.MicrophoneDevice::list() {
+///   println(device.session_label())
+/// }
+/// ```
+pub fn MicrophoneDevice::list() -> Array[MicrophoneDevice] {
+  MicrophoneDevice::parse_listing(native_microphone_listing_text())
+}

--- a/sys/microphone/ffi_native.mbt
+++ b/sys/microphone/ffi_native.mbt
@@ -1,0 +1,40 @@
+///|
+/// Encoding id for null-terminated UTF-8 strings.
+fn native_utf8_encoding() -> Int {
+  1
+}
+
+///|
+/// Encoding id for null-terminated UTF-16LE wide strings.
+fn native_utf16le_encoding() -> Int {
+  2
+}
+
+///|
+/// Return the native string encoding id used by the C stub.
+extern "c" fn native_microphone_listing_encoding() -> Int = "moonbit_microphone_listing_encoding"
+
+///|
+/// Return the native null-terminated device listing from the C stub.
+extern "c" fn native_microphone_listing_bytes() -> Bytes = "moonbit_microphone_listing"
+
+///|
+/// Decode native listing bytes with the selected string encoding.
+fn decode_native_listing(bytes : Bytes, encoding : Int) -> String {
+  if encoding == native_utf16le_encoding() {
+    @ffi.from_wstr_lossy(bytes)
+  } else if encoding == native_utf8_encoding() {
+    @ffi.from_cstr(bytes)
+  } else {
+    @ffi.from_cstr(bytes)
+  }
+}
+
+///|
+/// Decode the native string device listing.
+fn native_microphone_listing_text() -> String {
+  decode_native_listing(
+    native_microphone_listing_bytes(),
+    native_microphone_listing_encoding(),
+  )
+}

--- a/sys/microphone/microphone_test.mbt
+++ b/sys/microphone/microphone_test.mbt
@@ -1,0 +1,88 @@
+///|
+test "configs are normalized before chunk sizing" {
+  let defaults = @microphone.CaptureConfig::new()
+  inspect(defaults.channels, content="1")
+  inspect(defaults.sample_rate_hz, content="48000")
+  inspect(defaults.sample_format, content="F32")
+  let config = @microphone.CaptureConfig::new(
+    channels=0,
+    sample_rate_hz=4_000,
+    sample_format=I16,
+  ).normalized()
+  inspect(config.channels, content="1")
+  inspect(config.sample_rate_hz, content="8000")
+  inspect(config.recommended_chunk_frames(), content="80")
+}
+
+///|
+test "voice processing and liveness stay explicit" {
+  let device = @microphone.MicrophoneDevice::{
+    id: "mic-1",
+    name: "Studio Mic",
+    state: Recording,
+    default_config: @microphone.CaptureConfig::new(
+      channels=2,
+      sample_format=F32,
+      echo_cancellation=true,
+    ),
+    monitor_supported: true,
+  }
+  inspect(device.default_config.uses_voice_processing(), content="true")
+  inspect(device.is_live(), content="true")
+  inspect(
+    @microphone.CaptureConfig::new().uses_voice_processing(),
+    content="false",
+  )
+  let muted_device = @microphone.MicrophoneDevice::{
+    id: "mic-2",
+    name: "Muted Mic",
+    state: Muted,
+    default_config: device.default_config,
+    monitor_supported: false,
+  }
+  inspect(muted_device.is_live(), content="false")
+}
+
+///|
+test "labels and sample sizes are stable" {
+  let device = @microphone.MicrophoneDevice::{
+    id: "mic-1",
+    name: "Studio Mic",
+    state: Armed,
+    default_config: @microphone.CaptureConfig::new(
+      sample_rate_hz=16_000,
+      sample_format=I16,
+      noise_suppression=true,
+    ),
+    monitor_supported: false,
+  }
+  let i16 : @microphone.SampleFormat = I16
+  let u16 : @microphone.SampleFormat = U16
+  let f32 : @microphone.SampleFormat = F32
+  let idle : @microphone.CaptureState = Idle
+  let recording : @microphone.CaptureState = Recording
+  let muted : @microphone.CaptureState = Muted
+  inspect(i16.bytes_per_sample(), content="2")
+  inspect(u16.bytes_per_sample(), content="2")
+  inspect(f32.bytes_per_sample(), content="4")
+  inspect(idle.label(), content="idle")
+  inspect(recording.label(), content="recording")
+  inspect(muted.label(), content="muted")
+  inspect(device.session_label(), content="mic-1:armed:Studio Mic")
+}
+
+///|
+test "native microphone listings parse into devices" {
+  let devices = @microphone.MicrophoneDevice::parse_listing(
+    "\nalsa_input.usb-mic\r\nmonitor-source\nUSB Studio Mic\n",
+  )
+  inspect(devices.length(), content="2")
+  inspect(devices[0].session_label(), content="mic-0:idle:alsa_input.usb-mic")
+  inspect(devices[1].session_label(), content="mic-1:idle:USB Studio Mic")
+}
+
+///|
+test "native discovery returns a safe listing" {
+  let devices = @microphone.MicrophoneDevice::list()
+  inspect(devices.length() >= 0, content="true")
+}

--- a/sys/microphone/microphone_wbtest.mbt
+++ b/sys/microphone/microphone_wbtest.mbt
@@ -1,0 +1,23 @@
+///|
+test "private parser helpers keep monitor sources out" {
+  inspect(is_monitor_name("alsa_output.monitor"), content="true")
+  inspect(is_monitor_name("USB Studio Mic"), content="false")
+  let device = parsed_device("USB Studio Mic", 7)
+  inspect(device.session_label(), content="mic-7:idle:USB Studio Mic")
+  inspect(device.default_config.sample_rate_hz, content="48000")
+}
+
+///|
+test "native listing decoder uses ffi string helpers" {
+  inspect(
+    decode_native_listing(@ffi.to_cstr("Built-in Mic"), native_utf8_encoding()),
+    content="Built-in Mic",
+  )
+  inspect(
+    decode_native_listing(
+      @ffi.to_wstr("Built-in Mic"),
+      native_utf16le_encoding(),
+    ),
+    content="Built-in Mic",
+  )
+}

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,0 +1,21 @@
+name = "justjavac/microphone"
+
+version = "0.1.3"
+
+import {
+  "justjavac/ffi@0.2.3",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/microphone"
+
+license = "MIT"
+
+keywords = [ "moonbit", "native", "microphone", "audio" ]
+
+description = "Microphone capture device and session helpers."
+
+preferred_target = "native"
+
+source = "."

--- a/sys/microphone/moon.pkg
+++ b/sys/microphone/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "justjavac/ffi",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [
+    "native_buffer.c",
+    "native_linux.c",
+    "native_macos.c",
+    "native_unsupported.c",
+    "native_windows.c",
+  ],
+)

--- a/sys/microphone/native_buffer.c
+++ b/sys/microphone/native_buffer.c
@@ -1,0 +1,138 @@
+#include "native_buffer.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+moonbit_bytes_t moonbit_microphone_empty_bytes(void) {
+  return moonbit_make_bytes(1, 0);
+}
+
+int moonbit_microphone_append_bytes(
+  MoonBitMicrophoneBuffer *buffer,
+  const char *chunk,
+  size_t chunk_len
+) {
+  if (chunk_len == 0) {
+    return 1;
+  }
+  if (chunk_len > ((size_t)-1) - buffer->len - 1) {
+    return 0;
+  }
+  size_t needed = buffer->len + chunk_len;
+  if (needed > buffer->cap) {
+    size_t next_cap = buffer->cap == 0 ? 1024 : buffer->cap;
+    while (needed > next_cap) {
+      if (next_cap > ((size_t)-1) / 2) {
+        return 0;
+      }
+      next_cap *= 2;
+    }
+    char *next = (char *)realloc(buffer->data, next_cap);
+    if (next == NULL) {
+      return 0;
+    }
+    buffer->data = next;
+    buffer->cap = next_cap;
+  }
+  memcpy(buffer->data + buffer->len, chunk, chunk_len);
+  buffer->len += chunk_len;
+  return 1;
+}
+
+int moonbit_microphone_append_char(
+  MoonBitMicrophoneBuffer *buffer,
+  char ch
+) {
+  return moonbit_microphone_append_bytes(buffer, &ch, 1);
+}
+
+int moonbit_microphone_append_label_line(
+  MoonBitMicrophoneBuffer *buffer,
+  const char *label
+) {
+  if (label == NULL) {
+    return 1;
+  }
+
+  const char *start = label;
+  while (*start == ' ' || *start == '\t' || *start == '\r' || *start == '\n') {
+    start++;
+  }
+
+  const char *end = start + strlen(start);
+  while (
+    end > start &&
+    (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r' || end[-1] == '\n')
+  ) {
+    end--;
+  }
+
+  if (start == end) {
+    return 1;
+  }
+
+  if (buffer->len > 0 && !moonbit_microphone_append_char(buffer, '\n')) {
+    return 0;
+  }
+
+  for (const char *cursor = start; cursor < end; cursor++) {
+    char ch = *cursor;
+    if (ch == '\r' || ch == '\n') {
+      ch = ' ';
+    }
+    if (!moonbit_microphone_append_char(buffer, ch)) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+moonbit_bytes_t moonbit_microphone_buffer_to_terminated_bytes(
+  MoonBitMicrophoneBuffer *buffer,
+  size_t terminator_size
+) {
+  if (terminator_size == 0) {
+    terminator_size = 1;
+  }
+  if (
+    buffer->data == NULL ||
+    buffer->len == 0 ||
+    terminator_size > (size_t)INT32_MAX ||
+    buffer->len > (size_t)INT32_MAX - terminator_size
+  ) {
+    free(buffer->data);
+    return moonbit_make_bytes((int32_t)terminator_size, 0);
+  }
+
+  moonbit_bytes_t bytes = moonbit_make_bytes(
+    (int32_t)(buffer->len + terminator_size),
+    0
+  );
+  memcpy(bytes, buffer->data, buffer->len);
+  free(buffer->data);
+  return bytes;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbit_microphone_listing_encoding(void) {
+#if defined(_WIN32)
+  return MOONBIT_MICROPHONE_ENCODING_UTF16LE;
+#else
+  return MOONBIT_MICROPHONE_ENCODING_UTF8;
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbit_microphone_listing(void) {
+  MoonBitMicrophoneBuffer buffer = { 0 };
+  moonbit_microphone_collect_platform(&buffer);
+  size_t terminator_size =
+    moonbit_microphone_listing_encoding() ==
+    MOONBIT_MICROPHONE_ENCODING_UTF16LE ? 2 : 1;
+  return moonbit_microphone_buffer_to_terminated_bytes(
+    &buffer,
+    terminator_size
+  );
+}

--- a/sys/microphone/native_buffer.h
+++ b/sys/microphone/native_buffer.h
@@ -1,0 +1,42 @@
+#ifndef MOONBIT_MICROPHONE_NATIVE_BUFFER_H
+#define MOONBIT_MICROPHONE_NATIVE_BUFFER_H
+
+#include <moonbit.h>
+
+#include <stddef.h>
+
+typedef struct {
+  char *data;
+  size_t len;
+  size_t cap;
+} MoonBitMicrophoneBuffer;
+
+#define MOONBIT_MICROPHONE_ENCODING_UTF8 1
+#define MOONBIT_MICROPHONE_ENCODING_UTF16LE 2
+
+moonbit_bytes_t moonbit_microphone_empty_bytes(void);
+
+int moonbit_microphone_append_bytes(
+  MoonBitMicrophoneBuffer *buffer,
+  const char *chunk,
+  size_t chunk_len
+);
+
+int moonbit_microphone_append_char(
+  MoonBitMicrophoneBuffer *buffer,
+  char ch
+);
+
+int moonbit_microphone_append_label_line(
+  MoonBitMicrophoneBuffer *buffer,
+  const char *label
+);
+
+moonbit_bytes_t moonbit_microphone_buffer_to_terminated_bytes(
+  MoonBitMicrophoneBuffer *buffer,
+  size_t terminator_size
+);
+
+int moonbit_microphone_collect_platform(MoonBitMicrophoneBuffer *buffer);
+
+#endif

--- a/sys/microphone/native_linux.c
+++ b/sys/microphone/native_linux.c
@@ -1,0 +1,73 @@
+#if defined(__linux__)
+
+#include "native_buffer.h"
+
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int (*MoonBitAlsaDeviceNameHint)(int, const char *, void ***);
+typedef char *(*MoonBitAlsaDeviceNameGetHint)(const void *, const char *);
+typedef int (*MoonBitAlsaDeviceNameFreeHint)(void **);
+typedef void (*MoonBitAlsaConfigUpdateFreeGlobal)(void);
+
+int moonbit_microphone_collect_platform(MoonBitMicrophoneBuffer *buffer) {
+  void *alsa = dlopen("libasound.so.2", RTLD_LAZY | RTLD_LOCAL);
+  if (alsa == NULL) {
+    alsa = dlopen("libasound.so", RTLD_LAZY | RTLD_LOCAL);
+  }
+  if (alsa == NULL) {
+    return 0;
+  }
+
+  MoonBitAlsaDeviceNameHint device_name_hint =
+    (MoonBitAlsaDeviceNameHint)dlsym(alsa, "snd_device_name_hint");
+  MoonBitAlsaDeviceNameGetHint device_name_get_hint =
+    (MoonBitAlsaDeviceNameGetHint)dlsym(alsa, "snd_device_name_get_hint");
+  MoonBitAlsaDeviceNameFreeHint device_name_free_hint =
+    (MoonBitAlsaDeviceNameFreeHint)dlsym(alsa, "snd_device_name_free_hint");
+  MoonBitAlsaConfigUpdateFreeGlobal config_update_free_global =
+    (MoonBitAlsaConfigUpdateFreeGlobal)dlsym(
+      alsa,
+      "snd_config_update_free_global"
+    );
+
+  if (
+    device_name_hint == NULL ||
+    device_name_get_hint == NULL ||
+    device_name_free_hint == NULL
+  ) {
+    dlclose(alsa);
+    return 0;
+  }
+
+  void **hints = NULL;
+  if (device_name_hint(-1, "pcm", &hints) < 0 || hints == NULL) {
+    dlclose(alsa);
+    return 0;
+  }
+
+  for (void **hint = hints; *hint != NULL; hint++) {
+    char *io = device_name_get_hint(*hint, "IOID");
+    int capture_capable = io == NULL || strcmp(io, "Input") == 0;
+    if (capture_capable) {
+      char *name = device_name_get_hint(*hint, "NAME");
+      char *description = device_name_get_hint(*hint, "DESC");
+      const char *label =
+        description != NULL && description[0] != '\0' ? description : name;
+      moonbit_microphone_append_label_line(buffer, label);
+      free(description);
+      free(name);
+    }
+    free(io);
+  }
+
+  device_name_free_hint(hints);
+  if (config_update_free_global != NULL) {
+    config_update_free_global();
+  }
+  dlclose(alsa);
+  return 1;
+}
+
+#endif

--- a/sys/microphone/native_macos.c
+++ b/sys/microphone/native_macos.c
@@ -1,0 +1,183 @@
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include "native_buffer.h"
+
+#include <CoreAudio/CoreAudio.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+
+#define MOONBIT_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN 0
+
+typedef OSStatus (*MoonBitAudioGetPropertyDataSize)(
+  AudioObjectID,
+  const AudioObjectPropertyAddress *,
+  UInt32,
+  const void *,
+  UInt32 *
+);
+typedef OSStatus (*MoonBitAudioGetPropertyData)(
+  AudioObjectID,
+  const AudioObjectPropertyAddress *,
+  UInt32,
+  const void *,
+  UInt32 *,
+  void *
+);
+typedef Boolean (*MoonBitCFStringGetCString)(
+  CFStringRef,
+  char *,
+  CFIndex,
+  CFStringEncoding
+);
+typedef void (*MoonBitCFRelease)(CFTypeRef);
+
+static UInt32 moonbit_microphone_macos_input_channels(
+  AudioDeviceID device,
+  MoonBitAudioGetPropertyDataSize get_size,
+  MoonBitAudioGetPropertyData get_data
+) {
+  AudioObjectPropertyAddress address = {
+    kAudioDevicePropertyStreamConfiguration,
+    kAudioDevicePropertyScopeInput,
+    MOONBIT_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+  };
+
+  UInt32 data_size = 0;
+  if (get_size(device, &address, 0, NULL, &data_size) != noErr ||
+      data_size == 0) {
+    return 0;
+  }
+
+  AudioBufferList *buffers = (AudioBufferList *)malloc(data_size);
+  if (buffers == NULL) {
+    return 0;
+  }
+
+  UInt32 channels = 0;
+  if (get_data(device, &address, 0, NULL, &data_size, buffers) == noErr) {
+    for (UInt32 index = 0; index < buffers->mNumberBuffers; index++) {
+      channels += buffers->mBuffers[index].mNumberChannels;
+    }
+  }
+
+  free(buffers);
+  return channels;
+}
+
+int moonbit_microphone_collect_platform(MoonBitMicrophoneBuffer *buffer) {
+  void *core_audio = dlopen(
+    "/System/Library/Frameworks/CoreAudio.framework/CoreAudio",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  void *core_foundation = dlopen(
+    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+    RTLD_LAZY | RTLD_LOCAL
+  );
+  if (core_audio == NULL || core_foundation == NULL) {
+    if (core_audio != NULL) {
+      dlclose(core_audio);
+    }
+    if (core_foundation != NULL) {
+      dlclose(core_foundation);
+    }
+    return 0;
+  }
+
+  MoonBitAudioGetPropertyDataSize get_size =
+    (MoonBitAudioGetPropertyDataSize)dlsym(
+      core_audio,
+      "AudioObjectGetPropertyDataSize"
+    );
+  MoonBitAudioGetPropertyData get_data = (MoonBitAudioGetPropertyData)dlsym(
+    core_audio,
+    "AudioObjectGetPropertyData"
+  );
+  MoonBitCFStringGetCString string_get_cstring =
+    (MoonBitCFStringGetCString)dlsym(core_foundation, "CFStringGetCString");
+  MoonBitCFRelease cf_release =
+    (MoonBitCFRelease)dlsym(core_foundation, "CFRelease");
+
+  if (
+    get_size == NULL ||
+    get_data == NULL ||
+    string_get_cstring == NULL ||
+    cf_release == NULL
+  ) {
+    dlclose(core_foundation);
+    dlclose(core_audio);
+    return 0;
+  }
+
+  AudioObjectPropertyAddress devices_address = {
+    kAudioHardwarePropertyDevices,
+    kAudioObjectPropertyScopeGlobal,
+    MOONBIT_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+  };
+
+  UInt32 data_size = 0;
+  if (
+    get_size(kAudioObjectSystemObject, &devices_address, 0, NULL, &data_size) !=
+      noErr ||
+    data_size == 0
+  ) {
+    dlclose(core_foundation);
+    dlclose(core_audio);
+    return 0;
+  }
+
+  AudioDeviceID *devices = (AudioDeviceID *)malloc(data_size);
+  if (devices == NULL) {
+    dlclose(core_foundation);
+    dlclose(core_audio);
+    return 0;
+  }
+
+  if (
+    get_data(
+      kAudioObjectSystemObject,
+      &devices_address,
+      0,
+      NULL,
+      &data_size,
+      devices
+    ) == noErr
+  ) {
+    UInt32 device_count = data_size / sizeof(AudioDeviceID);
+    for (UInt32 index = 0; index < device_count; index++) {
+      AudioDeviceID device = devices[index];
+      if (moonbit_microphone_macos_input_channels(device, get_size, get_data) ==
+          0) {
+        continue;
+      }
+
+      CFStringRef name = NULL;
+      UInt32 name_size = sizeof(name);
+      AudioObjectPropertyAddress name_address = {
+        kAudioObjectPropertyName,
+        kAudioObjectPropertyScopeGlobal,
+        MOONBIT_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+      };
+
+      if (
+        get_data(device, &name_address, 0, NULL, &name_size, &name) == noErr &&
+        name != NULL
+      ) {
+        char utf8[1024];
+        if (
+          string_get_cstring(name, utf8, sizeof(utf8), kCFStringEncodingUTF8)
+        ) {
+          moonbit_microphone_append_label_line(buffer, utf8);
+        }
+        cf_release(name);
+      }
+    }
+  }
+
+  free(devices);
+  dlclose(core_foundation);
+  dlclose(core_audio);
+  return 1;
+}
+
+#endif

--- a/sys/microphone/native_unsupported.c
+++ b/sys/microphone/native_unsupported.c
@@ -1,0 +1,11 @@
+#if !defined(_WIN32) && !(defined(__APPLE__) && defined(__MACH__)) && \
+  !defined(__linux__)
+
+#include "native_buffer.h"
+
+int moonbit_microphone_collect_platform(MoonBitMicrophoneBuffer *buffer) {
+  (void)buffer;
+  return 0;
+}
+
+#endif

--- a/sys/microphone/native_windows.c
+++ b/sys/microphone/native_windows.c
@@ -1,0 +1,170 @@
+#if defined(_WIN32)
+
+#include "native_buffer.h"
+
+#include <mmdeviceapi.h>
+#include <objbase.h>
+#include <propkeydef.h>
+#include <propidl.h>
+#include <propsys.h>
+#include <windows.h>
+#include <wchar.h>
+
+#pragma comment(lib, "ole32.lib")
+
+static const GUID MOONBIT_MICROPHONE_CLSID_MMDEVICE_ENUMERATOR = {
+  0xbcde0395,
+  0xe52f,
+  0x467c,
+  { 0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e },
+};
+
+static const GUID MOONBIT_MICROPHONE_IID_IMMDEVICE_ENUMERATOR = {
+  0xa95664d2,
+  0x9614,
+  0x4f35,
+  { 0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6 },
+};
+
+static const PROPERTYKEY MOONBIT_MICROPHONE_PKEY_DEVICE_FRIENDLY_NAME = {
+  { 0xa45c254e,
+    0xdf1c,
+    0x4efd,
+    { 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0 } },
+  14,
+};
+
+static int moonbit_microphone_append_wide_unit(
+  MoonBitMicrophoneBuffer *buffer,
+  wchar_t unit
+) {
+  unsigned char bytes[2] = {
+    (unsigned char)((unsigned int)unit & 0xff),
+    (unsigned char)(((unsigned int)unit >> 8) & 0xff),
+  };
+  return moonbit_microphone_append_bytes(buffer, (const char *)bytes, 2);
+}
+
+static int moonbit_microphone_append_wide_label_line(
+  MoonBitMicrophoneBuffer *buffer,
+  const wchar_t *label
+) {
+  if (label == NULL) {
+    return 1;
+  }
+
+  const wchar_t *start = label;
+  while (*start == L' ' || *start == L'\t' || *start == L'\r' || *start == L'\n') {
+    start++;
+  }
+
+  const wchar_t *end = start + wcslen(start);
+  while (
+    end > start &&
+    (end[-1] == L' ' || end[-1] == L'\t' || end[-1] == L'\r' || end[-1] == L'\n')
+  ) {
+    end--;
+  }
+
+  if (start == end) {
+    return 1;
+  }
+
+  if (
+    buffer->len > 0 &&
+    !moonbit_microphone_append_wide_unit(buffer, L'\n')
+  ) {
+    return 0;
+  }
+
+  for (const wchar_t *cursor = start; cursor < end; cursor++) {
+    wchar_t unit = *cursor;
+    if (unit == L'\r' || unit == L'\n') {
+      unit = L' ';
+    }
+    if (!moonbit_microphone_append_wide_unit(buffer, unit)) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+int moonbit_microphone_collect_platform(MoonBitMicrophoneBuffer *buffer) {
+  HRESULT init = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+  int should_uninitialize = SUCCEEDED(init);
+  if (FAILED(init) && init != RPC_E_CHANGED_MODE) {
+    return 0;
+  }
+
+  IMMDeviceEnumerator *enumerator = NULL;
+  HRESULT hr = CoCreateInstance(
+    &MOONBIT_MICROPHONE_CLSID_MMDEVICE_ENUMERATOR,
+    NULL,
+    CLSCTX_ALL,
+    &MOONBIT_MICROPHONE_IID_IMMDEVICE_ENUMERATOR,
+    (void **)&enumerator
+  );
+  if (FAILED(hr) || enumerator == NULL) {
+    if (should_uninitialize) {
+      CoUninitialize();
+    }
+    return 0;
+  }
+
+  IMMDeviceCollection *collection = NULL;
+  hr = enumerator->lpVtbl->EnumAudioEndpoints(
+    enumerator,
+    eCapture,
+    DEVICE_STATE_ACTIVE,
+    &collection
+  );
+  if (FAILED(hr) || collection == NULL) {
+    enumerator->lpVtbl->Release(enumerator);
+    if (should_uninitialize) {
+      CoUninitialize();
+    }
+    return 0;
+  }
+
+  UINT count = 0;
+  if (SUCCEEDED(collection->lpVtbl->GetCount(collection, &count))) {
+    for (UINT index = 0; index < count; index++) {
+      IMMDevice *device = NULL;
+      if (FAILED(collection->lpVtbl->Item(collection, index, &device)) ||
+          device == NULL) {
+        continue;
+      }
+
+      IPropertyStore *store = NULL;
+      if (SUCCEEDED(device->lpVtbl->OpenPropertyStore(device, STGM_READ, &store)) &&
+          store != NULL) {
+        PROPVARIANT friendly_name;
+        PropVariantInit(&friendly_name);
+        if (SUCCEEDED(
+              store->lpVtbl->GetValue(
+                store,
+                &MOONBIT_MICROPHONE_PKEY_DEVICE_FRIENDLY_NAME,
+                &friendly_name
+              )
+            ) &&
+            friendly_name.vt == VT_LPWSTR) {
+          moonbit_microphone_append_wide_label_line(buffer, friendly_name.pwszVal);
+        }
+        PropVariantClear(&friendly_name);
+        store->lpVtbl->Release(store);
+      }
+
+      device->lpVtbl->Release(device);
+    }
+  }
+
+  collection->lpVtbl->Release(collection);
+  enumerator->lpVtbl->Release(enumerator);
+  if (should_uninitialize) {
+    CoUninitialize();
+  }
+  return 1;
+}
+
+#endif

--- a/sys/microphone/pkg.generated.mbti
+++ b/sys/microphone/pkg.generated.mbti
@@ -1,0 +1,59 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/microphone"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct CaptureConfig {
+  channels : Int
+  sample_rate_hz : Int
+  sample_format : SampleFormat
+  echo_cancellation : Bool
+  noise_suppression : Bool
+} derive(Eq, @debug.Debug)
+pub fn CaptureConfig::new(channels? : Int, sample_rate_hz? : Int, sample_format? : SampleFormat, echo_cancellation? : Bool, noise_suppression? : Bool) -> Self
+pub fn CaptureConfig::normalized(Self) -> Self
+pub fn CaptureConfig::recommended_chunk_frames(Self) -> Int
+pub fn CaptureConfig::uses_voice_processing(Self) -> Bool
+pub impl Show for CaptureConfig
+
+pub(all) enum CaptureState {
+  Idle
+  Armed
+  Recording
+  Muted
+} derive(Eq, @debug.Debug)
+pub fn CaptureState::label(Self) -> String
+pub impl Show for CaptureState
+
+pub(all) struct MicrophoneDevice {
+  id : String
+  name : String
+  state : CaptureState
+  default_config : CaptureConfig
+  monitor_supported : Bool
+} derive(Eq, @debug.Debug)
+pub fn MicrophoneDevice::is_live(Self) -> Bool
+pub fn MicrophoneDevice::list() -> Array[Self]
+pub fn MicrophoneDevice::parse_listing(String) -> Array[Self]
+pub fn MicrophoneDevice::session_label(Self) -> String
+pub impl Show for MicrophoneDevice
+
+pub(all) enum SampleFormat {
+  I16
+  U16
+  F32
+} derive(Eq, @debug.Debug)
+pub fn SampleFormat::bytes_per_sample(Self) -> Int
+pub impl Show for SampleFormat
+
+// Type aliases
+
+// Traits
+

--- a/sys/microphone/session.mbt
+++ b/sys/microphone/session.mbt
@@ -1,0 +1,47 @@
+///|
+/// Whether the microphone is currently armed or actively capturing.
+///
+/// `Armed` and `Recording` are live states because either state means the
+/// application has reserved the selected device for immediate capture. `Idle`
+/// and `Muted` are not live states, so this helper is suitable for UI badges,
+/// telemetry, and guard checks before reading capture buffers.
+pub fn MicrophoneDevice::is_live(self : MicrophoneDevice) -> Bool {
+  match self.state {
+    Armed => true
+    Recording => true
+    _ => false
+  }
+}
+
+///|
+/// Return a stable lowercase label for a capture state.
+///
+/// The labels are designed for logs, telemetry, and user settings where a
+/// compact string is easier to persist than a debug representation. They are
+/// intentionally independent of the derived `Show` output so future internal
+/// formatting changes do not affect persisted labels.
+///
+/// # Example
+/// ```mbt check
+/// test "label returns a stable lowercase string" {
+///   assert_eq(CaptureState::Recording.label(), "recording")
+/// }
+/// ```
+pub fn CaptureState::label(self : CaptureState) -> String {
+  match self {
+    Idle => "idle"
+    Armed => "armed"
+    Recording => "recording"
+    Muted => "muted"
+  }
+}
+
+///|
+/// Produce a concise session label for settings or telemetry.
+///
+/// The label combines the parsed device id, stable state label, and device
+/// name. It is deterministic for a single discovery result and convenient for
+/// logs such as `mic-0:idle:Built-in Microphone`.
+pub fn MicrophoneDevice::session_label(self : MicrophoneDevice) -> String {
+  "\{self.id}:\{self.state.label()}:\{self.name}"
+}

--- a/sys/microphone/types.mbt
+++ b/sys/microphone/types.mbt
@@ -1,0 +1,102 @@
+///|
+/// Runtime state for a microphone capture session.
+///
+/// `Idle` means the device is known but not prepared, `Armed` means the
+/// application is ready to begin capture, `Recording` means audio frames are
+/// actively being collected, and `Muted` means capture is intentionally
+/// suppressed while the device remains selected.
+pub(all) enum CaptureState {
+  Idle
+  Armed
+  Recording
+  Muted
+} derive(Debug, Eq)
+
+///|
+/// Sample representation requested from a microphone capture session.
+///
+/// `I16` and `U16` are 16-bit integer formats that are common in lower-level
+/// APIs. `F32` is the preferred normalized floating-point representation for
+/// processing pipelines because each sample is four bytes and typically maps
+/// to the `[-1.0, 1.0]` audio range.
+pub(all) enum SampleFormat {
+  I16
+  U16
+  F32
+} derive(Debug, Eq)
+
+///|
+/// Capture settings used when opening or describing a microphone stream.
+///
+/// `channels` and `sample_rate_hz` are normalized by `CaptureConfig::normalized` before
+/// chunk sizing is computed. `echo_cancellation` and `noise_suppression` are
+/// advisory voice-processing flags; support depends on the actual host audio
+/// stack, but keeping them in the config makes intent explicit at API
+/// boundaries.
+pub(all) struct CaptureConfig {
+  channels : Int
+  sample_rate_hz : Int
+  sample_format : SampleFormat
+  echo_cancellation : Bool
+  noise_suppression : Bool
+} derive(Debug, Eq)
+
+///|
+/// Microphone device descriptor returned by native discovery.
+///
+/// `id` is a stable identifier for the parsed listing within one discovery
+/// result, `name` is the human-facing device name, `state` starts at `Idle`,
+/// `default_config` is safe for low-latency voice capture, and
+/// `monitor_supported` reports whether this package recognized the entry as a
+/// monitor/source-loopback device.
+pub(all) struct MicrophoneDevice {
+  id : String
+  name : String
+  state : CaptureState
+  default_config : CaptureConfig
+  monitor_supported : Bool
+} derive(Debug, Eq)
+
+///|
+/// Write a derived debug representation to a `Show` logger.
+fn[T : Debug] write_debug_show(value : T, logger : &Logger) -> Unit {
+  logger.write_string(value.to_repr().to_string())
+}
+
+///|
+/// Render `CaptureState` with the derived debug representation.
+///
+/// The implementation keeps `inspect`, logs, and string interpolation aligned
+/// with the enum variant names while `CaptureState::label` remains the stable lowercase
+/// label for persisted settings.
+pub impl Show for CaptureState with fn output(self, logger : &Logger) -> Unit {
+  write_debug_show(self, logger)
+}
+
+///|
+/// Render `SampleFormat` with the derived debug representation.
+///
+/// This makes sample format values easy to print in tests and diagnostics
+/// without introducing a separate formatting table for the public enum.
+pub impl Show for SampleFormat with fn output(self, logger : &Logger) -> Unit {
+  write_debug_show(self, logger)
+}
+
+///|
+/// Render `CaptureConfig` with the derived debug representation.
+///
+/// The full record is printed, which is useful when checking normalized
+/// settings or comparing expected capture profiles in tests.
+pub impl Show for CaptureConfig with fn output(self, logger : &Logger) -> Unit {
+  write_debug_show(self, logger)
+}
+
+///|
+/// Render `MicrophoneDevice` with the derived debug representation.
+///
+/// Device descriptors include state and default configuration, so using the
+/// derived representation gives callers a compact diagnostic view of discovery
+/// results.
+pub impl Show for MicrophoneDevice with fn output(self, logger : &Logger) -> Unit {
+  write_debug_show(self, logger)
+}

--- a/sys/tray/LICENSE
+++ b/sys/tray/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justjavac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sys/tray/README.mbt.md
+++ b/sys/tray/README.mbt.md
@@ -1,0 +1,58 @@
+# justjavac/tray
+
+[![CI](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-tray)
+
+Cross-platform native tray helpers for MoonBit.
+
+Native tray events are queued with a fixed bound, so long-running apps should
+call `pump()` and `drain_events()` regularly.
+
+## Example
+
+```mbt nocheck
+guard @tray.is_supported() else {
+  return
+}
+
+let tray = @tray.create(
+  identifier="com.example.demo",
+  tooltip="MoonBit tray demo",
+)
+
+match tray {
+  Ok(tray) => {
+    match
+      tray.set_menu([
+        @tray.TrayMenuItem::normal(id="show", label="Show"),
+        @tray.TrayMenuItem::separator(),
+        @tray.TrayMenuItem::checkbox(id="launch", label="Launch", checked=true),
+        @tray.TrayMenuItem::submenu(
+          label="More",
+          items=[
+            @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+          ],
+        ),
+      ]) {
+      Ok(_) => ()
+      Err(error) => println("set_menu skipped: \{error}")
+    }
+    match tray.show() {
+      Ok(_) =>
+        match tray.pump() {
+          Ok(_) =>
+            for event in tray.drain_events() {
+              println(event.event_name())
+            }
+          Err(error) => println(error)
+        }
+      Err(error) => println(error)
+    }
+    tray.destroy()
+  }
+  Err(error) => println(error)
+}
+```

--- a/sys/tray/README.md
+++ b/sys/tray/README.md
@@ -1,0 +1,254 @@
+# justjavac/tray
+
+[![CI](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-tray)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/justjavac/tray)
+
+Cross-platform native tray helpers for MoonBit.
+
+This package focuses on a small, readable API for tray lifecycle management:
+detect support, create a tray handle, update the icon or tooltip, show or hide
+it, replace a context menu, drain tray/menu events, pump native events when
+needed, and destroy it cleanly.
+
+## Install
+
+```bash
+moon add justjavac/tray
+```
+
+This package supports the `native` target only.
+
+## What You Get
+
+- A lightweight tray icon lifecycle API for MoonBit native apps
+- Runtime support checks before you create a tray
+- Windows v1 tray icon click, right-click, and double-click events
+- Cross-platform v1 context menus with normal, separator, checkbox, and submenu items
+- Cross-platform v1 menu item click events
+- Cross-platform lifecycle backends for Windows, Linux, and macOS
+- No compile-time Linux or macOS GUI dependency in the package itself
+
+## Quick Start
+
+```mbt nocheck
+fn run_tray_demo() -> Unit {
+  guard @tray.is_supported() else {
+    println("tray backend unavailable: \{@tray.ensure_supported()}")
+    return
+  }
+
+  let tray = match @tray.create(
+    identifier="com.example.demo",
+    tooltip="MoonBit tray demo",
+  ) {
+    Ok(tray) => tray
+    Err(error) => {
+      println("create failed: \{error}")
+      return
+    }
+  }
+
+  ignore(tray.set_icon(Some("assets/tray.png")))
+  match tray.set_menu([
+    @tray.TrayMenuItem::normal(id="show", label="Show Window"),
+    @tray.TrayMenuItem::separator(),
+    @tray.TrayMenuItem::checkbox(
+      id="launch",
+      label="Launch at Login",
+      checked=true,
+    ),
+    @tray.TrayMenuItem::submenu(
+      label="More",
+      items=[
+        @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+      ],
+    ),
+  ]) {
+    Ok(_) => ()
+    Err(error) => println("set_menu skipped: \{error}")
+  }
+  match tray.show() {
+    Ok(_) => ()
+    Err(error) => {
+      println("show failed: \{error}")
+      tray.destroy()
+      return
+    }
+  }
+
+  loop {
+    match tray.pump() {
+      Ok(true) => ()
+      Ok(false) => break
+      Err(error) => {
+        println("pump failed: \{error}")
+        break
+      }
+    }
+    for event in tray.drain_events() {
+      println("tray event: \{event.event_name()}")
+    }
+  }
+
+  tray.destroy()
+}
+```
+
+## API Summary
+
+### Platform and capability helpers
+
+- `current_platform() -> Platform`
+- `default_identifier() -> String`
+- `is_supported() -> Bool`
+- `ensure_supported() -> Result[Unit, String]`
+
+### Tray lifecycle
+
+- `create(identifier? : String, icon? : String?, tooltip? : String) -> Result[Tray, String]`
+- `Tray::platform() -> Platform`
+- `Tray::identifier() -> String`
+- `Tray::icon() -> String?`
+- `Tray::tooltip() -> String`
+- `Tray::visible() -> Bool`
+- `Tray::is_visible() -> Bool`
+- `Tray::menu_items() -> Array[TrayMenuItem]`
+- `Tray::show(tooltip? : String?) -> Result[Bool, String]`
+- `Tray::hide() -> Result[Bool, String]`
+- `Tray::set_tooltip(String) -> Result[Bool, String]`
+- `Tray::set_icon(String?) -> Result[Bool, String]`
+- `Tray::set_menu(Array[TrayMenuItem]) -> Result[Bool, String]`
+- `Tray::drain_events() -> Array[TrayEvent]`
+- `Tray::pump(blocking? : Bool) -> Result[Bool, String]`
+- `Tray::destroy() -> Unit`
+
+### Menus and events
+
+- `TrayMenuItem::normal(id~ : String, label~ : String, enabled? : Bool)`
+- `TrayMenuItem::separator()`
+- `TrayMenuItem::checkbox(id~ : String, label~ : String, checked? : Bool, enabled? : Bool)`
+- `TrayMenuItem::submenu(label~ : String, items~ : Array[TrayMenuItem], enabled? : Bool)`
+- `TrayMenuItem::kind() -> TrayMenuItemKind`
+- `TrayEvent::event_name() -> String`
+- `TrayEvent::item_id() -> String?`
+
+Clickable menu ids must be non-empty, globally unique in the menu tree, shorter
+than 128 UTF-8 bytes, and must not contain NUL bytes or surrounding whitespace.
+
+### Return conventions
+
+- `show()` returns `Ok(true)` when the tray is visible after the call.
+- `hide()` returns `Ok(false)` when the tray is hidden after the call.
+- `set_tooltip()` and `set_icon()` return the current visible state.
+- `set_menu()` returns the current visible state.
+- `drain_events()` returns queued events and clears the queue.
+- Native event queues are bounded; call `pump()` and `drain_events()` regularly
+  so older click or menu events are not dropped under bursty input.
+- `pump()` returns `Ok(false)` only when the native loop asks the caller to stop.
+
+## Platform Notes
+
+| Platform | Backend | Notes |
+| --- | --- | --- |
+| Windows | Win32 notification area | Uses a hidden message window plus `Shell_NotifyIconW`. |
+| Linux | GTK 3 + AppIndicator | GUI runtime is loaded dynamically at runtime. |
+| macOS | AppKit `NSStatusItem` | AppKit is loaded through the Objective-C runtime. |
+
+### Windows
+
+- Works with the normal shell notification area.
+- Uses UTF-8 to UTF-16 conversion internally for tooltips and icon paths.
+- Supports nested context menus, menu item click events, and tray icon click events.
+- `pump()` processes the Win32 message queue and is safe to call in a regular loop.
+
+### Linux
+
+- Requires a desktop session with GTK 3 available.
+- Requires either `libayatana-appindicator3` or `libappindicator3` at runtime.
+- The package does not hard-link those libraries at build time; it probes them at runtime.
+- Tooltip updates are mapped to the AppIndicator title because Linux tray APIs do not expose one consistent tooltip concept.
+- Supports nested context menus and menu item click events.
+
+### macOS
+
+- Uses `NSStatusBar` / `NSStatusItem`.
+- Tray creation must happen on the main thread.
+- If no icon path is supplied, the backend falls back to a simple text title.
+- Supports nested context menus and menu item click events.
+
+## Event Loop Guidance
+
+`pump()` exists so native tray backends that need loop progress can keep moving.
+
+- On Windows, it advances the Win32 message queue.
+- On Linux, it runs one GTK main-loop iteration.
+- On macOS, it advances one AppKit event iteration.
+
+For simple apps, a non-blocking loop is often enough:
+
+```mbt nocheck
+loop {
+  match tray.pump() {
+    Ok(true) => ()
+    Ok(false) => break
+    Err(error) => {
+      println(error)
+      break
+    }
+  }
+}
+```
+
+If your app already owns a native GUI loop, do not call blocking `pump()` from
+the same thread. Integrate non-blocking `pump(blocking=false)` only at a point
+where it is acceptable for the tray library to advance pending native messages.
+
+## Current Scope
+
+This package currently covers tray icon lifecycle management and v1 interaction:
+
+- support detection
+- creation
+- icon updates
+- tooltip updates
+- visibility changes
+- cross-platform v1 context menu replacement with submenu support
+- cross-platform v1 menu item click events
+- Windows v1 click, right-click, and double-click tray events
+- event pumping
+- destruction
+
+Linux AppIndicator exposes menu item activation but not a consistent tray icon
+click stream, so `Click`, `RightClick`, and `DoubleClick` events are currently
+Windows-only.
+
+## Testing
+
+```bash
+moon test --target native
+moon test --target native --enable-coverage
+moon coverage analyze -p justjavac/tray -- -f summary
+```
+
+Optional native integration checks can be enabled locally:
+
+PowerShell:
+
+```powershell
+$env:MOONBIT_TRAY_RUN_NATIVE_TESTS = "1"
+moon test --target native --filter "native*"
+```
+
+POSIX shells:
+
+```bash
+MOONBIT_TRAY_RUN_NATIVE_TESTS=1 moon test --target native --filter "native*"
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,0 +1,21 @@
+name = "justjavac/tray"
+
+version = "0.1.7"
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/tray"
+
+license = "MIT"
+
+keywords = [ "tray", "desktop", "native", "windows", "macos", "linux" ]
+
+description = "Cross-platform native tray helpers for MoonBit."
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "+native",
+)

--- a/sys/tray/moon.pkg
+++ b/sys/tray/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "tray_native.c" ],
+)

--- a/sys/tray/native_ffi.mbt
+++ b/sys/tray/native_ffi.mbt
@@ -1,0 +1,109 @@
+///|
+/// Returns the numeric platform tag reported by the native tray backend.
+extern "C" fn current_platform_ffi() -> Int = "moonbit_tray_current_platform"
+
+///|
+/// Reports whether the native tray backend is available on the current machine.
+extern "C" fn is_supported_ffi() -> Bool = "moonbit_tray_is_supported"
+
+///|
+/// Returns the last support-probe error message as UTF-8 bytes.
+extern "C" fn support_error_ffi() -> Bytes = "moonbit_tray_support_error"
+
+///|
+/// Creates a native tray state and returns its opaque handle.
+#borrow(identifier, icon, tooltip)
+extern "C" fn create_state_ffi(
+  identifier : Bytes,
+  icon : Bytes,
+  tooltip : Bytes,
+) -> Int64 = "moonbit_tray_create"
+
+///|
+/// Returns the most recent create failure message as UTF-8 bytes.
+extern "C" fn last_create_error_ffi() -> Bytes = "moonbit_tray_last_create_error"
+
+///|
+/// Destroys the native tray state associated with the given handle.
+extern "C" fn destroy_state_ffi(state : Int64) -> Unit = "moonbit_tray_destroy"
+
+///|
+/// Shows the native tray icon and optionally updates its tooltip.
+#borrow(tooltip)
+extern "C" fn show_state_ffi(state : Int64, tooltip : Bytes) -> Bool = "moonbit_tray_show"
+
+///|
+/// Hides the native tray icon without freeing its handle.
+extern "C" fn hide_state_ffi(state : Int64) -> Bool = "moonbit_tray_hide"
+
+///|
+/// Updates the tooltip text stored by the native tray state.
+#borrow(tooltip)
+extern "C" fn set_tooltip_ffi(state : Int64, tooltip : Bytes) -> Bool = "moonbit_tray_set_tooltip"
+
+///|
+/// Updates the icon path stored by the native tray state.
+#borrow(icon)
+extern "C" fn set_icon_ffi(state : Int64, icon : Bytes) -> Bool = "moonbit_tray_set_icon"
+
+///|
+/// Starts a native menu replacement transaction.
+extern "C" fn menu_begin_ffi(state : Int64) -> Bool = "moonbit_tray_menu_begin"
+
+///|
+/// Adds a normal clickable item to the active native menu transaction.
+#borrow(id, label)
+extern "C" fn menu_add_normal_ffi(
+  state : Int64,
+  id : Bytes,
+  label : Bytes,
+  enabled : Int,
+) -> Bool = "moonbit_tray_menu_add_normal"
+
+///|
+/// Adds a checkbox item to the active native menu transaction.
+#borrow(id, label)
+extern "C" fn menu_add_checkbox_ffi(
+  state : Int64,
+  id : Bytes,
+  label : Bytes,
+  enabled : Int,
+  checked : Int,
+) -> Bool = "moonbit_tray_menu_add_checkbox"
+
+///|
+/// Adds a separator to the active native menu transaction.
+extern "C" fn menu_add_separator_ffi(state : Int64) -> Bool = "moonbit_tray_menu_add_separator"
+
+///|
+/// Starts a submenu in the active native menu transaction.
+#borrow(label)
+extern "C" fn menu_begin_submenu_ffi(
+  state : Int64,
+  label : Bytes,
+  enabled : Int,
+) -> Bool = "moonbit_tray_menu_begin_submenu"
+
+///|
+/// Ends the current submenu in the active native menu transaction.
+extern "C" fn menu_end_submenu_ffi(state : Int64) -> Bool = "moonbit_tray_menu_end_submenu"
+
+///|
+/// Commits the active native menu transaction.
+extern "C" fn menu_commit_ffi(state : Int64) -> Bool = "moonbit_tray_menu_commit"
+
+///|
+/// Aborts the active native menu transaction.
+extern "C" fn menu_abort_ffi(state : Int64) -> Unit = "moonbit_tray_menu_abort"
+
+///|
+/// Pumps one native event-loop step for the given tray handle.
+extern "C" fn pump_state_ffi(state : Int64, blocking : Int) -> Int = "moonbit_tray_pump"
+
+///|
+/// Polls one native tray event as a JSON payload.
+extern "C" fn poll_event_json_ffi(state : Int64) -> Bytes = "moonbit_tray_poll_event_json"
+
+///|
+/// Returns the most recent state-operation error message as UTF-8 bytes.
+extern "C" fn last_state_error_ffi(state : Int64) -> Bytes = "moonbit_tray_last_error"

--- a/sys/tray/pkg.generated.mbti
+++ b/sys/tray/pkg.generated.mbti
@@ -1,0 +1,80 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/tray"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn create(identifier? : String, icon? : String?, tooltip? : String) -> Result[Tray, String]
+
+pub fn current_platform() -> Platform
+
+pub fn default_identifier() -> String
+
+pub fn ensure_supported() -> Result[Unit, String]
+
+pub fn is_supported() -> Bool
+
+// Errors
+
+// Types and methods
+pub enum Platform {
+  Windows
+  Linux
+  MacOS
+  Unknown
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for Platform
+
+pub struct Tray {
+  // private fields
+}
+pub fn Tray::destroy(Self) -> Unit
+pub fn Tray::drain_events(Self) -> Array[TrayEvent]
+pub fn Tray::hide(Self) -> Result[Bool, String]
+pub fn Tray::icon(Self) -> String?
+pub fn Tray::identifier(Self) -> String
+pub fn Tray::is_visible(Self) -> Bool
+pub fn Tray::menu_items(Self) -> Array[TrayMenuItem]
+pub fn Tray::platform(Self) -> Platform
+pub fn Tray::pump(Self, blocking? : Bool) -> Result[Bool, String]
+pub fn Tray::set_icon(Self, String?) -> Result[Bool, String]
+pub fn Tray::set_menu(Self, Array[TrayMenuItem]) -> Result[Bool, String]
+pub fn Tray::set_tooltip(Self, String) -> Result[Bool, String]
+pub fn Tray::show(Self, tooltip? : String?) -> Result[Bool, String]
+pub fn Tray::tooltip(Self) -> String
+pub fn Tray::visible(Self) -> Bool
+
+pub(all) enum TrayEvent {
+  Click
+  RightClick
+  DoubleClick
+  MenuItemClick(String)
+} derive(Eq, @debug.Debug)
+pub fn TrayEvent::event_name(Self) -> String
+pub fn TrayEvent::item_id(Self) -> String?
+
+pub(all) enum TrayMenuItem {
+  Normal(id~ : String, label~ : String, enabled~ : Bool)
+  Separator
+  Checkbox(id~ : String, label~ : String, checked~ : Bool, enabled~ : Bool)
+  Submenu(label~ : String, items~ : Array[TrayMenuItem], enabled~ : Bool)
+} derive(Eq, @debug.Debug)
+pub fn TrayMenuItem::checkbox(id~ : String, label~ : String, checked? : Bool, enabled? : Bool) -> Self
+pub fn TrayMenuItem::kind(Self) -> TrayMenuItemKind
+pub fn TrayMenuItem::normal(id~ : String, label~ : String, enabled? : Bool) -> Self
+pub fn TrayMenuItem::separator() -> Self
+pub fn TrayMenuItem::submenu(label~ : String, items~ : Array[Self], enabled? : Bool) -> Self
+
+pub(all) enum TrayMenuItemKind {
+  Normal
+  Separator
+  Checkbox
+  Submenu
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/sys/tray/platform.mbt
+++ b/sys/tray/platform.mbt
@@ -1,0 +1,88 @@
+///|
+/// Desktop platform reported by the native tray backend.
+///
+/// `Windows`, `Linux`, and `MacOS` identify a backend this package knows how to
+/// drive. `Unknown` is returned when the native stub cannot map the host
+/// operating system to a supported variant, which typically also means tray
+/// creation will fail. Use this to branch platform-specific setup or to enrich
+/// diagnostics; the value is derived from `current_platform()`.
+pub enum Platform {
+  Windows
+  Linux
+  MacOS
+  Unknown
+} derive(Debug, Eq, ToJson)
+
+///|
+/// Renders a `Platform` as its capitalized backend name.
+pub impl Show for Platform with fn output(self, logger) {
+  logger.write_string(
+    match self {
+      Windows => "Windows"
+      Linux => "Linux"
+      MacOS => "MacOS"
+      Unknown => "Unknown"
+    },
+  )
+}
+
+///|
+/// Returns the desktop platform detected by the native backend for the current
+/// process.
+///
+/// The value is computed by the native stub so it matches the operating system
+/// that actually builds and runs the package.
+///
+/// Use this to branch platform-specific setup code around tray creation or to
+/// surface clearer diagnostics in logs and error messages. When the backend
+/// cannot map the host operating system to a known variant, this returns
+/// `Unknown`.
+pub fn current_platform() -> Platform {
+  platform_from_tag(current_platform_ffi())
+}
+
+///|
+/// Returns the default identifier used by `create()` when callers do not
+/// provide one.
+///
+/// The identifier is used as the native tray instance id on platforms that
+/// require one, and keeping it stable makes logs and diagnostics easier to
+/// follow.
+///
+/// Applications with a single tray icon can usually rely on this value as-is.
+/// Multi-tray applications may still prefer to provide their own stable,
+/// application-specific identifiers so native backends can distinguish
+/// instances consistently across runs.
+pub fn default_identifier() -> String {
+  "moonbit-tray"
+}
+
+///|
+/// Maps the native platform tag to the public `Platform` enum.
+fn platform_from_tag(tag : Int) -> Platform {
+  match tag {
+    1 => Windows
+    2 => Linux
+    3 => MacOS
+    _ => Unknown
+  }
+}
+
+///|
+/// Decodes the support-probe failure message or falls back to a generic error.
+fn support_error_message() -> String {
+  decode_bytes(support_error_ffi()).unwrap_or(
+    "tray is not supported on this platform",
+  )
+}
+
+///|
+/// Trims user input and replaces an empty identifier with the default value.
+fn normalize_identifier(identifier : String) -> String {
+  let trimmed = identifier.trim().to_owned()
+  if trimmed.is_empty() {
+    default_identifier()
+  } else {
+    trimmed
+  }
+}

--- a/sys/tray/tray.mbt
+++ b/sys/tray/tray.mbt
@@ -1,0 +1,809 @@
+///|
+/// Represents a system tray handle created by this package.
+///
+/// A `Tray` tracks the user-visible state that the MoonBit layer believes is
+/// active, including whether the tray is currently visible, which tooltip is
+/// being shown, and which icon path was last requested. The underlying native
+/// resources are released by calling `destroy()`.
+pub struct Tray {
+  priv mut handle : Int64
+  priv mut native : Bool
+  priv platform : Platform
+  priv identifier : String
+  priv mut icon : String?
+  priv mut tooltip : String
+  priv mut menu : Array[TrayMenuItem]
+  priv mut events : Array[TrayEvent]
+  priv mut visible : Bool
+  priv mut destroyed : Bool
+}
+
+///|
+/// Kind of context-menu item supported by tray v1.
+pub(all) enum TrayMenuItemKind {
+  Normal
+  Separator
+  Checkbox
+  Submenu
+} derive(Debug, Eq)
+
+///|
+/// One tray context-menu item.
+///
+/// Use `TrayMenuItem::normal`, `TrayMenuItem::separator`, and
+/// `TrayMenuItem::checkbox` to build clickable items. Use
+/// `TrayMenuItem::submenu` to group nested items. Clickable item ids must be
+/// unique across the whole menu tree.
+pub(all) enum TrayMenuItem {
+  Normal(id~ : String, label~ : String, enabled~ : Bool)
+  Separator
+  Checkbox(id~ : String, label~ : String, checked~ : Bool, enabled~ : Bool)
+  Submenu(label~ : String, items~ : Array[TrayMenuItem], enabled~ : Bool)
+} derive(Debug, Eq)
+
+///|
+/// Event emitted by the native tray backend.
+pub(all) enum TrayEvent {
+  Click
+  RightClick
+  DoubleClick
+  MenuItemClick(String)
+} derive(Debug, Eq)
+
+///|
+/// Builds a normal clickable menu item.
+pub fn TrayMenuItem::normal(
+  id~ : String,
+  label~ : String,
+  enabled? : Bool = true,
+) -> TrayMenuItem {
+  Normal(id~, label~, enabled~)
+}
+
+///|
+/// Builds a separator menu item.
+pub fn TrayMenuItem::separator() -> TrayMenuItem {
+  Separator
+}
+
+///|
+/// Builds a checkbox menu item.
+pub fn TrayMenuItem::checkbox(
+  id~ : String,
+  label~ : String,
+  checked? : Bool = false,
+  enabled? : Bool = true,
+) -> TrayMenuItem {
+  Checkbox(id~, label~, checked~, enabled~)
+}
+
+///|
+/// Builds a submenu containing nested menu items.
+pub fn TrayMenuItem::submenu(
+  label~ : String,
+  items~ : Array[TrayMenuItem],
+  enabled? : Bool = true,
+) -> TrayMenuItem {
+  Submenu(label~, items~, enabled~)
+}
+
+///|
+/// Returns the item kind.
+pub fn TrayMenuItem::kind(self : TrayMenuItem) -> TrayMenuItemKind {
+  match self {
+    Normal(_) => Normal
+    Separator => Separator
+    Checkbox(_) => Checkbox
+    Submenu(_) => Submenu
+  }
+}
+
+///|
+/// Returns the wire-format event name for a tray event.
+pub fn TrayEvent::event_name(self : TrayEvent) -> String {
+  match self {
+    Click => "click"
+    RightClick => "rightClick"
+    DoubleClick => "doubleClick"
+    MenuItemClick(_) => "menuItemClick"
+  }
+}
+
+///|
+/// Returns the clicked menu item id for `MenuItemClick` events.
+pub fn TrayEvent::item_id(self : TrayEvent) -> String? {
+  match self {
+    MenuItemClick(id) => Some(id)
+    _ => None
+  }
+}
+
+///|
+/// Returns whether the native backend can create tray instances on the current
+/// machine.
+///
+/// On Windows this is expected to be `true`. On other platforms, or when the
+/// required desktop runtime is unavailable, this returns `false`. This probe is
+/// side-effect free from the MoonBit caller's perspective and is useful for
+/// gating UI paths that would otherwise call `create()`.
+///
+/// This function answers only whether tray support appears available right now;
+/// it does not allocate a tray handle or make one visible. If you need a human
+/// readable explanation for a `false` result, call `ensure_supported()` instead.
+///
+/// # Example
+/// ```mbt check
+/// test "is_supported probes capability without creating a tray" {
+///   let _ : Bool = is_supported()
+/// }
+/// ```
+pub fn is_supported() -> Bool {
+  is_supported_ffi()
+}
+
+///|
+/// Validates that the native backend is available before any tray is created.
+///
+/// Use this when an application wants to show an actionable startup error
+/// instead of deferring the failure until `create()`. The error string is
+/// produced by the native backend when available, so callers can surface a
+/// platform-specific explanation to users.
+///
+/// Returns `Ok(())` when tray creation should be possible on the current
+/// machine. Returns `Err(message)` when the backend is missing, the desktop
+/// runtime is unavailable, or the platform is unsupported.
+pub fn ensure_supported() -> Result[Unit, String] {
+  if is_supported() {
+    Ok(())
+  } else {
+    Err(support_error_message())
+  }
+}
+
+///|
+/// Creates a tray handle with an optional icon path and initial tooltip.
+///
+/// - `identifier` should be a stable, non-empty id for the tray instance.
+/// - `icon` may be `None` to request the platform default tray icon.
+/// - `tooltip` becomes the initial hover text when the platform supports it.
+///
+/// The returned handle starts hidden, so callers can finish any last setup and
+/// then call `show()`. Empty or whitespace-only identifiers are normalized back
+/// to `default_identifier()`, and failures include the latest native error when
+/// the backend provides one.
+///
+/// On success this returns `Ok(tray)` with a live handle that can be shown,
+/// hidden, updated, pumped, and eventually destroyed. On failure this returns
+/// `Err(message)` with either the support-probe failure or the most recent
+/// backend creation error.
+///
+/// # Example
+/// ```mbt nocheck
+/// let tray = @tray.create(icon=Some("/path/to/icon.png"), tooltip="My App").unwrap()
+/// let _ = tray.show()
+/// // ... run the application event loop, calling `tray.pump()` as needed ...
+/// tray.destroy()
+/// ```
+pub fn create(
+  identifier? : String = default_identifier(),
+  icon? : String? = None,
+  tooltip? : String = "",
+) -> Result[Tray, String] {
+  match ensure_supported() {
+    Err(error) => Err(error)
+    Ok(_) => {
+      let normalized_identifier = normalize_identifier(identifier)
+      match validate_c_text("identifier", normalized_identifier) {
+        Err(error) => return Err(error)
+        Ok(_) => ()
+      }
+      match validate_optional_c_text("icon", icon) {
+        Err(error) => return Err(error)
+        Ok(_) => ()
+      }
+      match validate_c_text("tooltip", tooltip) {
+        Err(error) => return Err(error)
+        Ok(_) => ()
+      }
+      let handle = create_state_ffi(
+        encode_text(normalized_identifier),
+        encode_optional_text(icon),
+        encode_text(tooltip),
+      )
+      if handle == zero_handle() {
+        Err(
+          decode_bytes(last_create_error_ffi()).unwrap_or("tray.create failed"),
+        )
+      } else {
+        Ok({
+          handle,
+          native: true,
+          platform: current_platform(),
+          identifier: normalized_identifier,
+          icon,
+          tooltip,
+          menu: [],
+          events: [],
+          visible: false,
+          destroyed: false,
+        })
+      }
+    }
+  }
+}
+
+///|
+/// Returns the stable identifier associated with this tray handle.
+pub fn Tray::identifier(self : Tray) -> String {
+  self.identifier
+}
+
+///|
+/// Returns the platform reported when this tray handle was created.
+pub fn Tray::platform(self : Tray) -> Platform {
+  self.platform
+}
+
+///|
+/// Returns the last icon path requested through `create()` or `set_icon()`.
+pub fn Tray::icon(self : Tray) -> String? {
+  self.icon
+}
+
+///|
+/// Returns the last tooltip requested through `create()`, `show()`, or
+/// `set_tooltip()`.
+pub fn Tray::tooltip(self : Tray) -> String {
+  self.tooltip
+}
+
+///|
+/// Returns whether this tray handle is currently believed to be visible.
+pub fn Tray::is_visible(self : Tray) -> Bool {
+  self.visible
+}
+
+///|
+/// Alias for `is_visible()`.
+pub fn Tray::visible(self : Tray) -> Bool {
+  self.visible
+}
+
+///|
+/// Returns a clone of the last menu payload accepted by `set_menu()`.
+pub fn Tray::menu_items(self : Tray) -> Array[TrayMenuItem] {
+  clone_menu_items(self.menu)
+}
+
+///|
+/// Shows the tray icon and optionally replaces the tooltip in the same call.
+///
+/// Passing `tooltip=Some(...)` is the most efficient way to update the tooltip
+/// immediately before the tray becomes visible. The result reports the tray's
+/// visible state after the call, and invoking this on a simulated test tray
+/// updates only the MoonBit-side state.
+///
+/// Passing `tooltip=None` reuses the most recently stored tooltip. Successful
+/// calls always resolve to `Ok(true)`. If the tray has already been destroyed,
+/// or if the native backend rejects the operation, this returns `Err(message)`.
+pub fn Tray::show(
+  self : Tray,
+  tooltip? : String? = None,
+) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) => {
+      let next_tooltip = tooltip.unwrap_or(self.tooltip)
+      match validate_c_text("tooltip", next_tooltip) {
+        Err(error) => return Err(error)
+        Ok(_) => ()
+      }
+      if !self.native {
+        self.tooltip = next_tooltip
+        self.visible = true
+        Ok(true)
+      } else if show_state_ffi(self.handle, encode_text(next_tooltip)) {
+        self.tooltip = next_tooltip
+        self.visible = true
+        Ok(true)
+      } else {
+        Err(self.state_error(self.handle, "tray.show failed"))
+      }
+    }
+  }
+}
+
+///|
+/// Hides the tray icon while keeping the handle valid for later `show()` calls.
+///
+/// The returned boolean reflects the post-call visibility state, so successful
+/// calls resolve to `Ok(false)` whether the tray is native or simulated.
+///
+/// This is safe to call even when the tray is already hidden; the handle stays
+/// valid and can be shown again later. Destroyed trays still reject the call
+/// with an error.
+pub fn Tray::hide(self : Tray) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) =>
+      if !self.native {
+        self.visible = false
+        Ok(false)
+      } else if hide_state_ffi(self.handle) {
+        self.visible = false
+        Ok(false)
+      } else {
+        Err(self.state_error(self.handle, "tray.hide failed"))
+      }
+  }
+}
+
+///|
+/// Replaces the current tooltip text without changing visibility.
+///
+/// Platforms that cannot show a real tooltip may map this value to the nearest
+/// native concept available to the host desktop environment. The returned
+/// boolean mirrors whether the tray is visible after the update.
+///
+/// Hidden trays keep the new tooltip so the next `show()` call reuses it by
+/// default. Successful calls return the current visible state, while destroyed
+/// trays or backend failures return `Err(message)`.
+pub fn Tray::set_tooltip(self : Tray, tooltip : String) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) =>
+      match validate_c_text("tooltip", tooltip) {
+        Err(error) => Err(error)
+        Ok(_) =>
+          if !self.native {
+            self.tooltip = tooltip
+            Ok(self.visible)
+          } else if set_tooltip_ffi(self.handle, encode_text(tooltip)) {
+            self.tooltip = tooltip
+            Ok(self.visible)
+          } else {
+            Err(self.state_error(self.handle, "tray.set_tooltip failed"))
+          }
+      }
+  }
+}
+
+///|
+/// Changes the tray icon path or resets it to the platform default when `None`
+/// is passed.
+///
+/// This updates the stored icon preference even for simulated trays used in
+/// tests, and the returned boolean mirrors whether the tray is visible after
+/// the change.
+///
+/// Pass `Some(path)` to request a specific icon file, or `None` to fall back to
+/// the backend's default tray icon. Successful calls return the current visible
+/// state; destroyed trays and backend failures return `Err(message)`.
+pub fn Tray::set_icon(self : Tray, icon : String?) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) =>
+      match validate_optional_c_text("icon", icon) {
+        Err(error) => Err(error)
+        Ok(_) =>
+          if !self.native {
+            self.icon = icon
+            Ok(self.visible)
+          } else if set_icon_ffi(self.handle, encode_optional_text(icon)) {
+            self.icon = icon
+            Ok(self.visible)
+          } else {
+            Err(self.state_error(self.handle, "tray.set_icon failed"))
+          }
+      }
+  }
+}
+
+///|
+/// Replaces the context menu shown for this tray icon.
+///
+/// The menu supports `normal`, `separator`, `checkbox`, and nested `submenu`
+/// items. Normal and checkbox items must have non-empty `id` and `label`
+/// values; item ids must be unique across the whole menu tree so click events
+/// can be routed reliably.
+///
+/// Successful calls return the current visible state. Unsupported operating
+/// systems, missing native menu backends, or invalid menu payloads return
+/// `Err(message)`.
+pub fn Tray::set_menu(
+  self : Tray,
+  items : Array[TrayMenuItem],
+) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) =>
+      match validate_menu(items) {
+        Err(error) => Err(error)
+        Ok(_) => {
+          let stored_items = clone_menu_items(items)
+          if !self.native {
+            self.menu = stored_items
+            Ok(self.visible)
+          } else if apply_menu_transaction(self.handle, items) {
+            self.menu = stored_items
+            Ok(self.visible)
+          } else {
+            Err(self.state_error(self.handle, "tray.set_menu failed"))
+          }
+        }
+      }
+  }
+}
+
+///|
+/// Drains all currently queued tray events.
+///
+/// For native trays, this polls the backend event queue until it is empty. For
+/// simulated trays used in tests, this returns and clears the MoonBit-side
+/// event queue. Destroyed trays return an empty array.
+pub fn Tray::drain_events(self : Tray) -> Array[TrayEvent] {
+  if self.destroyed {
+    return []
+  }
+  if !self.native {
+    let drained = self.events
+    self.events = []
+    return drained
+  }
+  let drained : Array[TrayEvent] = []
+  let mut polling = true
+  while polling {
+    match decode_bytes(poll_event_json_ffi(self.handle)) {
+      Some(raw) =>
+        match decode_event(raw) {
+          Some(event) => drained.push(event)
+          None => ()
+        }
+      None => polling = false
+    }
+  }
+  drained
+}
+
+///|
+/// Pumps one native tray loop iteration.
+///
+/// Call this from long-running native applications when the host platform needs
+/// event-loop progress from the tray backend. A return value of `Ok(false)`
+/// means the backend asked to stop processing. Simulated trays always return
+/// `Ok(true)` so unit tests can exercise state transitions without a native
+/// message loop.
+///
+/// Passing `blocking=true` lets the backend wait for work before returning;
+/// `blocking=false` performs at most one non-blocking iteration. Backend errors
+/// and calls on destroyed trays return `Err(message)`.
+pub fn Tray::pump(
+  self : Tray,
+  blocking? : Bool = false,
+) -> Result[Bool, String] {
+  match self.ensure_alive() {
+    Err(error) => Err(error)
+    Ok(_) =>
+      if !self.native {
+        Ok(true)
+      } else {
+        let status = pump_state_ffi(self.handle, if blocking { 1 } else { 0 })
+        if status > 0 {
+          Ok(true)
+        } else if status == 0 {
+          Ok(false)
+        } else {
+          Err(self.state_error(self.handle, "tray.pump failed"))
+        }
+      }
+  }
+}
+
+///|
+/// Releases the underlying native resources and turns the handle into a no-op
+/// object that rejects later operations.
+///
+/// Calling `destroy()` more than once is safe; repeated calls are ignored after
+/// the first teardown has marked the handle as destroyed.
+///
+/// After destruction the tray becomes permanently unusable: `show()`, `hide()`,
+/// `set_tooltip()`, `set_icon()`, `set_menu()`, and `pump()` will all return
+/// errors instead of touching the native backend again.
+pub fn Tray::destroy(self : Tray) -> Unit {
+  if self.destroyed {
+    return ()
+  }
+  if self.native {
+    destroy_state_ffi(self.handle)
+  }
+  self.handle = zero_handle()
+  self.native = false
+  self.visible = false
+  self.events = []
+  self.destroyed = true
+}
+
+///|
+/// Validates all menu items before state or native resources are changed.
+fn validate_menu(items : Array[TrayMenuItem]) -> Result[Unit, String] {
+  let seen_ids : Array[String] = []
+  validate_menu_items(items, seen_ids, depth=0)
+}
+
+///|
+/// Maximum submenu depth accepted by the native transaction builder.
+fn max_menu_depth() -> Int {
+  8
+}
+
+///|
+/// Maximum UTF-8 bytes accepted for a clickable item id.
+fn max_menu_item_id_bytes() -> Int {
+  128
+}
+
+///|
+/// Maximum clickable menu items addressable by native command ids.
+fn max_menu_clickable_items() -> Int {
+  64
+}
+
+///|
+/// Validates a menu subtree and tracks clickable ids globally.
+fn validate_menu_items(
+  items : Array[TrayMenuItem],
+  seen_ids : Array[String],
+  depth~ : Int,
+) -> Result[Unit, String] {
+  if depth > max_menu_depth() {
+    return Err("tray menu submenu depth exceeds 8")
+  }
+  for item in items {
+    match item {
+      Normal(id~, label~, ..) | Checkbox(id~, label~, ..) =>
+        match validate_clickable_menu_item(id, label, seen_ids) {
+          Err(error) => return Err(error)
+          Ok(_) => ()
+        }
+      Separator => ()
+      Submenu(label~, items~, ..) => {
+        if label.trim().to_owned().is_empty() {
+          return Err("tray submenu label must not be empty")
+        }
+        if text_has_nul(label) {
+          return Err("tray submenu label must not contain NUL bytes")
+        }
+        match validate_menu_items(items, seen_ids, depth=depth + 1) {
+          Err(error) => return Err(error)
+          Ok(_) => ()
+        }
+      }
+    }
+  }
+  Ok(())
+}
+
+///|
+/// Validates a clickable menu item and records its id.
+fn validate_clickable_menu_item(
+  id : String,
+  label : String,
+  seen_ids : Array[String],
+) -> Result[Unit, String] {
+  let normalized_id = id.trim().to_owned()
+  let normalized_label = label.trim().to_owned()
+  if normalized_id.is_empty() {
+    return Err("tray menu item id must not be empty")
+  }
+  if id != normalized_id {
+    return Err("tray menu item id must not have leading or trailing whitespace")
+  }
+  if text_has_nul(id) {
+    return Err("tray menu item id must not contain NUL bytes")
+  }
+  if encode_text(id).length() >= max_menu_item_id_bytes() {
+    return Err("tray menu item id is too long")
+  }
+  if normalized_label.is_empty() {
+    return Err("tray menu item label must not be empty")
+  }
+  if text_has_nul(normalized_label) {
+    return Err("tray menu item label must not contain NUL bytes")
+  }
+  if seen_ids.contains(id) {
+    return Err("tray menu item id must be unique: " + id)
+  }
+  if seen_ids.length() >= max_menu_clickable_items() {
+    return Err("tray menu has too many clickable items")
+  }
+  seen_ids.push(id)
+  Ok(())
+}
+
+///|
+/// Rejects embedded NUL because native FFI strings are C strings.
+fn validate_c_text(field : String, value : String) -> Result[Unit, String] {
+  if text_has_nul(value) {
+    Err("tray " + field + " must not contain NUL bytes")
+  } else {
+    Ok(())
+  }
+}
+
+///|
+/// Rejects embedded NUL in optional native FFI strings.
+fn validate_optional_c_text(
+  field : String,
+  value : String?,
+) -> Result[Unit, String] {
+  match value {
+    Some(text) => validate_c_text(field, text)
+    None => Ok(())
+  }
+}
+
+///|
+/// Returns whether UTF-8 text contains an embedded C string terminator.
+fn text_has_nul(value : String) -> Bool {
+  for byte in encode_text(value) {
+    if byte.to_int() == 0 {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Clones menu items before storing caller-provided arrays in tray state.
+fn clone_menu_items(items : Array[TrayMenuItem]) -> Array[TrayMenuItem] {
+  let cloned : Array[TrayMenuItem] = []
+  for item in items {
+    cloned.push(
+      match item {
+        Normal(id~, label~, enabled~) => Normal(id~, label~, enabled~)
+        Separator => Separator
+        Checkbox(id~, label~, checked~, enabled~) =>
+          Checkbox(id~, label~, checked~, enabled~)
+        Submenu(label~, items~, enabled~) =>
+          Submenu(label~, items=clone_menu_items(items), enabled~)
+      },
+    )
+  }
+  cloned
+}
+
+///|
+/// Applies a native menu replacement transaction.
+fn apply_menu_transaction(handle : Int64, items : Array[TrayMenuItem]) -> Bool {
+  if !menu_begin_ffi(handle) {
+    return false
+  }
+  if append_menu_items(handle, items) && menu_commit_ffi(handle) {
+    true
+  } else {
+    menu_abort_ffi(handle)
+    false
+  }
+}
+
+///|
+/// Appends a menu subtree to the active native transaction.
+fn append_menu_items(handle : Int64, items : Array[TrayMenuItem]) -> Bool {
+  for item in items {
+    let ok = match item {
+      Normal(id~, label~, enabled~) =>
+        menu_add_normal_ffi(
+          handle,
+          encode_text(id),
+          encode_text(label),
+          bool_to_int(enabled),
+        )
+      Separator => menu_add_separator_ffi(handle)
+      Checkbox(id~, label~, checked~, enabled~) =>
+        menu_add_checkbox_ffi(
+          handle,
+          encode_text(id),
+          encode_text(label),
+          bool_to_int(enabled),
+          bool_to_int(checked),
+        )
+      Submenu(label~, items~, enabled~) =>
+        if menu_begin_submenu_ffi(
+            handle,
+            encode_text(label),
+            bool_to_int(enabled),
+          ) {
+          if append_menu_items(handle, items) {
+            menu_end_submenu_ffi(handle)
+          } else {
+            false
+          }
+        } else {
+          false
+        }
+    }
+    if !ok {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Converts a MoonBit boolean to the C ABI integer convention.
+fn bool_to_int(value : Bool) -> Int {
+  if value {
+    1
+  } else {
+    0
+  }
+}
+
+///|
+/// Decodes one native tray event JSON payload.
+fn decode_event(raw : String) -> TrayEvent? {
+  try @json.parse(raw) catch {
+    _ => None
+  } noraise {
+    json =>
+      match json {
+        Object(object) =>
+          match object.get("type") {
+            Some(String("click")) => Some(Click)
+            Some(String("rightClick")) => Some(RightClick)
+            Some(String("doubleClick")) => Some(DoubleClick)
+            Some(String("menuItemClick")) =>
+              match object.get("item_id") {
+                Some(String(item_id)) => Some(MenuItemClick(item_id))
+                _ => None
+              }
+            _ => None
+          }
+        _ => None
+      }
+  }
+}
+
+///|
+/// Rejects operations performed on a tray handle after it has been destroyed.
+fn Tray::ensure_alive(self : Tray) -> Result[Unit, String] {
+  if self.destroyed {
+    Err("tray handle has been destroyed")
+  } else {
+    Ok(())
+  }
+}
+
+///|
+/// Decodes the last native state error or falls back to the provided message.
+fn Tray::state_error(_self : Tray, handle : Int64, fallback : String) -> String {
+  decode_bytes(last_state_error_ffi(handle)).unwrap_or(fallback)
+}
+
+///|
+/// Encodes UTF-8 text for calls into the native backend.
+fn encode_text(value : String) -> Bytes {
+  @utf8.encode(value)
+}
+
+///|
+/// Encodes optional text as UTF-8 bytes, using an empty payload for `None`.
+fn encode_optional_text(value : String?) -> Bytes {
+  @utf8.encode(value.unwrap_or(""))
+}
+
+///|
+/// Decodes non-empty UTF-8 byte payloads into strings.
+fn decode_bytes(bytes : Bytes) -> String? {
+  if bytes.is_empty() {
+    None
+  } else {
+    Some(@utf8.decode_lossy(bytes))
+  }
+}
+
+///|
+/// Returns the sentinel handle value used for simulated or destroyed trays.
+fn zero_handle() -> Int64 {
+  Int64::from_int(0)
+}

--- a/sys/tray/tray_native.c
+++ b/sys/tray/tray_native.c
@@ -1,0 +1,2998 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <shellapi.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "user32.lib")
+#endif
+#elif defined(__linux__)
+#include <dlfcn.h>
+#include <sys/stat.h>
+#elif defined(__APPLE__)
+#include <dlfcn.h>
+#include <limits.h>
+#include <pthread.h>
+#endif
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#include "moonbit.h"
+
+#define MOONBIT_TRAY_MAX_EVENTS 32
+#define MOONBIT_TRAY_MAX_EVENT_BYTES 1024
+#define MOONBIT_TRAY_MAX_MENU_ITEMS 64
+#define MOONBIT_TRAY_MAX_MENU_ID_BYTES 128
+#define MOONBIT_TRAY_MAX_MENU_DEPTH 8
+
+#ifdef _WIN32
+#define MOONBIT_TRAY_CALLBACK_MESSAGE (WM_APP + 1)
+#define MOONBIT_TRAY_COMMAND_BASE 0x7000
+#endif
+
+typedef struct moonbit_tray_state {
+#ifdef _WIN32
+  HWND hwnd;
+  NOTIFYICONDATAW icon_data;
+  int32_t icon_owned;
+  HMENU menu;
+  HMENU pending_menu;
+  HMENU menu_stack[MOONBIT_TRAY_MAX_MENU_DEPTH + 1];
+  uint32_t menu_depth;
+  char menu_item_ids[MOONBIT_TRAY_MAX_MENU_ITEMS][MOONBIT_TRAY_MAX_MENU_ID_BYTES];
+  uint32_t menu_item_count;
+  char pending_menu_item_ids[MOONBIT_TRAY_MAX_MENU_ITEMS]
+                            [MOONBIT_TRAY_MAX_MENU_ID_BYTES];
+  uint32_t pending_menu_item_count;
+#elif defined(__linux__)
+  void *indicator;
+  void *menu;
+  void *pending_menu;
+  void *menu_stack[MOONBIT_TRAY_MAX_MENU_DEPTH + 1];
+  uint32_t menu_depth;
+  uint32_t pending_menu_item_count;
+#elif defined(__APPLE__)
+  void *pool;
+  void *app;
+  void *status_bar;
+  void *status_item;
+  void *button;
+  void *menu;
+  void *pending_menu;
+  void *menu_stack[MOONBIT_TRAY_MAX_MENU_DEPTH + 1];
+  uint32_t menu_depth;
+  uint32_t pending_menu_item_count;
+  void *menu_target;
+#endif
+  int32_t visible;
+  char events[MOONBIT_TRAY_MAX_EVENTS][MOONBIT_TRAY_MAX_EVENT_BYTES];
+  uint32_t event_head;
+  uint32_t event_count;
+  char last_error[256];
+} moonbit_tray_state_t;
+
+static char moonbit_tray_create_error[256];
+static char moonbit_tray_support_message[256];
+
+static moonbit_tray_state_t *moonbit_tray_from_handle(int64_t handle) {
+  return (moonbit_tray_state_t *)(uintptr_t)handle;
+}
+
+static int64_t moonbit_tray_to_handle(moonbit_tray_state_t *state) {
+  return (int64_t)(uintptr_t)state;
+}
+
+static const char *moonbit_tray_text_or(const char *value, const char *fallback) {
+  if (value == NULL || value[0] == '\0') {
+    return fallback;
+  }
+  return value;
+}
+
+static void moonbit_tray_set_message(char *buffer, size_t size, const char *message) {
+  if (size == 0) {
+    return;
+  }
+  if (message == NULL) {
+    buffer[0] = '\0';
+    return;
+  }
+  snprintf(buffer, size, "%s", message);
+}
+
+static void moonbit_tray_clear_message(char *buffer, size_t size) {
+  moonbit_tray_set_message(buffer, size, "");
+}
+
+static moonbit_bytes_t moonbit_tray_copy_message(const char *message) {
+  int32_t len;
+  moonbit_bytes_t bytes;
+  if (message == NULL) {
+    message = "";
+  }
+  len = (int32_t)strlen(message);
+  bytes = moonbit_make_bytes(len, 0);
+  if (len > 0) {
+    memcpy(bytes, message, (size_t)len);
+  }
+  return bytes;
+}
+
+static int32_t moonbit_tray_enqueue_event(
+    moonbit_tray_state_t *state,
+    const char *event_json) {
+  if (state == NULL || event_json == NULL) {
+    return 0;
+  }
+  size_t len = strlen(event_json);
+  if (len >= MOONBIT_TRAY_MAX_EVENT_BYTES) {
+    return 0;
+  }
+  if (state->event_count >= MOONBIT_TRAY_MAX_EVENTS) {
+    state->events[state->event_head][0] = '\0';
+    state->event_head = (state->event_head + 1) % MOONBIT_TRAY_MAX_EVENTS;
+    state->event_count--;
+  }
+  uint32_t index =
+      (state->event_head + state->event_count) % MOONBIT_TRAY_MAX_EVENTS;
+  memcpy(state->events[index], event_json, len + 1);
+  state->event_count++;
+  return 1;
+}
+
+static int32_t moonbit_tray_json_escape_string(
+    char *out,
+    size_t out_len,
+    const char *value) {
+  size_t written = 0;
+  if (out == NULL || out_len == 0 || value == NULL) {
+    return 0;
+  }
+  for (const unsigned char *cursor = (const unsigned char *)value;
+       *cursor != '\0';
+       cursor++) {
+    char escaped[8];
+    const char *chunk = escaped;
+    switch (*cursor) {
+    case '"':
+      chunk = "\\\"";
+      break;
+    case '\\':
+      chunk = "\\\\";
+      break;
+    case '\b':
+      chunk = "\\b";
+      break;
+    case '\f':
+      chunk = "\\f";
+      break;
+    case '\n':
+      chunk = "\\n";
+      break;
+    case '\r':
+      chunk = "\\r";
+      break;
+    case '\t':
+      chunk = "\\t";
+      break;
+    default:
+      if (*cursor < 0x20) {
+        snprintf(escaped, sizeof(escaped), "\\u%04x", *cursor);
+      } else {
+        escaped[0] = (char)*cursor;
+        escaped[1] = '\0';
+      }
+      break;
+    }
+    size_t chunk_len = strlen(chunk);
+    if (written + chunk_len >= out_len) {
+      return 0;
+    }
+    memcpy(out + written, chunk, chunk_len);
+    written += chunk_len;
+  }
+  out[written] = '\0';
+  return 1;
+}
+
+static int32_t moonbit_tray_enqueue_menu_event(
+    moonbit_tray_state_t *state,
+    const char *item_id) {
+  char escaped[MOONBIT_TRAY_MAX_MENU_ID_BYTES * 6];
+  char event_json[MOONBIT_TRAY_MAX_EVENT_BYTES];
+  if (!moonbit_tray_json_escape_string(escaped, sizeof(escaped), item_id)) {
+    return 0;
+  }
+  int written = snprintf(
+      event_json,
+      sizeof(event_json),
+      "{\"type\":\"menuItemClick\",\"item_id\":\"%s\"}",
+      escaped);
+  if (written < 0 || written >= (int)sizeof(event_json)) {
+    return 0;
+  }
+  return moonbit_tray_enqueue_event(state, event_json);
+}
+
+static const unsigned char moonbit_tray_test_bmp[] = {
+    0x42, 0x4d, 0x3a, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x28, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x13, 0x0b,
+    0x00, 0x00, 0x13, 0x0b, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x66,
+    0xcc, 0xff};
+
+static int32_t moonbit_tray_test_icon_path_buffer(
+    char *path,
+    size_t path_size) {
+#ifdef _WIN32
+  DWORD len;
+  int written;
+  if (path_size == 0) {
+    return 0;
+  }
+  len = GetTempPathA((DWORD)path_size, path);
+  if (len == 0 || len >= path_size) {
+    return 0;
+  }
+  written = snprintf(
+      path + len,
+      path_size - (size_t)len,
+      "moonbit-tray-test-icon-%lu.bmp",
+      (unsigned long)GetCurrentProcessId());
+  return written > 0 && (size_t)written < path_size - (size_t)len;
+#else
+  const char *tmp = getenv("TMPDIR");
+  if (tmp == NULL || tmp[0] == '\0') {
+    tmp = "/tmp";
+  }
+  {
+    int written = snprintf(
+        path,
+        path_size,
+        "%s/moonbit-tray-test-icon-%lu.bmp",
+        tmp,
+        (unsigned long)getpid());
+    return written > 0 && (size_t)written < path_size;
+  }
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_test_icon_path(void) {
+  char path[1024];
+  FILE *file;
+  if (!moonbit_tray_test_icon_path_buffer(path, sizeof(path))) {
+    return moonbit_tray_copy_message("");
+  }
+  file = fopen(path, "wb");
+  if (file == NULL) {
+    return moonbit_tray_copy_message("");
+  }
+  if (fwrite(
+          moonbit_tray_test_bmp,
+          1,
+          sizeof(moonbit_tray_test_bmp),
+          file) != sizeof(moonbit_tray_test_bmp)) {
+    fclose(file);
+    remove(path);
+    return moonbit_tray_copy_message("");
+  }
+  fclose(file);
+  return moonbit_tray_copy_message(path);
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_test_remove_file(
+    moonbit_bytes_t path) {
+  const char *text = (const char *)path;
+  if (text == NULL || text[0] == '\0') {
+    return 0;
+  }
+  return remove(text) == 0;
+}
+
+static char *moonbit_tray_strdup(const char *value) {
+  size_t len;
+  char *copy;
+  if (value == NULL) {
+    return NULL;
+  }
+  len = strlen(value);
+  copy = (char *)malloc(len + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  memcpy(copy, value, len + 1);
+  return copy;
+}
+
+#ifdef _WIN32
+static ATOM moonbit_tray_window_class = 0;
+
+static void moonbit_tray_win_destroy_menu(moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+  if (state->menu != NULL) {
+    DestroyMenu(state->menu);
+    state->menu = NULL;
+  }
+  state->menu_item_count = 0;
+  memset(state->menu_item_ids, 0, sizeof(state->menu_item_ids));
+}
+
+static void moonbit_tray_win_destroy_pending_menu(moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+  if (state->pending_menu != NULL) {
+    DestroyMenu(state->pending_menu);
+    state->pending_menu = NULL;
+  }
+  state->menu_depth = 0;
+  state->pending_menu_item_count = 0;
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+  memset(state->pending_menu_item_ids, 0, sizeof(state->pending_menu_item_ids));
+}
+
+static HMENU moonbit_tray_win_current_pending_menu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL ||
+      state->menu_depth == 0) {
+    return NULL;
+  }
+  return state->menu_stack[state->menu_depth - 1];
+}
+
+static uint32_t moonbit_tray_win_command_index(uint32_t command_id) {
+  if (command_id < MOONBIT_TRAY_COMMAND_BASE) {
+    return UINT32_MAX;
+  }
+  return command_id - MOONBIT_TRAY_COMMAND_BASE;
+}
+
+static void moonbit_tray_win_show_menu(moonbit_tray_state_t *state) {
+  if (state == NULL || state->menu == NULL) {
+    return;
+  }
+  POINT cursor;
+  if (!GetCursorPos(&cursor)) {
+    return;
+  }
+  SetForegroundWindow(state->hwnd);
+  TrackPopupMenu(
+      state->menu,
+      TPM_RIGHTBUTTON | TPM_BOTTOMALIGN | TPM_LEFTALIGN,
+      cursor.x,
+      cursor.y,
+      0,
+      state->hwnd,
+      NULL);
+  PostMessageW(state->hwnd, WM_NULL, 0, 0);
+}
+
+static LRESULT CALLBACK moonbit_tray_window_proc(
+    HWND hwnd,
+    UINT message,
+    WPARAM w_param,
+    LPARAM l_param) {
+  moonbit_tray_state_t *state =
+      (moonbit_tray_state_t *)GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+  if (message == MOONBIT_TRAY_CALLBACK_MESSAGE && state != NULL) {
+    switch ((UINT)l_param) {
+    case WM_LBUTTONUP:
+      moonbit_tray_enqueue_event(state, "{\"type\":\"click\"}");
+      return 0;
+    case WM_RBUTTONUP:
+      moonbit_tray_enqueue_event(state, "{\"type\":\"rightClick\"}");
+      moonbit_tray_win_show_menu(state);
+      return 0;
+    case WM_LBUTTONDBLCLK:
+      moonbit_tray_enqueue_event(state, "{\"type\":\"doubleClick\"}");
+      return 0;
+    default:
+      return 0;
+    }
+  }
+  switch (message) {
+  case WM_COMMAND:
+    if (state != NULL) {
+      uint32_t index = moonbit_tray_win_command_index(LOWORD(w_param));
+      if (index < state->menu_item_count) {
+        moonbit_tray_enqueue_menu_event(state, state->menu_item_ids[index]);
+        return 0;
+      }
+    }
+    break;
+  case WM_CLOSE:
+    DestroyWindow(hwnd);
+    return 0;
+  case WM_DESTROY:
+    SetWindowLongPtrW(hwnd, GWLP_USERDATA, (LONG_PTR)NULL);
+    return 0;
+  default:
+    return DefWindowProcW(hwnd, message, w_param, l_param);
+  }
+  return DefWindowProcW(hwnd, message, w_param, l_param);
+}
+
+static int32_t moonbit_tray_ensure_window_class(void) {
+  WNDCLASSEXW wc;
+  if (moonbit_tray_window_class != 0) {
+    return 1;
+  }
+  memset(&wc, 0, sizeof(wc));
+  wc.cbSize = sizeof(wc);
+  wc.lpfnWndProc = moonbit_tray_window_proc;
+  wc.hInstance = GetModuleHandleW(NULL);
+  wc.lpszClassName = L"MoonBitTrayWindow";
+  moonbit_tray_window_class = RegisterClassExW(&wc);
+  return moonbit_tray_window_class != 0;
+}
+
+static wchar_t *moonbit_tray_utf8_cstr_to_wide(const char *text) {
+  int32_t units;
+  wchar_t *wide;
+  if (text == NULL || text[0] == '\0') {
+    return NULL;
+  }
+  units = MultiByteToWideChar(CP_UTF8, 0, text, -1, NULL, 0);
+  if (units <= 0) {
+    return NULL;
+  }
+  wide = (wchar_t *)calloc((size_t)units, sizeof(wchar_t));
+  if (wide == NULL) {
+    return NULL;
+  }
+  if (MultiByteToWideChar(CP_UTF8, 0, text, -1, wide, units) <= 0) {
+    free(wide);
+    return NULL;
+  }
+  return wide;
+}
+
+static wchar_t *moonbit_tray_utf8_to_wide(moonbit_bytes_t value) {
+  return moonbit_tray_utf8_cstr_to_wide((const char *)value);
+}
+
+static void moonbit_tray_copy_tooltip(
+    NOTIFYICONDATAW *icon_data,
+    moonbit_bytes_t tooltip) {
+  wchar_t *wide = moonbit_tray_utf8_to_wide(tooltip);
+  if (wide == NULL) {
+    icon_data->szTip[0] = L'\0';
+    return;
+  }
+  wcsncpy(icon_data->szTip, wide, 127);
+  icon_data->szTip[127] = L'\0';
+  free(wide);
+}
+
+static HICON moonbit_tray_load_icon(
+    moonbit_bytes_t icon,
+    int32_t *owned) {
+  wchar_t *path = moonbit_tray_utf8_to_wide(icon);
+  HICON loaded = NULL;
+  if (owned != NULL) {
+    *owned = 0;
+  }
+  if (path != NULL) {
+    loaded = (HICON)LoadImageW(
+        NULL,
+        path,
+        IMAGE_ICON,
+        0,
+        0,
+        LR_DEFAULTSIZE | LR_LOADFROMFILE);
+    if (loaded != NULL && owned != NULL) {
+      *owned = 1;
+    }
+    if (loaded == NULL) {
+      ExtractIconExW(path, 0, NULL, &loaded, 1);
+      if (loaded != NULL && owned != NULL) {
+        *owned = 1;
+      }
+    }
+    free(path);
+  }
+  if (loaded == NULL) {
+    loaded = LoadIconW(NULL, (LPCWSTR)IDI_APPLICATION);
+  }
+  return loaded;
+}
+
+static void moonbit_tray_destroy_icon_if_owned(
+    HICON icon,
+    int32_t owned) {
+  if (owned && icon != NULL) {
+    DestroyIcon(icon);
+  }
+}
+
+static void moonbit_tray_commit_icon(
+    moonbit_tray_state_t *state,
+    HICON next_icon,
+    int32_t next_icon_owned) {
+  HICON old_icon = state->icon_data.hIcon;
+  int32_t old_icon_owned = state->icon_owned;
+  state->icon_data.hIcon = next_icon;
+  state->icon_owned = next_icon_owned;
+  state->icon_data.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  if (old_icon != next_icon) {
+    moonbit_tray_destroy_icon_if_owned(old_icon, old_icon_owned);
+  }
+}
+
+static int32_t moonbit_tray_replace_icon(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t icon) {
+  int32_t next_icon_owned = 0;
+  HICON next_icon = moonbit_tray_load_icon(icon, &next_icon_owned);
+  if (next_icon == NULL) {
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "failed to load tray icon");
+    return 0;
+  }
+  moonbit_tray_commit_icon(state, next_icon, next_icon_owned);
+  return 1;
+}
+
+static int32_t moonbit_tray_win_append_clickable_menu_item(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t id_bytes,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled,
+    int32_t checked,
+    int32_t checkbox) {
+  HMENU menu = moonbit_tray_win_current_pending_menu(state);
+  const char *id = (const char *)id_bytes;
+  const char *label = (const char *)label_bytes;
+  wchar_t *wide_label;
+  uint32_t index;
+  UINT flags = MF_STRING;
+  UINT_PTR command_id;
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->pending_menu_item_count >= MOONBIT_TRAY_MAX_MENU_ITEMS) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu has too many clickable items");
+    return 0;
+  }
+  if (id == NULL || id[0] == '\0' || label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu clickable items require id and label");
+    return 0;
+  }
+  if (strlen(id) >= sizeof(state->pending_menu_item_ids[0])) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu item id is too long");
+    return 0;
+  }
+  wide_label = moonbit_tray_utf8_cstr_to_wide(label);
+  if (wide_label == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to convert tray menu label");
+    return 0;
+  }
+  index = state->pending_menu_item_count;
+  if (!enabled) {
+    flags |= MF_GRAYED;
+  }
+  if (checkbox && checked) {
+    flags |= MF_CHECKED;
+  }
+  command_id = (UINT_PTR)(MOONBIT_TRAY_COMMAND_BASE + index);
+  if (!AppendMenuW(menu, flags, command_id, wide_label)) {
+    free(wide_label);
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to append tray menu item");
+    return 0;
+  }
+  free(wide_label);
+  snprintf(
+      state->pending_menu_item_ids[index],
+      sizeof(state->pending_menu_item_ids[index]),
+      "%s",
+      id);
+  state->pending_menu_item_count++;
+  return 1;
+}
+
+static int32_t moonbit_tray_win_begin_menu(moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return 0;
+  }
+  moonbit_tray_win_destroy_pending_menu(state);
+  state->pending_menu = CreatePopupMenu();
+  if (state->pending_menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create tray popup menu");
+    return 0;
+  }
+  state->menu_stack[0] = state->pending_menu;
+  state->menu_depth = 1;
+  state->pending_menu_item_count = 0;
+  memset(state->pending_menu_item_ids, 0, sizeof(state->pending_menu_item_ids));
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static int32_t moonbit_tray_win_add_separator(moonbit_tray_state_t *state) {
+  HMENU menu = moonbit_tray_win_current_pending_menu(state);
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (!AppendMenuW(menu, MF_SEPARATOR, 0, NULL)) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to append tray menu separator");
+    return 0;
+  }
+  return 1;
+}
+
+static int32_t moonbit_tray_win_begin_submenu(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled) {
+  HMENU parent = moonbit_tray_win_current_pending_menu(state);
+  HMENU submenu;
+  const char *label = (const char *)label_bytes;
+  wchar_t *wide_label;
+  UINT flags = MF_POPUP;
+  if (parent == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->menu_depth > MOONBIT_TRAY_MAX_MENU_DEPTH) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu submenu depth exceeds 8");
+    return 0;
+  }
+  if (label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu label must not be empty");
+    return 0;
+  }
+  wide_label = moonbit_tray_utf8_cstr_to_wide(label);
+  if (wide_label == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to convert tray submenu label");
+    return 0;
+  }
+  submenu = CreatePopupMenu();
+  if (submenu == NULL) {
+    free(wide_label);
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create tray submenu");
+    return 0;
+  }
+  if (!enabled) {
+    flags |= MF_GRAYED;
+  }
+  if (!AppendMenuW(parent, flags, (UINT_PTR)submenu, wide_label)) {
+    DestroyMenu(submenu);
+    free(wide_label);
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to append tray submenu");
+    return 0;
+  }
+  free(wide_label);
+  state->menu_stack[state->menu_depth] = submenu;
+  state->menu_depth++;
+  return 1;
+}
+
+static int32_t moonbit_tray_win_end_submenu(moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL || state->menu_depth <= 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is not active");
+    return 0;
+  }
+  state->menu_depth--;
+  state->menu_stack[state->menu_depth] = NULL;
+  return 1;
+}
+
+static int32_t moonbit_tray_win_commit_menu(moonbit_tray_state_t *state) {
+  HMENU old_menu;
+  if (state == NULL || state->pending_menu == NULL) {
+    return 0;
+  }
+  if (state->menu_depth != 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is still open");
+    return 0;
+  }
+  old_menu = state->menu;
+  state->menu = state->pending_menu;
+  state->pending_menu = NULL;
+  state->menu_item_count = state->pending_menu_item_count;
+  memcpy(
+      state->menu_item_ids,
+      state->pending_menu_item_ids,
+      sizeof(state->menu_item_ids));
+  state->pending_menu_item_count = 0;
+  memset(state->pending_menu_item_ids, 0, sizeof(state->pending_menu_item_ids));
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+  state->menu_depth = 0;
+  if (old_menu != NULL) {
+    DestroyMenu(old_menu);
+  }
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+#endif
+
+#if defined(__linux__)
+typedef void (*moonbit_tray_linux_gcallback_t)(void);
+typedef void (*moonbit_tray_linux_destroy_notify_t)(void *, void *);
+
+typedef struct moonbit_tray_linux_backend {
+  int32_t initialized;
+  void *gtk_lib;
+  void *indicator_lib;
+  int (*gtk_init_check)(int *, char ***);
+  void *(*gtk_menu_new)(void);
+  void *(*gtk_menu_item_new_with_label)(const char *);
+  void *(*gtk_check_menu_item_new_with_label)(const char *);
+  void *(*gtk_separator_menu_item_new)(void);
+  void (*gtk_menu_shell_append)(void *, void *);
+  int (*gtk_main_iteration_do)(int);
+  void (*gtk_widget_set_sensitive)(void *, int);
+  void (*gtk_widget_show_all)(void *);
+  void (*gtk_check_menu_item_set_active)(void *, int);
+  void (*gtk_menu_item_set_submenu)(void *, void *);
+  void (*gtk_widget_destroy)(void *);
+  void (*g_object_unref)(void *);
+  unsigned long (*g_signal_connect_data)(
+      void *,
+      const char *,
+      moonbit_tray_linux_gcallback_t,
+      void *,
+      moonbit_tray_linux_destroy_notify_t,
+      int);
+  void *(*app_indicator_new)(const char *, const char *, int);
+  void (*app_indicator_set_status)(void *, int);
+  void (*app_indicator_set_menu)(void *, void *);
+  void (*app_indicator_set_icon)(void *, const char *);
+  void (*app_indicator_set_icon_full)(void *, const char *, const char *);
+  void (*app_indicator_set_icon_theme_path)(void *, const char *);
+  void (*app_indicator_set_title)(void *, const char *);
+} moonbit_tray_linux_backend_t;
+
+enum {
+  MOONBIT_TRAY_APPINDICATOR_CATEGORY_APPLICATION_STATUS = 0,
+  MOONBIT_TRAY_APPINDICATOR_STATUS_PASSIVE = 0,
+  MOONBIT_TRAY_APPINDICATOR_STATUS_ACTIVE = 1,
+};
+
+static moonbit_tray_linux_backend_t moonbit_tray_linux_backend;
+
+typedef struct moonbit_tray_linux_menu_event {
+  moonbit_tray_state_t *state;
+  char item_id[MOONBIT_TRAY_MAX_MENU_ID_BYTES];
+} moonbit_tray_linux_menu_event_t;
+
+static void moonbit_tray_linux_menu_item_activate(
+    void *widget,
+    void *user_data) {
+  moonbit_tray_linux_menu_event_t *event_data =
+      (moonbit_tray_linux_menu_event_t *)user_data;
+  (void)widget;
+  if (event_data != NULL) {
+    moonbit_tray_enqueue_menu_event(
+        event_data->state,
+        event_data->item_id);
+  }
+}
+
+static void moonbit_tray_linux_free_signal_data(
+    void *data,
+    void *closure) {
+  (void)closure;
+  free(data);
+}
+
+static int32_t moonbit_tray_linux_open_library(
+    const char *const *names,
+    void **out_handle) {
+  const char *const *name = names;
+  if (*out_handle != NULL) {
+    return 1;
+  }
+  for (; *name != NULL; ++name) {
+    *out_handle = dlopen(*name, RTLD_LAZY | RTLD_GLOBAL);
+    if (*out_handle != NULL) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int32_t moonbit_tray_linux_load_symbol(
+    void **out_symbol,
+    void *library,
+    const char *name,
+    int32_t required) {
+  *out_symbol = dlsym(library, name);
+  if (*out_symbol == NULL && required) {
+    char message[256];
+    snprintf(message, sizeof(message), "failed to resolve %s", name);
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        message);
+    return 0;
+  }
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_backend_init(void) {
+  static const char *const gtk_names[] = {
+      "libgtk-3.so.0",
+      "libgtk-3.so",
+      NULL,
+  };
+  static const char *const indicator_names[] = {
+      "libayatana-appindicator3.so.1",
+      "libayatana-appindicator3.so",
+      "libappindicator3.so.1",
+      "libappindicator3.so",
+      NULL,
+  };
+  if (moonbit_tray_linux_backend.initialized > 0) {
+    return 1;
+  }
+  if (moonbit_tray_linux_backend.initialized < 0) {
+    return 0;
+  }
+  if (!moonbit_tray_linux_open_library(
+          gtk_names,
+          &moonbit_tray_linux_backend.gtk_lib)) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "GTK 3 runtime not found (expected libgtk-3)");
+    moonbit_tray_linux_backend.initialized = 0;
+    return 0;
+  }
+  if (!moonbit_tray_linux_open_library(
+          indicator_names,
+          &moonbit_tray_linux_backend.indicator_lib)) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "AppIndicator runtime not found (expected libayatana-appindicator3 or libappindicator3)");
+    moonbit_tray_linux_backend.initialized = 0;
+    return 0;
+  }
+  if (!moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_init_check,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_init_check",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_menu_new,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_menu_new",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_menu_item_new_with_label,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_menu_item_new_with_label",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_check_menu_item_new_with_label,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_check_menu_item_new_with_label",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_separator_menu_item_new,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_separator_menu_item_new",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_menu_shell_append,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_menu_shell_append",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_main_iteration_do,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_main_iteration_do",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_widget_set_sensitive,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_widget_set_sensitive",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_widget_show_all,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_widget_show_all",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_check_menu_item_set_active,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_check_menu_item_set_active",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_menu_item_set_submenu,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_menu_item_set_submenu",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.gtk_widget_destroy,
+          moonbit_tray_linux_backend.gtk_lib,
+          "gtk_widget_destroy",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.app_indicator_new,
+          moonbit_tray_linux_backend.indicator_lib,
+          "app_indicator_new",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.app_indicator_set_status,
+          moonbit_tray_linux_backend.indicator_lib,
+          "app_indicator_set_status",
+          1) ||
+      !moonbit_tray_linux_load_symbol(
+          (void **)&moonbit_tray_linux_backend.app_indicator_set_menu,
+          moonbit_tray_linux_backend.indicator_lib,
+          "app_indicator_set_menu",
+          1)) {
+    moonbit_tray_linux_backend.initialized = 0;
+    return 0;
+  }
+  moonbit_tray_linux_load_symbol(
+      (void **)&moonbit_tray_linux_backend.app_indicator_set_icon_full,
+      moonbit_tray_linux_backend.indicator_lib,
+      "app_indicator_set_icon_full",
+      0);
+  moonbit_tray_linux_load_symbol(
+      (void **)&moonbit_tray_linux_backend.app_indicator_set_icon,
+      moonbit_tray_linux_backend.indicator_lib,
+      "app_indicator_set_icon",
+      0);
+  moonbit_tray_linux_load_symbol(
+      (void **)&moonbit_tray_linux_backend.app_indicator_set_icon_theme_path,
+      moonbit_tray_linux_backend.indicator_lib,
+      "app_indicator_set_icon_theme_path",
+      0);
+  moonbit_tray_linux_load_symbol(
+      (void **)&moonbit_tray_linux_backend.app_indicator_set_title,
+      moonbit_tray_linux_backend.indicator_lib,
+      "app_indicator_set_title",
+      0);
+  moonbit_tray_linux_backend.g_object_unref =
+      (void (*)(void *))dlsym(RTLD_DEFAULT, "g_object_unref");
+  moonbit_tray_linux_backend.g_signal_connect_data =
+      (unsigned long (*)(
+          void *,
+          const char *,
+          moonbit_tray_linux_gcallback_t,
+          void *,
+          moonbit_tray_linux_destroy_notify_t,
+          int))dlsym(RTLD_DEFAULT, "g_signal_connect_data");
+  if (moonbit_tray_linux_backend.g_signal_connect_data == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "failed to resolve g_signal_connect_data");
+    moonbit_tray_linux_backend.initialized = -1;
+    return 0;
+  }
+  if (!moonbit_tray_linux_backend.gtk_init_check(NULL, NULL)) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "GTK initialization failed; make sure a desktop session is available");
+    moonbit_tray_linux_backend.initialized = 0;
+    return 0;
+  }
+  moonbit_tray_clear_message(
+      moonbit_tray_support_message,
+      sizeof(moonbit_tray_support_message));
+  moonbit_tray_linux_backend.initialized = 1;
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_has_path_separator(const char *icon) {
+  return icon != NULL && strchr(icon, '/') != NULL;
+}
+
+static int32_t moonbit_tray_linux_is_readable_file(const char *path) {
+  struct stat file_info;
+  if (path == NULL || path[0] == '\0') {
+    return 0;
+  }
+  if (stat(path, &file_info) != 0 || !S_ISREG(file_info.st_mode)) {
+    return 0;
+  }
+  return access(path, R_OK) == 0;
+}
+
+static int32_t moonbit_tray_linux_ascii_equals_ignore_case(
+    const char *left,
+    const char *right) {
+  char left_char;
+  char right_char;
+  if (left == NULL || right == NULL) {
+    return 0;
+  }
+  while (*left != '\0' && *right != '\0') {
+    left_char = *left;
+    right_char = *right;
+    if (left_char >= 'A' && left_char <= 'Z') {
+      left_char = (char)(left_char - 'A' + 'a');
+    }
+    if (right_char >= 'A' && right_char <= 'Z') {
+      right_char = (char)(right_char - 'A' + 'a');
+    }
+    if (left_char != right_char) {
+      return 0;
+    }
+    ++left;
+    ++right;
+  }
+  return *left == '\0' && *right == '\0';
+}
+
+static int32_t moonbit_tray_linux_has_icon_file_extension(const char *icon) {
+  static const char *const extensions[] = {
+      "bmp",
+      "gif",
+      "ico",
+      "jpeg",
+      "jpg",
+      "png",
+      "svg",
+      "tif",
+      "tiff",
+      "webp",
+      "xpm",
+      NULL,
+  };
+  const char *slash;
+  const char *base;
+  const char *dot;
+  const char *const *extension;
+  if (icon == NULL || icon[0] == '\0') {
+    return 0;
+  }
+  slash = strrchr(icon, '/');
+  base = slash == NULL ? icon : slash + 1;
+  dot = strrchr(base, '.');
+  if (dot == NULL || dot == base || dot[1] == '\0') {
+    return 0;
+  }
+  for (extension = extensions; *extension != NULL; ++extension) {
+    if (moonbit_tray_linux_ascii_equals_ignore_case(dot + 1, *extension)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int32_t moonbit_tray_linux_looks_like_path(
+    const char *icon,
+    int32_t is_readable_file) {
+  return icon != NULL &&
+         icon[0] != '\0' &&
+         (moonbit_tray_linux_has_path_separator(icon) ||
+          is_readable_file ||
+          moonbit_tray_linux_has_icon_file_extension(icon));
+}
+
+static char *moonbit_tray_linux_copy_range(const char *start, size_t length) {
+  char *copy = (char *)malloc(length + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  if (length > 0) {
+    memcpy(copy, start, length);
+  }
+  copy[length] = '\0';
+  return copy;
+}
+
+static int32_t moonbit_tray_linux_split_icon_path(
+    const char *path,
+    char **out_directory,
+    char **out_icon_name) {
+  const char *slash;
+  const char *base;
+  const char *dot;
+  size_t directory_length;
+  size_t icon_name_length;
+  *out_directory = NULL;
+  *out_icon_name = NULL;
+  if (path == NULL || path[0] == '\0') {
+    return 0;
+  }
+  slash = strrchr(path, '/');
+  base = slash == NULL ? path : slash + 1;
+  if (base[0] == '\0') {
+    return 0;
+  }
+  if (slash == NULL) {
+    *out_directory = moonbit_tray_linux_copy_range(".", 1);
+  } else {
+    directory_length = slash == path ? 1 : (size_t)(slash - path);
+    *out_directory = moonbit_tray_linux_copy_range(path, directory_length);
+  }
+  if (*out_directory == NULL) {
+    return 0;
+  }
+  dot = strrchr(base, '.');
+  icon_name_length =
+      dot != NULL && dot > base ? (size_t)(dot - base) : strlen(base);
+  *out_icon_name = moonbit_tray_linux_copy_range(base, icon_name_length);
+  if (*out_icon_name == NULL) {
+    free(*out_directory);
+    *out_directory = NULL;
+    return 0;
+  }
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_apply_icon(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t icon) {
+  const char *raw_icon = (const char *)icon;
+  const char *icon_name = moonbit_tray_text_or(raw_icon, "applications-system");
+  char *icon_directory = NULL;
+  char *theme_icon_name = NULL;
+  int32_t icon_is_readable_file = moonbit_tray_linux_is_readable_file(raw_icon);
+  int32_t icon_is_path =
+      moonbit_tray_linux_looks_like_path(raw_icon, icon_is_readable_file);
+  int32_t updated = 0;
+  if (icon_is_path && !icon_is_readable_file) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray icon file is not readable");
+    return 0;
+  }
+  if (icon_is_path) {
+    if (moonbit_tray_linux_backend.app_indicator_set_icon_theme_path == NULL) {
+      moonbit_tray_set_message(
+          state->last_error,
+          sizeof(state->last_error),
+          "AppIndicator icon theme path setter is unavailable");
+      return 0;
+    }
+    if (!moonbit_tray_linux_split_icon_path(
+            raw_icon,
+            &icon_directory,
+            &theme_icon_name)) {
+      moonbit_tray_set_message(
+          state->last_error,
+          sizeof(state->last_error),
+          "failed to prepare the tray icon path");
+      return 0;
+    }
+    moonbit_tray_linux_backend.app_indicator_set_icon_theme_path(
+        state->indicator,
+        icon_directory);
+    icon_name = theme_icon_name;
+  }
+  if (moonbit_tray_linux_backend.app_indicator_set_icon_full != NULL) {
+    moonbit_tray_linux_backend.app_indicator_set_icon_full(
+        state->indicator,
+        icon_name,
+        "");
+    updated = 1;
+  } else if (moonbit_tray_linux_backend.app_indicator_set_icon != NULL) {
+    moonbit_tray_linux_backend.app_indicator_set_icon(
+        state->indicator,
+        icon_name);
+    updated = 1;
+  } else {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "no AppIndicator icon setter is available");
+  }
+  free(icon_directory);
+  free(theme_icon_name);
+  if (!updated) {
+    return 0;
+  }
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static void moonbit_tray_linux_apply_tooltip(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t tooltip) {
+  if (moonbit_tray_linux_backend.app_indicator_set_title != NULL) {
+    moonbit_tray_linux_backend.app_indicator_set_title(
+        state->indicator,
+        moonbit_tray_text_or((const char *)tooltip, ""));
+  }
+}
+
+static void moonbit_tray_linux_destroy_menu_widget(void **menu) {
+  if (menu == NULL || *menu == NULL) {
+    return;
+  }
+  if (moonbit_tray_linux_backend.gtk_widget_destroy != NULL) {
+    moonbit_tray_linux_backend.gtk_widget_destroy(*menu);
+  } else if (moonbit_tray_linux_backend.g_object_unref != NULL) {
+    moonbit_tray_linux_backend.g_object_unref(*menu);
+  }
+  *menu = NULL;
+}
+
+static void moonbit_tray_linux_destroy_pending_menu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+  moonbit_tray_linux_destroy_menu_widget(&state->pending_menu);
+  state->menu_depth = 0;
+  state->pending_menu_item_count = 0;
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+}
+
+static void *moonbit_tray_linux_current_pending_menu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL ||
+      state->menu_depth == 0) {
+    return NULL;
+  }
+  return state->menu_stack[state->menu_depth - 1];
+}
+
+static int32_t moonbit_tray_linux_begin_menu(moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return 0;
+  }
+  moonbit_tray_linux_destroy_pending_menu(state);
+  state->pending_menu = moonbit_tray_linux_backend.gtk_menu_new();
+  if (state->pending_menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create GTK tray popup menu");
+    return 0;
+  }
+  state->menu_stack[0] = state->pending_menu;
+  state->menu_depth = 1;
+  state->pending_menu_item_count = 0;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_append_clickable_menu_item(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t id_bytes,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled,
+    int32_t checked,
+    int32_t checkbox) {
+  void *menu = moonbit_tray_linux_current_pending_menu(state);
+  const char *id = (const char *)id_bytes;
+  const char *label = (const char *)label_bytes;
+  void *item;
+  moonbit_tray_linux_menu_event_t *event_data;
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->pending_menu_item_count >= MOONBIT_TRAY_MAX_MENU_ITEMS) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu has too many clickable items");
+    return 0;
+  }
+  if (id == NULL || id[0] == '\0' || label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu clickable items require id and label");
+    return 0;
+  }
+  if (strlen(id) >= MOONBIT_TRAY_MAX_MENU_ID_BYTES) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu item id is too long");
+    return 0;
+  }
+  item = checkbox
+      ? moonbit_tray_linux_backend.gtk_check_menu_item_new_with_label(label)
+      : moonbit_tray_linux_backend.gtk_menu_item_new_with_label(label);
+  if (item == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create GTK tray menu item");
+    return 0;
+  }
+  event_data = (moonbit_tray_linux_menu_event_t *)calloc(
+      1,
+      sizeof(moonbit_tray_linux_menu_event_t));
+  if (event_data == NULL) {
+    moonbit_tray_linux_backend.gtk_widget_destroy(item);
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to allocate GTK tray menu event data");
+    return 0;
+  }
+  event_data->state = state;
+  snprintf(event_data->item_id, sizeof(event_data->item_id), "%s", id);
+  if (checked) {
+    moonbit_tray_linux_backend.gtk_check_menu_item_set_active(item, 1);
+  }
+  if (!enabled) {
+    moonbit_tray_linux_backend.gtk_widget_set_sensitive(item, 0);
+  }
+  moonbit_tray_linux_backend.g_signal_connect_data(
+      item,
+      "activate",
+      (moonbit_tray_linux_gcallback_t)moonbit_tray_linux_menu_item_activate,
+      event_data,
+      moonbit_tray_linux_free_signal_data,
+      0);
+  moonbit_tray_linux_backend.gtk_menu_shell_append(menu, item);
+  state->pending_menu_item_count++;
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_add_separator(
+    moonbit_tray_state_t *state) {
+  void *menu = moonbit_tray_linux_current_pending_menu(state);
+  void *item;
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  item = moonbit_tray_linux_backend.gtk_separator_menu_item_new();
+  if (item == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create GTK tray menu separator");
+    return 0;
+  }
+  moonbit_tray_linux_backend.gtk_menu_shell_append(menu, item);
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_begin_submenu(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled) {
+  void *parent = moonbit_tray_linux_current_pending_menu(state);
+  const char *label = (const char *)label_bytes;
+  void *item;
+  void *submenu;
+  if (parent == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->menu_depth > MOONBIT_TRAY_MAX_MENU_DEPTH) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu submenu depth exceeds 8");
+    return 0;
+  }
+  if (label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu label must not be empty");
+    return 0;
+  }
+  item = moonbit_tray_linux_backend.gtk_menu_item_new_with_label(label);
+  submenu = moonbit_tray_linux_backend.gtk_menu_new();
+  if (item == NULL || submenu == NULL) {
+    if (item != NULL) {
+      moonbit_tray_linux_backend.gtk_widget_destroy(item);
+    }
+    if (submenu != NULL) {
+      moonbit_tray_linux_backend.gtk_widget_destroy(submenu);
+    }
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create GTK tray submenu");
+    return 0;
+  }
+  if (!enabled) {
+    moonbit_tray_linux_backend.gtk_widget_set_sensitive(item, 0);
+  }
+  moonbit_tray_linux_backend.gtk_menu_item_set_submenu(item, submenu);
+  moonbit_tray_linux_backend.gtk_menu_shell_append(parent, item);
+  state->menu_stack[state->menu_depth] = submenu;
+  state->menu_depth++;
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_end_submenu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL || state->menu_depth <= 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is not active");
+    return 0;
+  }
+  state->menu_depth--;
+  state->menu_stack[state->menu_depth] = NULL;
+  return 1;
+}
+
+static int32_t moonbit_tray_linux_commit_menu(moonbit_tray_state_t *state) {
+  void *old_menu;
+  if (state == NULL || state->pending_menu == NULL) {
+    return 0;
+  }
+  if (state->menu_depth != 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is still open");
+    return 0;
+  }
+  old_menu = state->menu;
+  state->menu = state->pending_menu;
+  state->pending_menu = NULL;
+  state->pending_menu_item_count = 0;
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+  state->menu_depth = 0;
+  moonbit_tray_linux_backend.gtk_widget_show_all(state->menu);
+  moonbit_tray_linux_backend.app_indicator_set_menu(
+      state->indicator,
+      state->menu);
+  if (old_menu != NULL) {
+    moonbit_tray_linux_destroy_menu_widget(&old_menu);
+  }
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+#endif
+
+#if defined(__APPLE__)
+typedef void *moonbit_tray_id;
+typedef void *moonbit_tray_sel;
+typedef signed char moonbit_tray_bool;
+
+typedef struct moonbit_tray_macos_backend {
+  int32_t initialized;
+  void *objc_lib;
+  void *appkit_lib;
+  moonbit_tray_id (*objc_getClass)(const char *);
+  moonbit_tray_id (*objc_lookUpClass)(const char *);
+  moonbit_tray_id (*objc_allocateClassPair)(moonbit_tray_id, const char *, size_t);
+  void (*objc_registerClassPair)(moonbit_tray_id);
+  moonbit_tray_sel (*sel_registerName)(const char *);
+  int (*class_addIvar)(moonbit_tray_id, const char *, size_t, uint8_t, const char *);
+  int (*class_addMethod)(moonbit_tray_id, moonbit_tray_sel, void *, const char *);
+  void *(*object_getInstanceVariable)(moonbit_tray_id, const char *, void **);
+  void *(*object_setInstanceVariable)(moonbit_tray_id, const char *, void *);
+  void *objc_msgSend;
+  moonbit_tray_id menu_target_class;
+} moonbit_tray_macos_backend_t;
+
+static moonbit_tray_macos_backend_t moonbit_tray_macos_backend;
+
+static void moonbit_tray_macos_menu_action(
+    moonbit_tray_id target,
+    moonbit_tray_sel selector,
+    moonbit_tray_id sender);
+
+static int32_t moonbit_tray_macos_ensure_menu_target_class(void) {
+  moonbit_tray_id existing;
+  moonbit_tray_id superclass;
+  moonbit_tray_id target_class;
+  uint8_t pointer_alignment = sizeof(void *) == 8 ? 3 : 2;
+  if (moonbit_tray_macos_backend.menu_target_class != NULL) {
+    return 1;
+  }
+  existing = moonbit_tray_macos_backend.objc_lookUpClass(
+      "MoonBitTrayMenuTarget");
+  if (existing != NULL) {
+    moonbit_tray_macos_backend.menu_target_class = existing;
+    return 1;
+  }
+  superclass = moonbit_tray_macos_backend.objc_getClass("NSObject");
+  if (superclass == NULL) {
+    return 0;
+  }
+  target_class = moonbit_tray_macos_backend.objc_allocateClassPair(
+      superclass,
+      "MoonBitTrayMenuTarget",
+      0);
+  if (target_class == NULL) {
+    return 0;
+  }
+  if (!moonbit_tray_macos_backend.class_addIvar(
+          target_class,
+          "state",
+          sizeof(void *),
+          pointer_alignment,
+          "^v") ||
+      !moonbit_tray_macos_backend.class_addMethod(
+          target_class,
+          moonbit_tray_macos_backend.sel_registerName("moonbitTrayMenuAction:"),
+          (void *)moonbit_tray_macos_menu_action,
+          "v@:@")) {
+    return 0;
+  }
+  moonbit_tray_macos_backend.objc_registerClassPair(target_class);
+  moonbit_tray_macos_backend.menu_target_class = target_class;
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_backend_init(void) {
+  if (moonbit_tray_macos_backend.initialized > 0) {
+    return 1;
+  }
+  if (moonbit_tray_macos_backend.initialized < 0) {
+    return 0;
+  }
+  moonbit_tray_macos_backend.objc_lib =
+      dlopen("/usr/lib/libobjc.A.dylib", RTLD_LAZY | RTLD_GLOBAL);
+  if (moonbit_tray_macos_backend.objc_lib == NULL) {
+    moonbit_tray_macos_backend.objc_lib =
+        dlopen("/usr/lib/libobjc.dylib", RTLD_LAZY | RTLD_GLOBAL);
+  }
+  moonbit_tray_macos_backend.appkit_lib =
+      dlopen(
+          "/System/Library/Frameworks/AppKit.framework/AppKit",
+          RTLD_LAZY | RTLD_GLOBAL);
+  if (moonbit_tray_macos_backend.objc_lib == NULL ||
+      moonbit_tray_macos_backend.appkit_lib == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "AppKit or Objective-C runtime could not be loaded");
+    moonbit_tray_macos_backend.initialized = -1;
+    return 0;
+  }
+  moonbit_tray_macos_backend.objc_getClass =
+      (moonbit_tray_id(*)(const char *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "objc_getClass");
+  moonbit_tray_macos_backend.objc_lookUpClass =
+      (moonbit_tray_id(*)(const char *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "objc_lookUpClass");
+  moonbit_tray_macos_backend.objc_allocateClassPair =
+      (moonbit_tray_id(*)(moonbit_tray_id, const char *, size_t))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "objc_allocateClassPair");
+  moonbit_tray_macos_backend.objc_registerClassPair =
+      (void (*)(moonbit_tray_id))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "objc_registerClassPair");
+  moonbit_tray_macos_backend.sel_registerName =
+      (moonbit_tray_sel(*)(const char *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "sel_registerName");
+  moonbit_tray_macos_backend.class_addIvar =
+      (int (*)(moonbit_tray_id, const char *, size_t, uint8_t, const char *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "class_addIvar");
+  moonbit_tray_macos_backend.class_addMethod =
+      (int (*)(moonbit_tray_id, moonbit_tray_sel, void *, const char *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "class_addMethod");
+  moonbit_tray_macos_backend.object_getInstanceVariable =
+      (void *(*)(moonbit_tray_id, const char *, void **))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "object_getInstanceVariable");
+  moonbit_tray_macos_backend.object_setInstanceVariable =
+      (void *(*)(moonbit_tray_id, const char *, void *))dlsym(
+          moonbit_tray_macos_backend.objc_lib,
+          "object_setInstanceVariable");
+  moonbit_tray_macos_backend.objc_msgSend =
+      dlsym(moonbit_tray_macos_backend.objc_lib, "objc_msgSend");
+  if (moonbit_tray_macos_backend.objc_getClass == NULL ||
+      moonbit_tray_macos_backend.objc_lookUpClass == NULL ||
+      moonbit_tray_macos_backend.objc_allocateClassPair == NULL ||
+      moonbit_tray_macos_backend.objc_registerClassPair == NULL ||
+      moonbit_tray_macos_backend.sel_registerName == NULL ||
+      moonbit_tray_macos_backend.class_addIvar == NULL ||
+      moonbit_tray_macos_backend.class_addMethod == NULL ||
+      moonbit_tray_macos_backend.object_getInstanceVariable == NULL ||
+      moonbit_tray_macos_backend.object_setInstanceVariable == NULL ||
+      moonbit_tray_macos_backend.objc_msgSend == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "failed to resolve Objective-C runtime entry points");
+    moonbit_tray_macos_backend.initialized = -1;
+    return 0;
+  }
+  if (!moonbit_tray_macos_ensure_menu_target_class()) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "failed to register macOS tray menu target");
+    moonbit_tray_macos_backend.initialized = -1;
+    return 0;
+  }
+  moonbit_tray_clear_message(
+      moonbit_tray_support_message,
+      sizeof(moonbit_tray_support_message));
+  moonbit_tray_macos_backend.initialized = 1;
+  return 1;
+}
+
+static moonbit_tray_sel moonbit_tray_macos_sel(const char *name) {
+  return moonbit_tray_macos_backend.sel_registerName(name);
+}
+
+static moonbit_tray_id moonbit_tray_macos_class(const char *name) {
+  return moonbit_tray_macos_backend.objc_getClass(name);
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id(
+    moonbit_tray_id object,
+    const char *selector_name) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name));
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id_id(
+    moonbit_tray_id object,
+    const char *selector_name,
+    moonbit_tray_id arg) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel, moonbit_tray_id))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id_id_sel_id(
+    moonbit_tray_id object,
+    const char *selector_name,
+    moonbit_tray_id arg1,
+    moonbit_tray_sel arg2,
+    moonbit_tray_id arg3) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel, moonbit_tray_id, moonbit_tray_sel, moonbit_tray_id))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg1,
+      arg2,
+      arg3);
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id_cstring(
+    moonbit_tray_id object,
+    const char *selector_name,
+    const char *arg) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel, const char *))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id_double(
+    moonbit_tray_id object,
+    const char *selector_name,
+    double arg) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel, double))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static moonbit_tray_id moonbit_tray_macos_send_id_ulong_id_id_bool(
+    moonbit_tray_id object,
+    const char *selector_name,
+    unsigned long arg1,
+    moonbit_tray_id arg2,
+    moonbit_tray_id arg3,
+    moonbit_tray_bool arg4) {
+  return ((moonbit_tray_id(*)(moonbit_tray_id, moonbit_tray_sel, unsigned long, moonbit_tray_id, moonbit_tray_id, moonbit_tray_bool))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg1,
+      arg2,
+      arg3,
+      arg4);
+}
+
+static void moonbit_tray_macos_send_void(
+    moonbit_tray_id object,
+    const char *selector_name) {
+  ((void (*)(moonbit_tray_id, moonbit_tray_sel))
+       moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name));
+}
+
+static const char *moonbit_tray_macos_send_cstring(
+    moonbit_tray_id object,
+    const char *selector_name) {
+  return ((const char *(*)(moonbit_tray_id, moonbit_tray_sel))
+              moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name));
+}
+
+static void moonbit_tray_macos_send_void_id(
+    moonbit_tray_id object,
+    const char *selector_name,
+    moonbit_tray_id arg) {
+  ((void (*)(moonbit_tray_id, moonbit_tray_sel, moonbit_tray_id))
+       moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static void moonbit_tray_macos_send_void_long(
+    moonbit_tray_id object,
+    const char *selector_name,
+    long arg) {
+  ((void (*)(moonbit_tray_id, moonbit_tray_sel, long))
+       moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static void moonbit_tray_macos_send_void_bool(
+    moonbit_tray_id object,
+    const char *selector_name,
+    moonbit_tray_bool arg) {
+  ((void (*)(moonbit_tray_id, moonbit_tray_sel, moonbit_tray_bool))
+       moonbit_tray_macos_backend.objc_msgSend)(
+      object,
+      moonbit_tray_macos_sel(selector_name),
+      arg);
+}
+
+static moonbit_tray_id moonbit_tray_macos_new_pool(void) {
+  return moonbit_tray_macos_send_id(
+      moonbit_tray_macos_class("NSAutoreleasePool"),
+      "new");
+}
+
+static void moonbit_tray_macos_drain_pool(moonbit_tray_id pool) {
+  if (pool != NULL) {
+    moonbit_tray_macos_send_void(pool, "drain");
+  }
+}
+
+static moonbit_tray_id moonbit_tray_macos_string(const char *value) {
+  return moonbit_tray_macos_send_id_cstring(
+      moonbit_tray_macos_class("NSString"),
+      "stringWithUTF8String:",
+      moonbit_tray_text_or(value, ""));
+}
+
+static int32_t moonbit_tray_macos_apply_icon(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t icon) {
+  const char *icon_text = (const char *)icon;
+  moonbit_tray_id button =
+      state->button != NULL ? state->button : state->status_item;
+  moonbit_tray_id pool;
+  if (button == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "status item button is unavailable");
+    return 0;
+  }
+  pool = moonbit_tray_macos_new_pool();
+  if (icon_text != NULL && icon_text[0] != '\0') {
+    moonbit_tray_id path = moonbit_tray_macos_string(icon_text);
+    int32_t image_owned = 1;
+    moonbit_tray_id image = moonbit_tray_macos_send_id_id(
+        moonbit_tray_macos_send_id(
+            moonbit_tray_macos_class("NSImage"),
+            "alloc"),
+        "initWithContentsOfFile:",
+        path);
+    if (image == NULL) {
+      image_owned = 0;
+      image = moonbit_tray_macos_send_id_id(
+          moonbit_tray_macos_class("NSImage"),
+          "imageNamed:",
+          path);
+    }
+    if (image != NULL) {
+      moonbit_tray_macos_send_void_id(button, "setImage:", image);
+      if (image_owned) {
+        moonbit_tray_macos_send_void(image, "release");
+      }
+      moonbit_tray_macos_send_void_id(
+          button,
+          "setTitle:",
+          moonbit_tray_macos_string(""));
+      moonbit_tray_macos_drain_pool(pool);
+      moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+      return 1;
+    }
+  }
+  moonbit_tray_macos_send_void_id(button, "setImage:", NULL);
+  moonbit_tray_macos_send_void_id(
+      button,
+      "setTitle:",
+      moonbit_tray_macos_string("Tray"));
+  moonbit_tray_macos_drain_pool(pool);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static void moonbit_tray_macos_apply_tooltip(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t tooltip) {
+  moonbit_tray_id button =
+      state->button != NULL ? state->button : state->status_item;
+  if (button != NULL) {
+    moonbit_tray_id pool = moonbit_tray_macos_new_pool();
+    moonbit_tray_macos_send_void_id(
+        button,
+        "setToolTip:",
+        moonbit_tray_macos_string((const char *)tooltip));
+    moonbit_tray_macos_drain_pool(pool);
+  }
+}
+
+static void moonbit_tray_macos_menu_action(
+    moonbit_tray_id target,
+    moonbit_tray_sel selector,
+    moonbit_tray_id sender) {
+  moonbit_tray_state_t *state = NULL;
+  moonbit_tray_id represented = NULL;
+  const char *item_id = NULL;
+  (void)selector;
+  if (target == NULL || sender == NULL) {
+    return;
+  }
+  moonbit_tray_macos_backend.object_getInstanceVariable(
+      target,
+      "state",
+      (void **)&state);
+  represented = moonbit_tray_macos_send_id(sender, "representedObject");
+  if (represented != NULL) {
+    item_id = moonbit_tray_macos_send_cstring(represented, "UTF8String");
+  }
+  if (state != NULL && item_id != NULL) {
+    moonbit_tray_enqueue_menu_event(state, item_id);
+  }
+}
+
+static moonbit_tray_id moonbit_tray_macos_create_menu_target(
+    moonbit_tray_state_t *state) {
+  moonbit_tray_id target =
+      moonbit_tray_macos_send_id(
+          moonbit_tray_macos_backend.menu_target_class,
+          "new");
+  if (target == NULL) {
+    return NULL;
+  }
+  moonbit_tray_macos_backend.object_setInstanceVariable(
+      target,
+      "state",
+      state);
+  return target;
+}
+
+static moonbit_tray_id moonbit_tray_macos_new_menu(const char *title) {
+  return moonbit_tray_macos_send_id_id(
+      moonbit_tray_macos_send_id(
+          moonbit_tray_macos_class("NSMenu"),
+          "alloc"),
+      "initWithTitle:",
+      moonbit_tray_macos_string(title));
+}
+
+static moonbit_tray_id moonbit_tray_macos_new_menu_item(
+    const char *label,
+    moonbit_tray_sel action) {
+  return moonbit_tray_macos_send_id_id_sel_id(
+      moonbit_tray_macos_send_id(
+          moonbit_tray_macos_class("NSMenuItem"),
+          "alloc"),
+      "initWithTitle:action:keyEquivalent:",
+      moonbit_tray_macos_string(label),
+      action,
+      moonbit_tray_macos_string(""));
+}
+
+static void moonbit_tray_macos_release_menu(moonbit_tray_id *menu) {
+  if (menu == NULL || *menu == NULL) {
+    return;
+  }
+  moonbit_tray_macos_send_void(*menu, "release");
+  *menu = NULL;
+}
+
+static void moonbit_tray_macos_destroy_pending_menu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+  moonbit_tray_macos_release_menu((moonbit_tray_id *)&state->pending_menu);
+  state->menu_depth = 0;
+  state->pending_menu_item_count = 0;
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+}
+
+static moonbit_tray_id moonbit_tray_macos_current_pending_menu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL ||
+      state->menu_depth == 0) {
+    return NULL;
+  }
+  return (moonbit_tray_id)state->menu_stack[state->menu_depth - 1];
+}
+
+static int32_t moonbit_tray_macos_begin_menu(moonbit_tray_state_t *state) {
+  if (state == NULL || state->menu_target == NULL) {
+    return 0;
+  }
+  moonbit_tray_macos_destroy_pending_menu(state);
+  state->pending_menu = moonbit_tray_macos_new_menu("");
+  if (state->pending_menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create macOS tray menu");
+    return 0;
+  }
+  state->menu_stack[0] = state->pending_menu;
+  state->menu_depth = 1;
+  state->pending_menu_item_count = 0;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_append_clickable_menu_item(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t id_bytes,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled,
+    int32_t checked) {
+  moonbit_tray_id menu = moonbit_tray_macos_current_pending_menu(state);
+  const char *id = (const char *)id_bytes;
+  const char *label = (const char *)label_bytes;
+  moonbit_tray_id item;
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->pending_menu_item_count >= MOONBIT_TRAY_MAX_MENU_ITEMS) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu has too many clickable items");
+    return 0;
+  }
+  if (id == NULL || id[0] == '\0' || label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu clickable items require id and label");
+    return 0;
+  }
+  if (strlen(id) >= MOONBIT_TRAY_MAX_MENU_ID_BYTES) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu item id is too long");
+    return 0;
+  }
+  item = moonbit_tray_macos_new_menu_item(
+      label,
+      moonbit_tray_macos_sel("moonbitTrayMenuAction:"));
+  if (item == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create macOS tray menu item");
+    return 0;
+  }
+  moonbit_tray_macos_send_void_id(
+      item,
+      "setRepresentedObject:",
+      moonbit_tray_macos_string(id));
+  moonbit_tray_macos_send_void_id(item, "setTarget:", state->menu_target);
+  moonbit_tray_macos_send_void_bool(
+      item,
+      "setEnabled:",
+      (moonbit_tray_bool)(enabled ? 1 : 0));
+  moonbit_tray_macos_send_void_long(item, "setState:", checked ? 1L : 0L);
+  moonbit_tray_macos_send_void_id(menu, "addItem:", item);
+  moonbit_tray_macos_send_void(item, "release");
+  state->pending_menu_item_count++;
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_add_separator(
+    moonbit_tray_state_t *state) {
+  moonbit_tray_id menu = moonbit_tray_macos_current_pending_menu(state);
+  moonbit_tray_id item;
+  if (menu == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  item = moonbit_tray_macos_send_id(
+      moonbit_tray_macos_class("NSMenuItem"),
+      "separatorItem");
+  if (item == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create macOS tray menu separator");
+    return 0;
+  }
+  moonbit_tray_macos_send_void_id(menu, "addItem:", item);
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_begin_submenu(
+    moonbit_tray_state_t *state,
+    moonbit_bytes_t label_bytes,
+    int32_t enabled) {
+  moonbit_tray_id parent = moonbit_tray_macos_current_pending_menu(state);
+  const char *label = (const char *)label_bytes;
+  moonbit_tray_id item;
+  moonbit_tray_id submenu;
+  if (parent == NULL) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu transaction is not active");
+    return 0;
+  }
+  if (state->menu_depth > MOONBIT_TRAY_MAX_MENU_DEPTH) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray menu submenu depth exceeds 8");
+    return 0;
+  }
+  if (label == NULL || label[0] == '\0') {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu label must not be empty");
+    return 0;
+  }
+  item = moonbit_tray_macos_new_menu_item(label, NULL);
+  submenu = moonbit_tray_macos_new_menu(label);
+  if (item == NULL || submenu == NULL) {
+    if (item != NULL) {
+      moonbit_tray_macos_send_void(item, "release");
+    }
+    if (submenu != NULL) {
+      moonbit_tray_macos_send_void(submenu, "release");
+    }
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "failed to create macOS tray submenu");
+    return 0;
+  }
+  moonbit_tray_macos_send_void_bool(
+      item,
+      "setEnabled:",
+      (moonbit_tray_bool)(enabled ? 1 : 0));
+  moonbit_tray_macos_send_void_id(item, "setSubmenu:", submenu);
+  moonbit_tray_macos_send_void(submenu, "release");
+  moonbit_tray_macos_send_void_id(parent, "addItem:", item);
+  moonbit_tray_macos_send_void(item, "release");
+  state->menu_stack[state->menu_depth] = submenu;
+  state->menu_depth++;
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_end_submenu(
+    moonbit_tray_state_t *state) {
+  if (state == NULL || state->pending_menu == NULL || state->menu_depth <= 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is not active");
+    return 0;
+  }
+  state->menu_depth--;
+  state->menu_stack[state->menu_depth] = NULL;
+  return 1;
+}
+
+static int32_t moonbit_tray_macos_commit_menu(moonbit_tray_state_t *state) {
+  moonbit_tray_id old_menu;
+  if (state == NULL || state->pending_menu == NULL) {
+    return 0;
+  }
+  if (state->menu_depth != 1) {
+    moonbit_tray_set_message(
+        state->last_error,
+        sizeof(state->last_error),
+        "tray submenu transaction is still open");
+    return 0;
+  }
+  old_menu = (moonbit_tray_id)state->menu;
+  state->menu = state->pending_menu;
+  state->pending_menu = NULL;
+  state->pending_menu_item_count = 0;
+  memset(state->menu_stack, 0, sizeof(state->menu_stack));
+  state->menu_depth = 0;
+  moonbit_tray_macos_send_void_id(
+      state->status_item,
+      "setMenu:",
+      (moonbit_tray_id)state->menu);
+  if (old_menu != NULL) {
+    moonbit_tray_macos_send_void(old_menu, "release");
+  }
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+}
+
+static void moonbit_tray_macos_release_state(moonbit_tray_state_t *state) {
+  if (state == NULL) {
+    return;
+  }
+  moonbit_tray_macos_destroy_pending_menu(state);
+  if (state->status_item != NULL && state->menu != NULL) {
+    moonbit_tray_macos_send_void_id(state->status_item, "setMenu:", NULL);
+  }
+  moonbit_tray_macos_release_menu((moonbit_tray_id *)&state->menu);
+  if (state->menu_target != NULL) {
+    moonbit_tray_macos_backend.object_setInstanceVariable(
+        (moonbit_tray_id)state->menu_target,
+        "state",
+        NULL);
+    moonbit_tray_macos_send_void(
+        (moonbit_tray_id)state->menu_target,
+        "release");
+    state->menu_target = NULL;
+  }
+  if (state->status_item != NULL) {
+    if (state->status_bar != NULL) {
+      moonbit_tray_macos_send_void_id(
+          state->status_bar,
+          "removeStatusItem:",
+          state->status_item);
+    }
+    moonbit_tray_macos_send_void(state->status_item, "release");
+    state->status_item = NULL;
+  }
+  if (state->pool != NULL) {
+    moonbit_tray_macos_send_void(state->pool, "drain");
+    state->pool = NULL;
+  }
+}
+#endif
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_current_platform(void) {
+#ifdef _WIN32
+  return 1;
+#elif defined(__linux__)
+  return 2;
+#elif defined(__APPLE__)
+  return 3;
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_is_supported(void) {
+#ifdef _WIN32
+  return moonbit_tray_ensure_window_class();
+#elif defined(__linux__)
+  return moonbit_tray_linux_backend_init();
+#elif defined(__APPLE__)
+  if (!moonbit_tray_macos_backend_init()) {
+    return 0;
+  }
+  if (pthread_main_np() == 0) {
+    moonbit_tray_set_message(
+        moonbit_tray_support_message,
+        sizeof(moonbit_tray_support_message),
+        "macOS tray must be created on the main thread");
+    return 0;
+  }
+  moonbit_tray_clear_message(
+      moonbit_tray_support_message,
+      sizeof(moonbit_tray_support_message));
+  return 1;
+#else
+  moonbit_tray_set_message(
+      moonbit_tray_support_message,
+      sizeof(moonbit_tray_support_message),
+      "tray support is not available on this operating system");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_support_error(void) {
+  return moonbit_tray_copy_message(moonbit_tray_support_message);
+}
+
+MOONBIT_FFI_EXPORT int64_t moonbit_tray_create(
+    moonbit_bytes_t identifier,
+    moonbit_bytes_t icon,
+    moonbit_bytes_t tooltip) {
+  moonbit_tray_state_t *state;
+#ifdef _WIN32
+  if (!moonbit_tray_ensure_window_class()) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        moonbit_tray_support_message);
+    return 0;
+  }
+  state = (moonbit_tray_state_t *)calloc(1, sizeof(moonbit_tray_state_t));
+  if (state == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to allocate tray state");
+    return 0;
+  }
+  state->hwnd = CreateWindowExW(
+      0,
+      L"MoonBitTrayWindow",
+      L"MoonBitTrayWindow",
+      0,
+      0,
+      0,
+      0,
+      0,
+      HWND_MESSAGE,
+      NULL,
+      GetModuleHandleW(NULL),
+      NULL);
+  if (state->hwnd == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to create the hidden tray window");
+    free(state);
+    return 0;
+  }
+  SetWindowLongPtrW(state->hwnd, GWLP_USERDATA, (LONG_PTR)state);
+  memset(&state->icon_data, 0, sizeof(state->icon_data));
+  state->icon_data.cbSize = sizeof(state->icon_data);
+  state->icon_data.hWnd = state->hwnd;
+  state->icon_data.uID = 0x6D42;
+  state->icon_data.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  state->icon_data.uCallbackMessage = MOONBIT_TRAY_CALLBACK_MESSAGE;
+  moonbit_tray_copy_tooltip(&state->icon_data, tooltip);
+  if (!moonbit_tray_replace_icon(state, icon)) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        state->last_error);
+    DestroyWindow(state->hwnd);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  moonbit_tray_clear_message(
+      moonbit_tray_create_error,
+      sizeof(moonbit_tray_create_error));
+  return moonbit_tray_to_handle(state);
+#elif defined(__linux__)
+  if (!moonbit_tray_linux_backend_init()) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        moonbit_tray_support_message);
+    return 0;
+  }
+  state = (moonbit_tray_state_t *)calloc(1, sizeof(moonbit_tray_state_t));
+  if (state == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to allocate tray state");
+    return 0;
+  }
+  state->menu = moonbit_tray_linux_backend.gtk_menu_new();
+  if (state->menu == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to create the GTK tray menu");
+    free(state);
+    return 0;
+  }
+  state->indicator = moonbit_tray_linux_backend.app_indicator_new(
+      moonbit_tray_text_or((const char *)identifier, "moonbit-tray"),
+      moonbit_tray_text_or((const char *)icon, "applications-system"),
+      MOONBIT_TRAY_APPINDICATOR_CATEGORY_APPLICATION_STATUS);
+  if (state->indicator == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to create the AppIndicator instance");
+    moonbit_tray_linux_destroy_menu_widget(&state->menu);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_linux_backend.app_indicator_set_menu(state->indicator, state->menu);
+  moonbit_tray_linux_backend.app_indicator_set_status(
+      state->indicator,
+      MOONBIT_TRAY_APPINDICATOR_STATUS_PASSIVE);
+  if (!moonbit_tray_linux_apply_icon(state, icon)) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        state->last_error);
+    if (moonbit_tray_linux_backend.g_object_unref != NULL) {
+      moonbit_tray_linux_backend.g_object_unref(state->indicator);
+    }
+    moonbit_tray_linux_destroy_menu_widget(&state->menu);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_linux_apply_tooltip(state, tooltip);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  moonbit_tray_clear_message(
+      moonbit_tray_create_error,
+      sizeof(moonbit_tray_create_error));
+  return moonbit_tray_to_handle(state);
+#elif defined(__APPLE__)
+  if (!moonbit_tray_macos_backend_init()) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        moonbit_tray_support_message);
+    return 0;
+  }
+  if (pthread_main_np() == 0) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "macOS tray must be created on the main thread");
+    return 0;
+  }
+  state = (moonbit_tray_state_t *)calloc(1, sizeof(moonbit_tray_state_t));
+  if (state == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to allocate tray state");
+    return 0;
+  }
+  state->pool = moonbit_tray_macos_new_pool();
+  state->app = moonbit_tray_macos_send_id(
+      moonbit_tray_macos_class("NSApplication"),
+      "sharedApplication");
+  state->status_bar = moonbit_tray_macos_send_id(
+      moonbit_tray_macos_class("NSStatusBar"),
+      "systemStatusBar");
+  state->status_item = moonbit_tray_macos_send_id_double(
+      state->status_bar,
+      "statusItemWithLength:",
+      -1.0);
+  if (state->status_item == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to create the NSStatusItem");
+    moonbit_tray_macos_release_state(state);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_macos_send_id(state->status_item, "retain");
+  moonbit_tray_macos_send_void_bool(
+      state->status_item,
+      "setHighlightMode:",
+      (moonbit_tray_bool)1);
+  state->button = moonbit_tray_macos_send_id(state->status_item, "button");
+  state->menu_target = moonbit_tray_macos_create_menu_target(state);
+  if (state->menu_target == NULL) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        "failed to create macOS tray menu target");
+    moonbit_tray_macos_release_state(state);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_macos_send_void_bool(
+      state->app,
+      "activateIgnoringOtherApps:",
+      (moonbit_tray_bool)1);
+  if (!moonbit_tray_macos_apply_icon(state, icon)) {
+    moonbit_tray_set_message(
+        moonbit_tray_create_error,
+        sizeof(moonbit_tray_create_error),
+        state->last_error);
+    moonbit_tray_macos_release_state(state);
+    free(state);
+    return 0;
+  }
+  moonbit_tray_macos_apply_tooltip(state, tooltip);
+  moonbit_tray_macos_send_void_bool(
+      state->status_item,
+      "setVisible:",
+      (moonbit_tray_bool)0);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  moonbit_tray_clear_message(
+      moonbit_tray_create_error,
+      sizeof(moonbit_tray_create_error));
+  return moonbit_tray_to_handle(state);
+#else
+  moonbit_tray_set_message(
+      moonbit_tray_create_error,
+      sizeof(moonbit_tray_create_error),
+      "native tray backend is unavailable on this platform");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_last_create_error(void) {
+  return moonbit_tray_copy_message(moonbit_tray_create_error);
+}
+
+MOONBIT_FFI_EXPORT void moonbit_tray_destroy(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return;
+  }
+#ifdef _WIN32
+  if (state->visible) {
+    Shell_NotifyIconW(NIM_DELETE, &state->icon_data);
+  }
+  moonbit_tray_win_destroy_pending_menu(state);
+  moonbit_tray_win_destroy_menu(state);
+  if (state->icon_owned && state->icon_data.hIcon != NULL) {
+    DestroyIcon(state->icon_data.hIcon);
+  }
+  if (state->hwnd != NULL) {
+    DestroyWindow(state->hwnd);
+  }
+#elif defined(__linux__)
+  if (state->indicator != NULL) {
+    moonbit_tray_linux_backend.app_indicator_set_status(
+        state->indicator,
+        MOONBIT_TRAY_APPINDICATOR_STATUS_PASSIVE);
+  }
+  moonbit_tray_linux_destroy_pending_menu(state);
+  moonbit_tray_linux_destroy_menu_widget(&state->menu);
+  if (moonbit_tray_linux_backend.g_object_unref != NULL) {
+    if (state->indicator != NULL) {
+      moonbit_tray_linux_backend.g_object_unref(state->indicator);
+    }
+  }
+#elif defined(__APPLE__)
+  moonbit_tray_macos_release_state(state);
+#endif
+  free(state);
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_show(
+    int64_t handle,
+    moonbit_bytes_t tooltip) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  NOTIFYICONDATAW next_icon_data = state->icon_data;
+  moonbit_tray_copy_tooltip(&next_icon_data, tooltip);
+  if (state->visible) {
+    if (!Shell_NotifyIconW(NIM_MODIFY, &next_icon_data)) {
+      moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "Shell_NotifyIconW(NIM_MODIFY) failed");
+      return 0;
+    }
+    state->icon_data = next_icon_data;
+    moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+    return 1;
+  }
+  if (!Shell_NotifyIconW(NIM_ADD, &next_icon_data)) {
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "Shell_NotifyIconW(NIM_ADD) failed");
+    return 0;
+  }
+  state->icon_data = next_icon_data;
+  state->visible = 1;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__linux__)
+  moonbit_tray_linux_apply_tooltip(state, tooltip);
+  moonbit_tray_linux_backend.app_indicator_set_status(
+      state->indicator,
+      MOONBIT_TRAY_APPINDICATOR_STATUS_ACTIVE);
+  state->visible = 1;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__APPLE__)
+  moonbit_tray_macos_apply_tooltip(state, tooltip);
+  moonbit_tray_macos_send_void_bool(
+      state->status_item,
+      "setVisible:",
+      (moonbit_tray_bool)1);
+  state->visible = 1;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#else
+  (void)tooltip;
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_hide(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  if (!state->visible) {
+    moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+    return 1;
+  }
+  if (!Shell_NotifyIconW(NIM_DELETE, &state->icon_data)) {
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "Shell_NotifyIconW(NIM_DELETE) failed");
+    return 0;
+  }
+  state->visible = 0;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__linux__)
+  moonbit_tray_linux_backend.app_indicator_set_status(
+      state->indicator,
+      MOONBIT_TRAY_APPINDICATOR_STATUS_PASSIVE);
+  state->visible = 0;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__APPLE__)
+  moonbit_tray_macos_send_void_bool(
+      state->status_item,
+      "setVisible:",
+      (moonbit_tray_bool)0);
+  state->visible = 0;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_set_tooltip(
+    int64_t handle,
+    moonbit_bytes_t tooltip) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  if (!state->visible) {
+    moonbit_tray_copy_tooltip(&state->icon_data, tooltip);
+    moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+    return 1;
+  }
+  NOTIFYICONDATAW next_icon_data = state->icon_data;
+  moonbit_tray_copy_tooltip(&next_icon_data, tooltip);
+  if (!Shell_NotifyIconW(NIM_MODIFY, &next_icon_data)) {
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "Shell_NotifyIconW(NIM_MODIFY) failed");
+    return 0;
+  }
+  state->icon_data = next_icon_data;
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__linux__)
+  moonbit_tray_linux_apply_tooltip(state, tooltip);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__APPLE__)
+  moonbit_tray_macos_apply_tooltip(state, tooltip);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#else
+  (void)tooltip;
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_set_icon(
+    int64_t handle,
+    moonbit_bytes_t icon) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  if (!state->visible) {
+    if (!moonbit_tray_replace_icon(state, icon)) {
+      return 0;
+    }
+    moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+    return 1;
+  }
+  int32_t next_icon_owned = 0;
+  HICON next_icon = moonbit_tray_load_icon(icon, &next_icon_owned);
+  if (next_icon == NULL) {
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "failed to load tray icon");
+    return 0;
+  }
+  NOTIFYICONDATAW next_icon_data = state->icon_data;
+  next_icon_data.hIcon = next_icon;
+  next_icon_data.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  if (!Shell_NotifyIconW(NIM_MODIFY, &next_icon_data)) {
+    if (next_icon != state->icon_data.hIcon) {
+      moonbit_tray_destroy_icon_if_owned(next_icon, next_icon_owned);
+    }
+    moonbit_tray_set_message(state->last_error, sizeof(state->last_error), "Shell_NotifyIconW(NIM_MODIFY) failed");
+    return 0;
+  }
+  moonbit_tray_commit_icon(state, next_icon, next_icon_owned);
+  moonbit_tray_clear_message(state->last_error, sizeof(state->last_error));
+  return 1;
+#elif defined(__linux__)
+  return moonbit_tray_linux_apply_icon(state, icon);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_apply_icon(state, icon);
+#else
+  (void)icon;
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_begin(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_begin_menu(state);
+#elif defined(__linux__)
+  return moonbit_tray_linux_begin_menu(state);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_begin_menu(state);
+#else
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu is unsupported on this platform");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_add_normal(
+    int64_t handle,
+    moonbit_bytes_t id,
+    moonbit_bytes_t label,
+    int32_t enabled) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      0,
+      0);
+#elif defined(__linux__)
+  return moonbit_tray_linux_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      0,
+      0);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      0);
+#else
+  (void)id;
+  (void)label;
+  (void)enabled;
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_add_checkbox(
+    int64_t handle,
+    moonbit_bytes_t id,
+    moonbit_bytes_t label,
+    int32_t enabled,
+    int32_t checked) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      checked,
+      1);
+#elif defined(__linux__)
+  return moonbit_tray_linux_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      checked,
+      1);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_append_clickable_menu_item(
+      state,
+      id,
+      label,
+      enabled,
+      checked);
+#else
+  (void)id;
+  (void)label;
+  (void)enabled;
+  (void)checked;
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_add_separator(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_add_separator(state);
+#elif defined(__linux__)
+  return moonbit_tray_linux_add_separator(state);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_add_separator(state);
+#else
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_begin_submenu(
+    int64_t handle,
+    moonbit_bytes_t label,
+    int32_t enabled) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_begin_submenu(state, label, enabled);
+#elif defined(__linux__)
+  return moonbit_tray_linux_begin_submenu(state, label, enabled);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_begin_submenu(state, label, enabled);
+#else
+  (void)label;
+  (void)enabled;
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_end_submenu(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_end_submenu(state);
+#elif defined(__linux__)
+  return moonbit_tray_linux_end_submenu(state);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_end_submenu(state);
+#else
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_menu_commit(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return 0;
+  }
+#ifdef _WIN32
+  return moonbit_tray_win_commit_menu(state);
+#elif defined(__linux__)
+  return moonbit_tray_linux_commit_menu(state);
+#elif defined(__APPLE__)
+  return moonbit_tray_macos_commit_menu(state);
+#else
+  moonbit_tray_set_message(
+      state->last_error,
+      sizeof(state->last_error),
+      "tray menu transaction is not active");
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT void moonbit_tray_menu_abort(int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return;
+  }
+#ifdef _WIN32
+  moonbit_tray_win_destroy_pending_menu(state);
+#elif defined(__linux__)
+  moonbit_tray_linux_destroy_pending_menu(state);
+#elif defined(__APPLE__)
+  moonbit_tray_macos_destroy_pending_menu(state);
+#else
+  (void)state;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int32_t moonbit_tray_pump(
+    int64_t handle,
+    int32_t blocking) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return -1;
+  }
+#ifdef _WIN32
+  MSG message;
+  BOOL has_message;
+  if (blocking) {
+    has_message = GetMessageW(&message, NULL, 0, 0);
+    if (has_message <= 0) {
+      return 0;
+    }
+  } else {
+    has_message = PeekMessageW(&message, NULL, 0, 0, PM_REMOVE);
+    if (!has_message) {
+      return 1;
+    }
+  }
+  TranslateMessage(&message);
+  DispatchMessageW(&message);
+  return 1;
+#elif defined(__linux__)
+  (void)state;
+  moonbit_tray_linux_backend.gtk_main_iteration_do(blocking ? 1 : 0);
+  return 1;
+#elif defined(__APPLE__)
+  {
+    moonbit_tray_id pool = moonbit_tray_macos_new_pool();
+    moonbit_tray_id until = blocking
+        ? moonbit_tray_macos_send_id(
+              moonbit_tray_macos_class("NSDate"),
+              "distantFuture")
+        : moonbit_tray_macos_send_id(
+              moonbit_tray_macos_class("NSDate"),
+              "distantPast");
+    moonbit_tray_id event = moonbit_tray_macos_send_id_ulong_id_id_bool(
+        state->app,
+        "nextEventMatchingMask:untilDate:inMode:dequeue:",
+        ULONG_MAX,
+        until,
+        moonbit_tray_macos_string("kCFRunLoopDefaultMode"),
+        (moonbit_tray_bool)1);
+    if (event != NULL) {
+      moonbit_tray_macos_send_void_id(state->app, "sendEvent:", event);
+    }
+    moonbit_tray_macos_drain_pool(pool);
+    return 1;
+  }
+#else
+  (void)blocking;
+  return -1;
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_poll_event_json(
+    int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL || state->event_count == 0) {
+    return moonbit_tray_copy_message("");
+  }
+  const char *event_json = state->events[state->event_head];
+  moonbit_bytes_t result = moonbit_tray_copy_message(event_json);
+  state->events[state->event_head][0] = '\0';
+  state->event_head = (state->event_head + 1) % MOONBIT_TRAY_MAX_EVENTS;
+  state->event_count--;
+  return result;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_last_error(
+    int64_t handle) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state == NULL) {
+    return moonbit_tray_copy_message("tray state is null");
+  }
+  return moonbit_tray_copy_message(state->last_error);
+}

--- a/sys/tray/tray_test.mbt
+++ b/sys/tray/tray_test.mbt
@@ -1,0 +1,65 @@
+///|
+test "default identifier is stable" {
+  inspect(@tray.default_identifier(), content="moonbit-tray")
+}
+
+///|
+test "support probe stays consistent" {
+  let supported = @tray.is_supported()
+  let ensured = @tray.ensure_supported()
+  if supported {
+    debug_inspect(ensured, content="Ok(())")
+  } else {
+    guard ensured is Err(_) else {
+      fail("ensure_supported should return an error when support probe fails")
+    }
+  }
+}
+
+///|
+test "public menu constructors expose v1 item kinds" {
+  debug_inspect(
+    @tray.TrayMenuItem::normal(id="show", label="Show").kind(),
+    content="Normal",
+  )
+  debug_inspect(
+    @tray.TrayMenuItem::checkbox(id="launch", label="Launch", checked=true).kind(),
+    content="Checkbox",
+  )
+  debug_inspect(@tray.TrayMenuItem::separator().kind(), content="Separator")
+  debug_inspect(
+    @tray.TrayMenuItem::submenu(label="More", items=[
+      @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+    ]).kind(),
+    content="Submenu",
+  )
+}
+
+///|
+test "public tray event helpers expose event names and item ids" {
+  inspect(@tray.TrayEvent::Click.event_name(), content="click")
+  inspect(@tray.TrayEvent::RightClick.event_name(), content="rightClick")
+  inspect(@tray.TrayEvent::DoubleClick.event_name(), content="doubleClick")
+  let event = @tray.TrayEvent::MenuItemClick("show")
+  inspect(event.event_name(), content="menuItemClick")
+  debug_inspect(event.item_id(), content="Some(\"show\")")
+}
+
+///|
+test "native integration stays opt in" {
+  guard @env.get_env_var("MOONBIT_TRAY_RUN_NATIVE_TESTS") is Some("1") else {
+    inspect("skipped", content="skipped")
+    return ()
+  }
+  let tray = match @tray.create(tooltip="MoonBit tray integration") {
+    Ok(tray) => tray
+    Err(error) => fail(error)
+  }
+  debug_inspect(tray.show(), content="Ok(true)")
+  debug_inspect(
+    tray.set_tooltip("MoonBit tray integration updated"),
+    content="Ok(true)",
+  )
+  debug_inspect(tray.hide(), content="Ok(false)")
+  tray.destroy()
+}

--- a/sys/tray/tray_wbtest.mbt
+++ b/sys/tray/tray_wbtest.mbt
@@ -1,0 +1,331 @@
+///|
+extern "C" fn test_icon_path_ffi() -> Bytes = "moonbit_tray_test_icon_path"
+
+///|
+#borrow(path)
+extern "C" fn test_remove_file_ffi(path : Bytes) -> Bool = "moonbit_tray_test_remove_file"
+
+///|
+/// Builds a simulated tray value for white-box state transition tests.
+fn create_simulated_tray(
+  identifier? : String = default_identifier(),
+  icon? : String? = None,
+  tooltip? : String = "",
+  platform? : Platform = current_platform(),
+) -> Tray {
+  {
+    handle: zero_handle(),
+    native: false,
+    platform,
+    identifier: normalize_identifier(identifier),
+    icon,
+    tooltip,
+    menu: [],
+    events: [],
+    visible: false,
+    destroyed: false,
+  }
+}
+
+///|
+test "identifier normalization falls back to the default" {
+  inspect(normalize_identifier("   "), content="moonbit-tray")
+  inspect(normalize_identifier(" app.tray "), content="app.tray")
+}
+
+///|
+test "simulated tray lifecycle updates visible state" {
+  let tray = create_simulated_tray(
+    identifier="demo",
+    icon=Some("demo.ico"),
+    tooltip="initial",
+    platform=Windows,
+  )
+  debug_inspect((tray.visible, tray.tooltip), content="(false, \"initial\")")
+  inspect(tray.identifier(), content="demo")
+  inspect(tray.platform(), content="Windows")
+  debug_inspect(tray.icon(), content="Some(\"demo.ico\")")
+  inspect(tray.tooltip(), content="initial")
+  inspect(tray.is_visible(), content="false")
+  inspect(tray.visible(), content="false")
+  debug_inspect(tray.show(), content="Ok(true)")
+  debug_inspect((tray.visible, tray.tooltip), content="(true, \"initial\")")
+  inspect(tray.is_visible(), content="true")
+  debug_inspect(tray.set_tooltip("updated"), content="Ok(true)")
+  debug_inspect((tray.tooltip(), tray.visible()), content="(\"updated\", true)")
+  debug_inspect((tray.visible, tray.tooltip), content="(true, \"updated\")")
+  inspect(tray.tooltip(), content="updated")
+  debug_inspect(tray.set_icon(None), content="Ok(true)")
+  debug_inspect((tray.visible, tray.icon), content="(true, None)")
+  debug_inspect(tray.icon(), content="None")
+  debug_inspect((tray.icon(), tray.visible()), content="(None, true)")
+  debug_inspect(tray.hide(), content="Ok(false)")
+  inspect(tray.visible(), content="false")
+}
+
+///|
+test "show can replace the tooltip inline" {
+  let tray = create_simulated_tray(tooltip="before", platform=MacOS)
+  debug_inspect(tray.show(tooltip=Some("after")), content="Ok(true)")
+  debug_inspect((tray.tooltip, tray.visible), content="(\"after\", true)")
+}
+
+///|
+test "menu item validation rejects invalid clickable items" {
+  debug_inspect(
+    validate_menu([
+      TrayMenuItem::normal(id="show", label="Show"),
+      TrayMenuItem::separator(),
+      TrayMenuItem::checkbox(id="launch", label="Launch", checked=true),
+      TrayMenuItem::submenu(label="More", items=[
+        TrayMenuItem::normal(id="settings", label="Settings"),
+      ]),
+    ]),
+    content="Ok(())",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id="", label="Show")]),
+    content="Err(\"tray menu item id must not be empty\")",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id=" show ", label="Show")]),
+    content="Err(\"tray menu item id must not have leading or trailing whitespace\")",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id="show", label="  ")]),
+    content="Err(\"tray menu item label must not be empty\")",
+  )
+  let nul = @utf8.decode_lossy(Bytes::from_array([0]))
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id="show" + nul, label="Show")]),
+    content="Err(\"tray menu item id must not contain NUL bytes\")",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id="show", label="Show" + nul)]),
+    content="Err(\"tray menu item label must not contain NUL bytes\")",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::submenu(label="More" + nul, items=[])]),
+    content="Err(\"tray submenu label must not contain NUL bytes\")",
+  )
+  let long_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  debug_inspect(
+    validate_menu([TrayMenuItem::normal(id=long_id, label="Show")]),
+    content="Err(\"tray menu item id is too long\")",
+  )
+  debug_inspect(
+    validate_menu([
+      TrayMenuItem::normal(id="show", label="Show"),
+      TrayMenuItem::submenu(label="More", items=[
+        TrayMenuItem::checkbox(id="show", label="Show again"),
+      ]),
+    ]),
+    content="Err(\"tray menu item id must be unique: show\")",
+  )
+  debug_inspect(
+    validate_menu([TrayMenuItem::submenu(label=" ", items=[])]),
+    content="Err(\"tray submenu label must not be empty\")",
+  )
+  let too_many_items : Array[TrayMenuItem] = []
+  for i in 0..<65 {
+    too_many_items.push(TrayMenuItem::normal(id="item-\{i}", label="Item \{i}"))
+  }
+  debug_inspect(
+    validate_menu(too_many_items),
+    content="Err(\"tray menu has too many clickable items\")",
+  )
+  debug_inspect(
+    validate_c_text("tooltip", "hello" + nul),
+    content="Err(\"tray tooltip must not contain NUL bytes\")",
+  )
+}
+
+///|
+test "simulated tray menu replacement updates state" {
+  let tray = create_simulated_tray(platform=Windows)
+  let items = [
+    TrayMenuItem::normal(id="show", label="Show Window"),
+    TrayMenuItem::separator(),
+    TrayMenuItem::checkbox(id="launch", label="Launch", checked=true),
+    TrayMenuItem::submenu(label="More", items=[
+      TrayMenuItem::normal(id="settings", label="Settings"),
+    ]),
+  ]
+  debug_inspect(tray.set_menu(items), content="Ok(false)")
+  inspect(tray.menu.length(), content="4")
+  debug_inspect(tray.menu[2].kind(), content="Checkbox")
+  debug_inspect(tray.menu[3].kind(), content="Submenu")
+  let stored = tray.menu_items()
+  inspect(stored.length(), content="4")
+  items[0] = TrayMenuItem::normal(id="mutated", label="Mutated")
+  stored[0] = TrayMenuItem::normal(id="mutated-copy", label="Mutated Copy")
+  match tray.menu[0] {
+    Normal(id~, label~, ..) =>
+      inspect(id + ":" + label, content="show:Show Window")
+    _ => fail("expected normal menu item")
+  }
+}
+
+///|
+test "simulated tray event queue drains once" {
+  let tray = create_simulated_tray(platform=Windows)
+  tray.events.push(Click)
+  tray.events.push(RightClick)
+  tray.events.push(DoubleClick)
+  tray.events.push(MenuItemClick("show"))
+  debug_inspect(
+    tray.drain_events(),
+    content=(
+      #|[Click, RightClick, DoubleClick, MenuItemClick("show")]
+    ),
+  )
+  debug_inspect(tray.drain_events(), content="[]")
+}
+
+///|
+test "native event JSON decodes known events" {
+  debug_inspect(decode_event("{\"type\":\"click\"}"), content="Some(Click)")
+  debug_inspect(
+    decode_event("{\"type\":\"rightClick\"}"),
+    content="Some(RightClick)",
+  )
+  debug_inspect(
+    decode_event("{\"type\":\"doubleClick\"}"),
+    content="Some(DoubleClick)",
+  )
+  debug_inspect(
+    decode_event("{\"type\":\"menuItemClick\",\"item_id\":\"show\"}"),
+    content="Some(MenuItemClick(\"show\"))",
+  )
+  debug_inspect(decode_event("{\"type\":\"menuItemClick\"}"), content="None")
+}
+
+///|
+test "native hidden operations stay usable when backend is available" {
+  if is_supported() {
+    let tray = match
+      create(identifier="justjavac.tray.test", tooltip="hidden") {
+      Ok(tray) => tray
+      Err(error) => fail(error)
+    }
+    debug_inspect(
+      (tray.native, tray.visible, tray.destroyed),
+      content="(true, false, false)",
+    )
+    debug_inspect(tray.set_tooltip("hidden updated"), content="Ok(false)")
+    debug_inspect(tray.set_icon(None), content="Ok(false)")
+    match tray.set_menu([TrayMenuItem::normal(id="show", label="Show")]) {
+      Ok(visible) => {
+        match current_platform() {
+          Windows | Linux | MacOS => ()
+          Unknown => fail("expected known native tray platform")
+        }
+        inspect(visible, content="false")
+      }
+      Err(error) => assert_true(error.contains("unsupported"))
+    }
+    debug_inspect(tray.drain_events(), content="[]")
+    debug_inspect(tray.hide(), content="Ok(false)")
+    debug_inspect(tray.pump(), content="Ok(true)")
+    tray.destroy()
+    debug_inspect((tray.native, tray.destroyed), content="(false, true)")
+  } else {
+    inspect("unsupported", content="unsupported")
+  }
+}
+
+///|
+test "native macos custom icon path stays usable" {
+  guard @env.get_env_var("MOONBIT_TRAY_RUN_NATIVE_TESTS") is Some("1") &&
+    current_platform() is MacOS else {
+    inspect("skipped", content="skipped")
+    return ()
+  }
+  if !is_supported() {
+    inspect("unsupported", content="unsupported")
+    return ()
+  }
+  let icon_path = decode_bytes(test_icon_path_ffi()).unwrap_or("")
+  guard !icon_path.is_empty() else { fail("failed to create test tray icon") }
+  let tray = match
+    create(
+      identifier="justjavac.tray.test.icon",
+      icon=Some(icon_path),
+      tooltip="custom icon",
+    ) {
+    Ok(tray) => tray
+    Err(error) => {
+      ignore(test_remove_file_ffi(encode_text(icon_path)))
+      fail(error)
+    }
+  }
+  match tray.icon {
+    Some(path) => assert_eq(path, icon_path)
+    None => fail("custom icon path was not stored")
+  }
+  debug_inspect(tray.set_icon(Some(icon_path)), content="Ok(false)")
+  debug_inspect(tray.show(), content="Ok(true)")
+  debug_inspect(tray.set_icon(Some(icon_path)), content="Ok(true)")
+  debug_inspect(tray.hide(), content="Ok(false)")
+  tray.destroy()
+  ignore(test_remove_file_ffi(encode_text(icon_path)))
+}
+
+///|
+test "linux missing icon path returns an error" {
+  if is_supported() && current_platform() == Linux {
+    match
+      create(
+        identifier="justjavac.tray.test.missing-icon",
+        icon=Some(
+          "/tmp/moonbit-tray-missing-icon-7f324d1f85b741a99b2c-does-not-exist.png",
+        ),
+        tooltip="missing icon",
+      ) {
+      Ok(tray) => {
+        tray.destroy()
+        fail("expected missing Linux icon path to fail")
+      }
+      Err(error) => inspect(error, content="tray icon file is not readable")
+    }
+    match
+      create(
+        identifier="justjavac.tray.test.missing-relative-icon",
+        icon=Some(
+          "moonbit-tray-missing-icon-7f324d1f85b741a99b2c-does-not-exist.png",
+        ),
+        tooltip="missing relative icon",
+      ) {
+      Ok(tray) => {
+        tray.destroy()
+        fail("expected missing Linux relative icon path to fail")
+      }
+      Err(error) => inspect(error, content="tray icon file is not readable")
+    }
+  } else {
+    inspect("skipped", content="skipped")
+  }
+}
+
+///|
+test "destroy prevents later operations" {
+  let tray = create_simulated_tray(platform=Linux)
+  tray.destroy()
+  debug_inspect((tray.visible, tray.destroyed), content="(false, true)")
+  debug_inspect(tray.show(), content="Err(\"tray handle has been destroyed\")")
+  debug_inspect(tray.hide(), content="Err(\"tray handle has been destroyed\")")
+  debug_inspect(
+    tray.set_tooltip("ignored"),
+    content="Err(\"tray handle has been destroyed\")",
+  )
+  debug_inspect(
+    tray.set_icon(Some("icon.png")),
+    content="Err(\"tray handle has been destroyed\")",
+  )
+  debug_inspect(
+    tray.set_menu([TrayMenuItem::normal(id="show", label="Show")]),
+    content="Err(\"tray handle has been destroyed\")",
+  )
+  debug_inspect(tray.drain_events(), content="[]")
+  debug_inspect(tray.pump(), content="Err(\"tray handle has been destroyed\")")
+}


### PR DESCRIPTION
## Summary

Move the six `justjavac/*` native system binding packages used by the extensions into this repository as independently maintained modules under `sys/`:

- `sys/auto_launch` → `justjavac/auto_launch@0.1.3`
- `sys/clipboard` → `justjavac/clipboard@0.1.5`
- `sys/global_hotkey` → `justjavac/global_hotkey@0.1.4`
- `sys/keepawake` → `justjavac/keepawake@0.1.0`
- `sys/microphone` → `justjavac/microphone@0.1.3`
- `sys/tray` → `justjavac/tray@0.1.7`

Each module keeps its upstream name, version lineage, MIT license, and READMEs. Workspace membership overrides the Mooncakes editions, so `extensions/` builds against the in-repo sources with **zero changes** to its manifests. `justjavac/ffi`, `justjavac/case`, `justjavac/ci`, `justjavac/template`, and `justjavac/cdp` stay external.

The vendored sources were diffed file-by-file against the published Mooncakes versions; the only deviations are deliberate toolchain adaptations:

- Manual `Show` impls on public `Platform`/`AutoLaunchError` (deprecated `derive(Show)`), output unchanged; internal types derive only `Debug`/`Eq`.
- `StringView.to_string()` → `to_owned()` (3 sites).
- `try?` captures → `Ok(...) catch { e => Err(e) }` where tests keep the `Result` as data; cleanup suppression via `catch`.
- One snapshot moved from `inspect` to `debug_inspect`.
- `derive(Debug)` additions required by the current `assert_eq`.
- `ffi` requirement aligned at `0.2.3` across all modules (the resolver already picked it).

## Platform impact

No native code changes: per-platform C stubs (`*_macos.c` / `*_windows.c` / `*_linux.c`) are vendored verbatim. Publishing notes for the six modules are documented in `AGENTS.md` (they are republished from this repo only when their sources change).

## Validation

- `moon check --target native` — 0 errors, 0 warnings
- `moon test --target native` — 443/443 passed
- `moon test -p justjavac/auto_launch justjavac/clipboard justjavac/global_hotkey justjavac/keepawake justjavac/microphone justjavac/tray --target native` — 114/114 passed
- `moon fmt --check` — clean
- `node scripts/verify_generated.mjs` — OK