### PR TITLE
refactor: use core env arguments

### DIFF
--- a/e2e/test/moon.pkg
+++ b/e2e/test/moon.pkg
@@ -18,7 +18,6 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/x/fs" @mbfs,
   "moonbitlang/x/path",
-  "moonbitlang/x/sys",
 } for "wbtest"
 
 supported_targets = "native"

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -299,7 +299,7 @@ fn scenario_app_command(root : String) -> (String, Array[String]) raise {
 
 ///|
 fn current_test_executable() -> String raise {
-  let args = @sys.get_cli_args()
+  let args = @env.args()
   guard args.length() > 0 else { fail("test executable path is unavailable") }
   let executable = normalize_platform_path(args[0])
   let path = @path.Path(executable)

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -146,7 +146,7 @@ fn implicit_config_path() -> String? {
 
 ///|
 fn bundled_config_path() -> String? {
-  let argv = @sys.get_cli_args()
+  let argv = @env.args()
   guard argv.length() > 0 else { return None }
   let executable : @mbpath.Path = argv[0]
   let executable = executable.resolve()

--- a/proton/moon.pkg
+++ b/proton/moon.pkg
@@ -9,7 +9,6 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/x/fs" @mbfs,
   "moonbitlang/x/path" @mbpath,
-  "moonbitlang/x/sys",
   "justjavac/proton/bootstrap",
   "justjavac/proton/command" @proton_command,
   "justjavac/proton/core",


### PR DESCRIPTION
## Summary

- replace `@sys.get_cli_args()` with the core `@env.args()` API in Proton config discovery and E2E orchestration
- remove the now-unused `moonbitlang/x/sys` package imports

## Impact

This keeps command-line argument lookup on the MoonBit core API without changing runtime behavior or public Proton APIs.

## Validation

- `moon -C proton check --target native --diagnostic-limit 20`
- `moon -C e2e test test/orchestration_wbtest.mbt --target native --build-only --diagnostic-limit 20`
- `moon fmt --check`
- `git diff --check`