### PR TITLE
fix(cli): store CEF in global cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ desktop runtime. `.proton/` is a local runtime cache and should not be
 committed.
 
 `cef setup` stores downloaded CEF binaries in a shared user-level cache
-(`~/.proton/cache/cef`, overridable with `PROTON_CEF_CACHE`) so subsequent
-projects reuse the download instead of fetching it again.
+(`~/.proton/cache/cef/<platform>/<cef-name>`, with the cache root overridable
+through `PROTON_CEF_CACHE`) so subsequent projects reuse the download instead
+of fetching it again. The generated `.proton/runtime.json` records the resolved
+cache directory in `cef`. Relative `PROTON_CEF_CACHE` values are resolved from
+the project root.
 
 ## Application entry
 

--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -24,12 +24,12 @@ fn assert_safe_install_dir(
 
 ///|
 async fn install_cef_root(
-  extracted_root : String,
-  install_dir : String,
-  name : String,
-  sha256 : String,
-  root : String,
-  platform : ProtonPlatform,
+  extracted_root~ : String,
+  install_dir~ : String,
+  name~ : String,
+  sha256~ : String,
+  root~ : String,
+  platform~ : ProtonPlatform,
 ) -> Unit {
   assert_safe_install_dir(install_dir, root)
   remove_tree(install_dir)
@@ -60,22 +60,69 @@ async fn install_cef_root(
 }
 
 ///|
-/// Returns the shared user-level CEF cache directory for `name`, honoring the
-/// `PROTON_CEF_CACHE` override and otherwise defaulting to
-/// `~/.proton/cache/cef`. Returns `None` when no home directory is known, in
-/// which case caching stays project-local.
-fn global_cef_cache_dir(platform : ProtonPlatform, name : String) -> String? {
-  let root = match @env.get_env_var("PROTON_CEF_CACHE") {
-    Some(value) if value.trim().to_owned() != "" => value.trim().to_owned()
+fn cef_cache_dir(
+  cache_root~ : String,
+  platform~ : ProtonPlatform,
+  name~ : String,
+) -> String {
+  @fsutil.path_join(@fsutil.path_join(cache_root, platform.id), name)
+}
+
+///|
+fn resolve_global_cef_cache_root(
+  project_root~ : String,
+  configured_root~ : String?,
+  home~ : String?,
+) -> String? {
+  match configured_root {
+    Some(value) if value.trim().to_owned() != "" =>
+      Some(@fsutil.resolve_path(project_root, value.trim().to_owned()))
     _ => {
-      guard home_directory() is Some(home) else { return None }
-      @fsutil.path_join(
-        home,
-        @fsutil.path_join(".proton", @fsutil.path_join("cache", "cef")),
+      guard home is Some(home) && home.trim().to_owned() != "" else {
+        return None
+      }
+      let resolved_home = @fsutil.resolve_path(
+        project_root,
+        home.trim().to_owned(),
       )
+      Some(@fsutil.resolve_path(resolved_home, ".proton/cache/cef"))
     }
   }
-  Some(@fsutil.path_join(@fsutil.path_join(root, platform.id), name))
+}
+
+///|
+/// Returns the shared user-level CEF cache directory for `name`, honoring the
+/// `PROTON_CEF_CACHE` override and otherwise defaulting to
+/// `~/.proton/cache/cef`. Relative overrides are resolved from `project_root`.
+/// Returns `None` when no home directory is known, in which case caching stays
+/// project-local.
+fn global_cef_cache_dir(
+  project_root~ : String,
+  platform~ : ProtonPlatform,
+  name~ : String,
+) -> String? {
+  let cache_root = resolve_global_cef_cache_root(
+    project_root~,
+    configured_root=@env.get_env_var("PROTON_CEF_CACHE"),
+    home=home_directory(),
+  )
+  match cache_root {
+    Some(cache_root) => Some(cef_cache_dir(cache_root~, platform~, name~))
+    None => None
+  }
+}
+
+///|
+fn project_cef_cache_dir(
+  root~ : String,
+  platform~ : ProtonPlatform,
+  name~ : String,
+) -> String {
+  cef_cache_dir(
+    cache_root=@fsutil.resolve_path(root, ".proton/cache/cef"),
+    platform~,
+    name~,
+  )
 }
 
 ///|
@@ -94,36 +141,56 @@ fn home_directory() -> String? {
 
 ///|
 async fn ensure_cef_cache(
-  name : String,
-  url : String?,
-  sha256 : String,
-  root : String,
-  cache_dir : String,
-  platform : ProtonPlatform,
-) -> Unit {
+  root~ : String,
+  platform~ : ProtonPlatform,
+  name~ : String,
+  url~ : String?,
+  sha256~ : String,
+) -> String {
+  let project_cache = project_cef_cache_dir(root~, platform~, name~)
+  let cache_dir = global_cef_cache_dir(project_root=root, platform~, name~).unwrap_or(
+    project_cache,
+  )
   if installed_version(cache_dir) == name &&
     installed_checksum(cache_dir) == sha256 {
     normalize_cef_runtime_layout(cache_dir)
-    return
+    return cache_dir
   }
   let legacy_cache = @fsutil.path_join(root, ".cef-cache")
   if installed_version(legacy_cache) == name &&
     installed_checksum(legacy_cache) == sha256 {
-    install_cef_root(legacy_cache, cache_dir, name, sha256, root, platform)
-    return
+    install_cef_root(
+      extracted_root=legacy_cache,
+      install_dir=cache_dir,
+      name~,
+      sha256~,
+      root~,
+      platform~,
+    )
+    return cache_dir
   }
-  match global_cef_cache_dir(platform, name) {
-    Some(global_cache) if global_cache != cache_dir => {
-      if installed_version(global_cache) == name &&
-        installed_checksum(global_cache) == sha256 {
-        install_cef_root(global_cache, cache_dir, name, sha256, root, platform)
-        return
-      }
-      setup_downloaded_cef(name, url, sha256, root, global_cache, platform)
-      install_cef_root(global_cache, cache_dir, name, sha256, root, platform)
-    }
-    _ => setup_downloaded_cef(name, url, sha256, root, cache_dir, platform)
+  if project_cache != cache_dir &&
+    installed_version(project_cache) == name &&
+    installed_checksum(project_cache) == sha256 {
+    install_cef_root(
+      extracted_root=project_cache,
+      install_dir=cache_dir,
+      name~,
+      sha256~,
+      root~,
+      platform~,
+    )
+    return cache_dir
   }
+  setup_downloaded_cef(
+    name~,
+    url~,
+    sha256~,
+    root~,
+    install_dir=cache_dir,
+    platform~,
+  )
+  cache_dir
 }
 
 ///|
@@ -141,12 +208,12 @@ async fn ensure_download_tool(tool : String) -> Unit {
 
 ///|
 async fn setup_downloaded_cef(
-  name : String,
-  url : String?,
-  sha256 : String,
-  root : String,
-  install_dir : String,
-  platform : ProtonPlatform,
+  name~ : String,
+  url~ : String?,
+  sha256~ : String,
+  root~ : String,
+  install_dir~ : String,
+  platform~ : ProtonPlatform,
 ) -> Unit {
   ensure_download_tool("curl")
   ensure_download_tool("tar")
@@ -156,7 +223,14 @@ async fn setup_downloaded_cef(
     download_file(archive_url(name, url), archive_path, sha256)
     extract_tar_bz2(archive_path, temp_dir)
     let extracted_root = find_extracted_root(temp_dir, name, platform)
-    install_cef_root(extracted_root, install_dir, name, sha256, root, platform)
+    install_cef_root(
+      extracted_root~,
+      install_dir~,
+      name~,
+      sha256~,
+      root~,
+      platform~,
+    )
   } catch {
     error => {
       remove_tree(temp_dir) catch {

--- a/cli/cef/cef_platform_wbtest.mbt
+++ b/cli/cef/cef_platform_wbtest.mbt
@@ -29,11 +29,117 @@ test "public runtime layout lookup follows stable platform ids" {
 }
 
 ///|
-test "runtime manifests carry an explicit schema version" {
-  let manifest = runtime_manifest_json(
-    "0.1.5", "darwin-arm64", "cef-test", ".proton/runtime",
+test "runtime manifests separate portable and active metadata" {
+  let portable = runtime_manifest_json(
+    proton_version="0.1.5",
+    platform="darwin-arm64",
+    cef_name="cef-test",
+    cef_root=None,
+    dist=".proton/runtime",
   )
-  assert_true(manifest.contains("\"schema_version\":1"))
+  assert_true(portable.contains("\"schema_version\":1"))
+  let portable_json = @json.parse(portable) catch {
+    _ => abort("expected valid portable runtime manifest")
+  }
+  match portable_json {
+    Object(fields) => assert_eq(fields.get("cef"), None)
+    _ => abort("expected portable runtime manifest object")
+  }
+  let active = runtime_manifest_json(
+    proton_version="0.1.5",
+    platform="darwin-arm64",
+    cef_name="cef-test",
+    cef_root=Some("/Users/test/.proton/cache/cef/darwin-arm64/cef-test"),
+    dist=".proton/runtime",
+  )
+  let active_json = @json.parse(active) catch {
+    _ => abort("expected valid active runtime manifest")
+  }
+  assert_eq(
+    json_string_field(active_json, "cef", "active runtime manifest"),
+    "/Users/test/.proton/cache/cef/darwin-arm64/cef-test",
+  )
+}
+
+///|
+test "CEF cache paths are absolute and scoped by platform and archive" {
+  let project_root = @fsutil.resolve_path(".", "target/proton-cache-project")
+  let home = @fsutil.resolve_path(project_root, "../proton-cache-home")
+  let cache_root = resolve_global_cef_cache_root(
+    project_root~,
+    configured_root=None,
+    home=Some(home),
+  ).unwrap()
+  let platform = darwin_arm64_platform()
+  let actual = cef_cache_dir(cache_root~, platform~, name="cef-test")
+  let expected = @fsutil.path_join(
+    @fsutil.path_join(
+      @fsutil.resolve_path(home, ".proton/cache/cef"),
+      "darwin-arm64",
+    ),
+    "cef-test",
+  )
+  assert_true(@fsutil.path_is_absolute(actual))
+  assert_eq(actual, expected)
+}
+
+///|
+test "relative CEF cache overrides resolve from the project root" {
+  let project_root = @fsutil.resolve_path(".", "target/proton-cache-project")
+  let actual = resolve_global_cef_cache_root(
+    project_root~,
+    configured_root=Some("../shared-cef"),
+    home=Some("ignored-home"),
+  )
+  assert_eq(actual, Some(@fsutil.resolve_path(project_root, "../shared-cef")))
+  assert_eq(
+    resolve_global_cef_cache_root(
+      project_root~,
+      configured_root=None,
+      home=None,
+    ),
+    None,
+  )
+}
+
+///|
+async test "runtime metadata does not persist the active CEF cache path" {
+  let root = @fsutil.resolve_path(".", "target/proton-runtime-manifest")
+  let proton_dir = @fsutil.path_join(root, ".proton")
+  let runtime_dir = @fsutil.path_join(proton_dir, "runtime")
+  remove_tree(root)
+  ensure_dir(runtime_dir)
+  let cef_root = @fsutil.resolve_path(
+    root, "../shared-cef/darwin-arm64/cef-test",
+  )
+  write_runtime_metadata(
+    runtime_dir~,
+    proton_version="0.1.5",
+    platform="darwin-arm64",
+    cef_name="cef-test",
+    relative_dist=".proton/runtime",
+  )
+  write_active_runtime_manifest(
+    root~,
+    proton_version="0.1.5",
+    platform="darwin-arm64",
+    cef_name="cef-test",
+    cef_root~,
+    relative_dist=".proton/runtime",
+  )
+  let runtime_manifest_path = @fsutil.path_join(runtime_dir, "manifest.json")
+  let runtime_manifest = read_json_file(runtime_manifest_path)
+  match runtime_manifest {
+    Object(fields) => assert_eq(fields.get("cef"), None)
+    _ => abort("expected runtime metadata object")
+  }
+  let active_manifest_path = @fsutil.path_join(proton_dir, "runtime.json")
+  let active_manifest = read_json_file(active_manifest_path)
+  assert_eq(
+    json_string_field(active_manifest, "cef", active_manifest_path),
+    cef_root,
+  )
+  remove_tree(root)
 }
 
 ///|

--- a/cli/cef/cef_runtime_assembly.mbt
+++ b/cli/cef/cef_runtime_assembly.mbt
@@ -91,14 +91,14 @@ async fn copy_cef_runtime(
 
 ///|
 async fn assemble_runtime(
-  root : String,
-  platform : ProtonPlatform,
-  proton_version : String,
-  cef_name : String,
-  cef_root : String,
-  prebuilt_root : String,
-  runtime_dir : String,
-  relative_dist : String,
+  root~ : String,
+  platform~ : ProtonPlatform,
+  proton_version~ : String,
+  cef_name~ : String,
+  cef_root~ : String,
+  prebuilt_root~ : String,
+  runtime_dir~ : String,
+  relative_dist~ : String,
 ) -> Unit {
   assert_safe_generated_dir(runtime_dir, root)
   remove_tree(runtime_dir)
@@ -111,18 +111,26 @@ async fn assemble_runtime(
   }
   copy_cef_runtime(platform, cef_root, runtime_dir)
   write_runtime_metadata(
-    root,
-    runtime_dir,
-    proton_version,
-    platform.id,
-    cef_name,
-    relative_dist,
+    runtime_dir~,
+    proton_version~,
+    platform=platform.id,
+    cef_name~,
+    relative_dist~,
   )
   validate_runtime_dist(runtime_dir, platform)
+  write_active_runtime_manifest(
+    root~,
+    proton_version~,
+    platform=platform.id,
+    cef_name~,
+    cef_root~,
+    relative_dist~,
+  )
   validate_active_runtime_manifest(
-    root,
-    platform.id,
-    proton_version,
-    relative_dist,
+    root~,
+    platform=platform.id,
+    proton_version~,
+    cef_root~,
+    relative_dist~,
   )
 }

--- a/cli/cef/cef_runtime_manifest.mbt
+++ b/cli/cef/cef_runtime_manifest.mbt
@@ -1,30 +1,39 @@
 ///|
 fn runtime_manifest_json(
-  proton_version : String,
-  platform : String,
-  cef_name : String,
-  dist : String,
+  proton_version~ : String,
+  platform~ : String,
+  cef_name~ : String,
+  cef_root~ : String?,
+  dist~ : String,
 ) -> String {
-  Json::object({
+  let fields : Map[String, Json] = {
     "schema_version": Json::number(1.0, repr="1"),
     "platform": Json::string(platform),
     "proton_version": Json::string(proton_version),
     "cef_version": Json::string(cef_name),
     "dist": Json::string(dist),
-  }).stringify()
+  }
+  match cef_root {
+    Some(cef_root) => fields["cef"] = Json::string(cef_root)
+    None => ()
+  }
+  Json::object(fields).stringify()
 }
 
 ///|
 async fn write_runtime_metadata(
-  root : String,
-  runtime_dir : String,
-  proton_version : String,
-  platform : String,
-  cef_name : String,
-  relative_dist : String,
+  runtime_dir~ : String,
+  proton_version~ : String,
+  platform~ : String,
+  cef_name~ : String,
+  relative_dist~ : String,
 ) -> Unit raise CefFileSystemError {
   let manifest = runtime_manifest_json(
-    proton_version, platform, cef_name, relative_dist,
+    proton_version~,
+    platform~,
+    cef_name~,
+    cef_root=None,
+    dist=relative_dist,
   )
   let runtime_manifest_path = @fsutil.path_join(runtime_dir, "manifest.json")
   @async_fs.write_file(
@@ -36,22 +45,6 @@ async fn write_runtime_metadata(
       raise CefFileSystemError::Copy(
         source="<generated runtime manifest>",
         destination=runtime_manifest_path,
-        detail=@debug.render(Repr(err)),
-      )
-  }
-  let active_manifest_path = @fsutil.path_join(
-    @fsutil.path_join(root, ".proton"),
-    "runtime.json",
-  )
-  @async_fs.write_file(
-    active_manifest_path,
-    manifest + "\n",
-    create_mode=CreateOrTruncate,
-  ) catch {
-    err =>
-      raise CefFileSystemError::Copy(
-        source="<generated active runtime manifest>",
-        destination=active_manifest_path,
         detail=@debug.render(Repr(err)),
       )
   }
@@ -71,11 +64,46 @@ async fn write_runtime_metadata(
 }
 
 ///|
+async fn write_active_runtime_manifest(
+  root~ : String,
+  proton_version~ : String,
+  platform~ : String,
+  cef_name~ : String,
+  cef_root~ : String,
+  relative_dist~ : String,
+) -> Unit raise CefFileSystemError {
+  let manifest = runtime_manifest_json(
+    proton_version~,
+    platform~,
+    cef_name~,
+    cef_root=Some(cef_root),
+    dist=relative_dist,
+  )
+  let active_manifest_path = @fsutil.path_join(
+    @fsutil.path_join(root, ".proton"),
+    "runtime.json",
+  )
+  @async_fs.write_file(
+    active_manifest_path,
+    manifest + "\n",
+    create_mode=CreateOrTruncate,
+  ) catch {
+    err =>
+      raise CefFileSystemError::Copy(
+        source="<generated active runtime manifest>",
+        destination=active_manifest_path,
+        detail=@debug.render(Repr(err)),
+      )
+  }
+}
+
+///|
 async fn validate_active_runtime_manifest(
-  root : String,
-  platform : String,
-  proton_version : String,
-  relative_dist : String,
+  root~ : String,
+  platform~ : String,
+  proton_version~ : String,
+  cef_root~ : String,
+  relative_dist~ : String,
 ) -> Unit raise CefRuntimeError {
   let manifest_path = @fsutil.path_join(
     @fsutil.path_join(root, ".proton"),
@@ -89,6 +117,14 @@ async fn validate_active_runtime_manifest(
   let actual_version = json_string_field(json, "proton_version", manifest_path)
   if actual_version != proton_version {
     raise ActiveVersionMismatch(expected=proton_version, actual=actual_version)
+  }
+  let actual_cef = json_string_field(json, "cef", manifest_path)
+  if actual_cef != cef_root {
+    raise ManifestFieldValue(
+      path=manifest_path,
+      field="cef",
+      detail="expected \"" + cef_root + "\", got \"" + actual_cef + "\"",
+    )
   }
   let actual_dist = json_string_field(json, "dist", manifest_path)
   if actual_dist != relative_dist {

--- a/cli/cef/cef_setup.mbt
+++ b/cli/cef/cef_setup.mbt
@@ -85,23 +85,21 @@ async fn setup(
   validate_cef_name(name)
   let sha256 = resolve_cef_archive_sha256(platform, name, url, requested_sha256)
   let root = project_root(cwd)
-  let proton_root = @fsutil.path_join(root, ".proton")
   let prebuilt_root = find_prebuilt_root(root, platform)
   let proton_version = prebuilt_manifest_version(prebuilt_root)
-  let cache_dir = @fsutil.path_join(
-    @fsutil.path_join(
-      @fsutil.path_join(@fsutil.path_join(proton_root, "cache"), "cef"),
-      platform.id,
-    ),
-    name,
-  )
+  let cef_root = ensure_cef_cache(root~, platform~, name~, url~, sha256~)
   let relative_dist = relative_runtime_dist(proton_version, platform, name)
   let runtime_dir = @fsutil.path_join(root, relative_dist)
-  ensure_cef_cache(name, url, sha256, root, cache_dir, platform)
-  validate_cef_root(cache_dir, platform)
+  validate_cef_root(cef_root, platform)
   assemble_runtime(
-    root, platform, proton_version, name, cache_dir, prebuilt_root, runtime_dir,
-    relative_dist,
+    root~,
+    platform~,
+    proton_version~,
+    cef_name=name,
+    cef_root~,
+    prebuilt_root~,
+    runtime_dir~,
+    relative_dist~,
   )
   println(runtime_dir)
 }

--- a/cli/doctor/doctor_collectors.mbt
+++ b/cli/doctor/doctor_collectors.mbt
@@ -115,7 +115,7 @@ async fn runtime_manifest_from_project(
   match json {
     Object(object) => {
       let allowed = [
-        "schema_version", "platform", "proton_version", "cef_version", "dist",
+        "schema_version", "platform", "proton_version", "cef_version", "cef", "dist",
       ]
       for key in object.keys() {
         if !allowed.contains(key) {
@@ -139,8 +139,20 @@ async fn runtime_manifest_from_project(
       let cef_version = runtime_manifest_string_field(
         object, "cef_version", manifest_path,
       )
+      let cef_cache = match object.get("cef") {
+        Some(_) =>
+          Some(runtime_manifest_string_field(object, "cef", manifest_path))
+        None => None
+      }
       let dist = runtime_manifest_string_field(object, "dist", manifest_path)
-      Some({ schema_version, platform, proton_version, cef_version, dist })
+      Some({
+        schema_version,
+        platform,
+        proton_version,
+        cef_version,
+        cef_cache,
+        dist,
+      })
     }
     _ => raise InvalidRoot(path=manifest_path)
   }
@@ -935,6 +947,17 @@ async fn collect_runtime(
           manifest.cef_version,
         ),
       )
+      match manifest.cef_cache {
+        Some(cef_cache) =>
+          lines.push(
+            DoctorLine::coded(
+              "runtime.manifest.cef",
+              Neutral,
+              "CEF cache: " + cef_cache,
+            ),
+          )
+        None => ()
+      }
     }
     None => ()
   }

--- a/cli/doctor/doctor_types.mbt
+++ b/cli/doctor/doctor_types.mbt
@@ -193,6 +193,7 @@ priv struct DoctorRuntimeManifest {
   platform : String
   proton_version : String
   cef_version : String
+  cef_cache : String?
   dist : String
 }
 

--- a/cli/doctor/doctor_wbtest.mbt
+++ b/cli/doctor/doctor_wbtest.mbt
@@ -461,7 +461,7 @@ async test "doctor validates runtime manifest schema" {
   @mbfs.write_string_to_file(
     manifest_path,
     (
-      #|{"schema_version":1,"platform":"darwin-arm64","proton_version":"0.1.5","cef_version":"cef-test","dist":"runtime"}
+      #|{"schema_version":1,"platform":"darwin-arm64","proton_version":"0.1.5","cef_version":"cef-test","cef":"/Users/test/.proton/cache/cef/darwin-arm64/cef-test","dist":"runtime"}
     ),
     encoding="utf8",
   ) catch {
@@ -472,9 +472,26 @@ async test "doctor validates runtime manifest schema" {
     Some(manifest) => {
       assert_eq(manifest.schema_version, 1)
       assert_eq(manifest.platform, "darwin-arm64")
+      assert_eq(
+        manifest.cef_cache,
+        Some("/Users/test/.proton/cache/cef/darwin-arm64/cef-test"),
+      )
       assert_eq(manifest.dist, "runtime")
     }
     _ => abort("expected valid runtime manifest")
+  }
+  @mbfs.write_string_to_file(
+    manifest_path,
+    (
+      #|{"schema_version":1,"platform":"darwin-arm64","proton_version":"0.1.5","cef_version":"cef-test","dist":"runtime"}
+    ),
+    encoding="utf8",
+  ) catch {
+    err => abort(@debug.render(Repr(err)))
+  }
+  match runtime_manifest_from_project(project) {
+    Some(manifest) => assert_eq(manifest.cef_cache, None)
+    _ => abort("expected legacy runtime manifest to remain valid")
   }
   @mbfs.write_string_to_file(
     manifest_path,


### PR DESCRIPTION
## Summary

- store downloaded CEF runtimes in the shared user cache at `~/.proton/cache/cef/<platform>/<cef-name>`
- record the resolved absolute CEF cache path in the active `.proton/runtime.json` while keeping assembled runtime metadata portable
- keep project-local and legacy cache migration behavior, and expose the active CEF path in `proton_cli doctor`

## Validation

- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/codegen moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80` (204/204)
- `moon -C cli check --target native --diagnostic-limit 80`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C cli run . -- -C .. cef setup`
- `moon -C proton test native --target native --diagnostic-limit 80` (60/60)
- real 114 MB CEF download, extraction, global-cache installation, runtime assembly, and subsequent cache-reuse smoke test on darwin-arm64