### PR TITLE
chore(deps): bump remaining dependency pins to latest

### DIFF
--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -6,7 +6,7 @@ readme = "README.mbt.md"
 
 import {
   "moonbitlang/async@0.20.3",
-  "moonbitlang/x@0.4.47",
+  "moonbitlang/x@0.4.48",
 }
 
 repository = "https://github.com/moonbit-community/proton"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -11,7 +11,7 @@ import {
   "moonbitlang/moon_config@0.3.11",
   "moonbitlang/lexer@0.3.12",
   "moonbitlang/async@0.20.3",
-  "justjavac/ffi@0.2.3",
+  "justjavac/ffi@0.2.4",
 }
 
 readme = "codegen/README.md"

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -14,7 +14,7 @@ let default_proton_client_version = "0.1.1"
 let default_proton_rabbita_version = "0.1.1"
 
 ///|
-let default_rabbita_version = "0.14.0"
+let default_rabbita_version = "0.14.1"
 
 ///|
 fn scaffold_release_chain() -> String {

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -6,7 +6,7 @@ import {
   "moonbitlang/async@0.20.3",
   "moonbitlang/x@0.4.48",
   "justjavac/cdp@0.1.9",
-  "justjavac/proton@0.1.2",
+  "justjavac/proton@0.1.14",
   "justjavac/proton_updater@0.1.0",
   "justjavac/proton/examples@0.1.0",
 }

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -5,9 +5,9 @@ version = "0.1.0"
 import {
   "moonbitlang/x@0.4.48",
   "moonbitlang/async@0.20.3",
-  "justjavac/proton_ext@0.1.3",
-  "justjavac/proton_contract@0.1.0",
-  "justjavac/proton@0.1.2",
+  "justjavac/proton_ext@0.1.7",
+  "justjavac/proton_contract@0.1.1",
+  "justjavac/proton@0.1.14",
 }
 
 readme = "README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -3,14 +3,14 @@ name = "justjavac/proton_ext"
 version = "0.1.7"
 
 import {
-  "justjavac/ffi@0.2.3",
+  "justjavac/ffi@0.2.4",
   "moonbitlang/x@0.4.48",
   "moonbitlang/async@0.20.3",
   "justjavac/clipboard@0.1.5",
   "justjavac/tray@0.1.7",
   "justjavac/global_hotkey@0.1.4",
-  "justjavac/proton@0.1.6",
-  "justjavac/proton_contract@0.1.0",
+  "justjavac/proton@0.1.14",
+  "justjavac/proton_contract@0.1.1",
   "justjavac/microphone@0.1.3",
   "justjavac/auto_launch@0.1.3",
   "justjavac/keepawake@0.1.0",

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -3,7 +3,7 @@ name = "justjavac/proton"
 version = "0.1.14"
 
 import {
-  "justjavac/ffi@0.2.3",
+  "justjavac/ffi@0.2.4",
   "justjavac/proton_config@0.1.8",
   "justjavac/proton_contract@0.1.1",
   "justjavac/proton_updater@0.1.0",

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "justjavac/ffi"
 
-version = "0.2.3"
+version = "0.2.4"
 
 import {
   "moonbitlang/x@0.4.48",

--- a/sys/ffi/src/cstr.mbt
+++ b/sys/ffi/src/cstr.mbt
@@ -34,8 +34,12 @@ pub fn from_cstr(b : Bytes) -> String {
   if b.length() == 0 || b[b.length() - 1] != 0x00 {
     abort("expected null-terminated byte strings")
   }
+  let mut end = 0
+  while end < b.length() && b[end] != 0x00 {
+    end = end + 1
+  }
   let decoder = @encoding.decoder(UTF8)
-  decoder.decode_lossy(b[0:b.length() - 1])
+  decoder.decode_lossy(b[0:end])
 }
 
 ///|

--- a/sys/ffi/src/ffi_test.mbt
+++ b/sys/ffi/src/ffi_test.mbt
@@ -11,6 +11,11 @@ test "to_cstr appends a trailing nul" {
 }
 
 ///|
+test "from_cstr stops at first nul" {
+  assert_eq(@ffi.from_cstr(b"ffi\x00ignored\x00"), "ffi")
+}
+
+///|
 test "panic from_cstr requires terminator" {
   @ffi.from_cstr(b"ffi") |> ignore
 }
@@ -25,6 +30,14 @@ test "wstr round trip unicode" {
 test "to_wstr appends a trailing wide nul" {
   assert_eq(@ffi.to_wstr("Hi"), b"\x48\x00\x69\x00\x00\x00")
   assert_eq(@ffi.to_wstr(""), b"\x00\x00")
+}
+
+///|
+test "from_wstr_lossy stops at first wide nul" {
+  assert_eq(
+    @ffi.from_wstr_lossy(b"\x48\x00\x69\x00\x00\x00\x78\x00\x00\x00"),
+    "Hi",
+  )
 }
 
 ///|

--- a/sys/ffi/src/wstr.mbt
+++ b/sys/ffi/src/wstr.mbt
@@ -34,8 +34,12 @@ pub fn from_wstr_lossy(b : Bytes) -> String {
   if b.length() < 2 || b[b.length() - 2] != 0x00 || b[b.length() - 1] != 0x00 {
     abort("expected null-terminated wide strings")
   }
+  let mut end = 0
+  while end + 1 < b.length() && !(b[end] == 0x00 && b[end + 1] == 0x00) {
+    end = end + 2
+  }
   let decoder = @encoding.decoder(UTF16)
-  decoder.decode_lossy(b[0:b.length() - 2])
+  decoder.decode_lossy(b[0:end])
 }
 
 ///|


### PR DESCRIPTION
## Summary

Follow-up to #87, sweeping the remaining stale pins:

- **sys/ffi**: sync with upstream justjavac/ffi 0.2.4 — `from_cstr`/`from_wstr_lossy` now scan for the actual NUL terminator instead of assuming the last byte; the six `justjavac/ffi` pins move to 0.2.4.
- **Internal pins** aligned with their published versions: `proton` 0.1.14 (examples/e2e/extensions), `proton_ext` 0.1.7, `proton_contract` 0.1.1.
- **cdp** and **sys/ffi** now require `moonbitlang/x` 0.4.48 like the rest of the workspace.
- **`proton new` scaffolds** now depend on `moonbit-community/rabbita` 0.14.1.

All moonbitlang/* requirements were already at latest after #87. sys binding pins (clipboard, tray, etc.) intentionally stay at their local member versions — the newer registry releases of those modules have not been vendored into this repo.

## Platform impact

None — dependency metadata plus the vendored ffi string helpers.

## Validation

- `moon fmt` / `moon check --target native --deny-warn`
- `moon test -p justjavac/ffi justjavac/proton_cli/new --target native` — 28/28
- `moon -C examples check --target native`, `moon -C e2e build --target native`