### PR TITLE
feat(cli): make release packaging explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,8 @@ native checks before handing off larger refactors.
     --identifier "com.example.proton-release-smoke" -y --no-git
   proton_cli -C "$tmp_dir/release-smoke" cef setup
   proton_cli -C "$tmp_dir/release-smoke" build
-  proton_cli -C "$tmp_dir/release-smoke" package --target app --dry-run
-  proton_cli -C "$tmp_dir/release-smoke" package --target app
+  proton_cli -C "$tmp_dir/release-smoke" package --release --target app --dry-run
+  proton_cli -C "$tmp_dir/release-smoke" package --release --target app
   ```
 
 - The release is not complete until the independent scaffold passes

--- a/README.md
+++ b/README.md
@@ -431,18 +431,21 @@ Inspect the resolved bundle plan before creating artifacts:
 ```sh
 proton_cli package --dry-run
 proton_cli package
+proton_cli package --release
 ```
 
-The package command performs a release build unless `--no-build` is supplied.
-Package output is written to `target/proton-dist` by default. Icons, resources,
-output targets, signing, notarization, custom URL schemes, and macOS document
-types are configured through `moon.proton` and package command options.
+The package command performs a debug build by default. Pass `--release` to use
+MoonBit's release build mode, or `--no-build` to reuse an existing build from
+the selected mode. Package output is written to `target/proton-dist` by default.
+Icons, resources, output targets, signing, notarization, custom URL schemes, and
+macOS document types are configured through `moon.proton` and package command
+options.
 
 The `dmg` target is available on macOS. It creates a compressed disk image
 containing the app and an `/Applications` shortcut for drag-to-install:
 
 ```sh
-proton_cli package --target app --target dmg
+proton_cli package --release --target app --target dmg
 ```
 
 With `--notarize`, Proton submits the DMG when that target is enabled, then
@@ -473,7 +476,7 @@ revision as well as the reproducible publication time. The revision is embedded
 in the signed app and emitted into the signed manifest fragment:
 
 ```sh
-proton_cli package --target zip \
+proton_cli package --release --target zip \
   --updater-base-url https://example.com/releases \
   --updater-published-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --updater-revision 42

--- a/cli/new/templates.generated.mbt
+++ b/cli/new/templates.generated.mbt
@@ -844,7 +844,7 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|
           #|```sh
           #|proton_cli package --dry-run
-          #|proton_cli package
+          #|proton_cli package --release
           #|```
           #|
           #|## Layout

--- a/cli/new/templates/todo/files/README.md.mtpl
+++ b/cli/new/templates/todo/files/README.md.mtpl
@@ -58,7 +58,7 @@ Inspect the resolved package plan, then create the application and zip archive:
 
 ```sh
 proton_cli package --dry-run
-proton_cli package
+proton_cli package --release
 ```
 
 ## Layout

--- a/cli/package/error.mbt
+++ b/cli/package/error.mbt
@@ -110,7 +110,7 @@ pub fn PackagePlanError::message(self : PackagePlanError) -> String {
       "unsupported bundle.resources glob: " + path
     MissingInput(path~) => "package input is missing: " + path
     MissingExecutable(path~) =>
-      "package release executable not found under " +
+      "package executable not found under " +
       path +
       "; run proton package without --no-build first"
     InputOutsideProject(path~) =>

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -11,6 +11,7 @@ struct RawPackageOptions {
   targets : Array[String]
   output : String?
   build : Bool
+  release : Bool
   dry_run : Bool
   sign : Bool
   notarize : Bool
@@ -32,6 +33,7 @@ struct PackagePlan {
   targets : Array[String]
   output : String
   build : Bool
+  release : Bool
   base_dir : String
   frontend_dist : String?
   entry_paths : Array[String]
@@ -72,7 +74,8 @@ pub fn command() -> @argparse.Command {
     "package",
     about="Package a Proton application",
     flags=[
-      FlagArg("no-build", about="Reuse an existing release build"),
+      FlagArg("no-build", about="Reuse an existing package build"),
+      FlagArg("release", about="Build and package the release output"),
       FlagArg("dry-run", about="Print the resolved package plan"),
       FlagArg("sign", about="Sign the packaged application"),
       FlagArg(
@@ -201,6 +204,8 @@ fn package_options_from_matches(
       | (None with notarize = false),
       "no-build"? : Some(no_build)
       | (None with no_build = false),
+      "release"? : Some(release)
+      | (None with release = false),
       "dry-run"? : Some(dry_run)
       | (None with dry_run = false),
       "sign"? : Some(sign)
@@ -216,6 +221,7 @@ fn package_options_from_matches(
     targets,
     output: output.get(0),
     build: !no_build,
+    release,
     dry_run,
     sign: sign || notarize,
     notarize,
@@ -386,6 +392,7 @@ async fn build_package_plan(
     targets,
     output,
     build: raw.build,
+    release: raw.release,
     base_dir,
     frontend_dist,
     entry_paths,
@@ -618,6 +625,8 @@ fn print_package_plan(plan : PackagePlan, dry_run : Bool) -> Unit {
   println("  sign binaries: " + sign_binaries)
   let build = if plan.build { "yes" } else { "no" }
   println("  build: " + build)
+  let build_mode = if plan.release { "release" } else { "debug" }
+  println("  build mode: " + build_mode)
   println("  sign: " + bool_text(plan.sign))
   println("  notarize: " + bool_text(plan.notarize))
 }
@@ -634,12 +643,12 @@ fn bool_text(value : Bool) -> String {
 ///|
 async fn execute_package_plan(plan : PackagePlan) -> Unit {
   // Resolve the active runtime before any build work so a missing
-  // `proton_cli cef setup` fails fast instead of after a full release build.
+  // `proton_cli cef setup` fails fast instead of after a full application build.
   let runtime = read_active_runtime(plan.workspace_root)
   if plan.build {
-    run_release_build(plan)
+    run_package_build(plan)
   }
-  let executable = match find_release_executable(plan) {
+  let executable = match find_package_executable(plan) {
     Some(path) => path
     None =>
       raise PackagePlanError::MissingExecutable(path=plan.build_target_dir)
@@ -657,8 +666,15 @@ async fn is_macos_host() -> Bool {
 }
 
 ///|
-async fn run_release_build(plan : PackagePlan) -> Unit {
-  let moon_args = ["--release", "--target-dir", plan.build_target_dir]
+async fn run_package_build(plan : PackagePlan) -> Unit {
+  // Keep local packaging fast by default. Distribution builds opt into the
+  // Moon release mode explicitly through `proton_cli package --release`.
+  let moon_args : Array[String] = []
+  if plan.release {
+    moon_args.push("--release")
+  }
+  moon_args.push("--target-dir")
+  moon_args.push(plan.build_target_dir)
   let old_rpath = @env.get_env_var("PROTON_PACKAGE_RPATH")
   // Mach-O only. The link config reads this on darwin; the Linux branch
   // ignores it and keeps the absolute runtime rpath, which is what a
@@ -683,8 +699,13 @@ fn restore_package_env(name : String, value : String?) -> Unit {
 }
 
 ///|
-async fn find_release_executable(plan : PackagePlan) -> String? {
-  let root = @fsutil.resolve_path(plan.build_target_dir, "native/release/build")
+async fn find_package_executable(plan : PackagePlan) -> String? {
+  // `--no-build` must reuse the same build mode selected for this command.
+  let build_mode = if plan.release { "release" } else { "debug" }
+  let root = @fsutil.resolve_path(
+    plan.build_target_dir,
+    "native/" + build_mode + "/build",
+  )
   let package_name = path_basename(plan.app_package)
   find_named_file(root, package_name + ".exe")
 }

--- a/cli/package/package_macos_dmg_wbtest.mbt
+++ b/cli/package/package_macos_dmg_wbtest.mbt
@@ -16,6 +16,7 @@ fn macos_dmg_test_plan(root : String) -> PackagePlan {
     targets: ["app", "dmg"],
     output: root,
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -18,7 +18,15 @@ test "parse package args accepts repeated targets and overrides" {
   @debug.assert_eq(raw.targets, ["app", "zip", "dmg"])
   @debug.assert_eq(raw.output, Some("dist"))
   assert_false(raw.build)
+  assert_false(raw.release)
   assert_true(raw.dry_run)
+}
+
+///|
+test "parse package args enables release builds explicitly" {
+  let raw = parse_package_args(["--release"])
+  assert_true(raw.build)
+  assert_true(raw.release)
 }
 
 ///|
@@ -153,11 +161,19 @@ async test "package plan uses the host defaults" {
   @debug.assert_eq(plan.targets, expected_targets)
   assert_eq(plan.identifier, "dev.proton.demo")
   assert_eq(plan.version, "1.0.0")
+  assert_false(plan.release)
   assert_true(
     normalize_slashes(plan.build_target_dir).has_suffix(
       "/target/proton-package-build/dev-proton-demo",
     ),
   )
+  let release_plan = build_package_plan(
+    parse_package_args(["--release"]),
+    "moon.proton",
+    project,
+    0UL,
+  )
+  assert_true(release_plan.release)
 }
 
 ///|
@@ -587,6 +603,7 @@ async test "macOS icon selection stages icns and rejects a missing source" {
     targets: ["app"],
     output: root,
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
@@ -634,6 +651,7 @@ test "macOS plist contains bundle identity and executable" {
     targets: ["app"],
     output: "target",
     build: false,
+    release: false,
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
@@ -687,6 +705,7 @@ async test "package manifest records launch metadata" {
     targets: ["app"],
     output: "target",
     build: false,
+    release: false,
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
@@ -750,6 +769,7 @@ test "macOS helper plist matches its bundle identity" {
     targets: ["app"],
     output: "target",
     build: false,
+    release: false,
     base_dir: ".",
     frontend_dist: None,
     entry_paths: [],
@@ -797,6 +817,7 @@ async test "macOS ZIP uses the final app name without metadata entries" {
     targets: ["app", "zip"],
     output: root,
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     sign_binaries: [],
@@ -970,6 +991,7 @@ async test "macOS notarization validates success and cleans failed upload" {
     targets: ["app"],
     output: root,
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
@@ -1028,7 +1050,7 @@ async test "macOS notarization validates success and cleans failed upload" {
 }
 
 ///|
-async test "release executable lookup stays inside package target dir" {
+async test "debug executable lookup stays inside package target dir" {
   let root = "target/proton-package-executable-lookup"
   remove_tree(root)
   let package_target = @fsutil.resolve_path(root, "package-target")
@@ -1052,6 +1074,7 @@ async test "release executable lookup stays inside package target dir" {
     targets: ["app"],
     output: @fsutil.resolve_path(root, "output"),
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],
@@ -1064,16 +1087,16 @@ async test "release executable lookup stays inside package target dir" {
     sign: false,
     notarize: false,
   }
-  @debug.assert_eq(find_release_executable(plan), None)
+  @debug.assert_eq(find_package_executable(plan), None)
   let expected = @fsutil.resolve_path(
-    package_target, "native/release/build/vendor/app/app.exe",
+    package_target, "native/debug/build/vendor/app/app.exe",
   )
   ensure_dir(@fsutil.path_parent(expected))
   write_text(expected, "right")
-  match find_release_executable(plan) {
+  match find_package_executable(plan) {
     Some(actual) =>
       assert_eq(normalize_slashes(actual), normalize_slashes(expected))
-    None => abort("expected release executable")
+    None => abort("expected debug executable")
   }
 }
 
@@ -1133,6 +1156,7 @@ async test "Windows portable staging flattens runtime bin beside app executable"
     targets: ["app"],
     output,
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: None,
     entry_paths: [],

--- a/cli/package/package_windows_wbtest.mbt
+++ b/cli/package/package_windows_wbtest.mbt
@@ -19,6 +19,7 @@ fn windows_test_plan(
     targets,
     output: @fsutil.resolve_path(root, "output with spaces"),
     build: false,
+    release: false,
     base_dir: root,
     frontend_dist: Some(@fsutil.resolve_path(root, "frontend/dist")),
     entry_paths: [@fsutil.resolve_path(root, "frontend/dist/index.html")],

--- a/scripts/e2e_scaffold_source_smoke.mjs
+++ b/scripts/e2e_scaffold_source_smoke.mjs
@@ -735,7 +735,7 @@ async function main() {
     { cwd: projectDir, env: runtimeEnv() },
   );
   setFrontendPackageRevision("first");
-  localCli(["-C", projectDir, "package", "--target", "app", "--sign"], {
+  localCli(["-C", projectDir, "package", "--release", "--target", "app", "--sign"], {
     env: runtimeEnv({
       PROTON_MACOS_ALLOW_ADHOC: "1",
       PROTON_MACOS_SIGNING_IDENTITY: "-",
@@ -745,7 +745,7 @@ async function main() {
   let packaged = verifyPackagedApp();
   await runPackagedAppSmoke(packaged.executable, "first");
   setFrontendPackageRevision("second");
-  localCli(["-C", projectDir, "package", "--target", "app", "--sign"], {
+  localCli(["-C", projectDir, "package", "--release", "--target", "app", "--sign"], {
     env: runtimeEnv({
       PROTON_MACOS_ALLOW_ADHOC: "1",
       PROTON_MACOS_SIGNING_IDENTITY: "-",

--- a/scripts/macos_package_smoke.mjs
+++ b/scripts/macos_package_smoke.mjs
@@ -473,6 +473,7 @@ async function main() {
       exampleName,
       "--config",
       `${exampleName}/moon.proton`,
+      "--release",
       "--sign",
       "--target",
       "app",

--- a/scripts/windows_package_smoke.ps1
+++ b/scripts/windows_package_smoke.ps1
@@ -297,7 +297,7 @@ try {
         "-C", "cli", "run", ".", "--", "-C", "../examples",
         "package", "--package", $ExampleName,
         "--config", "$ExampleName/moon.proton",
-        "--sign", "--target", "app", "--target", "zip"
+        "--release", "--sign", "--target", "app", "--target", "zip"
     )
 
     Require-Path $PortableDir "proton_cli package did not create the portable directory."


### PR DESCRIPTION
## Summary

- make `proton_cli package` use a debug build by default
- add `proton_cli package --release` to select MoonBit release builds and matching release artifacts
- make `--no-build` reuse the artifact from the selected build mode
- update release documentation, generated project templates, and packaging smoke flows to pass `--release` explicitly

## Why

The package command previously appended MoonBit's `--release` argument unconditionally. This made local packaging slower and left callers no direct way to choose the debug output. Release and distribution flows now opt in explicitly, while local packaging stays debug by default.

## Validation

- `moon -C cli check --target native --diagnostic-limit 80`
- `moon -C cli test -p community/proton_cli/new community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80` (86 passed)
- `node scripts/verify_generated.mjs --skip-prebuilt-abi`
- `node --check scripts/e2e_scaffold_source_smoke.mjs`
- `node --check scripts/macos_package_smoke.mjs`
- `moon -C cli info package`
- `moon fmt --check`
- `git diff --check origin/main...HEAD`
- debug and release package dry-run smoke checks
