### PR TITLE
fix(cli): sign macOS bundles inside out

### DIFF
--- a/cli/cef/cef_platform.mbt
+++ b/cli/cef/cef_platform.mbt
@@ -236,6 +236,9 @@ fn installed_cef_relative_files(platform : ProtonPlatform) -> Array[String] {
     let libraries_root = "Release/Chromium Embedded Framework.framework/Libraries"
     files.push(@fsutil.path_join(libraries_root, "libEGL.dylib"))
     files.push(@fsutil.path_join(libraries_root, "libGLESv2.dylib"))
+    // Packaging signs every nested CEF Mach-O before sealing the framework.
+    // Reject incomplete archives during setup instead of failing at signing.
+    files.push(@fsutil.path_join(libraries_root, "libcef_sandbox.dylib"))
     files.push(@fsutil.path_join(libraries_root, "libvk_swiftshader.dylib"))
   }
   files
@@ -281,6 +284,7 @@ fn runtime_required_relative_files(platform : ProtonPlatform) -> Array[String] {
     [
       "bin/cef_process", "lib/libproton.dylib", "bin/libEGL.dylib", "bin/libGLESv2.dylib",
       "bin/libvk_swiftshader.dylib", "Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework",
+      "Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib",
       "Resources/icudtl.dat",
     ]
   } else {

--- a/cli/cef/cef_platform_wbtest.mbt
+++ b/cli/cef/cef_platform_wbtest.mbt
@@ -6,11 +6,12 @@ test "darwin arm64 platform has complete CEF and Proton runtime artifact lists" 
   assert_true(prebuilt.contains("lib/libproton.dylib"))
   assert_true(prebuilt.contains("include/proton_native.h"))
   let cef = installed_cef_relative_files(platform)
-  assert_true(
-    cef.contains(
-      "Release/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib",
-    ),
+  // The artifact list uses the current host's separator even when this test
+  // inspects the macOS platform description from Windows.
+  let sandbox_library = @fsutil.path_join(
+    "Release/Chromium Embedded Framework.framework/Libraries", "libcef_sandbox.dylib",
   )
+  assert_true(cef.contains(sandbox_library))
   let runtime = runtime_required_relative_files(platform)
   assert_true(runtime.contains("bin/cef_process"))
   assert_true(runtime.contains("lib/libproton.dylib"))

--- a/cli/cef/cef_platform_wbtest.mbt
+++ b/cli/cef/cef_platform_wbtest.mbt
@@ -1,16 +1,27 @@
 ///|
-test "darwin arm64 platform has proton and runtime artifact lists" {
+test "darwin arm64 platform has complete CEF and Proton runtime artifact lists" {
   let platform = darwin_arm64_platform()
   let prebuilt = proton_prebuilt_relative_files(platform)
   assert_true(prebuilt.contains("bin/cef_process"))
   assert_true(prebuilt.contains("lib/libproton.dylib"))
   assert_true(prebuilt.contains("include/proton_native.h"))
+  let cef = installed_cef_relative_files(platform)
+  assert_true(
+    cef.contains(
+      "Release/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib",
+    ),
+  )
   let runtime = runtime_required_relative_files(platform)
   assert_true(runtime.contains("bin/cef_process"))
   assert_true(runtime.contains("lib/libproton.dylib"))
   assert_true(
     runtime.contains(
       "Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework",
+    ),
+  )
+  assert_true(
+    runtime.contains(
+      "Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib",
     ),
   )
   assert_true(runtime.contains("Resources/icudtl.dat"))

--- a/cli/package/error.mbt
+++ b/cli/package/error.mbt
@@ -22,6 +22,7 @@ pub(all) suberror PackagePlanError {
   UnsupportedResourceGlob(path~ : String)
   MissingInput(path~ : String)
   MissingExecutable(path~ : String)
+  NotLaunchableMachO(path~ : String, filetype~ : Int)
   InputOutsideProject(path~ : String)
   MissingIcon(path~ : String)
 } derive(Debug, Eq)
@@ -113,6 +114,12 @@ pub fn PackagePlanError::message(self : PackagePlanError) -> String {
       "package executable not found under " +
       path +
       "; run proton package without --no-build first"
+    NotLaunchableMachO(path~, filetype~) =>
+      "staged bundle executable " +
+      path +
+      " is a Mach-O of type " +
+      macho_filetype_name(filetype) +
+      ", not MH_EXECUTE; the kernel refuses to spawn it"
     InputOutsideProject(path~) =>
       "package input must stay inside the project: " + path
     MissingIcon(path~) => "package icon is missing: " + path

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -57,6 +57,8 @@ priv struct StagedArtifact {
 struct MacosCodeSignTarget {
   path : String
   runtime_options : Bool
+  entitlements : Bool
+  identifier : String?
   deep : Bool
 } derive(Debug, Eq)
 
@@ -1647,35 +1649,88 @@ async fn sign_macos_app_with_identity(
     contents, "Resources/proton/lib/libproton.dylib",
   )
   let runtime_bin = @fsutil.resolve_path(contents, "Resources/proton/bin")
+  let cef_framework_libraries = @fsutil.resolve_path(cef_framework, "Libraries")
   let targets = [
+    // Sign the CEF framework inside-out. `codesign --deep` does not reliably
+    // replace CEF's existing ad-hoc signatures on these nested dylibs, so
+    // notarization otherwise sees neither Developer ID nor secure timestamps.
+    MacosCodeSignTarget::{
+      path: @fsutil.resolve_path(cef_framework_libraries, "libEGL.dylib"),
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
+      deep: false,
+    },
+    MacosCodeSignTarget::{
+      path: @fsutil.resolve_path(cef_framework_libraries, "libGLESv2.dylib"),
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
+      deep: false,
+    },
+    MacosCodeSignTarget::{
+      path: @fsutil.resolve_path(
+        cef_framework_libraries, "libcef_sandbox.dylib",
+      ),
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
+      deep: false,
+    },
+    MacosCodeSignTarget::{
+      path: @fsutil.resolve_path(
+        cef_framework_libraries, "libvk_swiftshader.dylib",
+      ),
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
+      deep: false,
+    },
     MacosCodeSignTarget::{
       path: cef_framework,
-      runtime_options: false,
-      deep: true,
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
+      // The nested dylibs above are already signed. Seal the framework without
+      // asking codesign to rediscover or rewrite nested code.
+      deep: false,
     },
     MacosCodeSignTarget::{
       path: @fsutil.resolve_path(runtime_bin, "libEGL.dylib"),
-      runtime_options: false,
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
       deep: false,
     },
     MacosCodeSignTarget::{
       path: @fsutil.resolve_path(runtime_bin, "libGLESv2.dylib"),
-      runtime_options: false,
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
       deep: false,
     },
     MacosCodeSignTarget::{
       path: @fsutil.resolve_path(runtime_bin, "libvk_swiftshader.dylib"),
-      runtime_options: false,
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
       deep: false,
     },
     MacosCodeSignTarget::{
       path: @fsutil.resolve_path(runtime_bin, "cef_process"),
-      runtime_options: false,
+      // This is a standalone executable, not passive library code. Apple
+      // requires its signature to carry the hardened runtime option, while CEF
+      // requires the stable identifier used by its subprocess bootstrap.
+      runtime_options: true,
+      entitlements: false,
+      identifier: Some("cef_process"),
       deep: false,
     },
     MacosCodeSignTarget::{
       path: libproton,
-      runtime_options: false,
+      runtime_options: true,
+      entitlements: false,
+      identifier: None,
       deep: false,
     },
   ]
@@ -1686,6 +1741,8 @@ async fn sign_macos_app_with_identity(
     targets.push(MacosCodeSignTarget::{
       path: binary,
       runtime_options: true,
+      entitlements: true,
+      identifier: None,
       deep: false,
     })
   }
@@ -1696,18 +1753,26 @@ async fn sign_macos_app_with_identity(
         "Frameworks/" + helper.bundle_name + ".app",
       ),
       runtime_options: true,
+      entitlements: true,
+      identifier: None,
       deep: false,
     })
   }
   targets.push(MacosCodeSignTarget::{
     path: main,
     runtime_options: true,
+    entitlements: true,
+    identifier: None,
     deep: false,
   })
   targets.push(MacosCodeSignTarget::{
     path: app,
     runtime_options: true,
-    deep: true,
+    entitlements: true,
+    identifier: None,
+    // Every nested target is signed above. Sign the outer bundle without
+    // deprecated deep traversal so it cannot rewrite inner identities.
+    deep: false,
   })
   require_macos_codesign_targets(targets)
   for target in targets {
@@ -1716,12 +1781,16 @@ async fn sign_macos_app_with_identity(
       target.path,
       runtime_options=target.runtime_options,
       deep=target.deep,
-      entitlements=Some(entitlements),
+      entitlements=if target.entitlements { Some(entitlements) } else { None },
+      identifier=target.identifier,
     )
   }
   for target in targets {
     verify_macos_codesign_target(target.path, deep=target.deep)
   }
+  // Deep verification is useful and non-mutating after every nested target has
+  // been signed explicitly.
+  verify_macos_codesign_target(app, deep=true)
   if verify_developer_id {
     verify_macos_developer_id(app)
   }
@@ -1808,6 +1877,7 @@ async fn codesign_target(
   runtime_options~ : Bool,
   deep~ : Bool,
   entitlements~ : String?,
+  identifier~ : String?,
 ) -> Unit {
   let args = macos_codesign_args(
     identity,
@@ -1815,6 +1885,7 @@ async fn codesign_target(
     runtime_options~,
     deep~,
     entitlements~,
+    identifier~,
   )
   let code = @process.run("codesign", args) catch {
     error =>
@@ -1866,8 +1937,9 @@ fn macos_codesign_args(
   runtime_options~ : Bool,
   deep~ : Bool,
   entitlements~ : String?,
+  identifier~ : String?,
 ) -> Array[String] {
-  let args : Array[String] = ["--force", "--timestamp", "--sign", identity]
+  let args : Array[String] = ["--force", "--timestamp"]
   if deep {
     args.push("--deep")
   }
@@ -1882,7 +1954,11 @@ fn macos_codesign_args(
     }
     _ => ()
   }
-  args.push(target)
+  match identifier {
+    Some(identifier) => args.append(["-i", identifier])
+    None => ()
+  }
+  args.append(["--sign", identity, target])
   args
 }
 

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -850,7 +850,19 @@ async fn stage_macos_app_impl(
   for dir in [macos, resources, frameworks] {
     ensure_dir(dir)
   }
-  copy_file(executable, @fsutil.resolve_path(macos, executable_name))
+  let staged_executable = @fsutil.resolve_path(macos, executable_name)
+  copy_file(executable, staged_executable)
+  // An app bundle's CFBundleExecutable must remain directly launchable even
+  // when the source was staged by a filesystem API that drops Unix modes.
+  @async_fs.chmod(staged_executable, 0o755) catch {
+    error =>
+      raise PackageFileSystemError::Copy(
+        source=executable,
+        destination=staged_executable,
+        detail="failed to make staged app executable: " +
+          @debug.render(Repr(error)),
+      )
+  }
   copy_tree(runtime, @fsutil.resolve_path(resources, "proton"))
   stage_release_project_config(
     plan.config_path,
@@ -874,6 +886,16 @@ async fn stage_macos_app_impl(
     )
     ensure_dir(helper_macos)
     copy_file(helper_source, helper_executable)
+    // Each CEF subprocess is the declared executable of its own helper app.
+    @async_fs.chmod(helper_executable, 0o755) catch {
+      error =>
+        raise PackageFileSystemError::Copy(
+          source=helper_source,
+          destination=helper_executable,
+          detail="failed to make staged helper executable: " +
+            @debug.render(Repr(error)),
+        )
+    }
     write_text(
       @fsutil.resolve_path(helper_app, "Contents/Info.plist"),
       helper_info_plist(plan, helper),

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -718,6 +718,11 @@ async fn find_named_file(root : String, name : String) -> String? {
   if @fsutil.path_is_file(root) {
     return if path_basename(root) == name { Some(root) } else { None }
   }
+  // A dSYM bundle mirrors the executable basename under Resources/DWARF, but
+  // that file contains debug symbols rather than runnable Mach-O code.
+  if path_basename(root).has_suffix(".dSYM") {
+    return None
+  }
   let entries = @async_fs.readdir(
     root,
     include_hidden=true,

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -839,6 +839,72 @@ async fn stage_macos_app(
 }
 
 ///|
+/// Mach-O `filetype` values this packager can name. Only `MH_EXECUTE` is
+/// spawnable; `MH_DSYM` is the one that actually shows up here, because a
+/// debug build mirrors the executable's basename inside
+/// `<name>.dSYM/Contents/Resources/DWARF/`.
+const MachoExecute : Int = 0x2
+
+///|
+fn macho_filetype_name(filetype : Int) -> String {
+  match filetype {
+    0x1 => "MH_OBJECT"
+    0x2 => "MH_EXECUTE"
+    0x6 => "MH_DYLIB"
+    0x8 => "MH_BUNDLE"
+    0xa => "MH_DSYM"
+    _ => "0x" + filetype.to_string()
+  }
+}
+
+///|
+fn macho_u32_le(data : Bytes, offset : Int) -> Int {
+  data[offset].to_int() |
+  (data[offset + 1].to_int() << 8) |
+  (data[offset + 2].to_int() << 16) |
+  (data[offset + 3].to_int() << 24)
+}
+
+///|
+/// The `filetype` of a thin little-endian Mach-O, or `None` for anything this
+/// reader will not judge.
+///
+/// 64- and 32-bit thin headers agree up to `filetype`, so one offset serves
+/// both. Universal binaries (`FAT_MAGIC`) and non-Mach-O files return `None`
+/// on purpose: the caller rejects only what it can prove wrong, so a format
+/// this function does not understand is never turned into a build failure.
+/// Extending to fat archives means walking the arch table and judging each
+/// contained header.
+fn macho_thin_filetype(data : Bytes) -> Int? {
+  guard data.length() >= 16 else { return None }
+  let magic = macho_u32_le(data, 0)
+  guard magic == 0xfeedfacf || magic == 0xfeedface else { return None }
+  Some(macho_u32_le(data, 12))
+}
+
+///|
+/// Refuse to ship a bundle executable the kernel will not spawn.
+///
+/// `codesign` cannot stand in for this: a dSYM companion is a legitimate
+/// Mach-O and signs and verifies exactly like the real binary, differing
+/// only in the header's `filetype`. Nor can the executable bit, which this
+/// packager sets on whatever it staged. So a bundle carrying symbols where
+/// its binary belongs passes every other check and then fails at launch with
+/// `Launchd job spawn failed` — this is the only place that catches it.
+async fn require_launchable_macho(path : String) -> Unit {
+  let data = @async_fs.read_file(path) catch {
+    error =>
+      raise PackageFileSystemError::Read(
+        path~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard macho_thin_filetype(data.binary()) is Some(filetype) else { return }
+  guard filetype != MachoExecute else { return }
+  raise PackagePlanError::NotLaunchableMachO(path~, filetype~)
+}
+
+///|
 async fn stage_macos_app_impl(
   plan : PackagePlan,
   executable : String,
@@ -868,6 +934,7 @@ async fn stage_macos_app_impl(
           @debug.render(Repr(error)),
       )
   }
+  require_launchable_macho(staged_executable)
   copy_tree(runtime, @fsutil.resolve_path(resources, "proton"))
   stage_release_project_config(
     plan.config_path,
@@ -901,6 +968,7 @@ async fn stage_macos_app_impl(
             @debug.render(Repr(error)),
         )
     }
+    require_launchable_macho(helper_executable)
     write_text(
       @fsutil.resolve_path(helper_app, "Contents/Info.plist"),
       helper_info_plist(plan, helper),

--- a/cli/package/package_macos_dmg.mbt
+++ b/cli/package/package_macos_dmg.mbt
@@ -87,6 +87,7 @@ async fn sign_macos_dmg(plan : PackagePlan, dmg : String) -> Unit {
     runtime_options=false,
     deep=false,
     entitlements=None,
+    identifier=None,
   )
   verify_macos_codesign_target(dmg, deep=false)
 }

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -1204,3 +1204,41 @@ async test "Windows portable staging flattens runtime bin beside app executable"
     @mbfs.path_exists(@fsutil.resolve_path(portable, "bin/proton.dll")),
   )
 }
+
+///|
+test "a thin Mach-O header yields its filetype" {
+  // An arm64 executable and its dSYM mirror: identical for twelve bytes, then
+  // MH_EXECUTE (2) against MH_DSYM (10). Nothing cheaper tells them apart —
+  // not the magic, not the size, not codesign.
+  let executable = b"\xcf\xfa\xed\xfe\x0c\x00\x00\x01\x00\x00\x00\x00\x02\x00\x00\x00"
+  let dsym = b"\xcf\xfa\xed\xfe\x0c\x00\x00\x01\x00\x00\x00\x00\x0a\x00\x00\x00"
+  assert_eq(macho_thin_filetype(executable), Some(0x2))
+  assert_eq(macho_thin_filetype(dsym), Some(0xa))
+  // 32-bit thin headers agree up to `filetype`, so one offset reads both.
+  let thin32 = b"\xce\xfa\xed\xfe\x0c\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00"
+  assert_eq(macho_thin_filetype(thin32), Some(0x6))
+}
+
+///|
+test "unjudgeable inputs are left alone rather than failed" {
+  // The caller rejects only what it can prove wrong, so a universal binary, a
+  // script, and a truncated file all read as None. A format this reader does
+  // not understand must never become a packaging failure.
+  let fat = b"\xca\xfe\xba\xbe\x00\x00\x00\x02\x01\x00\x00\x0c\x00\x00\x00\x00"
+  assert_eq(macho_thin_filetype(fat), None)
+  assert_eq(macho_thin_filetype(b"#!/bin/sh\necho hi\n"), None)
+  assert_eq(macho_thin_filetype(b"\xcf\xfa\xed\xfe"), None)
+}
+
+///|
+test "the rejection names the filetype it found" {
+  inspect(macho_filetype_name(0x2), content="MH_EXECUTE")
+  inspect(macho_filetype_name(0xa), content="MH_DSYM")
+  inspect(
+    PackagePlanError::NotLaunchableMachO(
+      path="SeekMoon.app/Contents/MacOS/seekmoon",
+      filetype=0xa,
+    ).message(),
+    content="staged bundle executable SeekMoon.app/Contents/MacOS/seekmoon is a Mach-O of type MH_DSYM, not MH_EXECUTE; the kernel refuses to spawn it",
+  )
+}

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -1058,7 +1058,7 @@ async test "macOS notarization validates success and cleans failed upload" {
 }
 
 ///|
-async test "debug executable lookup stays inside package target dir" {
+async test "package executable lookup ignores the dSYM mirror" {
   let root = "target/proton-package-executable-lookup"
   remove_tree(root)
   let package_target = @fsutil.resolve_path(root, "package-target")
@@ -1095,17 +1095,22 @@ async test "debug executable lookup stays inside package target dir" {
     sign: false,
     notarize: false,
   }
-  @debug.assert_eq(find_package_executable(plan), None)
   let expected = @fsutil.resolve_path(
     package_target, "native/debug/build/vendor/app/app.exe",
   )
+  @debug.assert_eq(find_package_executable(plan), None)
+  let dsym = @fsutil.resolve_path(
+    package_target, "native/debug/build/vendor/app/app.exe.dSYM/Contents/Resources/DWARF/app.exe",
+  )
+  ensure_dir(@fsutil.path_parent(dsym))
+  write_text(dsym, "debug symbols")
+  @debug.assert_eq(find_package_executable(plan), None)
   ensure_dir(@fsutil.path_parent(expected))
   write_text(expected, "right")
-  match find_package_executable(plan) {
-    Some(actual) =>
-      assert_eq(normalize_slashes(actual), normalize_slashes(expected))
-    None => abort("expected debug executable")
+  guard find_package_executable(plan) is Some(actual) else {
+    fail("expected debug executable")
   }
+  assert_eq(normalize_slashes(actual), normalize_slashes(expected))
 }
 
 ///|

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -441,6 +441,7 @@ test "macOS signing args apply hardened runtime entitlements to app code" {
     runtime_options=true,
     deep=false,
     entitlements=Some("proton.entitlements"),
+    identifier=None,
   )
   assert_true(args.contains("--timestamp"))
   assert_true(args.contains("--options"))
@@ -481,16 +482,21 @@ test "ad-hoc macOS signing requires an explicit diagnostic opt-in" {
 }
 
 ///|
-test "macOS framework signing uses deep sealing without app entitlements" {
+test "macOS CEF process signing preserves hardened runtime and identifier" {
   let args = macos_codesign_args(
     "Developer ID Application: Example",
-    "Chromium Embedded Framework.framework",
-    runtime_options=false,
-    deep=true,
-    entitlements=Some("proton.entitlements"),
+    "cef_process",
+    runtime_options=true,
+    deep=false,
+    entitlements=None,
+    identifier=Some("cef_process"),
   )
-  assert_true(args.contains("--deep"))
-  assert_false(args.contains("--options"))
+  assert_true(args.contains("--timestamp"))
+  assert_true(args.contains("--options"))
+  assert_true(args.contains("runtime"))
+  assert_true(args.contains("-i"))
+  assert_true(args.contains("cef_process"))
+  assert_false(args.contains("--deep"))
   assert_false(args.contains("--entitlements"))
 }
 
@@ -505,6 +511,8 @@ async test "macOS signing rejects a missing required target" {
       MacosCodeSignTarget::{
         path: missing,
         runtime_options: false,
+        entitlements: false,
+        identifier: None,
         deep: false,
       },
     ])

--- a/scripts/macos_package_smoke.mjs
+++ b/scripts/macos_package_smoke.mjs
@@ -308,7 +308,12 @@ function verifyBundle() {
     if (declaredExecutable !== helperNames[index]) {
       fail(`unexpected helper executable: ${declaredExecutable}`);
     }
+    fs.accessSync(executable, fs.constants.X_OK);
   }
+  fs.accessSync(
+    path.join(contents, "MacOS", executableName),
+    fs.constants.X_OK,
+  );
   const infoPlist = path.join(contents, "Info.plist");
   const plistExpectations = new Map([
     ["CFBundleIdentifier", "com.justjavac.proton.dev-extension-js"],


### PR DESCRIPTION
## Summary

- sign macOS bundle code from the innermost CEF/runtime targets outward
- avoid deprecated deep signing while retaining deep verification
- preserve executable permissions for the main app binary and all CEF helper binaries
- assert launchable bundle executables in the macOS packaging smoke test

## Validation

- `moon check package --target native --deny-warn`
- `moon test package --target native --deny-warn` (66/66)
- `moon info package`
- `moon fmt package`
- `node scripts/verify_generated.mjs`
- OpenSeek real packaging smoke: debug -> release -> debug; bundle UUID matched the selected build each time, executable mode stayed `755`, and strict ad-hoc code-sign verification passed

The signing/notarization path was also previously verified with a real signing identity and notarization.