### PR TITLE
ci: cache MoonBit build artifacts across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,21 @@ jobs:
         run: |
           moon version --all
 
+      # Restore the compiled dependency graph and registry downloads so the
+      # CLI install, framework checks, examples, and e2e steps start warm.
+      # Bump the epoch (v1) when a MoonBit toolchain upgrade misbehaves with
+      # a stale _build.
+      - name: Cache MoonBit build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            _build
+            .mooncakes
+          key: moon-${{ matrix.os }}-v1-${{ hashFiles('moon.work', '**/moon.mod', '**/moon.pkg') }}
+          restore-keys: |
+            moon-${{ matrix.os }}-v1-
+            moon-${{ matrix.os }}-
+
       - name: moon update
         run: |
           moon update


### PR DESCRIPTION
## Summary

Every moon step in the `moonbit` matrix job recompiled the same dependency graph from a cold `_build`: the `Install Proton CLI` step alone spent ~56-93s on Unix and ~112-153s on Windows, and the framework-check / examples / e2e steps paid further warm-up costs. The workflow had no `actions/cache` at all.

This adds one cache step (restored before `moon update`, right after `moon version`):

- **Path**: `_build` + `.mooncakes`
- **Key**: `moon-<os>-v1-<hash of moon.work + all moon.mod/moon.pkg>` — dependency or manifest changes invalidate naturally
- **Restore-keys**: `moon-<os>-v1-`, `moon-<os>-` — a manifest bump falls back to the previous graph and rebuilds only the delta
- **Epoch**: the `v1` segment can be bumped manually if a MoonBit toolchain upgrade misbehaves with a stale `_build`

Expected effect: the CLI install drops to cache-restore time (~20s), and framework check / examples / e2e all start with a warm dependency graph. Estimated ~1.5-2.5 min saved per platform, most visible on Windows. Worst case on a bad cache is a plain rebuild — no correctness risk.

## Validation plan

- First CI run on this PR is cold (cache miss) and saves the cache; a re-run then measures the warm path. Step timings will be compared against the previous `main` run in the PR checks.
- `prettier --check .github/workflows/ci.yml` passes (YAML parse).
