### PR TITLE
fix(e2e): retry transient dev-extension startup failures on CI

### DIFF
--- a/e2e/test/dev_extension_process_wbtest.mbt
+++ b/e2e/test/dev_extension_process_wbtest.mbt
@@ -498,9 +498,14 @@ async fn run_dev_extension_scenario_with_retry(
 fn retryable_dev_extension_error(error : Error) -> Bool {
   // This scenario deliberately reloads and replaces its direct page target.
   // On a loaded CI runner CEF can close the old page WebSocket just before the
-  // reconnect loop takes ownership.  Recreate the isolated scenario once;
-  // persistent transport closures still fail on the second attempt.
-  retryable_scenario_error(error)
+  // reconnect loop takes ownership, and a CDP command issued against the
+  // dying target then surfaces as CommandFailed.  Recreate the isolated
+  // scenario once; persistent transport closures still fail on the second
+  // attempt.
+  match error {
+    @client.BrowserError::CommandFailed(_, _) => true
+    _ => retryable_scenario_error(error)
+  }
 }
 
 ///|
@@ -508,7 +513,17 @@ test "dev extension retry classification stays narrow" {
   assert_true(retryable_dev_extension_error(@io.ReaderClosed))
   assert_true(
     retryable_dev_extension_error(
+      @client.BrowserError::CommandFailed(-32000, "Target closed"),
+    ),
+  )
+  assert_true(
+    retryable_dev_extension_error(
       Failure::Failure("scenario app exited before CDP became ready"),
+    ),
+  )
+  assert_false(
+    retryable_dev_extension_error(
+      @client.BrowserError::InvalidField("sessionId"),
     ),
   )
   assert_false(

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -645,9 +645,13 @@ fn retryable_startup_error(error : Error) -> Bool {
   // Retry only failures emitted by the explicit startup waiters.  Transport
   // retry classification is handled by retryable_scenario_error using typed
   // errors; broad text matches such as "connection reset" would hide bugs.
+  // The navigation waiter covers the page load right after Page.navigate,
+  // which can stall on a loaded CI runner while the local server and CEF
+  // settle.
   text.contains("scenario app exited before cdp became ready") ||
   text.contains("cdp endpoint did not start within") ||
-  text.contains("cdp page target did not become ready within")
+  text.contains("cdp page target did not become ready within") ||
+  text.contains("timed out waiting for navigation to")
 }
 
 ///|

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -51,6 +51,13 @@ test "scenario retries only startup and closed CDP transports" {
       Failure::Failure("scenario app exited before CDP became ready"),
     ),
   )
+  assert_true(
+    retryable_scenario_error(
+      Failure::Failure(
+        "timed out waiting for navigation to http://127.0.0.1:8080/probe.html",
+      ),
+    ),
+  )
   assert_false(
     retryable_scenario_error(Failure::Failure("connected CDP probe failed")),
   )


### PR DESCRIPTION
## Summary

The headless `47_dev_extension_js` e2e flaked on `ubuntu-latest` twice out of three recent runs (PR #65 checks and the subsequent `main` run), with two transient signatures that both escaped the scenario retry classification:

1. `BrowserError.CommandFailed` — a CDP command issued against the page target this scenario deliberately reloads and replaces; on a loaded runner CEF can close the old target's WebSocket mid-command.
2. `timed out waiting for navigation to http://127.0.0.1:.../probe.html` — the shared navigation waiter stalling while the local server and CEF settle.

Both are the same class of startup race the scenario-level retry (one fresh attempt) already exists for, but the classification rejected them, so the first transient failure killed the test.

## Changes

- `retryable_dev_extension_error` (`e2e/test/dev_extension_process_wbtest.mbt`): treat `@client.BrowserError::CommandFailed` as retryable, scoped to this scenario whose reload/replace dance makes it expected-transient. Other `BrowserError` variants stay non-retryable.
- `retryable_startup_error` (`e2e/test/orchestration_wbtest.mbt`): add the shared navigation waiter's timeout message to the explicit startup-waiter patterns, so every scenario recreates its isolated environment once before failing.
- Classification unit tests updated: new retryable cases asserted, plus `InvalidField` and probe assertion failures asserted non-retryable to keep the classification narrow.

No production code changes; test-orchestration only.

## Validation

- `moon -C e2e test -p justjavac/proton/e2e/test --target native --no-parallelize` — 17/17 passed locally (macOS)
- `moon -C e2e check --target native` — clean
- `moon fmt --check` — clean
