### PR TITLE
fix(cli): address macOS release validation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ application built and served by Warren, and `backend/` runs the Proton
 desktop runtime. `.proton/` is a local runtime cache and should not be
 committed.
 
+`cef setup` stores downloaded CEF binaries in a shared user-level cache
+(`~/.proton/cache/cef`, overridable with `PROTON_CEF_CACHE`) so subsequent
+projects reuse the download instead of fetching it again.
+
 ## Application entry
 
 Generated projects explicitly load `moon.proton` with `@proton.config(...)`
@@ -392,6 +396,24 @@ With `--notarize`, Proton submits the DMG when that target is enabled, then
 staples and validates both the DMG and the app before creating any requested
 ZIP archive. Without a `dmg` target, the existing app notarization flow is
 used. Windows supports the `app` and `zip` targets.
+
+### Open an unsigned app on macOS
+
+Apps packaged without `--sign` are ad-hoc signed. When such an app reaches
+another Mac through a download (including ZIP archives produced by the
+`zip` target), Gatekeeper quarantines it and macOS may launch it from a
+randomized App Translocation path. After confirming the app comes from a
+trusted source, remove the quarantine attribute from the top-level bundle:
+
+```sh
+xattr -d com.apple.quarantine "My App.app"
+```
+
+Do not use `xattr -cr`: recent macOS protects `com.apple.provenance`, which
+makes recursive removal fail with `Operation not permitted` without clearing
+the quarantine. Deleting the attribute from the top-level `.app` (or moving
+the app once in Finder) is sufficient. Apps signed and notarized with
+`--sign --notarize` skip this step entirely.
 
 ## Diagnose a project
 

--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -60,6 +60,37 @@ async fn install_cef_root(
 }
 
 ///|
+/// Returns the shared user-level CEF cache directory for `name`, honoring the
+/// `PROTON_CEF_CACHE` override and otherwise defaulting to
+/// `~/.proton/cache/cef`. Returns `None` when no home directory is known, in
+/// which case caching stays project-local.
+fn global_cef_cache_dir(platform : ProtonPlatform, name : String) -> String? {
+  let root = match @env.get_env_var("PROTON_CEF_CACHE") {
+    Some(value) if value.trim().to_owned() != "" => value.trim().to_owned()
+    _ =>
+      match home_directory() {
+        Some(home) => @fsutil.path_join(home, ".proton/cache/cef")
+        None => return None
+      }
+  }
+  Some(@fsutil.path_join(@fsutil.path_join(root, platform.id), name))
+}
+
+///|
+fn home_directory() -> String? {
+  let primary = if @path.sep == '\\' { "USERPROFILE" } else { "HOME" }
+  let fallback = if @path.sep == '\\' { "HOME" } else { "USERPROFILE" }
+  for name in [primary, fallback] {
+    match @env.get_env_var(name) {
+      Some(value) if value.trim().to_owned() != "" =>
+        return Some(value.trim().to_owned())
+      _ => ()
+    }
+  }
+  None
+}
+
+///|
 async fn ensure_cef_cache(
   name : String,
   url : String?,
@@ -79,7 +110,18 @@ async fn ensure_cef_cache(
     install_cef_root(legacy_cache, cache_dir, name, sha256, root, platform)
     return
   }
-  setup_downloaded_cef(name, url, sha256, root, cache_dir, platform)
+  match global_cef_cache_dir(platform, name) {
+    Some(global_cache) if global_cache != cache_dir => {
+      if installed_version(global_cache) == name &&
+        installed_checksum(global_cache) == sha256 {
+        install_cef_root(global_cache, cache_dir, name, sha256, root, platform)
+        return
+      }
+      setup_downloaded_cef(name, url, sha256, root, global_cache, platform)
+      install_cef_root(global_cache, cache_dir, name, sha256, root, platform)
+    }
+    _ => setup_downloaded_cef(name, url, sha256, root, cache_dir, platform)
+  }
 }
 
 ///|

--- a/cli/cef/cef_download.mbt
+++ b/cli/cef/cef_download.mbt
@@ -14,17 +14,44 @@ async fn make_temp_dir() -> String {
 }
 
 ///|
+let cef_download_max_attempts = 3
+
+///|
+let cef_download_retry_delay_ms = 2000
+
+///|
 async fn download_file(
   url : String,
   destination : String,
   expected_sha256 : String,
 ) -> Unit {
   @output.info("[INFO] Downloading CEF: " + url)
-  let code = @process.run("curl", ["-L", "--fail", "--output", destination, url]) catch {
-    err => raise CefDownloadError::Start(url~, detail=@debug.render(Repr(err)))
+  let mut last_code = 1
+  for attempt in 1..<=cef_download_max_attempts {
+    let code = @process.run("curl", [
+      "-L", "--fail", "--retry", "5", "--retry-all-errors", "--retry-delay", "2",
+      "--connect-timeout", "30", "--output", destination, url,
+    ]) catch {
+      err =>
+        raise CefDownloadError::Start(url~, detail=@debug.render(Repr(err)))
+    }
+    if code == 0 {
+      verify_file_sha256(destination, expected_sha256)
+      return
+    }
+    last_code = code
+    if attempt < cef_download_max_attempts {
+      @output.info(
+        "[INFO] CEF download attempt " +
+        attempt.to_string() +
+        " failed (curl exit " +
+        code.to_string() +
+        "); retrying",
+      )
+      @async.sleep(cef_download_retry_delay_ms)
+    }
   }
-  guard code == 0 else { raise CefDownloadError::CurlExit(url~, code~) }
-  verify_file_sha256(destination, expected_sha256)
+  raise CefDownloadError::CurlExit(url~, code=last_code)
 }
 
 ///|

--- a/cli/dev/dev.mbt
+++ b/cli/dev/dev.mbt
@@ -164,6 +164,11 @@ pub async fn run(cwd : String, matches : @argparse.Matches) -> Unit {
     @sys.get_env_var("LD_PRELOAD"),
   )
   @async.with_task_group(group => {
+    // Announce the wait before the frontend child starts writing to the
+    // terminal, so its startup output cannot interleave with this line.
+    if raw.wait_for_dev_server {
+      announce_frontend_server_wait(frontend_url, raw.ready_path)
+    }
     let frontend_process = maybe_start_frontend(
       group,
       frontend_working_dir,
@@ -733,6 +738,23 @@ fn unix_frontend_tree_kill_script() -> String {
 }
 
 ///|
+/// Prints the dev-server wait line. Called before the frontend process
+/// spawns: the child inherits the terminal, and its startup banner would
+/// otherwise race with (and partially overwrite) this line.
+async fn announce_frontend_server_wait(
+  frontend_url : String?,
+  ready_path : String?,
+) -> Unit {
+  match frontend_url {
+    None => ()
+    Some(url) => {
+      let endpoint = parse_dev_url_endpoint(url, ready_path)
+      @output.info("Waiting for frontend dev server: " + endpoint.url)
+    }
+  }
+}
+
+///|
 async fn wait_for_frontend(
   frontend_url : String?,
   ready_path : String?,
@@ -744,7 +766,6 @@ async fn wait_for_frontend(
     Some(url) => {
       let endpoint = parse_dev_url_endpoint(url, ready_path)
       validate_ready_probe(ready_path)
-      @output.info("Waiting for frontend dev server: " + endpoint.url)
       let mut elapsed = 0
       while elapsed <= timeout_ms {
         match frontend_exit_code(frontend_process) {

--- a/cli/new/moon.pkg
+++ b/cli/new/moon.pkg
@@ -5,6 +5,7 @@ import {
   "justjavac/proton_cli/arguments" @cli_args,
   "justjavac/proton_cli/codegen",
   "justjavac/proton_cli/fsutil",
+  "justjavac/proton_cli/output",
   "moonbitlang/async",
   "moonbitlang/async/fs" @async_fs,
   "moonbitlang/async/io",

--- a/cli/new/new_project.mbt
+++ b/cli/new/new_project.mbt
@@ -497,30 +497,71 @@ async fn maybe_init_git(
 }
 
 ///|
+let moon_check_max_attempts = 3
+
+///|
+let moon_check_retry_delay_ms = 2000
+
+///|
 async fn run_moon_check(
   options : NewProjectOptions,
   project_dir : String,
 ) -> Unit raise NewProjectToolError {
-  let (code, data) = @process.collect_output_merged("moon", [
-    "-C", project_dir, "check", "--target", "js,native", "--diagnostic-limit", "80",
-  ]) catch {
-    err => raise Start(tool="moon check", detail=@debug.render(Repr(err)))
-  }
-  let output = data.text() catch {
-    err =>
-      raise Start(tool="moon check output", detail=@debug.render(Repr(err)))
-  }
-  if output != "" {
-    @stdio.stderr.write(output) catch {
-      _ => ()
+  let mut attempt = 1
+  while true {
+    let (code, data) = @process.collect_output_merged("moon", [
+      "-C", project_dir, "check", "--target", "js,native", "--diagnostic-limit",
+      "80",
+    ]) catch {
+      err => raise Start(tool="moon check", detail=@debug.render(Repr(err)))
     }
-  }
-  if code != 0 {
+    let output = data.text() catch {
+      err =>
+        raise Start(tool="moon check output", detail=@debug.render(Repr(err)))
+    }
+    if output != "" {
+      @stdio.stderr.write(output) catch {
+        _ => ()
+      }
+    }
+    if code == 0 {
+      return
+    }
+    if attempt < moon_check_max_attempts &&
+      moon_check_has_transient_network_failure(output) {
+      @output.info(
+        "[INFO] moon check hit a transient network error; retrying (" +
+        (attempt + 1).to_string() +
+        "/" +
+        moon_check_max_attempts.to_string() +
+        ")",
+      )
+      @async.sleep(moon_check_retry_delay_ms) catch {
+        error =>
+          raise Start(
+            tool="moon check retry",
+            detail=@debug.render(Repr(error)),
+          )
+      }
+      attempt = attempt + 1
+      continue
+    }
     if moon_check_has_registry_resolution_failure(output) {
       raise RegistryDependenciesUnavailable(code~, project=options.target_dir)
     }
     raise MoonCheckFailed(code~, project=options.target_dir)
   }
+}
+
+///|
+fn moon_check_has_transient_network_failure(output : String) -> Bool {
+  let lowered = output.to_lower()
+  let markers = [
+    "tls handshake", "channel closed", "request or response body error", "connection reset",
+    "connection refused", "failed to download", "network is unreachable", "temporary failure",
+    "error sending request", "operation timed out",
+  ]
+  markers.any(fn(marker) { lowered.contains(marker) })
 }
 
 ///|

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -480,6 +480,9 @@ fn bool_text(value : Bool) -> String {
 
 ///|
 async fn execute_package_plan(plan : PackagePlan) -> Unit {
+  // Resolve the active runtime before any build work so a missing
+  // `proton_cli cef setup` fails fast instead of after a full release build.
+  let runtime = read_active_runtime(plan.workspace_root)
   if plan.build {
     run_release_build(plan)
   }
@@ -488,7 +491,6 @@ async fn execute_package_plan(plan : PackagePlan) -> Unit {
     None =>
       raise PackagePlanError::MissingExecutable(path=plan.build_target_dir)
   }
-  let runtime = read_active_runtime(plan.workspace_root)
   if @path.sep == '\\' {
     stage_windows_portable(plan, executable, runtime)
   } else if is_macos_host() {


### PR DESCRIPTION
## Summary

Fixes for the non-blocking issues recorded during the 0.1.14/0.1.12 release
validation on macOS (proton-demo PROTON_ISSUES.md):

- **package**: resolve the active runtime *before* the release build, so a
  missing `cef setup` fails fast instead of after a full 82-task build.
- **cef**: retry transient CEF download failures (curl `--retry` plus outer
  attempts) instead of dying on the first network hiccup.
- **cef**: share downloaded CEF binaries through a user-level cache
  (`~/.proton/cache/cef`, overridable with `PROTON_CEF_CACHE`) so new
  projects no longer re-download ~114 MB per project.
- **new**: retry `moon check` when its output shows transient registry /
  network error markers (e.g. `tls handshake eof`, `channel closed`).
- **dev**: print the "Waiting for frontend dev server" line before spawning
  the frontend child, whose startup banner raced with and partially
  overwrote the CLI status line.
- **docs**: record the working macOS quarantine removal command
  (non-recursive `xattr -d com.apple.quarantine`) and the shared CEF cache.

Out of scope (belongs to `moonbit-community/warren` or CEF upstream):
warren terser fallback UX, warren dev-server title injection, IPv6-only
remote debugging.

## Platform impact

- macOS: primary target of the validation; all fixes verified on
  darwin-arm64.
- Windows/Linux: cache and retry paths are platform-neutral; the
  `PROTON_CEF_CACHE` / `~/.proton` resolution follows the existing
  HOME/USERPROFILE conventions. No ABI or native runtime changes.

## Validation

- `moon -C cli test -p justjavac/proton_cli justjavac/proton_cli/arguments justjavac/proton_cli/build_cmd justjavac/proton_cli/cef justjavac/proton_cli/codegen justjavac/proton_cli/dev justjavac/proton_cli/doctor justjavac/proton_cli/fsutil justjavac/proton_cli/new justjavac/proton_cli/output justjavac/proton_cli/package --target native --no-parallelize --diagnostic-limit 80` — 181/181
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- Live smoke: `package` without `cef setup` now fails in <1s with the
  runtime-missing error; first `cef setup` populates the shared cache and a
  second project's setup skips the download entirely.
