### PR TITLE
build(release): scope the generic module names under `proton_`

### DIFF
--- a/.github/workflows/build-linux-prebuilt.yml
+++ b/.github/workflows/build-linux-prebuilt.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.PROTON_PREBUILT_SOURCE_SHA }}
 

--- a/.github/workflows/build-linux-prebuilt.yml
+++ b/.github/workflows/build-linux-prebuilt.yml
@@ -55,17 +55,13 @@ jobs:
         run: moon update
 
       - name: Set up CEF runtime
-        run: |
-          mkdir -p .proton-global-cache/linux-x64
-          mkdir -p .proton/cache/cef/linux-x64
-          moon -C cli run . -- -C .. cef setup
+        run: moon -C cli run . -- -C .. cef setup
 
       - name: Build and install Release runtime
         run: |
           runtime="$RUNNER_TEMP/proton-runtime"
           platform=$(node -p "require('./.proton/runtime.json').platform")
-          cef_name=$(node -p "require('./.proton/runtime.json').cef_version")
-          cef_root="$PWD/.proton/cache/cef/$platform/$cef_name"
+          cef_root=$(node -p "require('./.proton/runtime.json').cef")
           test "$platform" = "linux-x64"
           cmake -S native -B native/build-prebuilt \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/build-windows-prebuilt.yml
+++ b/.github/workflows/build-windows-prebuilt.yml
@@ -56,10 +56,7 @@ jobs:
 
       - name: Set up CEF runtime
         shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force .proton-global-cache\win32-x64 | Out-Null
-          New-Item -ItemType Directory -Force .proton\cache\cef\win32-x64 | Out-Null
-          moon -C cli run . -- -C .. cef setup
+        run: moon -C cli run . -- -C .. cef setup
 
       - name: Build and install Release runtime
         shell: pwsh
@@ -71,7 +68,7 @@ jobs:
             throw "unexpected platform: $($manifest.platform)"
           }
           $runtime = Join-Path $env:RUNNER_TEMP "proton-runtime"
-          $cefRoot = Join-Path $PWD ".proton\cache\cef\$($manifest.platform)\$($manifest.cef_version)"
+          $cefRoot = $manifest.cef
           cmake -S native -B native\build-prebuilt `
             "-DCMAKE_INSTALL_PREFIX=$runtime" `
             -DPROTON_WITH_ENGINE=ON `

--- a/.github/workflows/build-windows-prebuilt.yml
+++ b/.github/workflows/build-windows-prebuilt.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.PROTON_PREBUILT_SOURCE_SHA }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install MoonBit
         run: |
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache MoonBit packages
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,9 +246,9 @@ jobs:
               moonbit-community/proton_ext/notification moonbit-community/proton_ext/path \
               moonbit-community/proton_ext/shell moonbit-community/proton_ext/tray \
               --target native
-            xvfb-run -a moon test -p moonbit-community/auto_launch moonbit-community/clipboard \
-              moonbit-community/global_hotkey moonbit-community/keepawake moonbit-community/microphone \
-              moonbit-community/tray --target native
+            xvfb-run -a moon test -p moonbit-community/proton_auto_launch moonbit-community/proton_clipboard \
+              moonbit-community/proton_global_hotkey moonbit-community/proton_keepawake moonbit-community/proton_microphone \
+              moonbit-community/proton_tray --target native
           else
             moon -C extensions test -p moonbit-community/proton_ext \
               moonbit-community/proton_ext/auto_launch moonbit-community/proton_ext/clipboard \
@@ -258,9 +258,9 @@ jobs:
               moonbit-community/proton_ext/notification moonbit-community/proton_ext/path \
               moonbit-community/proton_ext/shell moonbit-community/proton_ext/tray \
               --target native
-            moon test -p moonbit-community/auto_launch moonbit-community/clipboard \
-              moonbit-community/global_hotkey moonbit-community/keepawake moonbit-community/microphone \
-              moonbit-community/tray --target native
+            moon test -p moonbit-community/proton_auto_launch moonbit-community/proton_clipboard \
+              moonbit-community/proton_global_hotkey moonbit-community/proton_keepawake moonbit-community/proton_microphone \
+              moonbit-community/proton_tray --target native
           fi
 
       - name: Test extensions on Windows
@@ -286,12 +286,12 @@ jobs:
           )
           moon -C extensions test -p $extensionPackages --target native
           $sysPackages = @(
-            "moonbit-community/auto_launch"
-            "moonbit-community/clipboard"
-            "moonbit-community/global_hotkey"
-            "moonbit-community/keepawake"
-            "moonbit-community/microphone"
-            "moonbit-community/tray"
+            "moonbit-community/proton_auto_launch"
+            "moonbit-community/proton_clipboard"
+            "moonbit-community/proton_global_hotkey"
+            "moonbit-community/proton_keepawake"
+            "moonbit-community/proton_microphone"
+            "moonbit-community/proton_tray"
           )
           moon test -p $sysPackages --target native
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PROTON_NO_UPDATE_CHECK: 1
+  PROTON_CEF_CACHE: ${{ github.workspace }}/.proton-global-cache
 
 jobs:
   format:
@@ -52,8 +53,8 @@ jobs:
       - name: Cache CEF downloads
         uses: actions/cache@v4
         with:
-          path: .proton/cache/cef
-          key: ${{ runner.os }}-cef-${{ hashFiles('cli/cef/cef_platform.mbt') }}
+          path: .proton-global-cache
+          key: ${{ runner.os }}-cef-global-${{ hashFiles('cli/cef/cef_platform.mbt') }}
 
       - name: Install MoonBit
         if: ${{ matrix.os != 'windows-latest' }}
@@ -130,9 +131,7 @@ jobs:
         run: |
           moon -C cli run . -- -C .. cef setup
           runtime="$PWD/$(node -p "require('./.proton/runtime.json').dist")"
-          platform=$(node -p "require('./.proton/runtime.json').platform")
-          cef_name=$(node -p "require('./.proton/runtime.json').cef_version")
-          cef_root="$PWD/.proton/cache/cef/$platform/$cef_name"
+          cef_root=$(node -p "require('./.proton/runtime.json').cef")
           cmake -S native -B native/build-engine \
             -DCMAKE_INSTALL_PREFIX="$runtime" \
             -DPROTON_WITH_ENGINE=ON \
@@ -164,7 +163,7 @@ jobs:
           }
           $manifest = Get-Content .proton\runtime.json | ConvertFrom-Json
           $runtime = Join-Path $PWD $manifest.dist
-          $cefRoot = Join-Path $PWD ".proton\cache\cef\$($manifest.platform)\$($manifest.cef_version)"
+          $cefRoot = $manifest.cef
           cmake -S native -B native\build-engine `
             "-DCMAKE_INSTALL_PREFIX=$runtime" `
             -DPROTON_WITH_ENGINE=ON `

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,13 +63,13 @@ jobs:
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater
 
-          publish_module sys/ffi moonbit-community/ffi
-          publish_module sys/auto_launch moonbit-community/auto_launch
-          publish_module sys/clipboard moonbit-community/clipboard
-          publish_module sys/global_hotkey moonbit-community/global_hotkey
-          publish_module sys/keepawake moonbit-community/keepawake
-          publish_module sys/microphone moonbit-community/microphone
-          publish_module sys/tray moonbit-community/tray
+          publish_module sys/ffi moonbit-community/proton_ffi
+          publish_module sys/auto_launch moonbit-community/proton_auto_launch
+          publish_module sys/clipboard moonbit-community/proton_clipboard
+          publish_module sys/global_hotkey moonbit-community/proton_global_hotkey
+          publish_module sys/keepawake moonbit-community/proton_keepawake
+          publish_module sys/microphone moonbit-community/proton_microphone
+          publish_module sys/tray moonbit-community/proton_tray
 
           publish_module client moonbit-community/proton_client
           publish_module rabbita moonbit-community/proton_rabbita

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Require main branch
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,19 @@ developer must perform them.
 - `extensions/`: `moonbit-community/proton_ext`; command extensions for examples and
   applications. Platform capability extensions are backed by the bindings
   under `sys/`.
-- `sys/<pkg>/`: independently maintained native system capability binding
-  modules (`moonbit-community/auto_launch`, `moonbit-community/clipboard`,
-  `moonbit-community/global_hotkey`, `moonbit-community/keepawake`, `moonbit-community/microphone`,
-  `moonbit-community/tray`) plus the shared FFI helper module `moonbit-community/ffi`
-  (`sys/ffi/`). Each keeps its upstream module name and version lineage and
-  is published from this repository under the Apache-2.0 license.
-- `cdp/`: `moonbit-community/cdp`; Chrome DevTools Protocol client and generated
+- `sys/<pkg>/`: native system capability binding modules
+  (`moonbit-community/proton_auto_launch`, `moonbit-community/proton_clipboard`,
+  `moonbit-community/proton_global_hotkey`, `moonbit-community/proton_keepawake`,
+  `moonbit-community/proton_microphone`, `moonbit-community/proton_tray`) plus the
+  shared FFI helper module `moonbit-community/proton_ffi` (`sys/ffi/`). All are
+  published from this repository under the Apache-2.0 license, on the workspace
+  version shared by every module. They carry the `proton_` prefix because that
+  is what they are: components of Proton, released on Proton's cadence. A bare
+  name like `clipboard` or `ffi` under an organization namespace would promise a
+  standalone community library, which none of these is. Their upstream names
+  (`justjavac/moonbit-<pkg>`) and independent version lineages are history;
+  attribution stays in each module's README and LICENSE.
+- `cdp/`: `moonbit-community/proton_cdp`; Chrome DevTools Protocol client and generated
   protocol bindings used only by the `e2e/` DevTools test automation. It is
   maintained here under the Apache-2.0 license as a workspace member and is
   not part of the release publishing chain. The `src/protocol/` tree is
@@ -89,7 +95,7 @@ developer must perform them.
 - `moon -C cli test codegen --target native`
 - `node scripts/verify_generated.mjs`
 - `moon -C extensions test -p moonbit-community/proton_ext moonbit-community/proton_ext/auto_launch moonbit-community/proton_ext/clipboard moonbit-community/proton_ext/dialog moonbit-community/proton_ext/fs moonbit-community/proton_ext/global_hotkey moonbit-community/proton_ext/keepawake moonbit-community/proton_ext/metadata_check moonbit-community/proton_ext/microphone moonbit-community/proton_ext/notification moonbit-community/proton_ext/path moonbit-community/proton_ext/shell moonbit-community/proton_ext/tray --target native`
-- `moon test -p moonbit-community/ffi moonbit-community/auto_launch moonbit-community/clipboard moonbit-community/global_hotkey moonbit-community/keepawake moonbit-community/microphone moonbit-community/tray --target native`
+- `moon test -p moonbit-community/proton_ffi moonbit-community/proton_auto_launch moonbit-community/proton_clipboard moonbit-community/proton_global_hotkey moonbit-community/proton_keepawake moonbit-community/proton_microphone moonbit-community/proton_tray --target native`
 - `moon -C examples build --target native`
 - `moon -C e2e build --target native`
 - `moon fmt` or `moon fmt --check`

--- a/cdp/README.mbt.md
+++ b/cdp/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/cdp
+# moonbit-community/proton_cdp
 
 ![Non-generated library coverage](https://img.shields.io/badge/non--generated%20library%20coverage-100%25-brightgreen.svg)
 
@@ -6,11 +6,11 @@ MoonBit library for the Chrome DevTools Protocol (CDP).
 
 ## Packages
 
-- `moonbit-community/cdp/protocol`: CDP wire types, bundled manifest, schema
+- `moonbit-community/proton_cdp/protocol`: CDP wire types, bundled manifest, schema
   validation, remote schema diff.
-- `moonbit-community/cdp/protocol/typed`: generated params, command builders, event
+- `moonbit-community/proton_cdp/protocol/typed`: generated params, command builders, event
   builders, result decoders.
-- `moonbit-community/cdp/client`: discovery, WebSocket client, events, targets,
+- `moonbit-community/proton_cdp/client`: discovery, WebSocket client, events, targets,
   browser launch helpers.
 
 ## Minimal Use

--- a/cdp/README.md
+++ b/cdp/README.md
@@ -1,4 +1,4 @@
-# moonbit-community/cdp
+# moonbit-community/proton_cdp
 
 ![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)
 ![Non-generated library coverage](https://img.shields.io/badge/non--generated%20library%20coverage-100%25-brightgreen.svg)
@@ -20,9 +20,9 @@ MoonBit library for the Chrome DevTools Protocol (CDP).
 
 | Package | Purpose |
 | --- | --- |
-| `moonbit-community/cdp/protocol` | Wire types, bundled manifest, schema validation, remote schema diff. |
-| `moonbit-community/cdp/protocol/typed` | Generated params, command builders, event builders, result decoders. |
-| `moonbit-community/cdp/client` | Discovery, WebSocket client, event buffer, target helpers, launch helpers. |
+| `moonbit-community/proton_cdp/protocol` | Wire types, bundled manifest, schema validation, remote schema diff. |
+| `moonbit-community/proton_cdp/protocol/typed` | Generated params, command builders, event builders, result decoders. |
+| `moonbit-community/proton_cdp/client` | Discovery, WebSocket client, event buffer, target helpers, launch helpers. |
 
 ## Docs
 
@@ -77,7 +77,7 @@ let response = page.send_schema_command(
 println(@client.cdp_response_result_json(response).stringify())
 ```
 
-Typed command builders live in `moonbit-community/cdp/protocol/typed`, for example
+Typed command builders live in `moonbit-community/proton_cdp/protocol/typed`, for example
 `@typed.runtime_evaluate_command`.
 
 ## Command Modes

--- a/cdp/docs/01-getting-started.mbt.md
+++ b/cdp/docs/01-getting-started.mbt.md
@@ -1,6 +1,6 @@
 # Getting started
 
-This page covers the minimum setup needed to connect `moonbit-community/cdp` to a
+This page covers the minimum setup needed to connect `moonbit-community/proton_cdp` to a
 Chrome-family browser with remote debugging enabled.
 
 ## Requirements
@@ -23,9 +23,9 @@ For an executable package that connects to CDP:
 ```moonbit
 import {
   "moonbitlang/async",
-  "moonbit-community/cdp/client",
-  "moonbit-community/cdp/protocol",
-  "moonbit-community/cdp/protocol/typed",
+  "moonbit-community/proton_cdp/client",
+  "moonbit-community/proton_cdp/protocol",
+  "moonbit-community/proton_cdp/protocol/typed",
 }
 
 supported_targets = "+native"

--- a/cdp/docs/README.mbt.md
+++ b/cdp/docs/README.mbt.md
@@ -1,6 +1,6 @@
-# moonbit-community/cdp documentation
+# moonbit-community/proton_cdp documentation
 
-`moonbit-community/cdp` is a MoonBit library for the Chrome DevTools Protocol
+`moonbit-community/proton_cdp` is a MoonBit library for the Chrome DevTools Protocol
 (CDP). It provides direct access to CDP messages with protocol metadata,
 schema-aware validation, generated typed command builders, remote debugging
 discovery, a WebSocket CDP client, target helpers, event buffering, and
@@ -8,16 +8,16 @@ optional local Chrome launch support.
 
 ## Packages
 
-- `moonbit-community/cdp/protocol`
+- `moonbit-community/proton_cdp/protocol`
   - CDP command, response, event, and error wire structs.
   - Bundled protocol manifest lookup.
   - Schema-aware command, event, and response validation.
   - Remote `/json/protocol` summary and diff helpers.
-- `moonbit-community/cdp/protocol/typed`
+- `moonbit-community/proton_cdp/protocol/typed`
   - Generated typed parameter structs.
   - Generated command builders for the bundled protocol.
   - Generated event builders and result decoders.
-- `moonbit-community/cdp/client`
+- `moonbit-community/proton_cdp/client`
   - Remote debugging discovery over `/json/version`, `/json/list`, and
     `/json/protocol`.
   - WebSocket CDP client.

--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,4 +1,4 @@
-name = "moonbit-community/cdp"
+name = "moonbit-community/proton_cdp"
 
 version = "0.1.14"
 

--- a/cdp/src/client/README.mbt.md
+++ b/cdp/src/client/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/cdp/client
+# moonbit-community/proton_cdp/client
 
 High-level Chrome DevTools Protocol client helpers for discovery, WebSocket
 connections, command dispatch, event buffering, target management, and browser

--- a/cdp/src/client/moon.pkg
+++ b/cdp/src/client/moon.pkg
@@ -6,7 +6,7 @@ import {
   "moonbitlang/async/http",
   "moonbitlang/async/process",
   "moonbitlang/async/websocket",
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
 }
 
 import {
@@ -16,8 +16,8 @@ import {
   "moonbitlang/async/socket",
   "moonbitlang/async/websocket",
   "moonbitlang/core/env",
-  "moonbit-community/cdp/protocol",
-  "moonbit-community/cdp/protocol/typed",
+  "moonbit-community/proton_cdp/protocol",
+  "moonbit-community/proton_cdp/protocol/typed",
 } for "test"
 
 import {

--- a/cdp/src/client/pkg.generated.mbti
+++ b/cdp/src/client/pkg.generated.mbti
@@ -1,8 +1,8 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/cdp/client"
+package "moonbit-community/proton_cdp/client"
 
 import {
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
   "moonbitlang/core/debug",
 }
 

--- a/cdp/src/protocol/README.mbt.md
+++ b/cdp/src/protocol/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/cdp/protocol
+# moonbit-community/proton_cdp/protocol
 
 Core Chrome DevTools Protocol wire types and schema helpers.
 

--- a/cdp/src/protocol/pkg.generated.mbti
+++ b/cdp/src/protocol/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/cdp/protocol"
+package "moonbit-community/proton_cdp/protocol"
 
 import {
   "moonbitlang/core/debug",

--- a/cdp/src/protocol/typed/README.mbt.md
+++ b/cdp/src/protocol/typed/README.mbt.md
@@ -1,10 +1,10 @@
-# moonbit-community/cdp/protocol/typed
+# moonbit-community/proton_cdp/protocol/typed
 
 Generated typed Chrome DevTools Protocol builders and JSON codecs.
 
 This package contains generated parameter/result structs, command builders,
 event builders, and result decoders for the bundled CDP schema. Builders return
-the wire message types from `moonbit-community/cdp/protocol`.
+the wire message types from `moonbit-community/proton_cdp/protocol`.
 
 ## Use
 

--- a/cdp/src/protocol/typed/moon.pkg
+++ b/cdp/src/protocol/typed/moon.pkg
@@ -1,16 +1,16 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
 }
 
 import {
   "moonbitlang/core/json",
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
 } for "test"
 
 import {
   "moonbitlang/core/json",
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
 } for "wbtest"
 
 options(

--- a/cdp/src/protocol/typed/pkg.generated.mbti
+++ b/cdp/src/protocol/typed/pkg.generated.mbti
@@ -1,8 +1,8 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/cdp/protocol/typed"
+package "moonbit-community/proton_cdp/protocol/typed"
 
 import {
-  "moonbit-community/cdp/protocol",
+  "moonbit-community/proton_cdp/protocol",
   "moonbitlang/core/debug",
 }
 

--- a/cdp/src/protocol/types.mbt
+++ b/cdp/src/protocol/types.mbt
@@ -127,7 +127,7 @@ pub(all) struct ProtocolType {
 /// Use `protocol_manifest` from the generated manifest file to obtain the
 /// current value, then the count and lookup methods in this file to inspect it.
 /// The manifest intentionally stores summary metadata; full generated typed
-/// structs and builders live in `moonbit-community/cdp/protocol/typed`.
+/// structs and builders live in `moonbit-community/proton_cdp/protocol/typed`.
 pub(all) struct ProtocolManifest {
   version : ProtocolVersion
   sources : Array[ProtocolSchemaSource]

--- a/cli/doctor/moon.pkg
+++ b/cli/doctor/moon.pkg
@@ -3,7 +3,7 @@ import {
   "moonbit-community/proton_cli/cef",
   "moonbit-community/proton_cli/codegen",
   "moonbit-community/proton_cli/fsutil",
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/async",
   "moonbitlang/async/fs" @async_fs,
   "moonbitlang/async/io",

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -11,7 +11,7 @@ import {
   "moonbitlang/moon_config@0.3.5",
   "moonbitlang/lexer@0.3.5",
   "moonbitlang/async@0.20.3",
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
 }
 
 readme = "codegen/README.md"

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -5,7 +5,7 @@ version = "0.1.14"
 import {
   "moonbitlang/async@0.20.3",
   "moonbitlang/x@0.4.48",
-  "moonbit-community/cdp@0.1.14",
+  "moonbit-community/proton_cdp@0.1.14",
   "moonbit-community/proton@0.1.14",
   "moonbit-community/proton_updater@0.1.14",
   "moonbit-community/proton/examples@0.1.14",

--- a/e2e/test/moon.pkg
+++ b/e2e/test/moon.pkg
@@ -2,7 +2,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
-  "moonbit-community/cdp/client",
+  "moonbit-community/proton_cdp/client",
 }
 
 import {

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -89,7 +89,7 @@ All runnable examples should import `moonbit-community/proton`. `moon.proton`
 configures app settings such as window, entry, debug, frontend, and bundle
 metadata.
 
-Tray v1 is implemented by the `tray` extension through `moonbit-community/tray`; Proton
+Tray v1 is implemented by the `tray` extension through `moonbit-community/proton_tray`; Proton
 native C does not expose a tray ABI. Windows is the baseline for tray-icon
 click/right-click/double-click events. Menu item clicks are the portable event
 path across Windows, Linux, and macOS when the desktop backend supports menu

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -76,7 +76,7 @@ extension settings in `moon.proton` are not the active registration surface.
 
 ## Tray Notes
 
-The tray extension is backed by `moonbit-community/tray`, which owns the platform tray
+The tray extension is backed by `moonbit-community/proton_tray`, which owns the platform tray
 native-stub. Proton native C stays limited to the CEF-backed runtime, windows,
 and bridge ABI. The v1 API exposes `support`, `show`, `hide`, `setIcon`,
 `setTooltip`, `setMenu`, and `destroy`.

--- a/extensions/auto_launch/moon.pkg
+++ b/extensions/auto_launch/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/auto_launch" @sys_auto_launch,
+  "moonbit-community/proton_auto_launch" @sys_auto_launch,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/extensions/clipboard/moon.pkg
+++ b/extensions/clipboard/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/clipboard" @sys_clipboard,
+  "moonbit-community/proton_clipboard" @sys_clipboard,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/extensions/global_hotkey/moon.pkg
+++ b/extensions/global_hotkey/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/global_hotkey" @sys_global_hotkey,
+  "moonbit-community/proton_global_hotkey" @sys_global_hotkey,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/extensions/keepawake/moon.pkg
+++ b/extensions/keepawake/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/keepawake" @sys_keepawake,
+  "moonbit-community/proton_keepawake" @sys_keepawake,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/extensions/microphone/moon.pkg
+++ b/extensions/microphone/moon.pkg
@@ -2,7 +2,7 @@ import {
   "moonbitlang/core/json",
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
-  "moonbit-community/microphone" @sys_microphone,
+  "moonbit-community/proton_microphone" @sys_microphone,
   "moonbit-community/proton_contract",
   "moonbit-community/proton_ext/microphone/contract" @microphone_contract,
 }

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -3,17 +3,17 @@ name = "moonbit-community/proton_ext"
 version = "0.1.14"
 
 import {
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
   "moonbitlang/x@0.4.48",
   "moonbitlang/async@0.20.3",
-  "moonbit-community/clipboard@0.1.14",
-  "moonbit-community/tray@0.1.14",
-  "moonbit-community/global_hotkey@0.1.14",
+  "moonbit-community/proton_clipboard@0.1.14",
+  "moonbit-community/proton_tray@0.1.14",
+  "moonbit-community/proton_global_hotkey@0.1.14",
   "moonbit-community/proton@0.1.14",
   "moonbit-community/proton_contract@0.1.14",
-  "moonbit-community/microphone@0.1.14",
-  "moonbit-community/auto_launch@0.1.14",
-  "moonbit-community/keepawake@0.1.14",
+  "moonbit-community/proton_microphone@0.1.14",
+  "moonbit-community/proton_auto_launch@0.1.14",
+  "moonbit-community/proton_keepawake@0.1.14",
 }
 
 readme = "README.md"

--- a/extensions/shell/moon.pkg
+++ b/extensions/shell/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/extensions/tray/extension.mbt
+++ b/extensions/tray/extension.mbt
@@ -68,7 +68,7 @@ fn tray_handle() -> @sys_tray.Tray raise TrayError {
   match app_command_tray_handle.val {
     Some(handle) => handle
     None =>
-      match @sys_tray.create(identifier="justjavac.proton.tray") {
+      match @sys_tray.create(identifier="moonbit-community.proton.tray") {
         Ok(handle) => {
           app_command_tray_handle.val = Some(handle)
           handle

--- a/extensions/tray/moon.pkg
+++ b/extensions/tray/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/tray" @sys_tray,
+  "moonbit-community/proton_tray" @sys_tray,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton"
 version = "0.1.14"
 
 import {
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
   "moonbit-community/proton_config@0.1.14",
   "moonbit-community/proton_contract@0.1.14",
   "moonbit-community/proton_updater@0.1.14",

--- a/proton/native/moon.pkg
+++ b/proton/native/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }

--- a/sys/auto_launch/README.mbt.md
+++ b/sys/auto_launch/README.mbt.md
@@ -1,10 +1,6 @@
-# moonbit-community/auto_launch
+# moonbit-community/proton_auto_launch
 
-[![CI](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/justjavac/moonbit-auto-launch/actions/workflows/ci.yml)
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-auto-launch/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-auto-launch)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
 
 Cross-platform auto-launch helpers for MoonBit.
 
@@ -13,12 +9,12 @@ Cross-platform auto-launch helpers for MoonBit.
 ```mbt check
 ///|
 test "public api can be called" {
-  ignore(@auto_launch.current_platform())
-  ignore(@auto_launch.is_supported())
+  ignore(@proton_auto_launch.current_platform())
+  ignore(@proton_auto_launch.is_supported())
 
-  let launcher = @auto_launch.new(
+  let launcher = @proton_auto_launch.new(
     "MoonBit Demo",
-    path=match @auto_launch.current_platform() {
+    path=match @proton_auto_launch.current_platform() {
       Windows => "C:\\Program Files\\MoonBit\\moonbit.exe"
       Macos => "/Applications/MoonBit.app/Contents/MacOS/MoonBit"
       Linux => "/usr/bin/moonbit"

--- a/sys/auto_launch/README.md
+++ b/sys/auto_launch/README.md
@@ -1,4 +1,4 @@
-# moonbit-community/auto_launch
+# moonbit-community/proton_auto_launch
 
 Cross-platform auto-launch helpers for MoonBit.
 
@@ -15,7 +15,7 @@ This project is inspired by and references [Teamwork/node-auto-launch](https://g
 ## Install
 
 ```bash
-moon add moonbit-community/auto_launch
+moon add moonbit-community/proton_auto_launch
 ```
 
 This package currently supports the `native` target.
@@ -24,9 +24,9 @@ This package currently supports the `native` target.
 
 ```moonbit
 fn main {
-  let launcher = match @auto_launch.new(
+  let launcher = match @proton_auto_launch.new(
     "MoonBit Demo",
-    path=match @auto_launch.current_platform() {
+    path=match @proton_auto_launch.current_platform() {
       Windows => "C:\\Program Files\\MoonBit\\moonbit.exe"
       Macos => "/Applications/MoonBit.app/Contents/MacOS/MoonBit"
       Linux => "/usr/bin/moonbit"
@@ -48,9 +48,9 @@ fn main {
 
 ## API
 
-- `@auto_launch.current_platform() -> Platform`
-- `@auto_launch.is_supported() -> Bool`
-- `@auto_launch.new(...) -> Result[AutoLaunch, AutoLaunchError]`
+- `@proton_auto_launch.current_platform() -> Platform`
+- `@proton_auto_launch.is_supported() -> Bool`
+- `@proton_auto_launch.new(...) -> Result[AutoLaunch, AutoLaunchError]`
 - `AutoLaunch::name() -> String`
 - `AutoLaunch::path() -> String`
 - `AutoLaunch::identifier() -> String`
@@ -67,7 +67,7 @@ moon test --target native
 
 # Coverage for the main package only; excludes src/examples/*
 moon test --target native --enable-coverage
-moon coverage analyze -p moonbit-community/auto_launch -- -f summary
+moon coverage analyze -p moonbit-community/proton_auto_launch -- -f summary
 moon info --target native
 ```
 

--- a/sys/auto_launch/auto_launch.mbt
+++ b/sys/auto_launch/auto_launch.mbt
@@ -111,7 +111,7 @@ fn new_with(
 ///
 /// # Example
 /// ```mbt nocheck
-/// let launcher = @auto_launch.new(
+/// let launcher = @proton_auto_launch.new(
 ///   "MoonBit Demo",
 ///   path="/usr/bin/moonbit",
 ///   launch_in_background=true,

--- a/sys/auto_launch/auto_launch_integration_test.mbt
+++ b/sys/auto_launch/auto_launch_integration_test.mbt
@@ -32,8 +32,8 @@ fn stable_test_path(platform : Platform) -> String {
 ///|
 /// Builds the launcher instance shared by the integration roundtrip test.
 fn new_integration_test_launcher() -> Result[AutoLaunch, AutoLaunchError] {
-  let platform = @auto_launch.current_platform()
-  @auto_launch.new(
+  let platform = @proton_auto_launch.current_platform()
+  @proton_auto_launch.new(
     "MoonBit Auto Launch Integration Test",
     path=stable_test_path(platform),
     identifier="moonbit-auto-launch-integration-test",
@@ -44,7 +44,7 @@ fn new_integration_test_launcher() -> Result[AutoLaunch, AutoLaunchError] {
 /// Verifies the real backend can enable, query, and disable one launcher entry.
 test "integration enable disable roundtrip" {
   guard integration_tests_enabled() else { return }
-  guard @auto_launch.is_supported() else {
+  guard @proton_auto_launch.is_supported() else {
     fail("integration tests were enabled on an unsupported platform")
   }
 

--- a/sys/auto_launch/auto_launch_test.mbt
+++ b/sys/auto_launch/auto_launch_test.mbt
@@ -1,14 +1,14 @@
 ///|
 /// Verifies that the public library symbols remain available to downstream callers.
 test "public api symbols are exported" {
-  ignore(@auto_launch.current_platform)
-  ignore(@auto_launch.is_supported)
-  ignore(@auto_launch.AutoLaunch::name)
-  ignore(@auto_launch.AutoLaunch::path)
-  ignore(@auto_launch.AutoLaunch::identifier)
-  ignore(@auto_launch.AutoLaunch::enable)
-  ignore(@auto_launch.AutoLaunch::disable)
-  ignore(@auto_launch.AutoLaunch::is_enabled)
+  ignore(@proton_auto_launch.current_platform)
+  ignore(@proton_auto_launch.is_supported)
+  ignore(@proton_auto_launch.AutoLaunch::name)
+  ignore(@proton_auto_launch.AutoLaunch::path)
+  ignore(@proton_auto_launch.AutoLaunch::identifier)
+  ignore(@proton_auto_launch.AutoLaunch::enable)
+  ignore(@proton_auto_launch.AutoLaunch::disable)
+  ignore(@proton_auto_launch.AutoLaunch::is_enabled)
 }
 
 ///|
@@ -31,12 +31,12 @@ fn new_public_test_launcher(
   launch_in_background? : Bool = false,
   extra_arguments? : Array[String] = [],
 ) -> Result[AutoLaunch, AutoLaunchError] {
-  let platform = @auto_launch.current_platform()
+  let platform = @proton_auto_launch.current_platform()
   let resolved_path = match path {
     Some(value) => value
     None => sample_public_app_path(platform)
   }
-  @auto_launch.new(
+  @proton_auto_launch.new(
     name,
     path=resolved_path,
     launch_in_background~,
@@ -48,11 +48,11 @@ fn new_public_test_launcher(
 ///|
 /// Ensures the public constructor rejects empty application names.
 test "new validates empty names" {
-  match @auto_launch.new("") {
+  match @proton_auto_launch.new("") {
     Err(EmptyName) => ()
     _ => fail("expected EmptyName")
   }
-  match @auto_launch.new("   ") {
+  match @proton_auto_launch.new("   ") {
     Err(EmptyName) => ()
     _ => fail("expected EmptyName")
   }
@@ -61,7 +61,7 @@ test "new validates empty names" {
 ///|
 /// Ensures the public constructor rejects relative explicit executable paths.
 test "new validates relative explicit paths" {
-  match @auto_launch.new("Auto Launch", path="relative/path") {
+  match @proton_auto_launch.new("Auto Launch", path="relative/path") {
     Err(RelativeExecutablePath(path)) => assert_eq(path, "relative/path")
     _ => fail("expected RelativeExecutablePath")
   }
@@ -70,7 +70,7 @@ test "new validates relative explicit paths" {
 ///|
 /// Ensures launcher creation succeeds on supported platforms with valid input.
 test "new creates a launcher on supported platforms" {
-  guard @auto_launch.is_supported() else { return }
+  guard @proton_auto_launch.is_supported() else { return }
 
   let launcher = match
     new_public_test_launcher("moonbit-auto-launch", launch_in_background=true, extra_arguments=[
@@ -87,7 +87,8 @@ test "new creates a launcher on supported platforms" {
 ///|
 /// Ensures runtime platform detection and support reporting stay consistent.
 test "current platform and support flag stay in sync" {
-  match (@auto_launch.current_platform(), @auto_launch.is_supported()) {
+  match
+    (@proton_auto_launch.current_platform(), @proton_auto_launch.is_supported()) {
     (Unsupported, false) => ()
     (Windows, true) => ()
     (Macos, true) => ()
@@ -99,7 +100,7 @@ test "current platform and support flag stay in sync" {
 ///|
 /// Exercises the public enable-disable roundtrip on Windows startup entries.
 test "public methods can roundtrip a windows startup entry" {
-  guard @auto_launch.current_platform() is Windows else { return }
+  guard @proton_auto_launch.current_platform() is Windows else { return }
 
   let launcher = match
     new_public_test_launcher(

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,4 +1,4 @@
-name = "moonbit-community/auto_launch"
+name = "moonbit-community/proton_auto_launch"
 
 version = "0.1.14"
 

--- a/sys/auto_launch/pkg.generated.mbti
+++ b/sys/auto_launch/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/auto_launch"
+package "moonbit-community/proton_auto_launch"
 
 import {
   "moonbitlang/core/debug",

--- a/sys/clipboard/README.mbt.md
+++ b/sys/clipboard/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/clipboard
+# moonbit-community/proton_clipboard
 
 Cross-platform native clipboard helpers for MoonBit `native` builds.
 
@@ -10,12 +10,12 @@ small synchronous API.
 ```mbt check
 ///|
 test "probe clipboard support and read text" {
-  match @clipboard.ensure_supported() {
+  match @proton_clipboard.ensure_supported() {
     Ok(_) => ()
     Err(message) => assert_true(!message.is_empty())
   }
 
-  match @clipboard.read_text() {
+  match @proton_clipboard.read_text() {
     Ok(Some(_text)) => ()
     Ok(None) => ()
     Err(message) => assert_true(!message.is_empty())

--- a/sys/clipboard/README.md
+++ b/sys/clipboard/README.md
@@ -1,9 +1,7 @@
-# moonbit-community/clipboard
+# moonbit-community/proton_clipboard
 
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-clipboard)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-clipboard)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-clipboard)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-clipboard/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-clipboard)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/proton_clipboard)
 
 Cross-platform native clipboard helpers for MoonBit `native` builds.
 
@@ -13,7 +11,7 @@ small synchronous API.
 ## Install
 
 ```bash
-moon add moonbit-community/clipboard
+moon add moonbit-community/proton_clipboard
 ```
 
 ## Quick Start
@@ -21,12 +19,12 @@ moon add moonbit-community/clipboard
 ```mbt check
 ///|
 test "probe clipboard support and read text" {
-  match @clipboard.ensure_supported() {
+  match @proton_clipboard.ensure_supported() {
     Ok(_) => ()
     Err(message) => assert_true(!message.is_empty())
   }
 
-  match @clipboard.read_text() {
+  match @proton_clipboard.read_text() {
     Ok(Some(_text)) => ()
     Ok(None) => ()
     Err(message) => assert_true(!message.is_empty())

--- a/sys/clipboard/clipboard_integration_test.mbt
+++ b/sys/clipboard/clipboard_integration_test.mbt
@@ -14,8 +14,8 @@ fn integration_tests_enabled() -> Bool {
 /// Restores the clipboard text captured before an integration test ran.
 fn restore_clipboard_text(original : String?) -> Result[Unit, String] {
   match original {
-    Some(text) => @clipboard.write_text(text)
-    None => @clipboard.write_text("")
+    Some(text) => @proton_clipboard.write_text(text)
+    None => @proton_clipboard.write_text("")
   }
 }
 
@@ -23,23 +23,23 @@ fn restore_clipboard_text(original : String?) -> Result[Unit, String] {
 test "integration write and read roundtrip" {
   guard integration_tests_enabled() else { return }
 
-  guard @clipboard.is_supported() else {
+  guard @proton_clipboard.is_supported() else {
     fail("integration tests were enabled on an unsupported platform")
   }
 
-  let original = match @clipboard.read_text() {
+  let original = match @proton_clipboard.read_text() {
     Ok(value) => value
     Err(error) => fail("failed to read clipboard before test: " + error)
   }
 
-  let probe = "moonbit-community/clipboard integration probe"
+  let probe = "moonbit-community/proton_clipboard integration probe"
 
-  match @clipboard.write_text(probe) {
+  match @proton_clipboard.write_text(probe) {
     Ok(_) => ()
     Err(error) => fail("failed to write clipboard probe text: " + error)
   }
 
-  let roundtrip_result = @clipboard.read_text()
+  let roundtrip_result = @proton_clipboard.read_text()
 
   match restore_clipboard_text(original) {
     Ok(_) => ()

--- a/sys/clipboard/clipboard_test.mbt
+++ b/sys/clipboard/clipboard_test.mbt
@@ -1,14 +1,15 @@
 ///|
 test "public api symbols are exported" {
-  ignore(@clipboard.is_supported)
-  ignore(@clipboard.ensure_supported)
-  ignore(@clipboard.read_text)
-  ignore(@clipboard.write_text)
+  ignore(@proton_clipboard.is_supported)
+  ignore(@proton_clipboard.ensure_supported)
+  ignore(@proton_clipboard.read_text)
+  ignore(@proton_clipboard.write_text)
 }
 
 ///|
 test "ensure_supported matches platform probe" {
-  match (@clipboard.is_supported(), @clipboard.ensure_supported()) {
+  match
+    (@proton_clipboard.is_supported(), @proton_clipboard.ensure_supported()) {
     (true, Ok(_)) => ()
     (false, Err(_)) => ()
     _ => fail("ensure_supported should agree with is_supported")

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,4 +1,4 @@
-name = "moonbit-community/clipboard"
+name = "moonbit-community/proton_clipboard"
 
 version = "0.1.14"
 

--- a/sys/clipboard/pkg.generated.mbti
+++ b/sys/clipboard/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/clipboard"
+package "moonbit-community/proton_clipboard"
 
 // Values
 pub fn ensure_supported() -> Result[Unit, String]

--- a/sys/ffi/README.mbt.md
+++ b/sys/ffi/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/ffi
+# moonbit-community/proton_ffi
 
 Helpers for converting MoonBit `String` values to and from null-terminated
 UTF-8 and UTF-16LE buffers at FFI boundaries.
@@ -11,11 +11,11 @@ now maintained inside the Proton repository and licensed under Apache-2.0.
 ```moonbit check
 ///|
 test {
-  let c_name = @ffi.to_cstr("ffi")
+  let c_name = @proton_ffi.to_cstr("ffi")
   assert_eq(c_name, b"ffi\x00")
-  assert_eq(@ffi.from_cstr(c_name), "ffi")
+  assert_eq(@proton_ffi.from_cstr(c_name), "ffi")
 
-  let wide_name = @ffi.to_wstr("世界")
-  assert_eq(@ffi.from_wstr_lossy(wide_name), "世界")
+  let wide_name = @proton_ffi.to_wstr("世界")
+  assert_eq(@proton_ffi.from_wstr_lossy(wide_name), "世界")
 }
 ```

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,4 +1,4 @@
-name = "moonbit-community/ffi"
+name = "moonbit-community/proton_ffi"
 
 version = "0.1.14"
 

--- a/sys/ffi/src/cstr.mbt
+++ b/sys/ffi/src/cstr.mbt
@@ -27,8 +27,8 @@
 /// # Example
 ///
 /// ```moonbit nocheck
-/// let raw = @ffi.to_cstr("hello")
-/// inspect(@ffi.from_cstr(raw), content="hello")
+/// let raw = @proton_ffi.to_cstr("hello")
+/// inspect(@proton_ffi.from_cstr(raw), content="hello")
 /// ```
 pub fn from_cstr(b : Bytes) -> String {
   if b.length() == 0 || b[b.length() - 1] != 0x00 {
@@ -60,7 +60,7 @@ pub fn from_cstr(b : Bytes) -> String {
 /// # Example
 ///
 /// ```moonbit nocheck
-/// inspect(@ffi.to_cstr("ffi"), content=b"ffi\x00")
+/// inspect(@proton_ffi.to_cstr("ffi"), content=b"ffi\x00")
 /// ```
 pub fn to_cstr(s : String) -> Bytes {
   @encoding.encode(UTF8, s + "\u{0000}")

--- a/sys/ffi/src/ffi_test.mbt
+++ b/sys/ffi/src/ffi_test.mbt
@@ -1,46 +1,46 @@
 ///|
 test "cstr round trip utf8" {
   let input = "Hello, 世界"
-  assert_eq(@ffi.from_cstr(@ffi.to_cstr(input)), input)
+  assert_eq(@proton_ffi.from_cstr(@proton_ffi.to_cstr(input)), input)
 }
 
 ///|
 test "to_cstr appends a trailing nul" {
-  assert_eq(@ffi.to_cstr("ffi"), b"ffi\x00")
-  assert_eq(@ffi.to_cstr(""), b"\x00")
+  assert_eq(@proton_ffi.to_cstr("ffi"), b"ffi\x00")
+  assert_eq(@proton_ffi.to_cstr(""), b"\x00")
 }
 
 ///|
 test "from_cstr stops at first nul" {
-  assert_eq(@ffi.from_cstr(b"ffi\x00ignored\x00"), "ffi")
+  assert_eq(@proton_ffi.from_cstr(b"ffi\x00ignored\x00"), "ffi")
 }
 
 ///|
 test "panic from_cstr requires terminator" {
-  @ffi.from_cstr(b"ffi") |> ignore
+  @proton_ffi.from_cstr(b"ffi") |> ignore
 }
 
 ///|
 test "wstr round trip unicode" {
   let input = "Hello, 世界 😀"
-  assert_eq(@ffi.from_wstr_lossy(@ffi.to_wstr(input)), input)
+  assert_eq(@proton_ffi.from_wstr_lossy(@proton_ffi.to_wstr(input)), input)
 }
 
 ///|
 test "to_wstr appends a trailing wide nul" {
-  assert_eq(@ffi.to_wstr("Hi"), b"\x48\x00\x69\x00\x00\x00")
-  assert_eq(@ffi.to_wstr(""), b"\x00\x00")
+  assert_eq(@proton_ffi.to_wstr("Hi"), b"\x48\x00\x69\x00\x00\x00")
+  assert_eq(@proton_ffi.to_wstr(""), b"\x00\x00")
 }
 
 ///|
 test "from_wstr_lossy stops at first wide nul" {
   assert_eq(
-    @ffi.from_wstr_lossy(b"\x48\x00\x69\x00\x00\x00\x78\x00\x00\x00"),
+    @proton_ffi.from_wstr_lossy(b"\x48\x00\x69\x00\x00\x00\x78\x00\x00\x00"),
     "Hi",
   )
 }
 
 ///|
 test "panic from_wstr_lossy requires terminator" {
-  @ffi.from_wstr_lossy(b"\x00") |> ignore
+  @proton_ffi.from_wstr_lossy(b"\x00") |> ignore
 }

--- a/sys/ffi/src/pkg.generated.mbti
+++ b/sys/ffi/src/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/ffi"
+package "moonbit-community/proton_ffi"
 
 // Values
 pub fn from_cstr(Bytes) -> String

--- a/sys/ffi/src/wstr.mbt
+++ b/sys/ffi/src/wstr.mbt
@@ -27,8 +27,8 @@
 /// # Example
 ///
 /// ```moonbit nocheck
-/// let raw = @ffi.to_wstr("Hello")
-/// inspect(@ffi.from_wstr_lossy(raw), content="Hello")
+/// let raw = @proton_ffi.to_wstr("Hello")
+/// inspect(@proton_ffi.from_wstr_lossy(raw), content="Hello")
 /// ```
 pub fn from_wstr_lossy(b : Bytes) -> String {
   if b.length() < 2 || b[b.length() - 2] != 0x00 || b[b.length() - 1] != 0x00 {
@@ -59,7 +59,7 @@ pub fn from_wstr_lossy(b : Bytes) -> String {
 /// # Example
 ///
 /// ```moonbit nocheck
-/// inspect(@ffi.to_wstr("Hi"), content=b"\x48\x00\x69\x00\x00\x00")
+/// inspect(@proton_ffi.to_wstr("Hi"), content=b"\x48\x00\x69\x00\x00\x00")
 /// ```
 pub fn to_wstr(s : String) -> Bytes {
   @encoding.encode(UTF16, s + "\u{0000}")

--- a/sys/global_hotkey/README.mbt.md
+++ b/sys/global_hotkey/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/global_hotkey
+# moonbit-community/proton_global_hotkey
 
 Cross-platform native global hotkey helpers for MoonBit.
 
@@ -9,8 +9,8 @@ This package targets `native` and supports Windows, macOS, and Linux X11 session
 ```mbt check
 ///|
 test "global_hotkey can be probed safely" {
-  ignore(@global_hotkey.is_supported())
-  match @global_hotkey.create() {
+  ignore(@proton_global_hotkey.is_supported())
+  match @proton_global_hotkey.create() {
     Ok(manager) => manager.destroy()
     Err(_) => ()
   }

--- a/sys/global_hotkey/README.md
+++ b/sys/global_hotkey/README.md
@@ -1,11 +1,7 @@
-# moonbit-community/global_hotkey
+# moonbit-community/proton_global_hotkey
 
-[![CI](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-global-hotkey/actions/workflows/ci.yml)
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-global-hotkey/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-global-hotkey)
-[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/global_hotkey)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/proton_global_hotkey)
 
 Cross-platform native global hotkey helpers for MoonBit.
 
@@ -22,7 +18,7 @@ This package targets `native` and supports Windows, macOS, and Linux X11 session
 ## Install
 
 ```bash
-moon add moonbit-community/global_hotkey
+moon add moonbit-community/proton_global_hotkey
 ```
 
 ## Quick start
@@ -31,15 +27,15 @@ Minimal checked example:
 
 ```mbt check
 test "global_hotkey support can be queried" {
-  ignore(@global_hotkey.is_supported())
-  ignore(@global_hotkey.ensure_supported())
+  ignore(@proton_global_hotkey.is_supported())
+  ignore(@proton_global_hotkey.ensure_supported())
 }
 ```
 
 Typical polling loop:
 
 ```mbt nocheck
-let manager = match @global_hotkey.create() {
+let manager = match @proton_global_hotkey.create() {
   Ok(manager) => manager
   Err(error) => fail(error)
 }
@@ -110,7 +106,7 @@ Key commands:
 ```bash
 moon check --target native
 moon test --target native
-moon coverage analyze -p moonbit-community/global_hotkey -- -f summary
+moon coverage analyze -p moonbit-community/proton_global_hotkey -- -f summary
 moon info
 moon fmt
 ```

--- a/sys/global_hotkey/global_hotkey.mbt
+++ b/sys/global_hotkey/global_hotkey.mbt
@@ -114,7 +114,7 @@ fn drain_with(take : () -> String?) -> Array[String] {
 ///
 /// ```mbt check
 /// test "support detection can be queried" {
-///   ignore(@global_hotkey.is_supported())
+///   ignore(@proton_global_hotkey.is_supported())
 /// }
 /// ```
 pub fn is_supported() -> Bool {
@@ -140,7 +140,7 @@ pub fn is_supported() -> Bool {
 ///
 /// ```mbt check
 /// test "support can be checked without registering anything" {
-///   ignore(@global_hotkey.ensure_supported())
+///   ignore(@proton_global_hotkey.ensure_supported())
 /// }
 /// ```
 pub fn ensure_supported() -> Result[Unit, String] {
@@ -173,7 +173,7 @@ pub fn ensure_supported() -> Result[Unit, String] {
 ///
 /// ```mbt check
 /// test "manager creation can be attempted safely" {
-///   match @global_hotkey.create() {
+///   match @proton_global_hotkey.create() {
 ///     Ok(manager) => manager.destroy()
 ///     Err(_) => ()
 ///   }
@@ -222,7 +222,7 @@ pub fn create() -> Result[GlobalHotkeyManager, String] {
 ///
 /// ```mbt check
 /// test "register may be attempted on a live manager" {
-///   match @global_hotkey.create() {
+///   match @proton_global_hotkey.create() {
 ///     Ok(manager) => {
 ///       ignore(manager.register("Ctrl+Shift+F24"))
 ///       ignore(manager.unregister("Ctrl+Shift+F24"))

--- a/sys/global_hotkey/global_hotkey_test.mbt
+++ b/sys/global_hotkey/global_hotkey_test.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Attempts candidate accelerators until one registers successfully.
 fn register_first_available(
-  manager : @global_hotkey.GlobalHotkeyManager,
+  manager : @proton_global_hotkey.GlobalHotkeyManager,
   candidates : Array[String],
 ) -> String? {
   for candidate in candidates {
@@ -15,13 +15,13 @@ fn register_first_available(
 
 ///|
 test "support checks are callable" {
-  ignore(@global_hotkey.is_supported())
-  ignore(@global_hotkey.ensure_supported())
+  ignore(@proton_global_hotkey.is_supported())
+  ignore(@proton_global_hotkey.ensure_supported())
 }
 
 ///|
 test "manager lifecycle can be exercised on the current machine" {
-  match @global_hotkey.create() {
+  match @proton_global_hotkey.create() {
     Err(_) => ()
     Ok(manager) => {
       assert_eq(manager.list().length(), 0)
@@ -41,7 +41,7 @@ test "manager lifecycle can be exercised on the current machine" {
 
 ///|
 test "native registration conflict surfaces as an error" {
-  match (@global_hotkey.create(), @global_hotkey.create()) {
+  match (@proton_global_hotkey.create(), @proton_global_hotkey.create()) {
     (Ok(first), Ok(second)) => {
       let candidates = ["Ctrl+Shift+F24", "Alt+Shift+F23"]
       match register_first_available(first, candidates) {
@@ -68,7 +68,7 @@ test "native registration conflict surfaces as an error" {
 
 ///|
 test "destroy makes future operations inert" {
-  match @global_hotkey.create() {
+  match @proton_global_hotkey.create() {
     Err(_) => ()
     Ok(manager) => {
       match manager.register("ctrl") {

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,4 +1,4 @@
-name = "moonbit-community/global_hotkey"
+name = "moonbit-community/proton_global_hotkey"
 
 version = "0.1.14"
 

--- a/sys/global_hotkey/pkg.generated.mbti
+++ b/sys/global_hotkey/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/global_hotkey"
+package "moonbit-community/proton_global_hotkey"
 
 import {
   "moonbitlang/core/debug",

--- a/sys/keepawake/README.mbt.md
+++ b/sys/keepawake/README.mbt.md
@@ -10,9 +10,9 @@ test {
 ```
 
 ```mbt nocheck
-let guard = @keepawake.acquire(
+let guard = @proton_keepawake.acquire(
   reason="Rendering a large animation",
-  scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+  scope=@proton_keepawake.Scope::PreventSystemAndDisplaySleep,
 )
 
 guard.release()

--- a/sys/keepawake/README.md
+++ b/sys/keepawake/README.md
@@ -1,9 +1,7 @@
-# keepawake
+# moonbit-community/proton_keepawake
 
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-keepawake)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-keepawake)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-keepawake)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-keepawake/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-keepawake)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/proton_keepawake)
 
 `keepawake` is a native-only MoonBit module that exposes a small, readable API
 for keeping a machine awake while long-running work is in progress.
@@ -18,26 +16,26 @@ maintain and easy to extend:
 
 ## Install
 
-Add the module to your project, then import `moonbit-community/keepawake`.
+Add the module to your project, then import `moonbit-community/proton_keepawake`.
 
 ```bash
-moon add moonbit-community/keepawake
+moon add moonbit-community/proton_keepawake
 ```
 
 Package configuration:
 
 ```moonbit
 import {
-  "moonbit-community/keepawake",
+  "moonbit-community/proton_keepawake",
 }
 ```
 
 ## API Overview
 
 ```moonbit
-let guard = @keepawake.acquire(
+let guard = @proton_keepawake.acquire(
   reason="Rendering a long animation",
-  scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+  scope=@proton_keepawake.Scope::PreventSystemAndDisplaySleep,
 )
 
 // ... perform the long-running work ...
@@ -48,13 +46,13 @@ guard.release()
 Use the scoped helper when you want automatic cleanup:
 
 ```moonbit
-let result = @keepawake.with_keepawake(
+let result = @proton_keepawake.with_keepawake(
   () => {
     // ... perform the long-running work ...
     "done"
   },
   reason="Syncing a large local cache",
-  scope=@keepawake.Scope::PreventSystemSleep,
+  scope=@proton_keepawake.Scope::PreventSystemSleep,
 )
 ```
 

--- a/sys/keepawake/guard.mbt
+++ b/sys/keepawake/guard.mbt
@@ -37,9 +37,9 @@ pub let default_reason : String = "MoonBit keepawake request"
 ///
 /// # Example
 /// ```mbt nocheck
-/// let guard = @keepawake.acquire(
+/// let guard = @proton_keepawake.acquire(
 ///   reason="Encoding a large video",
-///   scope=@keepawake.Scope::PreventSystemAndDisplaySleep,
+///   scope=@proton_keepawake.Scope::PreventSystemAndDisplaySleep,
 /// )
 ///
 /// // ... perform the long-running work ...
@@ -80,11 +80,11 @@ pub fn acquire(
 ///
 /// # Example
 /// ```mbt nocheck
-/// let summary = @keepawake.with_keepawake(
+/// let summary = @proton_keepawake.with_keepawake(
 ///   () => "done",
 ///   reason="Syncing local cache",
 ///   // ... perform long-running work ...
-///   scope=@keepawake.Scope::PreventSystemSleep,
+///   scope=@proton_keepawake.Scope::PreventSystemSleep,
 /// )
 /// ```
 pub fn[T] with_keepawake(

--- a/sys/keepawake/keepawake_test.mbt
+++ b/sys/keepawake/keepawake_test.mbt
@@ -2,9 +2,9 @@
 test "scope names stay stable" {
   debug_inspect(
     [
-      @keepawake.Scope::PreventSystemSleep.to_string(),
-      @keepawake.Scope::PreventDisplaySleep.to_string(),
-      @keepawake.Scope::PreventSystemAndDisplaySleep.to_string(),
+      @proton_keepawake.Scope::PreventSystemSleep.to_string(),
+      @proton_keepawake.Scope::PreventDisplaySleep.to_string(),
+      @proton_keepawake.Scope::PreventSystemAndDisplaySleep.to_string(),
     ],
     content=(
       #|[
@@ -19,9 +19,9 @@ test "scope names stay stable" {
 ///|
 test "acquire and release smoke test" {
   let result = Ok(
-    @keepawake.acquire(
+    @proton_keepawake.acquire(
       reason="blackbox smoke test",
-      scope=@keepawake.Scope::PreventSystemSleep,
+      scope=@proton_keepawake.Scope::PreventSystemSleep,
     ),
   ) catch {
     e => Err(e)
@@ -29,13 +29,13 @@ test "acquire and release smoke test" {
   match result {
     Ok(handle) => {
       assert_true(handle.active())
-      assert_eq(handle.scope(), @keepawake.Scope::PreventSystemSleep)
+      assert_eq(handle.scope(), @proton_keepawake.Scope::PreventSystemSleep)
       handle.release()
       assert_true(handle.active() == false)
       handle.release()
       assert_true(handle.active() == false)
     }
-    Err(@keepawake.BackendUnavailable(detail~)) =>
+    Err(@proton_keepawake.BackendUnavailable(detail~)) =>
       assert_true(
         detail.contains("systemd-inhibit") ||
         detail.contains("unsupported") ||
@@ -50,17 +50,17 @@ test "acquire and release smoke test" {
 ///|
 test "with_keepawake returns the action result" {
   let result : Result[String, Error] = Ok(
-    @keepawake.with_keepawake(
+    @proton_keepawake.with_keepawake(
       fn() { "kept awake" },
       reason="scoped smoke test",
-      scope=@keepawake.Scope::PreventSystemSleep,
+      scope=@proton_keepawake.Scope::PreventSystemSleep,
     ),
   ) catch {
     e => Err(e)
   }
   match result {
     Ok(value) => assert_eq(value, "kept awake")
-    Err(@keepawake.BackendUnavailable(detail~)) =>
+    Err(@proton_keepawake.BackendUnavailable(detail~)) =>
       assert_true(
         detail.contains("systemd-inhibit") ||
         detail.contains("unsupported") ||

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
-name = "moonbit-community/keepawake"
+name = "moonbit-community/proton_keepawake"
 
 version = "0.1.14"
 
 import {
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
 }
 
 readme = "README.mbt.md"

--- a/sys/keepawake/moon.pkg
+++ b/sys/keepawake/moon.pkg
@@ -1,10 +1,10 @@
 import {
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/encoding/utf8",
 }
 
 import {
-  "moonbit-community/keepawake/testsupport",
+  "moonbit-community/proton_keepawake/testsupport",
 } for "wbtest"
 
 supported_targets = "native"

--- a/sys/keepawake/pkg.generated.mbti
+++ b/sys/keepawake/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/keepawake"
+package "moonbit-community/proton_keepawake"
 
 import {
   "moonbitlang/core/debug",

--- a/sys/keepawake/testsupport/pkg.generated.mbti
+++ b/sys/keepawake/testsupport/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/keepawake/testsupport"
+package "moonbit-community/proton_keepawake/testsupport"
 
 // Values
 pub fn stub_linked() -> Bool

--- a/sys/microphone/README.mbt.md
+++ b/sys/microphone/README.mbt.md
@@ -1,11 +1,11 @@
-# moonbit-community/microphone
+# moonbit-community/proton_microphone
 
 Native-only microphone device discovery helpers for MoonBit.
 
 ```mbt nocheck
 ///|
 fn main {
-  let devices = @microphone.MicrophoneDevice::list()
+  let devices = @proton_microphone.MicrophoneDevice::list()
   for device in devices {
     println(device.session_label())
   }
@@ -15,11 +15,11 @@ fn main {
 ```mbt nocheck
 ///|
 fn example_label {
-  let device = @microphone.MicrophoneDevice::{
+  let device = @proton_microphone.MicrophoneDevice::{
     id: "mic-1",
     name: "Built-in Mic",
     state: Idle,
-    default_config: @microphone.CaptureConfig::new(
+    default_config: @proton_microphone.CaptureConfig::new(
       echo_cancellation=true,
       noise_suppression=true,
     ),

--- a/sys/microphone/README.md
+++ b/sys/microphone/README.md
@@ -1,11 +1,9 @@
-# moonbit-community/microphone
+# moonbit-community/proton_microphone
 
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-microphone)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-microphone)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-microphone)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-microphone/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-microphone)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/proton_microphone)
 
-`moonbit-community/microphone` is a native-only MoonBit package for microphone
+`moonbit-community/proton_microphone` is a native-only MoonBit package for microphone
 device discovery and capture-session metadata. It uses small C native stubs for host integration, and exposes a focused MoonBit API that works on Windows, Linux, and macOS.
 
 ## Platform Support
@@ -33,7 +31,7 @@ List visible microphone-like devices:
 ```mbt
 ///|
 fn main {
-  let devices = @microphone.MicrophoneDevice::list()
+  let devices = @proton_microphone.MicrophoneDevice::list()
   if devices.length() == 0 {
     println("No microphones found.")
   } else {
@@ -48,7 +46,7 @@ Normalize capture settings before using them to size buffers:
 
 ```mbt
 ///|
-fn chunk_bytes(config : @microphone.CaptureConfig) -> Int {
+fn chunk_bytes(config : @proton_microphone.CaptureConfig) -> Int {
   let normalized = config.normalized()
   normalized.recommended_chunk_frames() *
   normalized.channels *
@@ -60,7 +58,7 @@ Create a configuration by overriding only the fields that matter:
 
 ```mbt
 ///|
-let config = @microphone.CaptureConfig::new(
+let config = @proton_microphone.CaptureConfig::new(
   channels=2,
   sample_rate_hz=48_000,
   echo_cancellation=true,
@@ -72,7 +70,7 @@ Parse a known listing in tests:
 ```mbt
 ///|
 test "parse listing" {
-  let devices = @microphone.MicrophoneDevice::parse_listing(
+  let devices = @proton_microphone.MicrophoneDevice::parse_listing(
     "Built-in Microphone\nmonitor-source\nUSB Studio Mic\n",
   )
   inspect(devices.length(), content="2")

--- a/sys/microphone/discovery.mbt
+++ b/sys/microphone/discovery.mbt
@@ -71,7 +71,7 @@ pub fn MicrophoneDevice::parse_listing(
 ///
 /// # Example
 /// ```mbt nocheck
-/// for device in @microphone.MicrophoneDevice::list() {
+/// for device in @proton_microphone.MicrophoneDevice::list() {
 ///   println(device.session_label())
 /// }
 /// ```

--- a/sys/microphone/microphone_test.mbt
+++ b/sys/microphone/microphone_test.mbt
@@ -1,10 +1,10 @@
 ///|
 test "configs are normalized before chunk sizing" {
-  let defaults = @microphone.CaptureConfig::new()
+  let defaults = @proton_microphone.CaptureConfig::new()
   inspect(defaults.channels, content="1")
   inspect(defaults.sample_rate_hz, content="48000")
   inspect(defaults.sample_format, content="F32")
-  let config = @microphone.CaptureConfig::new(
+  let config = @proton_microphone.CaptureConfig::new(
     channels=0,
     sample_rate_hz=4_000,
     sample_format=I16,
@@ -16,11 +16,11 @@ test "configs are normalized before chunk sizing" {
 
 ///|
 test "voice processing and liveness stay explicit" {
-  let device = @microphone.MicrophoneDevice::{
+  let device = @proton_microphone.MicrophoneDevice::{
     id: "mic-1",
     name: "Studio Mic",
     state: Recording,
-    default_config: @microphone.CaptureConfig::new(
+    default_config: @proton_microphone.CaptureConfig::new(
       channels=2,
       sample_format=F32,
       echo_cancellation=true,
@@ -30,10 +30,10 @@ test "voice processing and liveness stay explicit" {
   inspect(device.default_config.uses_voice_processing(), content="true")
   inspect(device.is_live(), content="true")
   inspect(
-    @microphone.CaptureConfig::new().uses_voice_processing(),
+    @proton_microphone.CaptureConfig::new().uses_voice_processing(),
     content="false",
   )
-  let muted_device = @microphone.MicrophoneDevice::{
+  let muted_device = @proton_microphone.MicrophoneDevice::{
     id: "mic-2",
     name: "Muted Mic",
     state: Muted,
@@ -45,23 +45,23 @@ test "voice processing and liveness stay explicit" {
 
 ///|
 test "labels and sample sizes are stable" {
-  let device = @microphone.MicrophoneDevice::{
+  let device = @proton_microphone.MicrophoneDevice::{
     id: "mic-1",
     name: "Studio Mic",
     state: Armed,
-    default_config: @microphone.CaptureConfig::new(
+    default_config: @proton_microphone.CaptureConfig::new(
       sample_rate_hz=16_000,
       sample_format=I16,
       noise_suppression=true,
     ),
     monitor_supported: false,
   }
-  let i16 : @microphone.SampleFormat = I16
-  let u16 : @microphone.SampleFormat = U16
-  let f32 : @microphone.SampleFormat = F32
-  let idle : @microphone.CaptureState = Idle
-  let recording : @microphone.CaptureState = Recording
-  let muted : @microphone.CaptureState = Muted
+  let i16 : @proton_microphone.SampleFormat = I16
+  let u16 : @proton_microphone.SampleFormat = U16
+  let f32 : @proton_microphone.SampleFormat = F32
+  let idle : @proton_microphone.CaptureState = Idle
+  let recording : @proton_microphone.CaptureState = Recording
+  let muted : @proton_microphone.CaptureState = Muted
   inspect(i16.bytes_per_sample(), content="2")
   inspect(u16.bytes_per_sample(), content="2")
   inspect(f32.bytes_per_sample(), content="4")
@@ -73,7 +73,7 @@ test "labels and sample sizes are stable" {
 
 ///|
 test "native microphone listings parse into devices" {
-  let devices = @microphone.MicrophoneDevice::parse_listing(
+  let devices = @proton_microphone.MicrophoneDevice::parse_listing(
     "\nalsa_input.usb-mic\r\nmonitor-source\nUSB Studio Mic\n",
   )
   inspect(devices.length(), content="2")
@@ -83,6 +83,6 @@ test "native microphone listings parse into devices" {
 
 ///|
 test "native discovery returns a safe listing" {
-  let devices = @microphone.MicrophoneDevice::list()
+  let devices = @proton_microphone.MicrophoneDevice::list()
   inspect(devices.length() >= 0, content="true")
 }

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
-name = "moonbit-community/microphone"
+name = "moonbit-community/proton_microphone"
 
 version = "0.1.14"
 
 import {
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
 }
 
 readme = "README.mbt.md"

--- a/sys/microphone/moon.pkg
+++ b/sys/microphone/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
 }
 
 supported_targets = "native"

--- a/sys/microphone/pkg.generated.mbti
+++ b/sys/microphone/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/microphone"
+package "moonbit-community/proton_microphone"
 
 import {
   "moonbitlang/core/debug",

--- a/sys/tray/README.mbt.md
+++ b/sys/tray/README.mbt.md
@@ -1,4 +1,4 @@
-# moonbit-community/tray
+# moonbit-community/proton_tray
 
 Cross-platform native tray helpers for MoonBit.
 
@@ -8,11 +8,11 @@ call `pump()` and `drain_events()` regularly.
 ## Example
 
 ```mbt nocheck
-guard @tray.is_supported() else {
+guard @proton_tray.is_supported() else {
   return
 }
 
-let tray = @tray.create(
+let tray = @proton_tray.create(
   identifier="com.example.demo",
   tooltip="MoonBit tray demo",
 )
@@ -21,13 +21,13 @@ match tray {
   Ok(tray) => {
     match
       tray.set_menu([
-        @tray.TrayMenuItem::normal(id="show", label="Show"),
-        @tray.TrayMenuItem::separator(),
-        @tray.TrayMenuItem::checkbox(id="launch", label="Launch", checked=true),
-        @tray.TrayMenuItem::submenu(
+        @proton_tray.TrayMenuItem::normal(id="show", label="Show"),
+        @proton_tray.TrayMenuItem::separator(),
+        @proton_tray.TrayMenuItem::checkbox(id="launch", label="Launch", checked=true),
+        @proton_tray.TrayMenuItem::submenu(
           label="More",
           items=[
-            @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+            @proton_tray.TrayMenuItem::normal(id="settings", label="Settings"),
           ],
         ),
       ]) {

--- a/sys/tray/README.md
+++ b/sys/tray/README.md
@@ -1,11 +1,7 @@
-# moonbit-community/tray
+# moonbit-community/proton_tray
 
-[![CI](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-tray/actions/workflows/ci.yml)
-[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-tray)
-[![linux](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=linux&label=linux)](https://codecov.io/gh/justjavac/moonbit-tray)
-[![macos](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=macos&label=macos)](https://codecov.io/gh/justjavac/moonbit-tray)
-[![windows](https://img.shields.io/codecov/c/github/justjavac/moonbit-tray/main?flag=windows&label=windows)](https://codecov.io/gh/justjavac/moonbit-tray)
-[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/tray)
+[![CI](https://github.com/moonbit-community/proton/actions/workflows/ci.yml/badge.svg)](https://github.com/moonbit-community/proton/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mooncakes.io-green)](https://mooncakes.io/docs/moonbit-community/proton_tray)
 
 Cross-platform native tray helpers for MoonBit.
 
@@ -17,7 +13,7 @@ needed, and destroy it cleanly.
 ## Install
 
 ```bash
-moon add moonbit-community/tray
+moon add moonbit-community/proton_tray
 ```
 
 This package supports the `native` target only.
@@ -36,12 +32,12 @@ This package supports the `native` target only.
 
 ```mbt nocheck
 fn run_tray_demo() -> Unit {
-  guard @tray.is_supported() else {
-    println("tray backend unavailable: \{@tray.ensure_supported()}")
+  guard @proton_tray.is_supported() else {
+    println("tray backend unavailable: \{@proton_tray.ensure_supported()}")
     return
   }
 
-  let tray = match @tray.create(
+  let tray = match @proton_tray.create(
     identifier="com.example.demo",
     tooltip="MoonBit tray demo",
   ) {
@@ -54,17 +50,17 @@ fn run_tray_demo() -> Unit {
 
   ignore(tray.set_icon(Some("assets/tray.png")))
   match tray.set_menu([
-    @tray.TrayMenuItem::normal(id="show", label="Show Window"),
-    @tray.TrayMenuItem::separator(),
-    @tray.TrayMenuItem::checkbox(
+    @proton_tray.TrayMenuItem::normal(id="show", label="Show Window"),
+    @proton_tray.TrayMenuItem::separator(),
+    @proton_tray.TrayMenuItem::checkbox(
       id="launch",
       label="Launch at Login",
       checked=true,
     ),
-    @tray.TrayMenuItem::submenu(
+    @proton_tray.TrayMenuItem::submenu(
       label="More",
       items=[
-        @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+        @proton_tray.TrayMenuItem::normal(id="settings", label="Settings"),
       ],
     ),
   ]) {
@@ -231,7 +227,7 @@ Windows-only.
 ```bash
 moon test --target native
 moon test --target native --enable-coverage
-moon coverage analyze -p moonbit-community/tray -- -f summary
+moon coverage analyze -p moonbit-community/proton_tray -- -f summary
 ```
 
 Optional native integration checks can be enabled locally:

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
-name = "moonbit-community/tray"
+name = "moonbit-community/proton_tray"
 
 version = "0.1.14"
 
 import {
-  "moonbit-community/ffi@0.1.14",
+  "moonbit-community/proton_ffi@0.1.14",
 }
 
 readme = "README.mbt.md"

--- a/sys/tray/moon.pkg
+++ b/sys/tray/moon.pkg
@@ -1,12 +1,12 @@
 import {
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
 }
 
 import {
-  "moonbit-community/tray/testsupport",
+  "moonbit-community/proton_tray/testsupport",
 } for "wbtest"
 
 supported_targets = "native"

--- a/sys/tray/pkg.generated.mbti
+++ b/sys/tray/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/tray"
+package "moonbit-community/proton_tray"
 
 import {
   "moonbitlang/core/debug",

--- a/sys/tray/testsupport/moon.pkg
+++ b/sys/tray/testsupport/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbit-community/ffi",
+  "moonbit-community/proton_ffi" @ffi,
 }
 
 supported_targets = "native"

--- a/sys/tray/testsupport/pkg.generated.mbti
+++ b/sys/tray/testsupport/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "moonbit-community/tray/testsupport"
+package "moonbit-community/proton_tray/testsupport"
 
 // Values
 pub fn make_test_icon_path() -> Bytes

--- a/sys/tray/tray.mbt
+++ b/sys/tray/tray.mbt
@@ -183,7 +183,7 @@ pub fn ensure_supported() -> Result[Unit, String] {
 ///
 /// # Example
 /// ```mbt nocheck
-/// let tray = @tray.create(icon=Some("/path/to/icon.png"), tooltip="My App").unwrap()
+/// let tray = @proton_tray.create(icon=Some("/path/to/icon.png"), tooltip="My App").unwrap()
 /// let _ = tray.show()
 /// // ... run the application event loop, calling `tray.pump()` as needed ...
 /// tray.destroy()

--- a/sys/tray/tray_test.mbt
+++ b/sys/tray/tray_test.mbt
@@ -1,12 +1,12 @@
 ///|
 test "default identifier is stable" {
-  inspect(@tray.default_identifier(), content="moonbit-tray")
+  inspect(@proton_tray.default_identifier(), content="moonbit-tray")
 }
 
 ///|
 test "support probe stays consistent" {
-  let supported = @tray.is_supported()
-  let ensured = @tray.ensure_supported()
+  let supported = @proton_tray.is_supported()
+  let ensured = @proton_tray.ensure_supported()
   if supported {
     debug_inspect(ensured, content="Ok(())")
   } else {
@@ -19,17 +19,24 @@ test "support probe stays consistent" {
 ///|
 test "public menu constructors expose v1 item kinds" {
   debug_inspect(
-    @tray.TrayMenuItem::normal(id="show", label="Show").kind(),
+    @proton_tray.TrayMenuItem::normal(id="show", label="Show").kind(),
     content="Normal",
   )
   debug_inspect(
-    @tray.TrayMenuItem::checkbox(id="launch", label="Launch", checked=true).kind(),
+    @proton_tray.TrayMenuItem::checkbox(
+      id="launch",
+      label="Launch",
+      checked=true,
+    ).kind(),
     content="Checkbox",
   )
-  debug_inspect(@tray.TrayMenuItem::separator().kind(), content="Separator")
   debug_inspect(
-    @tray.TrayMenuItem::submenu(label="More", items=[
-      @tray.TrayMenuItem::normal(id="settings", label="Settings"),
+    @proton_tray.TrayMenuItem::separator().kind(),
+    content="Separator",
+  )
+  debug_inspect(
+    @proton_tray.TrayMenuItem::submenu(label="More", items=[
+      @proton_tray.TrayMenuItem::normal(id="settings", label="Settings"),
     ]).kind(),
     content="Submenu",
   )
@@ -37,10 +44,13 @@ test "public menu constructors expose v1 item kinds" {
 
 ///|
 test "public tray event helpers expose event names and item ids" {
-  inspect(@tray.TrayEvent::Click.event_name(), content="click")
-  inspect(@tray.TrayEvent::RightClick.event_name(), content="rightClick")
-  inspect(@tray.TrayEvent::DoubleClick.event_name(), content="doubleClick")
-  let event = @tray.TrayEvent::MenuItemClick("show")
+  inspect(@proton_tray.TrayEvent::Click.event_name(), content="click")
+  inspect(@proton_tray.TrayEvent::RightClick.event_name(), content="rightClick")
+  inspect(
+    @proton_tray.TrayEvent::DoubleClick.event_name(),
+    content="doubleClick",
+  )
+  let event = @proton_tray.TrayEvent::MenuItemClick("show")
   inspect(event.event_name(), content="menuItemClick")
   debug_inspect(event.item_id(), content="Some(\"show\")")
 }
@@ -51,7 +61,7 @@ test "native integration stays opt in" {
     inspect("skipped", content="skipped")
     return ()
   }
-  let tray = match @tray.create(tooltip="MoonBit tray integration") {
+  let tray = match @proton_tray.create(tooltip="MoonBit tray integration") {
     Ok(tray) => tray
     Err(error) => fail(error)
   }


### PR DESCRIPTION
## Why

Moving the project to the `moonbit-community` namespace changed what eight module names claim. Under a personal namespace, `justjavac/ffi` read as "one person's FFI helper" — no assertion of being canonical. Under an organization namespace, `moonbit-community/ffi` reads as *the community's* FFI library, and the same went for `cdp`, `clipboard`, `tray`, `microphone`, `keepawake`, `global_hotkey`, and `auto_launch`.

Every one of them is published out of a GUI framework's monorepo (`repository = https://github.com/moonbit-community/proton`), so the name was promising something this repository does not deliver.

Version alignment had already settled the question. All eight now move on the workspace version — `ffi` went from its own `0.2.4` to `0.1.14`, `cdp` from `0.1.9` — so they release when Proton releases, for reasons that may have nothing to do with them. They are Proton components, and the prefix now says so.

| before | after |
|---|---|
| `moonbit-community/ffi` | `moonbit-community/proton_ffi` |
| `moonbit-community/cdp` | `moonbit-community/proton_cdp` |
| `moonbit-community/clipboard` | `moonbit-community/proton_clipboard` |
| `moonbit-community/tray` | `moonbit-community/proton_tray` |
| `moonbit-community/microphone` | `moonbit-community/proton_microphone` |
| `moonbit-community/keepawake` | `moonbit-community/proton_keepawake` |
| `moonbit-community/global_hotkey` | `moonbit-community/proton_global_hotkey` |
| `moonbit-community/auto_launch` | `moonbit-community/proton_auto_launch` |

Directories are deliberately left alone. Every workspace member already uses a short directory name with a prefixed module name (`cli/` → `proton_cli`, `config/` → `proton_config`), so `sys/ffi/` and `cdp/` are now consistent with the other eleven rather than exceptions to them. `moon.work` needs no change, and `scripts/bump_version.mbtx` reads module names from `moon.work` dynamically, so `bump_version.mbtx patch` keeps working.

## Package aliases

The rename changes each module's default package alias, which surfaces in two places:

- **Dependency side.** Seven bare `moonbit-community/proton_ffi` imports get an explicit `@ffi` alias, matching how this repo already handles `@sys_tray` and `@async_fs`. No call site moves.
- **Self-reference side.** Blackbox tests and `///` doc tests referred to their own package by the old short alias (`@tray.create(...)`). These become `@proton_tray`, which is also what a user importing the module now gets by default — so the examples stay accurate rather than being papered over.

## Leftovers from the earlier migration

- The `sys` READMEs carried CI and coverage badges pointing at the standalone `justjavac/moonbit-*` repositories this code no longer lives in. CI badges now point here; the codecov badges are removed, because this repository publishes no coverage and a badge showing another project's numbers is worse than none.
- `sys/keepawake/README.md` still had its pre-migration title.
- `AGENTS.md` claimed each `sys` module "keeps its upstream module name and version lineage" — false on both counts since the namespace migration and version alignment. Rewritten to state why the prefix exists.

Attribution is untouched: upstream credit stays in each module's README, and `LICENSE.md` is unchanged.

## ⚠️ One behaviour change

The tray extension registered itself as `justjavac.proton.tray`, now `moonbit-community.proton.tray`. On Linux that string is the AppIndicator id passed to `app_indicator_new()` (`sys/tray/tray_native.c:2488`), which desktop environments key per-indicator settings off — existing Linux users lose that indicator's placement once. macOS and Windows do not use it.

## Validation

`moon check --deny-warn` on the workspace and all six modules, `moon fmt --check`, `node scripts/verify_generated.mjs` OK.

| suite | result |
|---|---|
| sys modules | 125/125 |
| extensions | 30/30 |
| proton native | 60/60 |
| cli | 201/201 |
| cdp | 734/734 |
| e2e | 18/18 |
| examples | build clean |