### PR TITLE
fix(native): use wide Win32 APIs so UTF-8 paths and messages survive on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,13 @@ native checks before handing off larger refactors.
 - Keep the C ABI small, C-compatible, and MoonBit-friendly. Export only
   `proton_*` functions, plain integer status codes, fixed-width integer types,
   opaque `Int64` handles, UTF-8 strings, and caller-owned output buffers.
+- Treat every `char*` string as UTF-8 end to end. On Windows, never call the
+  ANSI (`...A`) Win32 variants: they reinterpret text through the process
+  codepage and mangle non-ASCII paths and messages. Call the `...W` variant
+  explicitly (do not rely on the `UNICODE` macro) and convert at the boundary
+  with `MultiByteToWideChar(CP_UTF8, ...)` / `WideCharToMultiByte(CP_UTF8,
+  ...)`. The same rule covers ANSI CRT file calls: use `_wfopen`, `_wstat64`,
+  and `_wremove` instead of `fopen`, `stat`, and `remove` for Windows paths.
 - Do not expose C++ types, CEF structs, Objective-C objects, Win32 handles, or
   owned pointers across the public ABI. Platform details belong behind
   `src/proton_engine.h` and the per-platform native implementation files.

--- a/cli/package/package_windows_icon.c
+++ b/cli/package/package_windows_icon.c
@@ -63,7 +63,7 @@ static void package_icon_windows_error(char *buffer, int32_t buffer_length,
           wide_message[length - 1] == L' ')) {
     wide_message[--length] = L'\0';
   }
-  char system_message[1024] = {0};
+  char system_message[512 * 3] = {0};
   if (length > 0 &&
       WideCharToMultiByte(CP_UTF8, 0, wide_message, -1, system_message,
                           (int)sizeof(system_message), NULL, NULL) > 0) {

--- a/cli/package/package_windows_icon.c
+++ b/cli/package/package_windows_icon.c
@@ -52,17 +52,21 @@ static void package_icon_windows_error(char *buffer, int32_t buffer_length,
   if (buffer == NULL || buffer_length <= 0) {
     return;
   }
-  char system_message[512] = {0};
-  DWORD length = FormatMessageA(
+  wchar_t wide_message[512] = {0};
+  DWORD length = FormatMessageW(
       FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-      error_code, 0, system_message, (DWORD)sizeof(system_message), NULL);
+      error_code, 0, wide_message,
+      (DWORD)(sizeof(wide_message) / sizeof(wide_message[0])), NULL);
   while (length > 0 &&
-         (system_message[length - 1] == '\r' ||
-          system_message[length - 1] == '\n' ||
-          system_message[length - 1] == ' ')) {
-    system_message[--length] = '\0';
+         (wide_message[length - 1] == L'\r' ||
+          wide_message[length - 1] == L'\n' ||
+          wide_message[length - 1] == L' ')) {
+    wide_message[--length] = L'\0';
   }
-  if (length > 0) {
+  char system_message[1024] = {0};
+  if (length > 0 &&
+      WideCharToMultiByte(CP_UTF8, 0, wide_message, -1, system_message,
+                          (int)sizeof(system_message), NULL, NULL) > 0) {
     snprintf(buffer, (size_t)buffer_length, "%s failed (Windows error %lu): %s",
              operation, (unsigned long)error_code, system_message);
   } else {

--- a/native/src/engine/cef_common/assets.h
+++ b/native/src/engine/cef_common/assets.h
@@ -8,6 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 /* Every engine spells this the same way for a given platform, so the header
    supplies it rather than making each includer define it first. Engines that
    still declare their own keep it -- the definitions agree. */
@@ -225,6 +229,21 @@ static const char *proton_engine_asset_mime_type(const char *path) {
   return "application/octet-stream";
 }
 
+static FILE *proton_engine_asset_fopen_read(const char *path) {
+#ifdef _WIN32
+  /* Asset paths are UTF-8; ANSI fopen() would mangle non-ASCII roots. */
+  wchar_t wide_path[4096];
+  if (MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path,
+                          (int)(sizeof(wide_path) /
+                                sizeof(wide_path[0]))) <= 0) {
+    return NULL;
+  }
+  return _wfopen(wide_path, L"rb");
+#else
+  return fopen(path, "rb");
+#endif
+}
+
 static int proton_engine_read_asset_file(const char *path,
                                          char **out_data,
                                          size_t *out_len) {
@@ -236,7 +255,7 @@ static int proton_engine_read_asset_file(const char *path,
   if (path == NULL || path[0] == '\0') {
     return 0;
   }
-  FILE *file = fopen(path, "rb");
+  FILE *file = proton_engine_asset_fopen_read(path);
   if (file == NULL) {
     return 0;
   }

--- a/native/src/engine/cef_common/bridge_renderer.c
+++ b/native/src/engine/cef_common/bridge_renderer.c
@@ -61,11 +61,24 @@ static unsigned long proton_engine_bridge_process_id(void) {
 }
 
 static void proton_engine_bridge_log(const char *format, ...) {
+#if defined(_WIN32)
+  wchar_t wide_path[4096] = {0};
+  DWORD path_len = GetEnvironmentVariableW(
+      L"PROTON_NATIVE_LOG", wide_path,
+      (DWORD)(sizeof(wide_path) / sizeof(wide_path[0])));
+  if (path_len == 0 ||
+      path_len >= sizeof(wide_path) / sizeof(wide_path[0]) ||
+      format == NULL) {
+    return;
+  }
+  FILE *file = _wfopen(wide_path, L"ab");
+#else
   const char *path = getenv("PROTON_NATIVE_LOG");
   if (path == NULL || path[0] == '\0' || format == NULL) {
     return;
   }
   FILE *file = fopen(path, "ab");
+#endif
   if (file == NULL) {
     return;
   }

--- a/native/src/engine/cef_win/proton_engine_cef_win.c
+++ b/native/src/engine/cef_win/proton_engine_cef_win.c
@@ -551,12 +551,21 @@ static int CEF_CALLBACK proton_engine_on_media_permission(
 static void proton_engine_log_to_env(const char *env_name,
                                      const char *format,
                                      va_list args) {
-  char path[PROTON_ENGINE_MAX_PATH_BYTES] = {0};
-  DWORD written = GetEnvironmentVariableA(env_name, path, (DWORD)sizeof(path));
-  if (written == 0 || written >= sizeof(path)) {
+  wchar_t wide_env_name[128] = {0};
+  if (MultiByteToWideChar(CP_UTF8, 0, env_name, -1, wide_env_name,
+                          (int)(sizeof(wide_env_name) /
+                                sizeof(wide_env_name[0]))) <= 0) {
     return;
   }
-  FILE *file = fopen(path, "ab");
+  wchar_t wide_path[4096] = {0};
+  DWORD written = GetEnvironmentVariableW(
+      wide_env_name, wide_path,
+      (DWORD)(sizeof(wide_path) / sizeof(wide_path[0])));
+  if (written == 0 ||
+      written >= sizeof(wide_path) / sizeof(wide_path[0])) {
+    return;
+  }
+  FILE *file = _wfopen(wide_path, L"ab");
   if (file == NULL) {
     return;
   }
@@ -719,14 +728,21 @@ static bool proton_engine_module_dir(char *out, size_t out_len) {
     return false;
   }
   HMODULE module = NULL;
-  if (!GetModuleHandleExA(
+  if (!GetModuleHandleExW(
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-          (LPCSTR)&proton_engine_module_dir, &module)) {
+          (LPCWSTR)&proton_engine_module_dir, &module)) {
     return false;
   }
-  DWORD written = GetModuleFileNameA(module, out, (DWORD)out_len);
-  if (written == 0 || written >= out_len) {
+  wchar_t wide_path[4096] = {0};
+  DWORD wide_written = GetModuleFileNameW(
+      module, wide_path, (DWORD)(sizeof(wide_path) / sizeof(wide_path[0])));
+  if (wide_written == 0 ||
+      wide_written >= sizeof(wide_path) / sizeof(wide_path[0])) {
+    return false;
+  }
+  if (WideCharToMultiByte(CP_UTF8, 0, wide_path, -1, out, (int)out_len,
+                          NULL, NULL) <= 0) {
     return false;
   }
   return proton_engine_path_parent(out);

--- a/native/src/proton_config.c
+++ b/native/src/proton_config.c
@@ -397,18 +397,42 @@ static const char *const proton_menu_config_keys[] = {
 };
 
 static bool proton_path_exists(const char *path) {
-  struct stat info;
-  return path != NULL && path[0] != '\0' && stat(path, &info) == 0;
-}
-
-static bool proton_dir_exists(const char *path) {
-  struct stat info;
-  if (path == NULL || path[0] == '\0' || stat(path, &info) != 0) {
+  if (path == NULL || path[0] == '\0') {
     return false;
   }
 #ifdef _WIN32
+  /* Paths are UTF-8; ANSI stat() would mangle non-ASCII locations. */
+  wchar_t wide_path[4096];
+  struct _stat64 info;
+  return MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path,
+                             (int)(sizeof(wide_path) /
+                                   sizeof(wide_path[0]))) > 0 &&
+         _wstat64(wide_path, &info) == 0;
+#else
+  struct stat info;
+  return stat(path, &info) == 0;
+#endif
+}
+
+static bool proton_dir_exists(const char *path) {
+  if (path == NULL || path[0] == '\0') {
+    return false;
+  }
+#ifdef _WIN32
+  wchar_t wide_path[4096];
+  struct _stat64 info;
+  if (MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path,
+                          (int)(sizeof(wide_path) /
+                                sizeof(wide_path[0]))) <= 0 ||
+      _wstat64(wide_path, &info) != 0) {
+    return false;
+  }
   return (info.st_mode & _S_IFDIR) != 0;
 #else
+  struct stat info;
+  if (stat(path, &info) != 0) {
+    return false;
+  }
   return S_ISDIR(info.st_mode);
 #endif
 }

--- a/native/src/proton_config.c
+++ b/native/src/proton_config.c
@@ -471,14 +471,21 @@ static bool proton_module_dir(char *out, size_t out_len) {
     return false;
   }
   HMODULE module = NULL;
-  if (!GetModuleHandleExA(
+  if (!GetModuleHandleExW(
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-          (LPCSTR)&proton_module_dir, &module)) {
+          (LPCWSTR)&proton_module_dir, &module)) {
     return false;
   }
-  DWORD written = GetModuleFileNameA(module, out, (DWORD)out_len);
-  if (written == 0 || written >= out_len) {
+  wchar_t wide_path[4096] = {0};
+  DWORD wide_written = GetModuleFileNameW(
+      module, wide_path, (DWORD)(sizeof(wide_path) / sizeof(wide_path[0])));
+  if (wide_written == 0 ||
+      wide_written >= sizeof(wide_path) / sizeof(wide_path[0])) {
+    return false;
+  }
+  if (WideCharToMultiByte(CP_UTF8, 0, wide_path, -1, out, (int)out_len,
+                          NULL, NULL) <= 0) {
     return false;
   }
   return proton_path_parent(out);

--- a/native/tests/proton_exports_smoke.c
+++ b/native/tests/proton_exports_smoke.c
@@ -9,13 +9,13 @@
 typedef HMODULE proton_library_t;
 #define PROTON_LIBRARY_NAME "proton.dll"
 static proton_library_t proton_open_library(void) {
-  return LoadLibraryA(PROTON_LIBRARY_NAME);
+  return LoadLibraryW(L"proton.dll");
 }
 static void *proton_find_symbol(proton_library_t library, const char *name) {
   return (void *)GetProcAddress(library, name);
 }
 static void proton_print_loader_error(void) {
-  fprintf(stderr, "LoadLibraryA(%s) failed with error %lu\n",
+  fprintf(stderr, "LoadLibraryW(%s) failed with error %lu\n",
           PROTON_LIBRARY_NAME, (unsigned long)GetLastError());
 }
 #else

--- a/native/tests/proton_smoke.c
+++ b/native/tests/proton_smoke.c
@@ -89,19 +89,31 @@ static int run_app_instance_secondary(const char *executable,
                                       const char *identifier,
                                       const char *activation_kind) {
 #ifdef _WIN32
-  char executable_path[MAX_PATH];
-  if (GetModuleFileNameA(NULL, executable_path, MAX_PATH) == 0) {
+  wchar_t wide_executable_path[MAX_PATH];
+  if (GetModuleFileNameW(NULL, wide_executable_path, MAX_PATH) == 0) {
+    return fail("failed to locate app instance test executable");
+  }
+  char executable_path[MAX_PATH * 3];
+  if (WideCharToMultiByte(CP_UTF8, 0, wide_executable_path, -1,
+                          executable_path, (int)sizeof(executable_path), NULL,
+                          NULL) <= 0) {
     return fail("failed to locate app instance test executable");
   }
   char command[2048];
   snprintf(command, sizeof(command), "\"%s\" --app-instance-secondary %s %s",
            executable_path, identifier, activation_kind);
-  STARTUPINFOA startup;
+  wchar_t wide_command[2048];
+  if (MultiByteToWideChar(CP_UTF8, 0, command, -1, wide_command,
+                          (int)(sizeof(wide_command) /
+                                sizeof(wide_command[0]))) <= 0) {
+    return fail("failed to start secondary app instance process");
+  }
+  STARTUPINFOW startup;
   PROCESS_INFORMATION process;
   memset(&startup, 0, sizeof(startup));
   memset(&process, 0, sizeof(process));
   startup.cb = sizeof(startup);
-  if (!CreateProcessA(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL,
+  if (!CreateProcessW(NULL, wide_command, NULL, NULL, FALSE, 0, NULL, NULL,
                       &startup, &process)) {
     return fail("failed to start secondary app instance process");
   }
@@ -526,11 +538,18 @@ static void smoke_app_entry(void) {
           runtime, wakeup_source, (int32_t)sizeof(wakeup_source), &required);
     }
     if (g_app_entry_wakeup_status == PROTON_OK) {
-      wakeup_reader =
-          CreateFileA(wakeup_source, GENERIC_READ, 0, NULL, OPEN_EXISTING,
-                      FILE_ATTRIBUTE_NORMAL, NULL);
-      if (wakeup_reader == INVALID_HANDLE_VALUE) {
+      wchar_t wide_wakeup_source[256];
+      if (MultiByteToWideChar(CP_UTF8, 0, wakeup_source, -1,
+                              wide_wakeup_source,
+                              (int)(sizeof(wide_wakeup_source) /
+                                    sizeof(wide_wakeup_source[0]))) <= 0) {
         g_app_entry_wakeup_status = PROTON_ERR_PLATFORM;
+      } else {
+        wakeup_reader = CreateFileW(wide_wakeup_source, GENERIC_READ, 0, NULL,
+                                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (wakeup_reader == INVALID_HANDLE_VALUE) {
+          g_app_entry_wakeup_status = PROTON_ERR_PLATFORM;
+        }
       }
     }
     if (g_app_entry_wakeup_status == PROTON_OK) {

--- a/native/tests/proton_win_overlay_smoke.c
+++ b/native/tests/proton_win_overlay_smoke.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 static int expect_status(const char *label, int32_t actual, int32_t expected) {
   if (actual == expected) {
@@ -109,9 +110,10 @@ static BOOL CALLBACK find_largest_visible_child(HWND child, LPARAM data) {
 }
 
 static BOOL CALLBACK find_renderer_child(HWND child, LPARAM data) {
-  char class_name[128];
-  if (GetClassNameA(child, class_name, (int)sizeof(class_name)) > 0 &&
-      strstr(class_name, "RenderWidgetHost") != NULL) {
+  wchar_t class_name[128];
+  if (GetClassNameW(child, class_name,
+                    (int)(sizeof(class_name) / sizeof(class_name[0]))) > 0 &&
+      wcsstr(class_name, L"RenderWidgetHost") != NULL) {
     ((renderer_child_t *)data)->hwnd = child;
     return FALSE;
   }
@@ -318,20 +320,27 @@ static int expect_web_draggable_regions(proton_runtime_id_t runtime,
       "document.querySelector('#bar').style.webkitAppRegion='drag';"
       "},0);"
       "</script></body></html>";
-  char temp_dir[MAX_PATH];
-  char html_path[MAX_PATH];
-  char html_url[MAX_PATH + 16];
-  DWORD temp_len = GetTempPathA((DWORD)sizeof(temp_dir), temp_dir);
-  if (temp_len == 0 || temp_len >= sizeof(temp_dir) ||
-      snprintf(html_path, sizeof(html_path), "%sproton-overlay-%lu.html",
-               temp_dir, (unsigned long)GetCurrentProcessId()) >=
-          (int)sizeof(html_path)) {
+  wchar_t wide_temp_dir[MAX_PATH];
+  wchar_t wide_html_path[MAX_PATH];
+  char html_path[MAX_PATH * 3];
+  char html_url[MAX_PATH * 3 + 16];
+  DWORD temp_len = GetTempPathW(
+      (DWORD)(sizeof(wide_temp_dir) / sizeof(wide_temp_dir[0])),
+      wide_temp_dir);
+  if (temp_len == 0 ||
+      temp_len >= sizeof(wide_temp_dir) / sizeof(wide_temp_dir[0]) ||
+      swprintf(wide_html_path,
+               sizeof(wide_html_path) / sizeof(wide_html_path[0]),
+               L"%sproton-overlay-%lu.html", wide_temp_dir,
+               (unsigned long)GetCurrentProcessId()) < 0 ||
+      WideCharToMultiByte(CP_UTF8, 0, wide_html_path, -1, html_path,
+                          (int)sizeof(html_path), NULL, NULL) <= 0) {
     fprintf(stderr, "overlay draggable HTML temp file could not be created\n");
     return 1;
   }
-  FILE *file = fopen(html_path, "wb");
+  FILE *file = _wfopen(wide_html_path, L"wb");
   if (file == NULL) {
-    DeleteFileA(html_path);
+    DeleteFileW(wide_html_path);
     fprintf(stderr, "overlay draggable HTML temp file could not be written\n");
     return 1;
   }
@@ -339,7 +348,7 @@ static int expect_web_draggable_regions(proton_runtime_id_t runtime,
   const int write_failed = fwrite(html, 1, html_len, file) != html_len;
   const int close_failed = fclose(file) != 0;
   if (write_failed || close_failed) {
-    DeleteFileA(html_path);
+    DeleteFileW(wide_html_path);
     fprintf(stderr, "overlay draggable HTML temp file could not be written\n");
     return 1;
   }
@@ -351,7 +360,7 @@ static int expect_web_draggable_regions(proton_runtime_id_t runtime,
   snprintf(html_url, sizeof(html_url), "file:///%s", html_path);
   if (expect_status("overlay load draggable HTML",
                     proton_window_load_url(window, html_url), PROTON_OK)) {
-    DeleteFileA(html_path);
+    DeleteFileW(wide_html_path);
     return 1;
   }
 
@@ -386,7 +395,7 @@ static int expect_web_draggable_regions(proton_runtime_id_t runtime,
     }
     Sleep(10);
   }
-  DeleteFileA(html_path);
+  DeleteFileW(wide_html_path);
   if (passed) {
     return 0;
   }

--- a/sys/auto_launch/auto_launch_native.c
+++ b/sys/auto_launch/auto_launch_native.c
@@ -94,7 +94,7 @@ static void mb_set_windows_error(DWORD code, const char *fallback) {
     wide_message[len - 1] = L'\0';
     len--;
   }
-  char message[1024] = "";
+  char message[512 * 3] = "";
   if (WideCharToMultiByte(CP_UTF8, 0, wide_message, -1, message,
                           (int)sizeof(message), NULL, NULL) <= 0) {
     mb_set_error((int32_t)code, fallback);

--- a/sys/auto_launch/auto_launch_native.c
+++ b/sys/auto_launch/auto_launch_native.c
@@ -72,15 +72,15 @@ static char *mb_bytes_to_c_string(moonbit_bytes_t bytes) {
 
 #ifdef _WIN32
 static void mb_set_windows_error(DWORD code, const char *fallback) {
-  char message[512] = "";
+  wchar_t wide_message[512] = {0};
   DWORD flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
-  DWORD len = FormatMessageA(
+  DWORD len = FormatMessageW(
     flags,
     NULL,
     code,
     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-    message,
-    (DWORD)sizeof(message),
+    wide_message,
+    (DWORD)(sizeof(wide_message) / sizeof(wide_message[0])),
     NULL
   );
   if (len == 0) {
@@ -89,9 +89,16 @@ static void mb_set_windows_error(DWORD code, const char *fallback) {
   }
 
   while (len > 0 &&
-         (message[len - 1] == '\r' || message[len - 1] == '\n' || message[len - 1] == ' ')) {
-    message[len - 1] = '\0';
+         (wide_message[len - 1] == L'\r' || wide_message[len - 1] == L'\n' ||
+          wide_message[len - 1] == L' ')) {
+    wide_message[len - 1] = L'\0';
     len--;
+  }
+  char message[1024] = "";
+  if (WideCharToMultiByte(CP_UTF8, 0, wide_message, -1, message,
+                          (int)sizeof(message), NULL, NULL) <= 0) {
+    mb_set_error((int32_t)code, fallback);
+    return;
   }
   mb_set_error((int32_t)code, message);
 }

--- a/sys/keepawake/native_windows.c
+++ b/sys/keepawake/native_windows.c
@@ -43,19 +43,41 @@ static void keepawake_set_windows_error(
   const char *prefix
 ) {
   DWORD error_code = GetLastError();
-  char *system_message = NULL;
-  DWORD message_len = FormatMessageA(
+  wchar_t *wide_message = NULL;
+  DWORD message_len = FormatMessageW(
     FORMAT_MESSAGE_ALLOCATE_BUFFER |
       FORMAT_MESSAGE_FROM_SYSTEM |
       FORMAT_MESSAGE_IGNORE_INSERTS,
     NULL,
     error_code,
     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-    (LPSTR)&system_message,
+    (LPWSTR)&wide_message,
     0,
     NULL
   );
-  if (message_len == 0 || system_message == NULL) {
+  if (message_len == 0 || wide_message == NULL) {
+    keepawake_set_error(
+      guard,
+      status,
+      "%s (GetLastError=%lu)",
+      prefix,
+      (unsigned long)error_code
+    );
+    return;
+  }
+  char system_message[1024] = "";
+  int converted = WideCharToMultiByte(
+    CP_UTF8,
+    0,
+    wide_message,
+    -1,
+    system_message,
+    (int)sizeof(system_message),
+    NULL,
+    NULL
+  );
+  LocalFree(wide_message);
+  if (converted <= 0) {
     keepawake_set_error(
       guard,
       status,
@@ -72,7 +94,6 @@ static void keepawake_set_windows_error(
     prefix,
     system_message
   );
-  LocalFree(system_message);
 }
 
 static uint32_t keepawake_windows_state_for_scope(int32_t scope) {

--- a/sys/tray/testsupport/testsupport_native.c
+++ b/sys/tray/testsupport/testsupport_native.c
@@ -35,25 +35,66 @@ static const unsigned char moonbit_tray_test_bmp[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x66,
     0xcc, 0xff};
 
+/* Paths crossing this boundary are UTF-8; on Windows the ANSI CRT calls
+   would mangle non-ASCII temp directories, so go through the wide CRT. */
+static FILE *moonbit_tray_test_fopen_write(const char *path) {
+#ifdef _WIN32
+  wchar_t wide_path[1024];
+  if (MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path,
+                          (int)(sizeof(wide_path) /
+                                sizeof(wide_path[0]))) <= 0) {
+    return NULL;
+  }
+  return _wfopen(wide_path, L"wb");
+#else
+  return fopen(path, "wb");
+#endif
+}
+
+static int moonbit_tray_test_remove(const char *path) {
+#ifdef _WIN32
+  wchar_t wide_path[1024];
+  if (MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path,
+                          (int)(sizeof(wide_path) /
+                                sizeof(wide_path[0]))) <= 0) {
+    return 0;
+  }
+  return _wremove(wide_path) == 0;
+#else
+  return remove(path) == 0;
+#endif
+}
+
 static int32_t moonbit_tray_test_icon_path_buffer(
     char *path,
     size_t path_size) {
 #ifdef _WIN32
-  DWORD len;
+  wchar_t wide_temp[1024];
+  DWORD wide_len;
+  int len;
   int written;
+  size_t temp_len;
   if (path_size == 0) {
     return 0;
   }
-  len = GetTempPathA((DWORD)path_size, path);
-  if (len == 0 || len >= path_size) {
+  wide_len = GetTempPathW(
+      (DWORD)(sizeof(wide_temp) / sizeof(wide_temp[0])), wide_temp);
+  if (wide_len == 0 ||
+      wide_len >= sizeof(wide_temp) / sizeof(wide_temp[0])) {
     return 0;
   }
+  len = WideCharToMultiByte(CP_UTF8, 0, wide_temp, -1, path, (int)path_size,
+                            NULL, NULL);
+  if (len <= 1) {
+    return 0;
+  }
+  temp_len = (size_t)(len - 1);
   written = snprintf(
-      path + len,
-      path_size - (size_t)len,
+      path + temp_len,
+      path_size - temp_len,
       "moonbit-tray-test-icon-%lu.bmp",
       (unsigned long)GetCurrentProcessId());
-  return written > 0 && (size_t)written < path_size - (size_t)len;
+  return written > 0 && (size_t)written < path_size - temp_len;
 #else
   const char *tmp = getenv("TMPDIR");
   if (tmp == NULL || tmp[0] == '\0') {
@@ -77,7 +118,7 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_test_icon_path(void) {
   if (!moonbit_tray_test_icon_path_buffer(path, sizeof(path))) {
     return moonbit_tray_copy_message("");
   }
-  file = fopen(path, "wb");
+  file = moonbit_tray_test_fopen_write(path);
   if (file == NULL) {
     return moonbit_tray_copy_message("");
   }
@@ -87,7 +128,7 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_test_icon_path(void) {
           sizeof(moonbit_tray_test_bmp),
           file) != sizeof(moonbit_tray_test_bmp)) {
     fclose(file);
-    remove(path);
+    moonbit_tray_test_remove(path);
     return moonbit_tray_copy_message("");
   }
   fclose(file);
@@ -100,6 +141,6 @@ MOONBIT_FFI_EXPORT int32_t moonbit_tray_test_remove_file(
   if (text == NULL || text[0] == '\0') {
     return 0;
   }
-  return remove(text) == 0;
+  return moonbit_tray_test_remove(text);
 }
 


### PR DESCRIPTION
## Summary

Every `char*` string crossing the native boundary is UTF-8, but several
Windows call sites used the ANSI (`...A`) Win32 variants or ANSI CRT file
calls, which reinterpret text through the process codepage (CP_ACP):

- **Runtime breakage (high):** `GetModuleFileNameA` in
  `proton_engine_cef_win.c` / `proton_config.c` produced CP_ACP module paths
  that were later decoded as UTF-8 (`cef_string_from_utf8`). A bundled app
  installed under a non-ASCII directory (e.g. a CJK user profile) failed to
  locate `cef_process.exe` and could not start. `stat()` had the same ANSI
  problem when validating bundled runtime files.
- **Mojibake diagnostics (medium):** `FormatMessageA` in
  `sys/auto_launch`, `sys/keepawake`, and `cli/package` returned localized
  error text in CP_ACP that MoonBit read as UTF-8.
- **Same class in shared/debug/test code:** asset serving and the
  `PROTON_NATIVE_LOG` debug log used ANSI `fopen`/`getenv`; the native smoke
  tests and the tray test helper used ANSI path APIs.

All of these now use the explicit `...W` variants with
`MultiByteToWideChar`/`WideCharToMultiByte(CP_UTF8)` at the boundary, and
`_wfopen`/`_wstat64`/`_wremove` instead of the ANSI CRT calls. A repo-wide
sweep confirms no `...A` calls or `...A` struct types remain in C sources,
and AGENTS.md now documents the rule.

## Platform impact

Windows-only behavior change; non-Windows code paths are untouched (POSIX
branches keep `fopen`/`stat`/`dladdr`). No ABI changes; no MoonBit API
changes.

## Validation

- `cmake --build native/build-engine --config Debug` (proton.dll,
  cef_process.exe, all test executables)
- `ctest --test-dir native/build-engine -C Debug --output-on-failure` — 6/6
- `moon test -p justjavac/auto_launch --target native` — 25/25
- `moon test -p justjavac/keepawake --target native` — 18/18
- `moon test -p justjavac/tray --target native` — 19/19
- `moon -C cli test -p justjavac/proton_cli/package --target native` — 63/63