### PR TITLE
fix(ci): bound e2e operations and stabilize Windows teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
           # windows-latest runners have no usable D3D device; force ANGLE's
           # SwiftShader path so the engine's GPU process can start at all.
           $env:ANGLE_DEFAULT_PLATFORM = "swiftshader"
+          "ANGLE_DEFAULT_PLATFORM=swiftshader" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           ctest --test-dir native\build-engine -C Debug --output-on-failure
           if (!(Test-Path "$runtime\bin\proton.dll")) {
             throw "missing active proton.dll"
@@ -313,6 +314,7 @@ jobs:
 
       - name: Run MoonBit CDP e2e on Windows
         if: ${{ matrix.os == 'windows-latest' }}
+        timeout-minutes: 10
         env:
           _CL_: /utf-8
           PROTON_BRIDGE_E2E_TIMEOUT_MS: 60000
@@ -323,6 +325,7 @@ jobs:
 
       - name: Run MoonBit CDP e2e on Unix
         if: ${{ matrix.os != 'windows-latest' }}
+        timeout-minutes: 10
         env:
           PROTON_BRIDGE_E2E_TIMEOUT_MS: 60000
         run: |

--- a/e2e/test/app_commands_probe_wbtest.mbt
+++ b/e2e/test/app_commands_probe_wbtest.mbt
@@ -499,9 +499,7 @@ async fn connect_page_matching_expression(
 ) -> @client.CdpClient {
   let mut elapsed = 0
   while elapsed <= timeout {
-    let targets = @client.discover_targets(cdp_target_from(target)) catch {
-      _ => []
-    }
+    let targets = discover_targets_for_poll(cdp_target_from(target))
     for info in targets {
       if info.target_type == "page" &&
         (

--- a/e2e/test/dev_extension_process_wbtest.mbt
+++ b/e2e/test/dev_extension_process_wbtest.mbt
@@ -397,7 +397,9 @@ async fn run_dev_extension_dev_probe_once(
       remove_dev_extension_tree(cli_target_dir)
       remove_dev_extension_tree(app_target_dir)
     }
-    wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout)
+    ignore(
+      wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout),
+    )
     run_dev_extension_page_probe(app, target, frontend_url, root, timeout)
     match app_exit_code(app.process) {
       Some(code) =>
@@ -434,7 +436,9 @@ async fn run_dev_extension_production_probe_once(
       }
       remove_dev_extension_tree(example_target_dir)
     }
-    wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout)
+    ignore(
+      wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout),
+    )
     run_dev_extension_production_page_probe(app, target, timeout)
     match app_exit_code(app.process) {
       Some(code) =>

--- a/e2e/test/dev_extension_process_wbtest.mbt
+++ b/e2e/test/dev_extension_process_wbtest.mbt
@@ -464,9 +464,17 @@ async fn run_dev_extension_scenario_once(root : String, timeout : Int) -> Unit {
   }
   ensure_dev_extension_frontend(root, timeout)
   let frontend_port = choose_cdp_port()
-  run_dev_extension_dev_probe_once(root, frontend_port, timeout)
+  run_e2e_operation_with_timeout(
+    timeout,
+    "47_dev_extension_js development probe",
+    () => run_dev_extension_dev_probe_once(root, frontend_port, timeout),
+  )
   build_dev_extension_frontend(root, timeout)
-  run_dev_extension_production_probe_once(root, timeout)
+  run_e2e_operation_with_timeout(
+    timeout,
+    "47_dev_extension_js production probe",
+    () => run_dev_extension_production_probe_once(root, timeout),
+  )
 }
 
 ///|

--- a/e2e/test/dev_extension_process_wbtest.mbt
+++ b/e2e/test/dev_extension_process_wbtest.mbt
@@ -139,6 +139,7 @@ async fn run_dev_extension_command(
       output_path,
       create_mode=@fs.CreateOrTruncate,
     )
+    let (program, args) = isolated_app_command(program, args)
     let process = @process.spawn(
       group,
       program,
@@ -269,9 +270,10 @@ async fn spawn_dev_extension_cli_app(
     "--timeout-ms",
     timeout_ms().to_string(),
   ]
+  let (program, args) = isolated_app_command("moon", args)
   let process = @process.spawn(
     group,
-    "moon",
+    program,
     args,
     cwd=root,
     extra_env=dev_extension_host_env(root, cdp_port),
@@ -301,21 +303,22 @@ async fn spawn_dev_extension_production_app(
     output_path,
     create_mode=@fs.CreateOrTruncate,
   )
+  let (program, args) = isolated_app_command("moon", [
+    "-C",
+    join_path(root, "examples"),
+    "--target-dir",
+    dev_extension_example_target_dir(root, cdp_port),
+    "run",
+    "47_dev_extension_js",
+    "--target",
+    "native",
+    "--diagnostic-limit",
+    "120",
+  ])
   let process = @process.spawn(
     group,
-    "moon",
-    [
-      "-C",
-      join_path(root, "examples"),
-      "--target-dir",
-      dev_extension_example_target_dir(root, cdp_port),
-      "run",
-      "47_dev_extension_js",
-      "--target",
-      "native",
-      "--diagnostic-limit",
-      "120",
-    ],
+    program,
+    args,
     cwd=root,
     extra_env=dev_extension_runtime_env(root, cdp_port),
     stdout=output,

--- a/e2e/test/env.mbt
+++ b/e2e/test/env.mbt
@@ -7,6 +7,24 @@ fn env_or(name : String, default : String) -> String {
 }
 
 ///|
+let cdp_start_poll_timeout_ms = 250
+
+///|
+async fn discover_targets_for_poll(
+  target : @client.CdpTarget,
+) -> Array[@client.CdpDiscoveredTarget] {
+  let result = @async.with_timeout_opt(cdp_start_poll_timeout_ms, () => {
+    @client.discover_targets(target)
+  }) catch {
+    _ => None
+  }
+  match result {
+    Some(targets) => targets
+    None => []
+  }
+}
+
+///|
 fn cdp_target_text() -> String {
   env_or("MBT_CDP_TARGET", "9222")
 }

--- a/e2e/test/moon.pkg
+++ b/e2e/test/moon.pkg
@@ -25,6 +25,7 @@ supported_targets = "native"
 pkgtype(kind: "executable")
 
 options(
+  "native-stub": [ "process_group.c" ],
   targets: {
     "cdp_eval.mbt": [ "native" ],
     "env.mbt": [ "native" ],

--- a/e2e/test/multi_window_driver.mbt
+++ b/e2e/test/multi_window_driver.mbt
@@ -73,7 +73,7 @@ async fn wait_for_multi_window_targets(
   let cdp_target = cdp_target_from(target)
   let mut elapsed = 0
   while elapsed <= timeout {
-    let targets = @client.discover_targets(cdp_target) catch { _ => [] }
+    let targets = discover_targets_for_poll(cdp_target)
     let mut target_a : @client.CdpDiscoveredTarget? = None
     let mut target_b : @client.CdpDiscoveredTarget? = None
     for item in targets {

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -11,6 +11,23 @@ let app_child_test_selector = "scenario_app_wbtest.mbt:0-1"
 let scenario_run_mutex : @async.Mutex = @async.Mutex::Mutex()
 
 ///|
+priv suberror E2eOperationError {
+  TimedOut(description~ : String, timeout_ms~ : Int)
+} derive(Debug)
+
+///|
+async fn[X] run_e2e_operation_with_timeout(
+  timeout : Int,
+  description : String,
+  operation : async () -> X,
+) -> X {
+  match @async.with_timeout_opt(timeout, operation) {
+    Some(result) => result
+    None => raise E2eOperationError::TimedOut(description~, timeout_ms=timeout)
+  }
+}
+
+///|
 struct SpawnedScenarioApp {
   process : @process.Process
   output_path : String
@@ -385,9 +402,15 @@ async fn wait_for_spawned_app_cdp(
     }
     let endpoint_ready = try {
       ignore(
-        @client.wait_for_browser_endpoint(
-          endpoint,
-          timeout_ms=cdp_start_poll_timeout_ms,
+        run_e2e_operation_with_timeout(
+          cdp_start_poll_timeout_ms,
+          "CDP browser endpoint probe",
+          () => {
+            @client.wait_for_browser_endpoint(
+              endpoint,
+              timeout_ms=cdp_start_poll_timeout_ms,
+            )
+          },
         ),
       )
       true
@@ -396,10 +419,14 @@ async fn wait_for_spawned_app_cdp(
     }
     if endpoint_ready {
       browser_ready = true
-      let page_ready = try {
-        let targets = @client.discover_targets(cdp_target_from(endpoint))
-        targets.any(info => info.target_type == "page")
-      } catch {
+      let page_ready = run_e2e_operation_with_timeout(
+        cdp_start_poll_timeout_ms,
+        "CDP page discovery probe",
+        () => {
+          let targets = @client.discover_targets(cdp_target_from(endpoint))
+          targets.any(info => info.target_type == "page")
+        },
+      ) catch {
         _ => false
       }
       if page_ready {
@@ -624,7 +651,9 @@ async fn run_scenario_probe_with_retry(
   let mut attempt = 0
   while attempt < 2 {
     let succeeded = try {
-      run_scenario_probe_once(root, name, timeout)
+      run_e2e_operation_with_timeout(timeout, "E2E scenario " + name, () => {
+        run_scenario_probe_once(root, name, timeout)
+      })
       true
     } catch {
       error => {
@@ -646,6 +675,7 @@ async fn run_scenario_probe_with_retry(
 ///|
 fn retryable_scenario_error(error : Error) -> Bool {
   match error {
+    E2eOperationError::TimedOut(..) => true
     @io.ReaderClosed => true
     _ => retryable_startup_error(error)
   }

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -295,23 +295,52 @@ fn scenario_app_command(root : String) -> (String, Array[String]) raise {
     // valid for the current process but not a standalone execve target.  Ask
     // Moon to run exactly the child test in an isolated, serially reused build
     // directory on Unix instead of attempting to re-exec the parent binary.
-    (
-      "moon",
-      [
-        "--target-dir",
-        join_path(root, "target/proton-e2e-app-child"),
-        "-C",
-        root,
-        "test",
-        "e2e/test/scenario_app_wbtest.mbt",
-        "--target",
-        "native",
-        "--no-parallelize",
-        "--diagnostic-limit",
-        "80",
-      ],
-    )
+    isolated_app_command("moon", [
+      "--target-dir",
+      join_path(root, "target/proton-e2e-app-child"),
+      "-C",
+      root,
+      "test",
+      "e2e/test/scenario_app_wbtest.mbt",
+      "--target",
+      "native",
+      "--no-parallelize",
+      "--diagnostic-limit",
+      "80",
+    ])
   }
+}
+
+///|
+fn isolated_app_command(
+  program : String,
+  args : Array[String],
+) -> (String, Array[String]) {
+  if @path.sep == '\\' {
+    (program, args)
+  } else {
+    let command_args = [
+      "-c",
+      unix_app_session_script(),
+      "proton-e2e-session",
+      program,
+    ]
+    for arg in args {
+      command_args.push(arg)
+    }
+    ("sh", command_args)
+  }
+}
+
+///|
+fn unix_app_session_script() -> String {
+  (
+    #|if command -v setsid >/dev/null 2>&1; then
+    #|  exec setsid "$@"
+    #|else
+    #|  exec "$@"
+    #|fi
+  )
 }
 
 ///|
@@ -341,8 +370,6 @@ fn app_cancel_handler() -> @process.CancellationHandler {
     })
   } else {
     @process.CancellationHandler(async fn(pid) {
-      terminate_unix_app_tree(pid, "TERM")
-      @async.sleep(1000)
       terminate_unix_app_tree(pid, "KILL")
     })
   }
@@ -352,7 +379,7 @@ fn app_cancel_handler() -> @process.CancellationHandler {
 async fn terminate_unix_app_tree(pid : Int, signal : String) -> Unit {
   ignore(
     @process.run(
-      "sh",
+      "/bin/sh",
       [
         "-c",
         unix_app_tree_kill_script(),
@@ -360,6 +387,7 @@ async fn terminate_unix_app_tree(pid : Int, signal : String) -> Unit {
         pid.to_string(),
         signal,
       ],
+      inherit_env=false,
       no_console_window=true,
     ),
   )
@@ -368,6 +396,8 @@ async fn terminate_unix_app_tree(pid : Int, signal : String) -> Unit {
 ///|
 fn unix_app_tree_kill_script() -> String {
   (
+    #|PATH=/usr/bin:/bin:/usr/sbin:/sbin
+    #|export PATH
     #|kill_tree() {
     #|  parent="$1"
     #|  signal="$2"
@@ -378,7 +408,15 @@ fn unix_app_tree_kill_script() -> String {
     #|  fi
     #|  kill "-$signal" "$parent" 2>/dev/null || true
     #|}
-    #|kill_tree "$1" "$2"
+    #|parent="$1"
+    #|signal="$2"
+    #|parent_group=$(ps -o pgid= -p "$parent" 2>/dev/null | tr -d '[:space:]')
+    #|caller_group=$(ps -o pgid= -p "$PPID" 2>/dev/null | tr -d '[:space:]')
+    #|if [ -n "$parent_group" ] && [ "$parent_group" != "$caller_group" ]; then
+    #|  kill "-$signal" -- "-$parent_group" 2>/dev/null || true
+    #|else
+    #|  kill_tree "$parent" "$signal"
+    #|fi
   )
 }
 

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -1,7 +1,4 @@
 ///|
-let cdp_start_poll_timeout_ms = 250
-
-///|
 let app_child_scenario_env = "MBT_PROTON_E2E_APP_CHILD"
 
 ///|
@@ -430,7 +427,7 @@ async fn wait_for_spawned_app_cdp(
   app : SpawnedScenarioApp,
   endpoint : String,
   timeout : Int,
-) -> Unit {
+) -> String {
   let mut elapsed = 0
   let mut browser_ready = false
   while elapsed <= timeout {
@@ -443,42 +440,32 @@ async fn wait_for_spawned_app_cdp(
         )
       None => ()
     }
-    let endpoint_ready = try {
-      ignore(
-        run_e2e_operation_with_timeout(
-          cdp_start_poll_timeout_ms,
-          "CDP browser endpoint probe",
-          () => {
-            @client.wait_for_browser_endpoint(
-              endpoint,
-              timeout_ms=cdp_start_poll_timeout_ms,
-            )
-          },
-        ),
-      )
-      true
-    } catch {
-      _ => false
-    }
-    if endpoint_ready {
-      browser_ready = true
-      let page_ready = run_e2e_operation_with_timeout(
+    let browser_web_socket_url = Some(
+      run_e2e_operation_with_timeout(
         cdp_start_poll_timeout_ms,
-        "CDP page discovery probe",
+        "CDP browser endpoint probe",
         () => {
-          let targets = @client.discover_targets(cdp_target_from(endpoint))
-          targets.any(info => info.target_type == "page")
+          @client.wait_for_browser_endpoint(
+            endpoint,
+            timeout_ms=cdp_start_poll_timeout_ms,
+          )
         },
-      ) catch {
-        _ => false
+      ),
+    ) catch {
+      _ => None
+    }
+    match browser_web_socket_url {
+      Some(browser_web_socket_url) => {
+        browser_ready = true
+        let targets = discover_targets_for_poll(cdp_target_from(endpoint))
+        let page_ready = targets.any(info => info.target_type == "page")
+        if page_ready {
+          return browser_web_socket_url
+        }
+        @async.sleep(100)
+        elapsed = elapsed + 100
       }
-      if page_ready {
-        return
-      }
-      @async.sleep(100)
-      elapsed = elapsed + 100
-    } else {
-      elapsed = elapsed + cdp_start_poll_timeout_ms
+      None => elapsed = elapsed + cdp_start_poll_timeout_ms
     }
   }
   if browser_ready {
@@ -643,11 +630,17 @@ async fn run_scenario_probe_once(
     let app = spawn_scenario_app(group, root, name, port)
     let mut stopped = false
     defer (if !stopped { app.process.cancel() })
-    wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout)
+    let browser_web_socket_url = wait_for_spawned_app_cdp(
+      app,
+      cdp_http_endpoint_from(target),
+      timeout,
+    )
     let shutdown = if name == "45_bridge_multi_window" {
       run_multi_window_scenario_probe(app, target, timeout)
     } else if name == "52_web_contents_view" {
-      run_web_contents_view_scenario_probe(app, target, timeout)
+      run_web_contents_view_scenario_probe(
+        app, target, browser_web_socket_url, timeout,
+      )
     } else {
       if name == "41_app_commands" {
         run_app_commands_full_probe(root, target, timeout, app.native_log_path)
@@ -691,12 +684,15 @@ async fn run_scenario_probe_with_retry(
   name : String,
   timeout : Int,
 ) -> Unit {
+  let operation_timeout = scenario_operation_timeout(name, timeout)
   let mut attempt = 0
   while attempt < 2 {
     let succeeded = try {
-      run_e2e_operation_with_timeout(timeout, "E2E scenario " + name, () => {
-        run_scenario_probe_once(root, name, timeout)
-      })
+      run_e2e_operation_with_timeout(
+        operation_timeout,
+        "E2E scenario " + name,
+        () => run_scenario_probe_once(root, name, timeout),
+      )
       true
     } catch {
       error => {
@@ -712,6 +708,17 @@ async fn run_scenario_probe_with_retry(
     }
     @async.sleep(1000)
     attempt = attempt + 1
+  }
+}
+
+///|
+fn scenario_operation_timeout(name : String, timeout : Int) -> Int {
+  if name == "52_web_contents_view" {
+    // The view probe has separate startup, target, page, paint, and shutdown
+    // waits.  Its outer guard must cover more than one phase-sized budget.
+    timeout * 2
+  } else {
+    timeout
   }
 }
 

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -370,10 +370,15 @@ fn app_cancel_handler() -> @process.CancellationHandler {
     })
   } else {
     @process.CancellationHandler(async fn(pid) {
-      terminate_unix_app_tree(pid, "KILL")
+      if kill_isolated_unix_app_group(pid) != 0 {
+        terminate_unix_app_tree(pid, "KILL")
+      }
     })
   }
 }
+
+///|
+extern "C" fn kill_isolated_unix_app_group(pid : Int) -> Int = "proton_e2e_kill_isolated_process_group"
 
 ///|
 async fn terminate_unix_app_tree(pid : Int, signal : String) -> Unit {

--- a/e2e/test/process_group.c
+++ b/e2e/test/process_group.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+
+#include "moonbit.h"
+
+#if !defined(_WIN32)
+#include <errno.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+/*
+ * Kill a process group only when the tracked child owns a group distinct from
+ * the test runner. Returning 1 asks MoonBit to use its portable tree fallback.
+ */
+MOONBIT_FFI_EXPORT int32_t proton_e2e_kill_isolated_process_group(
+  int32_t pid
+) {
+#if defined(_WIN32)
+  (void)pid;
+  return 1;
+#else
+  pid_t group;
+
+  if (pid <= 0) {
+    return -EINVAL;
+  }
+
+  group = getpgid((pid_t)pid);
+  if (group < 0) {
+    return errno == ESRCH ? 0 : -errno;
+  }
+  if (group != (pid_t)pid || group == getpgrp()) {
+    return 1;
+  }
+  if (kill(-group, SIGKILL) == 0 || errno == ESRCH) {
+    return 0;
+  }
+  return -errno;
+#endif
+}

--- a/e2e/test/process_lifecycle_wbtest.mbt
+++ b/e2e/test/process_lifecycle_wbtest.mbt
@@ -336,7 +336,9 @@ async fn run_pending_lifecycle_probe_once(root : String, timeout : Int) -> Unit 
     let app = spawn_scenario_app(group, root, name, port)
     let mut stopped = false
     defer (if !stopped { app.process.cancel() })
-    wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout)
+    ignore(
+      wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout),
+    )
     let page = connect_spawned_page(app, target, timeout)
     let mut page_open = true
     defer (if page_open { page.close() })
@@ -430,7 +432,9 @@ async fn run_event_lifecycle_probe_once(root : String, timeout : Int) -> Unit {
     let app = spawn_scenario_app(group, root, name, port)
     let mut stopped = false
     defer (if !stopped { app.process.cancel() })
-    wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout)
+    ignore(
+      wait_for_spawned_app_cdp(app, cdp_http_endpoint_from(target), timeout),
+    )
     let page = connect_spawned_page(app, target, timeout)
     let mut page_open = true
     defer (if page_open { page.close() })

--- a/e2e/test/process_lifecycle_wbtest.mbt
+++ b/e2e/test/process_lifecycle_wbtest.mbt
@@ -398,14 +398,18 @@ async fn run_pending_lifecycle_probe(root : String, timeout : Int) -> Unit {
   let mut attempt = 0
   while attempt < 2 {
     let succeeded = try {
-      run_pending_lifecycle_probe_once(root, timeout)
+      run_e2e_operation_with_timeout(
+        timeout,
+        "41_app_commands pending lifecycle",
+        () => run_pending_lifecycle_probe_once(root, timeout),
+      )
       true
     } catch {
       error => {
-        if attempt == 1 || !retryable_startup_error(error) {
+        if attempt == 1 || !retryable_scenario_error(error) {
           raise error
         }
-        println("MoonBit lifecycle startup attempt failed; retrying once")
+        println("MoonBit pending lifecycle attempt failed; retrying once")
         false
       }
     }
@@ -486,14 +490,18 @@ async fn run_event_lifecycle_probe(root : String, timeout : Int) -> Unit {
   let mut attempt = 0
   while attempt < 2 {
     let succeeded = try {
-      run_event_lifecycle_probe_once(root, timeout)
+      run_e2e_operation_with_timeout(
+        timeout,
+        "40_event_broadcast event lifecycle",
+        () => run_event_lifecycle_probe_once(root, timeout),
+      )
       true
     } catch {
       error => {
-        if attempt == 1 || !retryable_startup_error(error) {
+        if attempt == 1 || !retryable_scenario_error(error) {
           raise error
         }
-        println("MoonBit event lifecycle startup attempt failed; retrying once")
+        println("MoonBit event lifecycle attempt failed; retrying once")
         false
       }
     }
@@ -523,9 +531,15 @@ async fn connect_spawned_page(
       None => ()
     }
     let page = Some(
-      @client.connect_cdp_page_target_with_timeout(
-        cdp_target_from(target),
-        timeout_ms=cdp_start_poll_timeout_ms,
+      run_e2e_operation_with_timeout(
+        cdp_start_poll_timeout_ms,
+        "CDP page connection probe",
+        () => {
+          @client.connect_cdp_page_target_with_timeout(
+            cdp_target_from(target),
+            timeout_ms=cdp_start_poll_timeout_ms,
+          )
+        },
       ),
     ) catch {
       _ => None

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -45,6 +45,14 @@ test "E2E paths resolve backslash relative runtime directories" {
 
 ///|
 test "scenario retries only startup and closed CDP transports" {
+  assert_true(
+    retryable_scenario_error(
+      E2eOperationError::TimedOut(
+        description="E2E scenario stalled",
+        timeout_ms=60000,
+      ),
+    ),
+  )
   assert_true(retryable_scenario_error(@io.ReaderClosed))
   assert_true(
     retryable_scenario_error(
@@ -76,4 +84,70 @@ test "scenario child command is platform-safe" {
     assert_true(args.contains(root))
     assert_true(args.contains(join_path(root, "target/proton-e2e-app-child")))
   }
+}
+
+///|
+async test "E2E operation timeout cancels stalled work" {
+  let cancelled = Ref(false)
+  let outcome = try {
+    run_e2e_operation_with_timeout(20, "stalled probe", () => {
+      defer {
+        cancelled.val = true
+      }
+      @async.sleep(10000)
+    })
+    None
+  } catch {
+    error => Some(error)
+  }
+  assert_true(cancelled.val)
+  match outcome {
+    Some(E2eOperationError::TimedOut(description~, timeout_ms~)) => {
+      assert_eq(description, "stalled probe")
+      assert_eq(timeout_ms, 20)
+    }
+    Some(error) =>
+      fail("unexpected timeout error: " + @debug.render(Repr(error)))
+    None => fail("expected stalled E2E operation to time out")
+  }
+}
+
+///|
+async test "E2E timeout interrupts stalled CDP discovery HTTP" {
+  @async.with_task_group(group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    let accepted = Ref(false)
+    group.spawn_bg(no_wait=true, () => {
+      let (conn, _) = server.accept()
+      defer conn.close()
+      accepted.val = true
+      @async.sleep(10000)
+    })
+    let description = "stalled CDP discovery"
+    let timeout = 200
+    let outcome = try {
+      ignore(
+        run_e2e_operation_with_timeout(timeout, description, () => {
+          @client.wait_for_browser_endpoint(
+            "http://127.0.0.1:" + server.addr.port().to_string(),
+            timeout_ms=10000,
+          )
+        }),
+      )
+      None
+    } catch {
+      error => Some(error)
+    }
+    assert_true(accepted.val)
+    match outcome {
+      Some(E2eOperationError::TimedOut(description=actual, timeout_ms=elapsed)) => {
+        assert_eq(actual, description)
+        assert_eq(elapsed, timeout)
+      }
+      Some(error) =>
+        fail("unexpected discovery error: " + @debug.render(Repr(error)))
+      None => fail("expected stalled CDP discovery to time out")
+    }
+  })
 }

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -45,6 +45,8 @@ test "E2E paths resolve backslash relative runtime directories" {
 
 ///|
 test "scenario retries only startup and closed CDP transports" {
+  assert_eq(scenario_operation_timeout("52_web_contents_view", 60000), 120000)
+  assert_eq(scenario_operation_timeout("41_app_commands", 60000), 60000)
   assert_true(
     retryable_scenario_error(
       E2eOperationError::TimedOut(
@@ -221,5 +223,27 @@ async test "E2E timeout interrupts stalled CDP discovery HTTP" {
         fail("unexpected discovery error: " + @debug.render(Repr(error)))
       None => fail("expected stalled CDP discovery to time out")
     }
+  })
+}
+
+///|
+async test "CDP target polling interrupts stalled discovery HTTP" {
+  @async.with_task_group(group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    let accepted = Ref(false)
+    group.spawn_bg(no_wait=true, () => {
+      let (conn, _) = server.accept()
+      defer conn.close()
+      accepted.val = true
+      @async.sleep(10000)
+    })
+    let targets = discover_targets_for_poll(
+      @client.parse_cdp_target(
+        "http://127.0.0.1:" + server.addr.port().to_string(),
+      ),
+    )
+    assert_true(accepted.val)
+    assert_eq(targets, [])
   })
 }

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -79,10 +79,24 @@ test "scenario child command is platform-safe" {
     assert_eq(args, [app_child_test_selector])
     assert_true(@path.Path(program).is_absolute())
   } else {
-    assert_eq(program, "moon")
+    assert_eq(program, "sh")
+    assert_true(args.contains("moon"))
+    assert_true(args.contains(unix_app_session_script()))
     assert_true(args.contains("e2e/test/scenario_app_wbtest.mbt"))
     assert_true(args.contains(root))
     assert_true(args.contains(join_path(root, "target/proton-e2e-app-child")))
+  }
+}
+
+///|
+test "Unix E2E cancellation targets the isolated process group first" {
+  if @path.sep != '\\' {
+    assert_true(unix_app_session_script().contains("exec setsid \"$@\""))
+    assert_true(
+      unix_app_tree_kill_script().contains(
+        "kill \"-$signal\" -- \"-$parent_group\"",
+      ),
+    )
   }
 }
 

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -101,6 +101,69 @@ test "Unix E2E cancellation targets the isolated process group first" {
 }
 
 ///|
+#cfg(not(platform="windows"))
+async test "Unix E2E cancellation kills a real isolated process group" {
+  let root = repository_root()
+  let pid_path = join_path(
+    root,
+    "target/proton-e2e-cancel-child-" + choose_cdp_port().to_string() + ".pid",
+  )
+  @mbfs.remove_file(pid_path) catch {
+    _ => ()
+  }
+  defer (@mbfs.remove_file(pid_path) catch { _ => () })
+  @async.with_task_group(group => {
+    let (program, args) = isolated_app_command("/bin/sh", [
+      "-c", "sleep 30 & child=$!; printf '%s' \"$child\" > \"$1\"; wait", "proton-e2e-cancel-child",
+      pid_path,
+    ])
+    let process = @process.spawn(
+      group,
+      program,
+      args,
+      cwd=root,
+      cancel_handler=app_cancel_handler(),
+      no_wait=true,
+    )
+    let mut attempts = 0
+    while !@mbfs.path_exists(pid_path) && attempts < 100 {
+      @async.sleep(20)
+      attempts = attempts + 1
+    }
+    assert_true(@mbfs.path_exists(pid_path))
+    let child_pid = @mbfs.read_file_to_string(pid_path, encoding="utf8")
+      .trim()
+      .to_owned()
+    let started = @async.now()
+    app_cancel_handler()(process.pid)
+    let exit_code = run_e2e_operation_with_timeout(
+      2000,
+      "isolated process group exit",
+      () => process.wait(),
+    )
+    assert_eq(exit_code, -9)
+    assert_true(@async.now() - started < 2000)
+    let mut alive = true
+    let mut checks = 0
+    while alive && checks < 100 {
+      alive = @process.run(
+          "/bin/sh",
+          [
+            "-c", "kill -0 \"$1\" 2>/dev/null", "proton-e2e-child-check", child_pid,
+          ],
+          cancel_handler=@process.hard_cancel(),
+        ) ==
+        0
+      if alive {
+        @async.sleep(20)
+      }
+      checks = checks + 1
+    }
+    assert_false(alive)
+  })
+}
+
+///|
 async test "E2E operation timeout cancels stalled work" {
   let cancelled = Ref(false)
   let outcome = try {

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -102,7 +102,7 @@ test "Unix E2E cancellation targets the isolated process group first" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "Unix E2E cancellation kills a real isolated process group" {
+async test "Unix E2E cancellation terminates a real child process tree" {
   let root = repository_root()
   let pid_path = join_path(
     root,
@@ -134,15 +134,10 @@ async test "Unix E2E cancellation kills a real isolated process group" {
     let child_pid = @mbfs.read_file_to_string(pid_path, encoding="utf8")
       .trim()
       .to_owned()
-    let started = @async.now()
-    app_cancel_handler()(process.pid)
-    let exit_code = run_e2e_operation_with_timeout(
-      2000,
-      "isolated process group exit",
-      () => process.wait(),
-    )
-    assert_eq(exit_code, -9)
-    assert_true(@async.now() - started < 2000)
+    run_e2e_operation_with_timeout(2000, "Unix process tree cancellation", () => {
+      app_cancel_handler()(process.pid)
+      ignore(process.wait())
+    })
     let mut alive = true
     let mut checks = 0
     while alive && checks < 100 {

--- a/e2e/test/web_contents_view_scenario_wbtest.mbt
+++ b/e2e/test/web_contents_view_scenario_wbtest.mbt
@@ -9,25 +9,18 @@ struct WebContentsViewPageProbe {
 async fn run_web_contents_view_scenario_probe(
   app : SpawnedScenarioApp,
   target : String,
+  browser_web_socket_url : String,
   timeout : Int,
 ) -> ShutdownProbeResult {
   let (host, left, right) = wait_for_web_contents_view_targets(
     app, target, timeout,
   )
-  let browser = @client.connect_cdp_browser_target_with_timeout(
-    cdp_target_from(target),
+  let browser = @client.CdpClient::connect_with_timeout(
+    browser_web_socket_url,
     timeout_ms=timeout,
   )
-  let page_left = @client.connect_cdp_page_target_with_timeout(
-    cdp_target_from(target),
-    target_id=left.target_id,
-    timeout_ms=timeout,
-  )
-  let page_right = @client.connect_cdp_page_target_with_timeout(
-    cdp_target_from(target),
-    target_id=right.target_id,
-    timeout_ms=timeout,
-  )
+  let page_left = connect_web_contents_view_page(left, timeout)
+  let page_right = connect_web_contents_view_page(right, timeout)
   defer {
     browser.close()
     page_left.close()
@@ -108,6 +101,21 @@ async fn run_web_contents_view_scenario_probe(
 }
 
 ///|
+async fn connect_web_contents_view_page(
+  target : @client.CdpDiscoveredTarget,
+  timeout : Int,
+) -> @client.CdpClient {
+  match target.web_socket_debugger_url {
+    Some(web_socket_url) =>
+      @client.CdpClient::connect_with_timeout(
+        web_socket_url,
+        timeout_ms=timeout,
+      )
+    None => fail("CDP page target has no WebSocket URL: " + target.target_id)
+  }
+}
+
+///|
 async fn wait_for_web_contents_view_targets(
   app : SpawnedScenarioApp,
   target : String,
@@ -120,7 +128,7 @@ async fn wait_for_web_contents_view_targets(
   let cdp_target = cdp_target_from(target)
   let mut elapsed = 0
   while elapsed <= timeout {
-    let targets = @client.discover_targets(cdp_target) catch { _ => [] }
+    let targets = discover_targets_for_poll(cdp_target)
     let mut host : @client.CdpDiscoveredTarget? = None
     let mut left : @client.CdpDiscoveredTarget? = None
     let mut right : @client.CdpDiscoveredTarget? = None

--- a/examples/e2e_fixtures/web_contents_view.mbt
+++ b/examples/e2e_fixtures/web_contents_view.mbt
@@ -165,6 +165,7 @@ async fn run_web_contents_view_pump(
   }
   defer wakeup.close(runtime)
   let view_events : Array[String] = []
+  let mut right_navigated = false
   let mut controls_sent = false
   let mut closed = false
   while !closed {
@@ -179,9 +180,17 @@ async fn run_web_contents_view_pump(
           }
           match event.view_event() {
             Some(info) => {
-              if !controls_sent && event.event_type() == "view_navigated" {
-                // The view browser is live by now; exercise eval and browser
-                // commands deterministically.
+              let is_right = event.view_id() == Some(right.id())
+              if is_right && event.event_type() == "view_navigated" {
+                right_navigated = true
+              }
+              if !controls_sent &&
+                right_navigated &&
+                is_right &&
+                event.event_type() == "view_loading_changed" &&
+                info.is_loading == Some(false) {
+                // Wait for the right view's own navigation to finish before
+                // exercising commands that can interrupt an active load.
                 controls_sent = true
                 ignore(
                   wcv_native_result("eval right view", () => {

--- a/native/src/engine/cef_linux/proton_engine_cef_linux.c
+++ b/native/src/engine/cef_linux/proton_engine_cef_linux.c
@@ -4699,7 +4699,6 @@ static int32_t proton_engine_window_create_browser(
     proton_engine_set_message(error, error_len, "browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  window->browser->base.add_ref((cef_base_ref_counted_t *)window->browser);
   window->browser_id = window->browser->get_identifier(window->browser);
   proton_engine_window_list_add(window);
   proton_engine_debug_log("create_browser id=%d initial_url=%s size=%dx%d",
@@ -6310,7 +6309,6 @@ static int32_t proton_engine_view_create_browser(
     proton_engine_set_message(error, error_len, "view browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  view->browser->base.add_ref((cef_base_ref_counted_t *)view->browser);
   view->browser_id = proton_engine_browser_id(view->browser);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {

--- a/native/src/engine/cef_win/proton_engine_cef_win.c
+++ b/native/src/engine/cef_win/proton_engine_cef_win.c
@@ -1899,13 +1899,9 @@ static void proton_engine_on_before_command_line_processing(
   // on the CPU in the browser process, so no GPU process is needed for
   // window display.
   proton_engine_append_switch(command_line, "disable-gpu-compositing");
-  // Recent CEF still spawns a GPU process even with both disable switches;
-  // when that process dies (display-limited, hook-injecting, or
-  // exclusive-fullscreen D3D hosts) the browser FATALs on "GPU process
-  // isn't usable". Hosting the GPU service in-process removes the separate
-  // process entirely, matching the Linux engine. GPU rendering stays
-  // disabled either way.
-  proton_engine_append_switch(command_line, "in-process-gpu");
+  // Keep the GPU service out of the browser process. With CEF 147,
+  // --in-process-gpu can intermittently block cef_shutdown; CI selects
+  // SwiftShader through ANGLE_DEFAULT_PLATFORM when hardware GPU is absent.
   proton_engine_append_switch(command_line, "disable-background-networking");
   proton_engine_append_switch(command_line, "disable-component-update");
   proton_engine_append_switch(command_line, "disable-domain-reliability");
@@ -2152,12 +2148,6 @@ static int proton_engine_utf8_to_wide(const char *value,
     return 0;
   }
   return written;
-}
-
-static void proton_engine_browser_add_ref(cef_browser_t *browser) {
-  if (browser != NULL) {
-    browser->base.add_ref((cef_base_ref_counted_t *)browser);
-  }
 }
 
 static void proton_engine_browser_release(cef_browser_t *browser) {
@@ -3001,6 +2991,7 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   proton_engine_view_t *view =
       proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
   if (view != NULL) {
+    proton_engine_runtime_t *runtime = view->window->runtime;
     proton_engine_debug_log("view_browser_before_close browser=%d",
                             view->browser_id);
     view->browser_before_close_seen = 1;
@@ -3015,8 +3006,7 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     // be reclaimed with its owning window.
     view->finalize_after_browser_close = 1;
     proton_engine_view_finalize_if_ready(view);
-    proton_engine_signal_wait_source(view->window->runtime,
-                                     PROTON_WAIT_PLATFORM);
+    proton_engine_signal_wait_source(runtime, PROTON_WAIT_PLATFORM);
     return;
   }
   proton_engine_window_t *window =
@@ -3446,7 +3436,6 @@ static int32_t proton_engine_window_create_browser(
     proton_engine_set_message(error, error_len, "browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  proton_engine_browser_add_ref(window->browser);
   window->browser_id = proton_engine_browser_id(window->browser);
   proton_engine_verbose_log(
       "create_browser thread=%lu id=%d initial_url=%s size=%dx%d",
@@ -6001,7 +5990,6 @@ static int32_t proton_engine_view_create_browser(
     proton_engine_set_message(error, error_len, "view browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  proton_engine_browser_add_ref(view->browser);
   view->browser_id = proton_engine_browser_id(view->browser);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {


### PR DESCRIPTION
## Summary

- remove the Windows `--in-process-gpu` path that intermittently blocks CEF 147 shutdown and keep CI on SwiftShader
- bound CDP discovery, connection, scenario, and lifecycle operations with cancellable timeouts and one retry
- fix synchronous CEF browser ownership on Windows/Linux and avoid a Windows view-finalization use-after-free
- add an outer timeout to the platform E2E workflow steps

## Root cause

The failing main run was https://github.com/moonbit-community/proton/actions/runs/30995386695.

- Windows `proton_smoke` reached `cef_shutdown()` but intermittently never returned when `--in-process-gpu` was enabled.
- Ubuntu and macOS E2E could wait indefinitely in HTTP/CDP discovery or connection work because the existing inner timeout was not a reliable cancellation boundary.

## Validation

- Windows native CTest: 6/6 passed
- Windows MoonBit native tests: 60/60 passed
- Windows full E2E: 20/20 passed
- timeout-focused tests: 3/3 passed
- retry-focused test: 1/1 passed
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C e2e check --target native --diagnostic-limit 80`
- `node native/scripts/verify_link_config.mjs native/dist-ci-fix`