### PR TITLE
fix(cli): keep the dev runtime bin directory on the app PATH on Windows

### DIFF
--- a/cli/dev/dev.mbt
+++ b/cli/dev/dev.mbt
@@ -529,6 +529,74 @@ fn dev_frontend_process_env(
 }
 
 ///|
+/// Finalizes the environment for the app child process on Windows.
+///
+/// `@process.run` appends the inherited environment block after `extra_env`,
+/// so the block handed to `moon` contains every overridden variable twice.
+/// `moon` launches the app through Rust's process API, which rebuilds the
+/// environment block and keeps the *last* duplicate of each variable; the
+/// inherited original `Path` therefore shadows the prepended runtime `bin`
+/// directory and the app exits immediately with 0xC0000135 because
+/// `proton.dll` and the CEF libraries are not on its DLL search path.
+/// Returning a complete environment with the overrides applied and spawning
+/// with `inherit_env=false` keeps exactly one entry per variable, so the
+/// runtime `bin` directory survives the handoff.
+#cfg(platform="windows")
+fn dev_app_spawn_env(
+  overrides : Map[String, String],
+) -> (Map[String, String], Bool) {
+  let env = dev_windows_parent_env()
+  for key, value in overrides {
+    // Variable names are case-insensitive on Windows; drop any inherited
+    // spelling of an overridden name so only one entry remains.
+    for existing in env.keys().collect() {
+      if existing != key && existing.to_lower() == key.to_lower() {
+        env.remove(existing)
+      }
+    }
+    env[key] = value
+  }
+  (env, false)
+}
+
+///|
+/// Non-Windows platforms keep the existing behavior: the child inherits the
+/// parent environment and `extra_env` carries the overrides, leaving the
+/// established rpath and loader-variable handling untouched.
+#cfg(not(platform="windows"))
+fn dev_app_spawn_env(
+  overrides : Map[String, String],
+) -> (Map[String, String], Bool) {
+  (overrides, true)
+}
+
+///|
+#cfg(platform="windows")
+extern "C" fn dev_windows_env_block() -> String = "proton_cli_dev_env_block"
+
+///|
+/// Reads the parent process environment block with the original variable
+/// names and values preserved. The wide-character block is used instead of
+/// `@sys.get_env_vars` so non-ASCII values survive the round trip into the
+/// child process environment.
+#cfg(platform="windows")
+fn dev_windows_parent_env() -> Map[String, String] {
+  let env : Map[String, String] = Map([])
+  for entry in dev_windows_env_block().split("\u{0}") {
+    match entry.split_once("=") {
+      Some((key, value)) =>
+        // Nameless entries are per-drive current-directory records such as
+        // `=C:`; the child defaults them to its own working directory.
+        if key != "" {
+          env[key.to_owned()] = value.to_owned()
+        }
+      None => ()
+    }
+  }
+  env
+}
+
+///|
 fn path_env_key() -> String {
   if @path.sep == '\\' {
     match @sys.get_env_var("Path") {
@@ -946,7 +1014,14 @@ async fn run_app(
     }
   }
   @output.info("Starting Proton app: moon " + moon_args.join(" "))
-  let code = @process.run("moon", moon_args, cwd=root, extra_env=env) catch {
+  let (spawn_env, inherit_env) = dev_app_spawn_env(env)
+  let code = @process.run(
+    "moon",
+    moon_args,
+    cwd=root,
+    extra_env=spawn_env,
+    inherit_env~,
+  ) catch {
     err => raise Start(role="MoonBit app", detail=@debug.render(Repr(err)))
   }
   code

--- a/cli/dev/dev_env_block.c
+++ b/cli/dev/dev_env_block.c
@@ -1,0 +1,38 @@
+#include <string.h>
+
+#include "moonbit.h"
+
+/*
+ * Keep this stub limited to reading the raw process environment block.
+ * Parsing, override merging, and child-process spawn policy belong in
+ * dev.mbt.
+ */
+#ifdef _WIN32
+#include <windows.h>
+
+/*
+ * Returns the current process environment block as a MoonBit string of
+ * UTF-16 code units, keeping each embedded NUL separator. The result ends
+ * with the NUL that terminates the last entry; the final block terminator
+ * is not included.
+ *
+ * moonbitlang/x/sys get_env_vars() reads the ANSI environment block, which
+ * mangles non-ASCII values before they are re-encoded for a child process.
+ * Reading the wide block here keeps every inherited value intact.
+ */
+MOONBIT_FFI_EXPORT moonbit_string_t proton_cli_dev_env_block(void) {
+  LPWCH env_block = GetEnvironmentStringsW();
+  if (env_block == NULL) {
+    return moonbit_make_string(0, 0);
+  }
+
+  int len = 1;
+  while (env_block[len - 1] != 0 || env_block[len] != 0) {
+    ++len;
+  }
+  moonbit_string_t result = moonbit_make_string_raw(len);
+  memcpy(result, env_block, len * sizeof(WCHAR));
+  FreeEnvironmentStringsW(env_block);
+  return result;
+}
+#endif

--- a/cli/dev/dev_wbtest.mbt
+++ b/cli/dev/dev_wbtest.mbt
@@ -325,6 +325,60 @@ test "dev frontend does not inherit the injected CEF preload" {
 }
 
 ///|
+test "dev app spawn env applies overrides to the child environment" {
+  let previous_probe = @sys.get_env_var("PROTON_DEV_SPAWN_PROBE")
+  let previous_keep = @sys.get_env_var("PROTON_DEV_SPAWN_KEEP")
+  defer {
+    match previous_probe {
+      Some(value) => @sys.set_env_var("PROTON_DEV_SPAWN_PROBE", value)
+      None => @sys.unset_env_var("PROTON_DEV_SPAWN_PROBE")
+    }
+    match previous_keep {
+      Some(value) => @sys.set_env_var("PROTON_DEV_SPAWN_KEEP", value)
+      None => @sys.unset_env_var("PROTON_DEV_SPAWN_KEEP")
+    }
+  }
+  @sys.set_env_var("PROTON_DEV_SPAWN_PROBE", "parent-value")
+  @sys.set_env_var("PROTON_DEV_SPAWN_KEEP", "keep-value")
+  let overrides = {
+    "PROTON_DEV_SPAWN_PROBE": "override-value",
+    "PROTON_DEV_SPAWN_EXTRA": "extra-value",
+  }
+  let (env, inherit_env) = dev_app_spawn_env(overrides)
+  @debug.assert_eq(env.get("PROTON_DEV_SPAWN_PROBE"), Some("override-value"))
+  @debug.assert_eq(env.get("PROTON_DEV_SPAWN_EXTRA"), Some("extra-value"))
+  if @path.sep == '\\' {
+    // Windows spawns receive one complete environment so a rebuilt block
+    // cannot shadow overridden variables with inherited duplicates.
+    @debug.assert_eq(inherit_env, false)
+    @debug.assert_eq(env.get("PROTON_DEV_SPAWN_KEEP"), Some("keep-value"))
+  } else {
+    // Other platforms keep inheritance plus overrides untouched.
+    @debug.assert_eq(inherit_env, true)
+    @debug.assert_eq(env.get("PROTON_DEV_SPAWN_KEEP"), None)
+  }
+}
+
+///|
+test "dev app spawn env replaces inherited Windows variable spellings" {
+  if @path.sep == '\\' {
+    let previous = @sys.get_env_var("proton_dev_case_probe")
+    defer (match previous {
+      Some(value) => @sys.set_env_var("proton_dev_case_probe", value)
+      None => @sys.unset_env_var("proton_dev_case_probe")
+    })
+    @sys.set_env_var("proton_dev_case_probe", "parent-value")
+    let (env, _) = dev_app_spawn_env({ "PROTON_DEV_CASE_PROBE": "override" })
+    let spellings = env
+      .keys()
+      .filter(key => key.to_lower() == "proton_dev_case_probe")
+      .collect()
+    @debug.assert_eq(spellings, ["PROTON_DEV_CASE_PROBE"])
+    @debug.assert_eq(env.get("PROTON_DEV_CASE_PROBE"), Some("override"))
+  }
+}
+
+///|
 async test "read dev runtime honors PROTON_NATIVE_DIST override" {
   let root = "target/proton-dev-runtime-env"
   let runtime = create_fake_dev_runtime(root)

--- a/cli/dev/moon.pkg
+++ b/cli/dev/moon.pkg
@@ -21,3 +21,7 @@ import {
 } for "wbtest"
 
 supported_targets = "native"
+
+options(
+  "native-stub": [ "dev_env_block.c" ],
+)


### PR DESCRIPTION
## Problem

On Windows, `proton_cli dev` started the app and it exited immediately with `-1073741515` (0xC0000135, STATUS_DLL_NOT_FOUND). The dev-built `app.exe` links `proton.dll` and the CEF libraries dynamically, and those live only in `.proton/runtimes/<rid>/bin` — never next to the exe.

`dev_process_env` already prepended that `bin` directory to `Path`, but the prepend never survived the process handoff:

1. `moonbitlang/async` appends the inherited environment block **after** `extra_env` when spawning on Windows, so `moon` receives two `Path` entries: prepended first, inherited original second.
2. `moon` launches the app through Rust's process API, which rebuilds the environment block and keeps the **last** duplicate of each variable. The inherited original `Path` wins and the prepend is silently dropped.

## Fix

In `run_app`, build one complete environment for the app process on Windows and spawn `moon` with `inherit_env=false`:

- `cli/dev/dev_env_block.c`: new FFI stub reading the raw environment block via `GetEnvironmentStringsW`. The ANSI-based `x/sys` enumeration would mangle non-ASCII values (e.g. CJK user profiles) on the round trip into the child.
- `dev_app_spawn_env` (platform-split via `#cfg`): on Windows, snapshot the parent environment, apply the dev overrides with case-insensitive name deduplication, and return `inherit_env=false` so every variable appears exactly once and the runtime `bin` directory cannot be shadowed. Non-Windows platforms keep the existing inherit-plus-overrides behavior untouched (rpath / loader variables unchanged).
- Frontend spawn and the runtime-missing error path are unchanged.

## Validation

- Reproduced the crash on Windows with a fresh `proton_cli new` project: `app exited with code -1073741515` before the fix.
- After the fix, on the 0.1.14 release chain (matching reported environment): the app loads all DLLs, CEF initializes (`DevTools listening on ws://127.0.0.1:9222/...`), the window is created and the app reaches entry-page loading (fails only with `ERR_CONNECTION_REFUSED` when the frontend dev server is intentionally not started in the test). No more 0xC0000135.
- New whitebox tests cover override merging and case-insensitive Windows name replacement: `moon -C cli test -p justjavac/proton_cli/dev --target native` → 23/23.
- `moon -C cli check --target native --diagnostic-limit 80` and `moon fmt --check` clean.