### PR TITLE
fix(cli): check new scaffolds with --target js,native

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,13 +188,14 @@ native checks before handing off larger refactors.
     --identifier "com.example.proton-release-smoke" -y --no-git
   proton_cli -C "$tmp_dir/release-smoke" cef setup
   proton_cli -C "$tmp_dir/release-smoke" build
-  proton_cli -C "$tmp_dir/release-smoke" package app --dry-run
-  proton_cli -C "$tmp_dir/release-smoke" package app
+  proton_cli -C "$tmp_dir/release-smoke" package --target app --dry-run
+  proton_cli -C "$tmp_dir/release-smoke" package --target app
   ```
 
-- The release is not complete until the independent scaffold passes its default
-  `moon check`, native build, package-plan validation, and real package creation
-  using registry dependencies and the setup-managed runtime.
+- The release is not complete until the independent scaffold passes
+  `moon check --target js,native`, native build, package-plan validation, and
+  real package creation using registry dependencies and the setup-managed
+  runtime.
 
 ## Coding Conventions
 - Use MoonBit with 2-space indentation and `///|` top-level separators.

--- a/cli/new/new_project.mbt
+++ b/cli/new/new_project.mbt
@@ -524,7 +524,7 @@ async fn run_moon_check(
   project_dir : String,
 ) -> Unit raise NewProjectToolError {
   let (code, data) = @process.collect_output_merged("moon", [
-    "-C", project_dir, "check", "--diagnostic-limit", "80",
+    "-C", project_dir, "check", "--target", "js,native", "--diagnostic-limit", "80",
   ]) catch {
     err => raise Start(tool="moon check", detail=@debug.render(Repr(err)))
   }

--- a/cli/new/templates.generated.mbt
+++ b/cli/new/templates.generated.mbt
@@ -771,7 +771,7 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|## Commands
           #|
           #|- Format with `moon fmt`.
-          #|- Check with `moon check --diagnostic-limit 80`.
+          #|- Check with `moon check --target js,native --diagnostic-limit 80`.
           #|- Run with `proton_cli dev` from the project root.
           #|- Build with `proton_cli build`.
           #|- Inspect packaging with `proton_cli package --dry-run`.
@@ -812,7 +812,7 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|## Check
           #|
           #|```sh
-          #|moon check --diagnostic-limit 80
+          #|moon check --target js,native --diagnostic-limit 80
           #|```
           #|
           #|## Dev

--- a/cli/new/templates/todo/files/AGENTS.md.mtpl
+++ b/cli/new/templates/todo/files/AGENTS.md.mtpl
@@ -5,7 +5,7 @@ This is a MoonBit Proton native desktop app.
 ## Commands
 
 - Format with `moon fmt`.
-- Check with `moon check --diagnostic-limit 80`.
+- Check with `moon check --target js,native --diagnostic-limit 80`.
 - Run with `proton_cli dev` from the project root.
 - Build with `proton_cli build`.
 - Inspect packaging with `proton_cli package --dry-run`.

--- a/cli/new/templates/todo/files/README.md.mtpl
+++ b/cli/new/templates/todo/files/README.md.mtpl
@@ -17,7 +17,7 @@ proton_cli cef setup
 ## Check
 
 ```sh
-moon check --diagnostic-limit 80
+moon check --target js,native --diagnostic-limit 80
 ```
 
 ## Dev


### PR DESCRIPTION
## Summary

`proton_cli new` runs `moon check` after scaffolding. With recent moon toolchains the default target is wasm, while the generated `shared` package only supports `js` and `native`, so the check fails with `Package '..._shared' does not support target backend 'wasm'` and the whole scaffold is rolled back. Found during the 0.1.10 registry smoke test.

- `cli/new/new_project.mbt`: pin the built-in check to `--target js,native`, the scaffold's actual targets.
- Template `README.md` / `AGENTS.md`: update the documented check command so users don't hit the same failure manually; regenerated `templates.generated.mbt`.
- Root `AGENTS.md`: fix the stale release-smoke commands (`proton_cli package app ...` → `proton_cli package --target app ...`; positional `app` is rejected by the published CLI).

## Platform impact

None — CLI scaffolding path only; no native runtime or ABI changes.

## Validation

- `node scripts/verify_generated.mjs`
- `moon -C cli test new --target native` (19/19)
- `moon fmt`
- End-to-end: built the local CLI and ran `proton new` in a temp dir — scaffold commits successfully with `moon check completed successfully.`
- Full registry smoke before the fix (`proton_cli 0.1.10`): `cef setup`, `dev`, `build`, `package --target app` all pass on darwin-arm64; packaged `.app` launches.