### PR TITLE
chore(deps): bump moonbitlang/x to 0.4.49, parser/lexer to 0.3.13

### DIFF
--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -6,7 +6,7 @@ readme = "README.mbt.md"
 
 import {
   "moonbitlang/async@0.20.3",
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
 }
 
 repository = "https://github.com/moonbit-community/proton"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -6,10 +6,10 @@ import {
   "moonbit-community/proton_config@0.1.14",
   "moonbit-community/proton_rsa@0.1.14",
   "moonbit-community/proton_updater@0.1.14",
-  "moonbitlang/x@0.4.48",
-  "moonbitlang/parser@0.3.2",
+  "moonbitlang/x@0.4.49",
+  "moonbitlang/parser@0.3.13",
   "moonbitlang/moon_config@0.3.5",
-  "moonbitlang/lexer@0.3.5",
+  "moonbitlang/lexer@0.3.13",
   "moonbitlang/async@0.20.3",
   "moonbit-community/proton_ffi@0.1.14",
 }

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -3,9 +3,9 @@ name = "moonbit-community/proton_config"
 version = "0.1.14"
 
 import {
-  "moonbitlang/lexer@0.3.5",
+  "moonbitlang/lexer@0.3.13",
   "moonbitlang/moon_config@0.3.5",
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
 }
 
 repository = "https://github.com/moonbit-community/proton"

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.14"
 
 import {
   "moonbitlang/async@0.20.3",
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
   "moonbit-community/proton_cdp@0.1.14",
   "moonbit-community/proton@0.1.14",
   "moonbit-community/proton_updater@0.1.14",

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton/examples"
 version = "0.1.14"
 
 import {
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
   "moonbitlang/async@0.20.3",
   "moonbit-community/proton_ext@0.1.14",
   "moonbit-community/proton_contract@0.1.14",

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.14"
 
 import {
   "moonbit-community/proton_ffi@0.1.14",
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
   "moonbitlang/async@0.20.3",
   "moonbit-community/proton_clipboard@0.1.14",
   "moonbit-community/proton_tray@0.1.14",

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -9,8 +9,8 @@ import {
   "moonbit-community/proton_updater@0.1.14",
   "moonbit-community/proton_rsa@0.1.14",
   "moonbitlang/async@0.20.3",
-  "moonbitlang/x@0.4.48",
-  "moonbitlang/lexer@0.3.5",
+  "moonbitlang/x@0.4.49",
+  "moonbitlang/lexer@0.3.13",
 }
 
 readme = "README.md"

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_ffi"
 version = "0.1.14"
 
 import {
-  "moonbitlang/x@0.4.48",
+  "moonbitlang/x@0.4.49",
 }
 
 readme = "README.mbt.md"


### PR DESCRIPTION
## Why

`moon check` currently fails on older `moonbitlang/x` releases: `x/path/win32/path.mbt` uses the unanchored `lexscan` syntax that the current toolchain rejects (`[4218] Regex patterns of cases in lexscan must be anchored…`). `moonbitlang/x@0.4.49` fixes it.

While here, the parser toolchain pins were inconsistent across modules:

| module | before | after |
|---|---|---|
| `cli` | `parser@0.3.2`, `lexer@0.3.5` | `parser@0.3.13`, `lexer@0.3.13` |
| `proton` | `lexer@0.3.5` | `lexer@0.3.13` |
| `config` | `lexer@0.3.5` | `lexer@0.3.13` |
| all 8 | `x@0.4.48` | `x@0.4.49` |

0.4.49 and 0.3.13 are the latest published versions.

## Scope

moon.mod-only — no source changes were required.

## Verification

`moon check` reports **0 errors, 0 warnings** in all eight modules: `cdp`, `proton`, `config`, `cli`, `extensions`, `sys/ffi`, `examples`, `e2e`.

Not run: `moon test`. The `parser`/`lexer` jump is several patch releases, so behavioral changes would not surface in a typecheck.

## Overlap with #95

#97 (merged into #95's branch) already bumped `cli/moon.mod` to parser/lexer 0.3.12. This PR is based on `main` instead, so it will conflict with #95 in `cli/moon.mod` — resolve in favor of 0.3.13. It additionally covers `proton/` and `config/`, which #97 left on lexer 0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)