### PR TITLE
feat(cli): sign configured resource binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ bisect.coverage
 # Package prebuilt Proton artifacts are intentionally shipped.
 !proton/prebuilt/
 !proton/prebuilt/**
+
+# Local linked worktrees created by Claude Code.
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ single_instance = true
 bundle = {
   active: true,
   targets: ["app", "zip"],
-  resources: ["bin/worker"],
+  resources: ["helpers/worker"],
   sign: {
-    binaries: ["bin/worker"],
+    binaries: ["helpers/worker"],
   },
   url_schemes: ["my-app"],
   document_types: [
@@ -382,10 +382,11 @@ bundle = {
 does not copy anything; it names resource files that `proton_cli` must sign.
 Both arrays use paths relative to the directory containing `moon.proton`. For
 the example above, the signing target is
-`My App.app/Contents/Resources/bin/worker` on macOS and
-`My App/bin/worker` in a Windows portable package. Use the platform's actual
-filename, such as `bin/worker.exe`, for a Windows executable. Globs are allowed
-for `bundle.resources` only; every `bundle.sign.binaries` entry names one file.
+`My App.app/Contents/Resources/helpers/worker` on macOS and
+`My App/helpers/worker` in a Windows portable package. Use the platform's actual
+filename, such as `helpers/worker.exe`, for a Windows executable. Globs are
+allowed for `bundle.resources` only; every `bundle.sign.binaries` entry names
+one file.
 
 Inspect the resolved bundle plan before creating artifacts:
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,10 @@ single_instance = true
 bundle = {
   active: true,
   targets: ["app", "zip"],
+  resources: ["bin/worker"],
+  sign: {
+    binaries: ["bin/worker"],
+  },
   url_schemes: ["my-app"],
   document_types: [
     {
@@ -373,6 +377,15 @@ bundle = {
   output: "target/proton-dist",
 }
 ```
+
+`bundle.resources` copies project files into the package. `bundle.sign.binaries`
+does not copy anything; it names resource files that `proton_cli` must sign.
+Both arrays use paths relative to the directory containing `moon.proton`. For
+the example above, the signing target is
+`My App.app/Contents/Resources/bin/worker` on macOS and
+`My App/bin/worker` in a Windows portable package. Use the platform's actual
+filename, such as `bin/worker.exe`, for a Windows executable. Globs are allowed
+for `bundle.resources` only; every `bundle.sign.binaries` entry names one file.
 
 Inspect the resolved bundle plan before creating artifacts:
 

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -36,6 +36,7 @@ struct PackagePlan {
   frontend_dist : String?
   entry_paths : Array[String]
   resources : Array[String]
+  sign_binaries : Array[String]
   icons : Array[String]
   url_schemes : Array[String]
   document_types : Array[@proton_config.ProjectDocumentType]
@@ -364,6 +365,10 @@ async fn build_package_plan(
     frontend_dist,
     entry_paths,
     resources: copy_strings(bundle.resources),
+    sign_binaries: match bundle.sign {
+      Some(sign) => sign.binaries()
+      None => []
+    },
     icons: copy_strings(bundle.icon),
     url_schemes: copy_strings(bundle.url_schemes),
     document_types: bundle.document_types.copy(),
@@ -580,6 +585,12 @@ fn print_package_plan(plan : PackagePlan, dry_run : Bool) -> Unit {
   println("  targets: " + plan.targets.join(", "))
   println("  output: " + plan.output)
   println("  build target: " + plan.build_target_dir)
+  let sign_binaries = if plan.sign_binaries.length() == 0 {
+    "none"
+  } else {
+    plan.sign_binaries.join(", ")
+  }
+  println("  sign binaries: " + sign_binaries)
   let build = if plan.build { "yes" } else { "no" }
   println("  build: " + build)
   println("  sign: " + bool_text(plan.sign))
@@ -1054,6 +1065,25 @@ async fn stage_project_inputs(plan : PackagePlan, destination : String) -> Unit 
     }
     copy_tree(source, @fsutil.resolve_path(destination, relative))
   }
+}
+
+///|
+/// Resolves `bundle.sign.binaries` into the files copied below a package's
+/// resource root. Signing never copies a file; every target must already have
+/// been staged through `bundle.resources`.
+fn PackagePlan::sign_binary_targets(
+  self : PackagePlan,
+  resource_root : String,
+) -> Array[String] raise PackagePlanError {
+  let targets : Array[String] = []
+  for binary in self.sign_binaries {
+    let relative = match relative_to_base(self.base_dir, binary) {
+      Some(relative) => relative
+      None => raise PackagePlanError::InputOutsideProject(path=binary)
+    }
+    targets.push(@fsutil.resolve_path(resource_root, relative))
+  }
+  targets
 }
 
 ///|
@@ -1603,6 +1633,16 @@ async fn sign_macos_app_with_identity(
       deep: false,
     },
   ]
+  for
+    binary in plan.sign_binary_targets(
+      @fsutil.resolve_path(contents, "Resources"),
+    ) {
+    targets.push(MacosCodeSignTarget::{
+      path: binary,
+      runtime_options: true,
+      deep: false,
+    })
+  }
   for helper in macos_helper_specs(plan.product_name, plan.identifier) {
     targets.push(MacosCodeSignTarget::{
       path: @fsutil.resolve_path(

--- a/cli/package/package_macos_dmg.mbt
+++ b/cli/package/package_macos_dmg.mbt
@@ -110,7 +110,8 @@ async fn verify_macos_dmg(dmg : String) -> Unit {
 
 ///|
 async fn run_hdiutil(args : Array[String], stage~ : String) -> Unit {
-  let code = @process.run("/usr/bin/hdiutil", args) catch {
+  // MoonBit tests reserve stdout for structured events, so capture both streams.
+  let (code, stdout, stderr) = @process.collect_output("/usr/bin/hdiutil", args) catch {
     error =>
       raise MacosSigningError::ToolFailure(
         stage~,
@@ -118,9 +119,20 @@ async fn run_hdiutil(args : Array[String], stage~ : String) -> Unit {
       )
   }
   guard code == 0 else {
+    let stdout = stdout.text() catch {
+      error => "failed to decode stdout: " + @debug.render(Repr(error))
+    }
+    let stderr = stderr.text() catch {
+      error => "failed to decode stderr: " + @debug.render(Repr(error))
+    }
     raise MacosSigningError::ToolFailure(
       stage~,
-      detail="exit code " + code.to_string(),
+      detail="exit code " +
+        code.to_string() +
+        "\nstdout:\n" +
+        stdout +
+        "\nstderr:\n" +
+        stderr,
     )
   }
 }

--- a/cli/package/package_macos_dmg_wbtest.mbt
+++ b/cli/package/package_macos_dmg_wbtest.mbt
@@ -19,6 +19,7 @@ fn macos_dmg_test_plan(root : String) -> PackagePlan {
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: [],

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -209,6 +209,44 @@ async test "package plan stages every window file entry" {
 }
 
 ///|
+async test "configured signing binaries resolve through staged resources" {
+  let root = @fsutil.resolve_path("target", "proton-package-sign-binaries")
+  remove_tree(root)
+  let binary = @fsutil.resolve_path(root, "bin/worker")
+  ensure_dir(@fsutil.path_parent(binary))
+  write_text(binary, "binary")
+  let project = @proton_config.ProjectConfig::new(
+    root,
+    @proton_config.ProjectWindowConfig::new("Demo", 800, 600),
+    @proton_config.ProjectEntry::Html("<main>demo</main>"),
+    @proton_config.ProjectMetadata::new(
+      "Demo",
+      identifier=Some("dev.proton.sign-binaries"),
+      version=Some("1.0.0"),
+    ),
+    bundle=Some(
+      @proton_config.ProjectBundleConfig::new(
+        active=true,
+        resources=[binary],
+        sign=Some(@proton_config.ProjectSignConfig::new(binaries=[binary])),
+      ),
+    ),
+  )
+  let plan = build_package_plan(
+    parse_package_args([]),
+    @fsutil.resolve_path(root, "moon.proton"),
+    project,
+    0UL,
+  )
+  let resource_root = @fsutil.resolve_path(root, "staged resources")
+  ensure_dir(resource_root)
+  stage_project_inputs(plan, resource_root)
+  let staged_binary = @fsutil.resolve_path(resource_root, "bin/worker")
+  assert_true(@fsutil.path_is_file(staged_binary))
+  @debug.assert_eq(plan.sign_binary_targets(resource_root), [staged_binary])
+}
+
+///|
 async test "package plan uses configured backend module and package" {
   let base_dir = @fsutil.resolve_path("target", "proton package module paths")
   let backend_path = @fsutil.resolve_path(base_dir, "modules/backend app")
@@ -552,6 +590,7 @@ async test "macOS icon selection stages icns and rejects a missing source" {
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: ["icon.png", icon],
     url_schemes: [],
@@ -598,6 +637,7 @@ test "macOS plist contains bundle identity and executable" {
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: ["devtoys"],
@@ -650,6 +690,7 @@ async test "package manifest records launch metadata" {
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: ["devtoys"],
@@ -712,6 +753,7 @@ test "macOS helper plist matches its bundle identity" {
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: [],
@@ -757,6 +799,7 @@ async test "macOS ZIP uses the final app name without metadata entries" {
     build: false,
     base_dir: root,
     frontend_dist: None,
+    sign_binaries: [],
     entry_paths: [],
     resources: [],
     icons: [],
@@ -930,6 +973,7 @@ async test "macOS notarization validates success and cleans failed upload" {
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: [],
@@ -1011,6 +1055,7 @@ async test "release executable lookup stays inside package target dir" {
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: [],
@@ -1091,6 +1136,7 @@ async test "Windows portable staging flattens runtime bin beside app executable"
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
+    sign_binaries: [],
     resources: [],
     icons: [],
     url_schemes: [],

--- a/cli/package/package_windows.mbt
+++ b/cli/package/package_windows.mbt
@@ -446,8 +446,8 @@ async fn validate_windows_portable_layout(
 fn windows_owned_sign_targets(
   plan : PackagePlan,
   output : String,
-) -> Array[String] {
-  [
+) -> Array[String] raise PackagePlanError {
+  let targets = [
     @fsutil.resolve_path(
       output,
       package_executable_name(plan.product_name) + ".exe",
@@ -455,6 +455,12 @@ fn windows_owned_sign_targets(
     @fsutil.resolve_path(output, "cef_process.exe"),
     @fsutil.resolve_path(output, "proton.dll"),
   ]
+  for target in plan.sign_binary_targets(output) {
+    if !targets.contains(target) {
+      targets.push(target)
+    }
+  }
+  targets
 }
 
 ///|

--- a/cli/package/package_windows_wbtest.mbt
+++ b/cli/package/package_windows_wbtest.mbt
@@ -155,13 +155,11 @@ test "Windows signtool args use SHA-256 and RFC3161 timestamp" {
 test "Windows signing includes configured resource binaries" {
   let root = "target/proton-package-windows-configured-signing"
   let plan = windows_test_plan(root, ["app"], true)
-  plan.sign_binaries.push(
-    @fsutil.resolve_path(root, "bundle resources/worker.exe"),
-  )
+  plan.sign_binaries.push(@fsutil.resolve_path(root, "helpers/worker.exe"))
   let output = @fsutil.resolve_path(root, "portable")
   assert_true(
     windows_owned_sign_targets(plan, output).contains(
-      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+      @fsutil.resolve_path(output, "helpers/worker.exe"),
     ),
   )
 }
@@ -173,7 +171,7 @@ async test "Windows signtool signs and verifies configured resource binaries" {
   remove_tree(root)
   let output = @fsutil.resolve_path(root, "portable")
   let plan = windows_test_plan(root, ["app"], true)
-  let binary = @fsutil.resolve_path(root, "bundle resources/worker.exe")
+  let binary = @fsutil.resolve_path(root, "helpers/worker.exe")
   plan.sign_binaries.push(binary)
   for target in windows_owned_sign_targets(plan, output) {
     write_windows_test_file(target, "binary")
@@ -199,13 +197,12 @@ async test "Windows signtool signs and verifies configured resource binaries" {
       "sign|/fd|SHA256|/f|" +
       certificate +
       "|" +
-      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+      @fsutil.resolve_path(output, "helpers/worker.exe"),
     ),
   )
   assert_true(
     text.contains(
-      "verify|/pa|/all|/v|" +
-      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+      "verify|/pa|/all|/v|" + @fsutil.resolve_path(output, "helpers/worker.exe"),
     ),
   )
 }
@@ -297,10 +294,11 @@ async test "Windows portable staging is atomic and excludes build artifacts" {
 async test "Windows portable stages a configured signing binary from resources" {
   let root = "target/proton-package-windows-resource-signing"
   let (executable, _) = prepare_windows_test_inputs(root)
-  let binary = @fsutil.resolve_path(root, "bundle resources/worker.exe")
+  let binary = @fsutil.resolve_path(root, "helpers/worker.exe")
   write_windows_test_file(binary, "worker")
   let runtime = prepare_windows_test_runtime(root)
   let plan = windows_test_plan(root, ["app"], false)
+  plan.resources.push(binary)
   plan.sign_binaries.push(binary)
   stage_windows_portable_with_options(
     plan,
@@ -311,9 +309,7 @@ async test "Windows portable stages a configured signing binary from resources" 
     false,
   )
   let output = windows_portable_output(plan)
-  let staged_binary = @fsutil.resolve_path(
-    output, "bundle resources/worker.exe",
-  )
+  let staged_binary = @fsutil.resolve_path(output, "helpers/worker.exe")
   assert_true(@fsutil.path_is_file(staged_binary))
   assert_true(windows_owned_sign_targets(plan, output).contains(staged_binary))
 }

--- a/cli/package/package_windows_wbtest.mbt
+++ b/cli/package/package_windows_wbtest.mbt
@@ -22,6 +22,7 @@ fn windows_test_plan(
     base_dir: root,
     frontend_dist: Some(@fsutil.resolve_path(root, "frontend/dist")),
     entry_paths: [@fsutil.resolve_path(root, "frontend/dist/index.html")],
+    sign_binaries: [],
     resources: [@fsutil.resolve_path(root, "bundle resources/**")],
     icons: [],
     url_schemes: [],
@@ -151,6 +152,65 @@ test "Windows signtool args use SHA-256 and RFC3161 timestamp" {
 }
 
 ///|
+test "Windows signing includes configured resource binaries" {
+  let root = "target/proton-package-windows-configured-signing"
+  let plan = windows_test_plan(root, ["app"], true)
+  plan.sign_binaries.push(
+    @fsutil.resolve_path(root, "bundle resources/worker.exe"),
+  )
+  let output = @fsutil.resolve_path(root, "portable")
+  assert_true(
+    windows_owned_sign_targets(plan, output).contains(
+      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+    ),
+  )
+}
+
+///|
+#cfg(platform="windows")
+async test "Windows signtool signs and verifies configured resource binaries" {
+  let root = "target/proton-package-windows-configured-signtool"
+  remove_tree(root)
+  let output = @fsutil.resolve_path(root, "portable")
+  let plan = windows_test_plan(root, ["app"], true)
+  let binary = @fsutil.resolve_path(root, "bundle resources/worker.exe")
+  plan.sign_binaries.push(binary)
+  for target in windows_owned_sign_targets(plan, output) {
+    write_windows_test_file(target, "binary")
+  }
+  for target in windows_upstream_signature_targets(output) {
+    write_windows_test_file(target, "upstream")
+  }
+  let certificate = @fsutil.resolve_path(root, "test certificate.pfx")
+  write_windows_test_file(certificate, "certificate")
+  let log = @fsutil.resolve_path(root, "signtool.log")
+  let old_log = @sys.get_env_var("PROTON_TEST_SIGNTOOL_LOG")
+  @sys.set_env_var("PROTON_TEST_SIGNTOOL_LOG", log)
+  defer restore_package_env("PROTON_TEST_SIGNTOOL_LOG", old_log)
+  sign_windows_portable_configured(
+    plan,
+    output,
+    windows_test_sign_tool(root, "success"),
+    WindowsSigningConfig::{ certificate, password: "", timestamp: None },
+  )
+  let text = @async_fs.read_file(log).text()
+  assert_true(
+    text.contains(
+      "sign|/fd|SHA256|/f|" +
+      certificate +
+      "|" +
+      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+    ),
+  )
+  assert_true(
+    text.contains(
+      "verify|/pa|/all|/v|" +
+      @fsutil.resolve_path(output, "bundle resources/worker.exe"),
+    ),
+  )
+}
+
+///|
 async test "Windows icon selection accepts ico and rejects a missing source" {
   let root = "target/proton-package-windows-icon"
   remove_tree(root)
@@ -231,6 +291,31 @@ async test "Windows portable staging is atomic and excludes build artifacts" {
   }
   assert_false(@mbfs.path_exists(windows_portable_staging(plan)))
   assert_false(@mbfs.path_exists(output + ".backup"))
+}
+
+///|
+async test "Windows portable stages a configured signing binary from resources" {
+  let root = "target/proton-package-windows-resource-signing"
+  let (executable, _) = prepare_windows_test_inputs(root)
+  let binary = @fsutil.resolve_path(root, "bundle resources/worker.exe")
+  write_windows_test_file(binary, "worker")
+  let runtime = prepare_windows_test_runtime(root)
+  let plan = windows_test_plan(root, ["app"], false)
+  plan.sign_binaries.push(binary)
+  stage_windows_portable_with_options(
+    plan,
+    executable,
+    runtime,
+    default_windows_sign_tool(),
+    None,
+    false,
+  )
+  let output = windows_portable_output(plan)
+  let staged_binary = @fsutil.resolve_path(
+    output, "bundle resources/worker.exe",
+  )
+  assert_true(@fsutil.path_is_file(staged_binary))
+  assert_true(windows_owned_sign_targets(plan, output).contains(staged_binary))
 }
 
 ///|

--- a/config/config_test.mbt
+++ b/config/config_test.mbt
@@ -267,6 +267,9 @@ test "project config rebases file entry and frontend paths from config directory
     #|  targets: ["app", "zip", "dmg"],
     #|  icon: ["icons/icon.ico"],
     #|  resources: ["resources/**"],
+    #|  sign: {
+    #|    binaries: ["bin/worker"],
+    #|  },
     #|  output: "target/proton-dist",
     #|}
     #|
@@ -308,6 +311,12 @@ test "project config rebases file entry and frontend paths from config directory
   assert_true(
     normalize_test_path(bundle.resources[0]).has_suffix(
       "target/proton-config/subdir/resources/**",
+    ),
+  )
+  let sign = bundle.sign.unwrap()
+  assert_true(
+    normalize_test_path(sign.binaries()[0]).has_suffix(
+      "target/proton-config/subdir/bin/worker",
     ),
   )
   assert_true(
@@ -372,6 +381,12 @@ test "project config rejects absolute project paths with field-specific errors" 
       ),
     ),
     (
+      "bundle.sign.binaries[0]",
+      project_config_for_path_test(
+        html_entry, "bundle = { sign: { binaries: [\"/bin/worker\"] } }",
+      ),
+    ),
+    (
       "bundle.output",
       project_config_for_path_test(
         html_entry, "bundle = { output: \"/target/proton-dist\" }",
@@ -390,6 +405,20 @@ test "project config rejects absolute project paths with field-specific errors" 
       " must be a relative path; absolute paths and drive prefixes are not allowed",
     )
   }
+}
+
+///|
+test "project config rejects signing binary globs under the correct field" {
+  let source = project_config_for_path_test(
+    "{ kind: \"html\", value: \"<main>App</main>\" }", "bundle = { sign: { binaries: [\"bin/*.exe\"] } }",
+  )
+  let error = expect_project_config_error(() => {
+    load_project_config_from_text(source, "target/proton-config")
+  })
+  assert_eq(
+    error.message(),
+    "moon.proton.bundle.sign.binaries[0] must name one file; glob patterns are not supported",
+  )
 }
 
 ///|

--- a/config/pkg.generated.mbti
+++ b/config/pkg.generated.mbti
@@ -78,12 +78,13 @@ pub(all) struct ProjectBundleConfig {
   targets : Array[String]
   icon : Array[String]
   resources : Array[String]
+  sign : ProjectSignConfig?
   url_schemes : Array[String]
   document_types : Array[ProjectDocumentType]
   output : String
 } derive(Eq, @debug.Debug)
 pub fn ProjectBundleConfig::active(Self) -> Bool
-pub fn ProjectBundleConfig::new(active? : Bool, targets? : Array[String], icon? : Array[String], resources? : Array[String], url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String) -> Self
+pub fn ProjectBundleConfig::new(active? : Bool, targets? : Array[String], icon? : Array[String], resources? : Array[String], sign? : ProjectSignConfig?, url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String) -> Self
 pub fn ProjectBundleConfig::output(Self) -> String
 
 pub(all) struct ProjectConfig {
@@ -160,6 +161,12 @@ pub(all) struct ProjectPermissionGrant {
   scope : Json
 } derive(Eq, @debug.Debug)
 pub fn ProjectPermissionGrant::new(String, String, String, scope? : Json) -> Self
+
+pub(all) struct ProjectSignConfig {
+  binaries : Array[String]
+} derive(Eq, @debug.Debug)
+pub fn ProjectSignConfig::binaries(Self) -> Array[String]
+pub fn ProjectSignConfig::new(binaries? : Array[String]) -> Self
 
 pub(all) enum ProjectTitlebarStyle {
   TitlebarDefault

--- a/config/project_config.mbt
+++ b/config/project_config.mbt
@@ -175,11 +175,32 @@ pub fn ProjectFrontendConfig::path(self : ProjectFrontendConfig) -> String? {
 }
 
 ///|
+/// Signing settings for files copied through `bundle.resources`.
+pub(all) struct ProjectSignConfig {
+  binaries : Array[String]
+} derive(Eq, Debug)
+
+///|
+/// Creates signing settings for package-relative resource binaries.
+pub fn ProjectSignConfig::new(
+  binaries? : Array[String] = [],
+) -> ProjectSignConfig {
+  ProjectSignConfig::{ binaries: copy_strings(binaries) }
+}
+
+///|
+/// Returns the project paths whose packaged copies must be signed.
+pub fn ProjectSignConfig::binaries(self : ProjectSignConfig) -> Array[String] {
+  copy_strings(self.binaries)
+}
+
+///|
 pub(all) struct ProjectBundleConfig {
   active : Bool
   targets : Array[String]
   icon : Array[String]
   resources : Array[String]
+  sign : ProjectSignConfig?
   url_schemes : Array[String]
   document_types : Array[ProjectDocumentType]
   output : String
@@ -214,6 +235,7 @@ pub fn ProjectBundleConfig::new(
   targets? : Array[String] = [],
   icon? : Array[String] = [],
   resources? : Array[String] = [],
+  sign? : ProjectSignConfig? = None,
   url_schemes? : Array[String] = [],
   document_types? : Array[ProjectDocumentType] = [],
   output? : String = "target/proton-dist",
@@ -223,6 +245,7 @@ pub fn ProjectBundleConfig::new(
     targets: copy_strings(targets),
     icon: copy_strings(icon),
     resources: copy_strings(resources),
+    sign,
     url_schemes: copy_strings(url_schemes),
     document_types: document_types.copy(),
     output,

--- a/config/project_decode.mbt
+++ b/config/project_decode.mbt
@@ -579,7 +579,7 @@ fn optional_project_bundle(
     None => None
     Some(Obj(bundle_fields, _)) => {
       validate_object_fields(bundle_fields, "bundle", [
-        "active", "targets", "icon", "resources", "url_schemes", "document_types",
+        "active", "targets", "icon", "resources", "sign", "url_schemes", "document_types",
         "output",
       ])
       let active = optional_bool_config_field(
@@ -608,6 +608,7 @@ fn optional_project_bundle(
           "bundle.resources[" + index.to_string() + "]",
         )
       }
+      let sign = optional_project_sign(bundle_fields, base_dir)
       let url_schemes = optional_string_array_config_field(
         bundle_fields, "url_schemes", "bundle.url_schemes",
       )
@@ -627,6 +628,7 @@ fn optional_project_bundle(
           targets~,
           icon~,
           resources~,
+          sign~,
           url_schemes~,
           document_types~,
           output~,
@@ -706,6 +708,41 @@ fn optional_project_updater(
     Some(_) =>
       raise InvalidField(
         path="moon.proton.updater",
+        expectation="must be an object",
+      )
+  }
+}
+
+///|
+fn optional_project_sign(
+  fields : Array[ConfigField],
+  base_dir : String,
+) -> ProjectSignConfig? raise ProjectConfigError {
+  match find_config_field(fields, "sign") {
+    None => None
+    Some(Obj(sign_fields, _)) => {
+      validate_object_fields(sign_fields, "bundle.sign", ["binaries"])
+      let binaries = optional_string_array_config_field(
+        sign_fields, "binaries", "bundle.sign.binaries",
+      )
+      for index, path in binaries {
+        if path.contains("*") {
+          raise InvalidField(
+            path="moon.proton.bundle.sign.binaries[" + index.to_string() + "]",
+            expectation="must name one file; glob patterns are not supported",
+          )
+        }
+        binaries[index] = rebase_project_path(
+          path,
+          base_dir,
+          "bundle.sign.binaries[" + index.to_string() + "]",
+        )
+      }
+      Some(ProjectSignConfig::new(binaries~))
+    }
+    Some(_) =>
+      raise InvalidField(
+        path="moon.proton.bundle.sign",
         expectation="must be an object",
       )
   }

--- a/proton/bootstrap/config_test.mbt
+++ b/proton/bootstrap/config_test.mbt
@@ -279,6 +279,9 @@ test "load_proton_project_config_from_file decodes tooling blocks and moon.mod m
       #|  targets: ["app", "zip"],
       #|  icon: ["icons/icon.ico"],
       #|  resources: ["resources/**"],
+      #|  sign: {
+      #|    binaries: ["bin/worker"],
+      #|  },
       #|  url_schemes: ["desktop-app"],
       #|  document_types: [{
       #|    name: "Desktop document",
@@ -350,6 +353,15 @@ test "load_proton_project_config_from_file decodes tooling blocks and moon.mod m
           "target/proton-project-config/resources/**",
         ),
       )
+      match bundle.sign() {
+        Some(sign) =>
+          assert_true(
+            normalize_test_slashes(sign.binaries()[0]).has_suffix(
+              "target/proton-project-config/bin/worker",
+            ),
+          )
+        None => fail("expected bundle sign config")
+      }
       assert_true(
         normalize_test_slashes(bundle.output()).has_suffix(
           "target/proton-project-config/target/proton-dist",
@@ -424,6 +436,19 @@ test "load_proton_project_config_from_file decodes tooling blocks and moon.mod m
             bundle.get("url_schemes"),
             Some(Json::array([Json::string("desktop-app")])),
           )
+          match bundle.get("sign") {
+            Some(Object(sign)) =>
+              match sign.get("binaries") {
+                Some(Array([String(path)])) =>
+                  assert_true(
+                    normalize_test_slashes(path).has_suffix(
+                      "target/proton-project-config/bin/worker",
+                    ),
+                  )
+                _ => fail("expected bundle sign binaries summary")
+              }
+            _ => fail("expected bundle sign summary")
+          }
           match bundle.get("document_types") {
             Some(Array([Object(document_type)])) => {
               @debug.assert_eq(

--- a/proton/bootstrap/pkg.generated.mbti
+++ b/proton/bootstrap/pkg.generated.mbti
@@ -54,9 +54,10 @@ pub fn ProtonBundleConfig::active(Self) -> Bool
 pub fn ProtonBundleConfig::document_extensions(Self) -> Array[String]
 pub fn ProtonBundleConfig::document_types(Self) -> Array[@proton_config.ProjectDocumentType]
 pub fn ProtonBundleConfig::icon(Self) -> Array[String]
-pub fn ProtonBundleConfig::new(active? : Bool, targets? : Array[String], icon? : Array[String], resources? : Array[String], url_schemes? : Array[String], document_types? : Array[@proton_config.ProjectDocumentType], output? : String) -> Self
+pub fn ProtonBundleConfig::new(active? : Bool, targets? : Array[String], icon? : Array[String], resources? : Array[String], sign? : ProtonSignConfig?, url_schemes? : Array[String], document_types? : Array[@proton_config.ProjectDocumentType], output? : String) -> Self
 pub fn ProtonBundleConfig::output(Self) -> String
 pub fn ProtonBundleConfig::resources(Self) -> Array[String]
+pub fn ProtonBundleConfig::sign(Self) -> ProtonSignConfig?
 pub fn ProtonBundleConfig::targets(Self) -> Array[String]
 pub fn ProtonBundleConfig::url_schemes(Self) -> Array[String]
 
@@ -79,6 +80,10 @@ pub fn ProtonProjectConfig::new(LoadedAppManifest, ProtonAppMetadata, single_ins
 pub fn ProtonProjectConfig::single_instance(Self) -> Bool
 pub fn ProtonProjectConfig::to_summary_json(Self) -> Json
 pub fn ProtonProjectConfig::updater(Self) -> ProtonUpdaterConfig?
+
+type ProtonSignConfig
+pub fn ProtonSignConfig::binaries(Self) -> Array[String]
+pub fn ProtonSignConfig::new(binaries? : Array[String]) -> Self
 
 type ProtonUpdaterConfig
 pub fn ProtonUpdaterConfig::checks_on_launch(Self) -> Bool

--- a/proton/bootstrap/proton_config_load.mbt
+++ b/proton/bootstrap/proton_config_load.mbt
@@ -178,6 +178,9 @@ fn proton_bundle_from_project_bundle(
     targets=bundle.targets,
     icon=bundle.icon,
     resources=bundle.resources,
+    sign=bundle.sign.map(fn(sign) {
+      ProtonSignConfig::new(binaries=sign.binaries())
+    }),
     url_schemes=bundle.url_schemes,
     document_types=bundle.document_types,
     output=bundle.output(),

--- a/proton/bootstrap/proton_project_config.mbt
+++ b/proton/bootstrap/proton_project_config.mbt
@@ -118,12 +118,33 @@ pub fn ProtonFrontendConfig::path(self : ProtonFrontendConfig) -> String? {
 }
 
 ///|
+/// Signing settings from `bundle.sign` in `moon.proton`.
+struct ProtonSignConfig {
+  binaries : Array[String]
+}
+
+///|
+/// Creates signing settings for packaged resource binaries.
+pub fn ProtonSignConfig::new(
+  binaries? : Array[String] = [],
+) -> ProtonSignConfig {
+  ProtonSignConfig::{ binaries: copy_strings(binaries) }
+}
+
+///|
+/// Returns the project paths whose packaged copies must be signed.
+pub fn ProtonSignConfig::binaries(self : ProtonSignConfig) -> Array[String] {
+  copy_strings(self.binaries)
+}
+
+///|
 /// Bundle input settings from `moon.proton`.
 struct ProtonBundleConfig {
   active : Bool
   targets : Array[String]
   icon : Array[String]
   resources : Array[String]
+  sign : ProtonSignConfig?
   url_schemes : Array[String]
   document_types : Array[@proton_config.ProjectDocumentType]
   output : String
@@ -135,6 +156,7 @@ pub fn ProtonBundleConfig::new(
   targets? : Array[String] = [],
   icon? : Array[String] = [],
   resources? : Array[String] = [],
+  sign? : ProtonSignConfig? = None,
   url_schemes? : Array[String] = [],
   document_types? : Array[@proton_config.ProjectDocumentType] = [],
   output? : String = "target/proton-dist",
@@ -144,6 +166,7 @@ pub fn ProtonBundleConfig::new(
     targets: copy_strings(targets),
     icon: copy_strings(icon),
     resources: copy_strings(resources),
+    sign,
     url_schemes: copy_strings(url_schemes),
     document_types: document_types.copy(),
     output,
@@ -170,6 +193,11 @@ pub fn ProtonBundleConfig::resources(
   self : ProtonBundleConfig,
 ) -> Array[String] {
   copy_strings(self.resources)
+}
+
+///|
+pub fn ProtonBundleConfig::sign(self : ProtonBundleConfig) -> ProtonSignConfig? {
+  self.sign
 }
 
 ///|

--- a/proton/bootstrap/proton_project_summary.mbt
+++ b/proton/bootstrap/proton_project_summary.mbt
@@ -76,6 +76,11 @@ fn bundle_summary_json(bundle : ProtonBundleConfig?) -> Json {
         "targets": string_array_json(bundle.targets()),
         "icon": string_array_json(bundle.icon()),
         "resources": string_array_json(bundle.resources()),
+        "sign": match bundle.sign() {
+          Some(sign) =>
+            Json::object({ "binaries": string_array_json(sign.binaries()) })
+          None => Json::null()
+        },
         "url_schemes": string_array_json(bundle.url_schemes()),
         "document_types": Json::array(
           bundle


### PR DESCRIPTION
## Summary

- add `bundle.sign.binaries` for packaged resource files that must be signed
- include configured binaries in macOS hardened-runtime signing and Windows signtool signing and verification
- preserve the field through bootstrap config and summary output, including generated interfaces
- reject globs and non-portable paths under the exact config field

## Why

Application-owned executables copied with `bundle.resources` were not part of Proton's signing target list. Copying and signing are now intentionally separate: `bundle.resources` stages a file, while `bundle.sign.binaries` selects staged files for signing on macOS and Windows.

## Impact

Projects can declare additional packaged executables once and have Proton include them in the platform signing flow. Existing projects without `bundle.sign.binaries` are unchanged.

## Validation

- `moon -C config check . --target native --deny-warn --diagnostic-limit 80`
- `moon -C cli check package --target native --deny-warn --diagnostic-limit 80`
- `moon -C proton check bootstrap --target native --deny-warn --diagnostic-limit 80`
- config tests: 30 passed
- bootstrap tests: 12 passed
- package tests excluding DMG: 38 passed
- Windows package tests on macOS host: 10 passed
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`