### PR TITLE
Fix Proton CLI builds on MoonBit 0.10.7 nightly

### DIFF
--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -7,9 +7,9 @@ import {
   "moonbit-community/proton_rsa@0.1.14",
   "moonbit-community/proton_updater@0.1.14",
   "moonbitlang/x@0.4.48",
-  "moonbitlang/parser@0.3.2",
-  "moonbitlang/moon_config@0.3.5",
-  "moonbitlang/lexer@0.3.5",
+  "moonbitlang/parser@0.3.12",
+  "moonbitlang/moon_config@0.3.11",
+  "moonbitlang/lexer@0.3.12",
   "moonbitlang/async@0.20.3",
   "moonbit-community/proton_ffi@0.1.14",
 }


### PR DESCRIPTION
## Summary

- upgrade `moonbitlang/parser` from 0.3.2 to 0.3.12
- align `moonbitlang/lexer` at 0.3.12 and `moonbitlang/moon_config` at 0.3.11
- restore compatibility with the MoonBit 0.10.7 nightly lexscan syntax checks

## Context

OpenSeek CI began failing while installing Proton CLI with 671 parse errors in the old `moonbitlang/parser` lexer. The failing runners use `moonc v0.10.7+02084b382` (2026-08-07); the previous passing run and current local dev channel use 0.10.6. Parser 0.3.12 uses the new anchored `re"^..."` lexscan syntax.

## Validation

- `moon check --target native --warn-list +73` (0 errors)
- `moon test codegen --target native` (6 passed)
- `moon info`
- `moon fmt --check`
- `moon install --target-dir target/proton-cli-build ./lepus/cli --bin target/proton-tools` from OpenSeek's `desktop/` directory
