### PR TITLE
fix(native): preserve bridge when opening DevTools

### DIFF
--- a/.github/workflows/build-macos-prebuilt.yml
+++ b/.github/workflows/build-macos-prebuilt.yml
@@ -1,0 +1,108 @@
+name: build macOS prebuilt
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-macos-prebuilt-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PROTON_NO_UPDATE_CHECK: 1
+  PROTON_CEF_CACHE: ${{ github.workspace }}/.proton-global-cache
+  PROTON_PREBUILT_SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'build-prebuilt' }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.PROTON_PREBUILT_SOURCE_SHA }}
+
+      - name: Cache MoonBit packages
+        uses: actions/cache@v4
+        with:
+          path: .mooncakes
+          key: macOS-prebuilt-mooncakes-${{ hashFiles('**/moon.mod') }}
+          restore-keys: macOS-prebuilt-mooncakes-
+
+      - name: Cache CEF downloads
+        uses: actions/cache@v4
+        with:
+          path: .proton-global-cache
+          key: macOS-prebuilt-cef-${{ hashFiles('cli/cef/cef_platform.mbt') }}
+
+      - name: Install MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s latest
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: Resolve dependencies
+        run: moon update
+
+      - name: Set up CEF runtime
+        run: moon -C cli run . -- -C .. cef setup
+
+      - name: Build and install Release runtime
+        run: |
+          runtime="$RUNNER_TEMP/proton-runtime"
+          platform=$(node -p "require('./.proton/runtime.json').platform")
+          cef_root=$(node -p "require('./.proton/runtime.json').cef")
+          test "$platform" = "darwin-arm64"
+          test "$(uname -m)" = "arm64"
+          cmake -S native -B native/build-prebuilt \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$runtime" \
+            -DPROTON_WITH_ENGINE=ON \
+            -DPROTON_ENGINE_ROOT="$cef_root"
+          cmake --build native/build-prebuilt --parallel
+          cmake --install native/build-prebuilt --strip
+          echo "PROTON_PREBUILT_RUNTIME=$runtime" >> "$GITHUB_ENV"
+
+      - name: Test Release runtime
+        run: |
+          PROTON_TEST_SKIP_MANAGED_APP_RUNNER=1 \
+            ctest --test-dir native/build-prebuilt --output-on-failure
+          node native/scripts/verify_link_config.mjs "$PROTON_PREBUILT_RUNTIME"
+
+      - name: Stage package prebuilt
+        run: |
+          destination="$PWD/proton/prebuilt/darwin-arm64"
+          install -d "$destination/bin" "$destination/include" "$destination/lib"
+          install -m 755 "$PROTON_PREBUILT_RUNTIME/bin/cef_process" \
+            "$destination/bin/cef_process"
+          install -m 644 "$PROTON_PREBUILT_RUNTIME/include/proton_native.h" \
+            "$destination/include/proton_native.h"
+          install -m 755 "$PROTON_PREBUILT_RUNTIME/lib/libproton.dylib" \
+            "$destination/lib/libproton.dylib"
+          install -m 644 "$PROTON_PREBUILT_RUNTIME/manifest.json" \
+            "$destination/manifest.json"
+
+      - name: Verify package prebuilt ABI
+        run: node scripts/verify_prebuilt_abi.mjs darwin-arm64
+
+      # upload-artifact does not preserve Unix executable modes. Keep the
+      # staged directory in a tar archive so cef_process remains executable.
+      - name: Archive macOS prebuilt
+        run: |
+          tar -C proton/prebuilt -czf \
+            "$RUNNER_TEMP/proton-prebuilt-darwin-arm64-${PROTON_PREBUILT_SOURCE_SHA}.tar.gz" \
+            darwin-arm64
+
+      - name: Upload macOS prebuilt
+        uses: actions/upload-artifact@v4
+        with:
+          name: proton-prebuilt-darwin-arm64-${{ env.PROTON_PREBUILT_SOURCE_SHA }}
+          path: ${{ runner.temp }}/proton-prebuilt-darwin-arm64-${{ env.PROTON_PREBUILT_SOURCE_SHA }}.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0

--- a/e2e/test/devtools_scenario_wbtest.mbt
+++ b/e2e/test/devtools_scenario_wbtest.mbt
@@ -1,0 +1,57 @@
+///|
+async fn evaluate_bool_in_context(
+  page : @client.CdpClient,
+  expression : String,
+  context_id : Int,
+) -> Bool {
+  let response = page.send_schema_command("Runtime.evaluate", params={
+    "expression": expression,
+    "contextId": context_id,
+    "returnByValue": true,
+  })
+  match @client.cdp_response_result_json(response) {
+    { "result": { "value": true, .. }, .. } => true
+    _ => false
+  }
+}
+
+///|
+async fn run_devtools_scenario_page_probe(
+  app : SpawnedScenarioApp,
+  target : String,
+  timeout : Int,
+) -> Unit {
+  let page = connect_spawned_page(
+    app,
+    target,
+    timeout,
+    title="Proton DevTools API",
+  )
+  defer page.close()
+  ignore(page.send_schema_command("Runtime.enable"))
+  wait_for_ready(page, scenario_ready_expression("54_devtools"), timeout)
+  let frame_tree = @typed.PageGetFrameTreeResult::from_json(
+    @client.cdp_response_result_json(
+      page.send_schema_command("Page.getFrameTree"),
+    ),
+  )
+  let isolated_context = @typed.PageCreateIsolatedWorldResult::from_json(
+    @client.cdp_response_result_json(
+      page.send_schema_command("Page.createIsolatedWorld", params={
+        "frameId": frame_tree.frame_tree.frame.id.value,
+        "worldName": "DevTools Performance Metrics",
+        "grantUniveralAccess": false,
+      }),
+    ),
+  )
+  guard evaluate_bool(page, scenario_probe_expression("54_devtools"), true) else {
+    fail("DevTools disposed the main page bridge")
+  }
+  guard evaluate_bool_in_context(
+    page,
+    "typeof globalThis.__MoonBit__ === 'undefined'",
+    isolated_context.execution_context_id.value,
+  ) else {
+    fail("Proton bridge was injected into a DevTools isolated context")
+  }
+}

--- a/e2e/test/env.mbt
+++ b/e2e/test/env.mbt
@@ -63,7 +63,8 @@ fn is_supported_scenario(name : String) -> Bool {
     | "45_bridge_multi_window"
     | "46_asset_sidecar_resources"
     | "47_dev_extension_js"
-    | "52_web_contents_view" => true
+    | "52_web_contents_view"
+    | "54_devtools" => true
     _ => false
   }
 }

--- a/e2e/test/main.mbt
+++ b/e2e/test/main.mbt
@@ -29,10 +29,18 @@ async fn run_connected_scenario_probe(
     run_multi_window_driver_probe(target, timeout)
     return
   }
-  let page = @client.connect_cdp_page_target_with_timeout(
-    cdp_target_from(target),
-    timeout_ms=timeout,
-  )
+  let page = if name == "54_devtools" {
+    @client.connect_cdp_page_target_with_timeout(
+      cdp_target_from(target),
+      title="Proton DevTools API",
+      timeout_ms=timeout,
+    )
+  } else {
+    @client.connect_cdp_page_target_with_timeout(
+      cdp_target_from(target),
+      timeout_ms=timeout,
+    )
+  }
   defer page.close()
   ignore(page.send_schema_command("Runtime.enable"))
   wait_for_ready(page, scenario_ready_expression(name), timeout)

--- a/e2e/test/moon.pkg
+++ b/e2e/test/moon.pkg
@@ -16,6 +16,7 @@ import {
   "moonbitlang/core/encoding/base64",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
+  "moonbit-community/proton_cdp/protocol/typed",
   "moonbitlang/x/fs" @mbfs,
   "moonbitlang/x/path",
 } for "wbtest"
@@ -34,6 +35,7 @@ options(
     "asset_sidecar_scenario_wbtest.mbt": [ "native" ],
     "dev_extension_scenario_wbtest.mbt": [ "native" ],
     "dev_extension_process_wbtest.mbt": [ "native" ],
+    "devtools_scenario_wbtest.mbt": [ "native" ],
     "extension_scenarios_wbtest.mbt": [ "native" ],
     "event_scenario_wbtest.mbt": [ "native" ],
     "multi_window_scenario_wbtest.mbt": [ "native" ],

--- a/e2e/test/orchestration_wbtest.mbt
+++ b/e2e/test/orchestration_wbtest.mbt
@@ -641,6 +641,18 @@ async fn run_scenario_probe_once(
       run_web_contents_view_scenario_probe(
         app, target, browser_web_socket_url, timeout,
       )
+    } else if name == "54_devtools" {
+      run_devtools_scenario_page_probe(app, target, timeout)
+      match app_exit_code(app.process) {
+        Some(code) =>
+          fail(
+            "scenario app exited before the probe completed: code=" +
+            code.to_string() +
+            app_output_suffix(app.output_path),
+          )
+        None => ()
+      }
+      finish_scenario_app(app, target)
     } else {
       if name == "41_app_commands" {
         run_app_commands_full_probe(root, target, timeout, app.native_log_path)
@@ -804,6 +816,13 @@ async test "headless 52_web_contents_view runs as a self-hosted e2e" {
   let root = repository_root()
   let timeout = timeout_ms()
   run_scenario_probe_with_retry(root, "52_web_contents_view", timeout)
+}
+
+///|
+async test "headless 54_devtools preserves the page bridge" {
+  scenario_run_mutex.acquire()
+  defer scenario_run_mutex.release()
+  run_scenario_probe_with_retry(repository_root(), "54_devtools", timeout_ms())
 }
 
 ///|

--- a/e2e/test/probes.mbt
+++ b/e2e/test/probes.mbt
@@ -214,6 +214,23 @@ fn scenario_probe_expression(name : String) -> String raise {
         #|  return document.body?.textContent.includes('marker') ?? false;
         #|})()
       )
+    "54_devtools" =>
+      (
+        #|;(async () => {
+        #|  if (location.href !== "https://proton.localhost/") return false;
+        #|  if (document.title !== "Proton DevTools API") return false;
+        #|  const invoke = window.__MoonBit__?.core?.invokeOp;
+        #|  if (typeof invoke !== "function") return false;
+        #|  try {
+        #|    await invoke("app:devtoolsBridgeProbe", {});
+        #|    return false;
+        #|  } catch (error) {
+        #|    const message = String(error?.message || error);
+        #|    return error?.code === "remote_failure" &&
+        #|      message.includes("bridge op is not registered");
+        #|  }
+        #|})()
+      )
     _ => fail("unsupported E2E scenario: " + name)
   }
 }

--- a/e2e/test/process_lifecycle_wbtest.mbt
+++ b/e2e/test/process_lifecycle_wbtest.mbt
@@ -522,6 +522,7 @@ async fn connect_spawned_page(
   app : SpawnedScenarioApp,
   target : String,
   timeout : Int,
+  title? : String,
 ) -> @client.CdpClient {
   let mut elapsed = 0
   while elapsed <= timeout {
@@ -541,6 +542,7 @@ async fn connect_spawned_page(
         () => {
           @client.connect_cdp_page_target_with_timeout(
             cdp_target_from(target),
+            title?,
             timeout_ms=cdp_start_poll_timeout_ms,
           )
         },

--- a/e2e/test/ready.mbt
+++ b/e2e/test/ready.mbt
@@ -35,6 +35,8 @@ fn scenario_ready_expression(name : String) -> String raise {
       "Boolean(window.__MoonBit__?.core?.invokeOp && window.__MoonBit__?.add?.slowAdd && window.__MoonBit__?.events?.on)"
     "52_web_contents_view" =>
       "['Web Contents View Host','WCV Left','WCV Right'].includes(document.title) && document.readyState === 'complete'"
+    "54_devtools" =>
+      "document.title === 'Proton DevTools API' && typeof window.__MoonBit__?.core?.invokeOp === 'function'"
     _ => fail("unsupported E2E scenario: " + name)
   }
 }

--- a/e2e/test/scenario_app_wbtest.mbt
+++ b/e2e/test/scenario_app_wbtest.mbt
@@ -9,6 +9,7 @@ fn run_scenario_app_child() -> Unit raise {
     Some("40_event_broadcast") => @e2e_fixtures.run_event_broadcast()
     Some("45_bridge_multi_window") => @e2e_fixtures.run_multi_window()
     Some("52_web_contents_view") => @e2e_fixtures.run_web_contents_view()
+    Some("54_devtools") => @e2e_fixtures.run_devtools()
     Some("46_asset_sidecar_resources") => @e2e_fixtures.run_asset_sidecar()
     Some("42_attribute_codegen_commands") =>
       @e2e_fixtures.run_attribute_codegen_commands()

--- a/e2e/test/scenario_validation_wbtest.mbt
+++ b/e2e/test/scenario_validation_wbtest.mbt
@@ -4,7 +4,7 @@ test "CDP E2E scenario names are explicitly supported" {
     name in [
       "38_async_extension_add", "39_sync_async_extensions", "40_event_broadcast",
       "41_app_commands", "42_attribute_codegen_commands", "45_bridge_multi_window",
-      "46_asset_sidecar_resources", "47_dev_extension_js",
+      "46_asset_sidecar_resources", "47_dev_extension_js", "54_devtools",
     ] {
     assert_true(is_supported_scenario(name))
   }

--- a/examples/54_devtools/main.mbt
+++ b/examples/54_devtools/main.mbt
@@ -1,0 +1,48 @@
+///|
+let page =
+  #|<!doctype html>
+  #|<html lang="en">
+  #|  <head>
+  #|    <meta charset="utf-8">
+  #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+  #|    <title>Proton DevTools API</title>
+  #|    <style>
+  #|      :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+  #|      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #111827; color: #f9fafb; }
+  #|      main { width: min(680px, calc(100vw - 64px)); padding: 40px; border: 1px solid #374151; border-radius: 20px; background: #1f2937; box-shadow: 0 24px 60px #0006; }
+  #|      h1 { margin-top: 0; font-size: 32px; }
+  #|      code { color: #93c5fd; }
+  #|      li { margin: 12px 0; line-height: 1.5; }
+  #|      .status { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #064e3b; color: #a7f3d0; font-size: 13px; }
+  #|    </style>
+  #|  </head>
+  #|  <body>
+  #|    <main>
+  #|      <span class="status">open_devtools called</span>
+  #|      <h1 id="probe-title">Proton DevTools API</h1>
+  #|      <p>This example calls <code>BrowserHandle::open_devtools()</code> when the main window becomes ready.</p>
+  #|      <ol>
+  #|        <li>Confirm that a separate DevTools window opened automatically.</li>
+  #|        <li>Use the Elements panel to inspect <code>#probe-title</code>.</li>
+  #|        <li>Close DevTools and confirm that this window remains open.</li>
+  #|      </ol>
+  #|    </main>
+  #|  </body>
+  #|</html>
+  #|
+
+///|
+fn main {
+  @proton.run(() => {
+    @proton.html("DevTools API", page, width=900, height=700, debug=true)
+    .window_lifecycle(
+      on_ready=context => {
+        let browser = context.handle().browser()
+        browser.open_devtools()
+        browser
+      },
+      on_close=fn(browser) { browser.close_devtools() catch { _ => () } },
+    )
+    .run_or_abort()
+  })
+}

--- a/examples/54_devtools/moon.pkg
+++ b/examples/54_devtools/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/54_devtools/pkg.generated.mbti
+++ b/examples/54_devtools/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/54_devtools"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -84,6 +84,8 @@ moon -C examples run 01_run --target native
   extension, with view events keeping the sidebar in sync.
 - `53_view_minimal`: the minimal declarative web contents view example:
   `with_view` plus `@proton.view`, no lifecycle hooks required.
+- `54_devtools`: opens CEF DevTools programmatically through
+  `BrowserHandle::open_devtools` and closes it with the window lifecycle.
 
 All runnable examples should import `moonbit-community/proton`. `moon.proton`
 configures app settings such as window, entry, debug, frontend, and bundle

--- a/examples/e2e_fixtures/pkg.generated.mbti
+++ b/examples/e2e_fixtures/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub fn run_async_extension_add() -> Unit
 
 pub fn run_attribute_codegen_commands() -> Unit
 
+pub fn run_devtools() -> Unit
+
 pub fn run_event_broadcast() -> Unit
 
 pub fn run_multi_window() -> Unit

--- a/examples/e2e_fixtures/scenarios.mbt
+++ b/examples/e2e_fixtures/scenarios.mbt
@@ -325,3 +325,31 @@ pub fn run_asset_sidecar() -> Unit {
     app.run_or_abort()
   })
 }
+
+///|
+let devtools_resource : String =
+  #|<!doctype html>
+  #|<html><head><meta charset="utf-8"><title>Proton DevTools API</title></head>
+  #|<body><h1>DevTools Bridge Lifecycle</h1></body></html>
+
+///|
+pub fn run_devtools() -> Unit {
+  @proton.run(() => {
+    @proton.html(
+      "Proton DevTools API",
+      devtools_resource,
+      width=900,
+      height=700,
+      debug=true,
+    )
+    .window_lifecycle(
+      on_ready=context => {
+        let browser = context.handle().browser()
+        browser.open_devtools()
+        browser
+      },
+      on_close=fn(browser) { browser.close_devtools() catch { _ => () } },
+    )
+    .run_or_abort()
+  })
+}

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -255,6 +255,26 @@ if(PROTON_WITH_ENGINE)
       DESTINATION bin
     )
     install(TARGETS cef_process RUNTIME DESTINATION bin)
+
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/../proton/moon.mod"
+         PROTON_MOON_VERSION_LINE REGEX "^version = ")
+    string(REGEX REPLACE "^version = \"([^\"]+)\".*$" "\\1"
+           PROTON_PREBUILT_VERSION "${PROTON_MOON_VERSION_LINE}")
+    set(PROTON_PREBUILT_MANIFEST
+        "${CMAKE_BINARY_DIR}/proton_prebuilt_manifest.json")
+    file(WRITE "${PROTON_PREBUILT_MANIFEST}"
+      "{\n"
+      "  \"platform\": \"darwin-arm64\",\n"
+      "  \"proton_version\": \"${PROTON_PREBUILT_VERSION}\",\n"
+      "  \"artifacts\": {\n"
+      "    \"shared_lib\": \"lib/libproton.dylib\",\n"
+      "    \"helper\": \"bin/cef_process\",\n"
+      "    \"header\": \"include/proton_native.h\"\n"
+      "  }\n"
+      "}\n"
+    )
+    install(FILES "${PROTON_PREBUILT_MANIFEST}" DESTINATION .
+            RENAME manifest.json)
   elseif(UNIX)
     set(PROTON_ENGINE_SHARED_LIB "${PROTON_ENGINE_ROOT}/Release/libcef.so")
     if(NOT EXISTS "${PROTON_ENGINE_SHARED_LIB}")

--- a/native/README.md
+++ b/native/README.md
@@ -306,17 +306,17 @@ proton/prebuilt/darwin-arm64/manifest.json
 
 CEF runtime files are assembled later by `proton_cli cef setup` into `.proton/`.
 
-Maintainers without a local Linux or Windows build host can run the manual
-`build Linux prebuilt` or `build Windows prebuilt` GitHub Actions workflow for
-the branch and commit under review. Each workflow builds and tests a Release
-runtime on its native host, stages only the package artifacts listed above,
-verifies their exported ABI, and uploads an archive rooted at the platform
-directory. The workflows never commit or push binaries; download and inspect
-the archive before replacing the matching `proton/prebuilt/<platform>`
-directory. Before these workflows exist on the default branch, a maintainer can
-trigger both for a pull request by adding the `build-prebuilt` label. The
-label-triggered build checks out the pull request head commit, not GitHub's
-synthetic merge commit.
+Maintainers without a local macOS, Linux, or Windows build host can run the
+manual `build macOS prebuilt`, `build Linux prebuilt`, or
+`build Windows prebuilt` GitHub Actions workflow for the branch and commit under
+review. Each workflow builds and tests a Release runtime on its native host,
+stages only the package artifacts listed above, verifies their exported ABI,
+and uploads an archive rooted at the platform directory. The workflows never
+commit or push binaries; download and inspect the archive before replacing the
+matching `proton/prebuilt/<platform>` directory. Before these workflows exist
+on the default branch, a maintainer can trigger all three for a pull request by
+adding the `build-prebuilt` label. The label-triggered build checks out the pull
+request head commit, not GitHub's synthetic merge commit.
 
 MoonBit FFI consumers only link `proton.lib`/`proton.dll` on Windows or
 `libproton.so` on Linux or `libproton.dylib` on macOS. They do not link CEF

--- a/native/src/engine/cef_common/bridge_renderer.c
+++ b/native/src/engine/cef_common/bridge_renderer.c
@@ -142,6 +142,28 @@ static char *proton_engine_bridge_frame_url(cef_frame_t *frame) {
              : NULL;
 }
 
+static int proton_engine_bridge_is_default_context(
+    cef_frame_t *frame,
+    cef_v8_context_t *context) {
+  if (frame == NULL || context == NULL || !frame->is_main(frame)) {
+    return 0;
+  }
+  cef_v8_context_t *default_context = frame->get_v8_context(frame);
+  int is_default = 0;
+  if (default_context != NULL && context->is_same != NULL) {
+    /* CEF's C API consumes refptr parameters. Keep the getter reference while
+       transferring a temporary reference to is_same. */
+    default_context->base.add_ref(
+        (cef_base_ref_counted_t *)default_context);
+    is_default = context->is_same(context, default_context);
+  }
+  if (default_context != NULL) {
+    default_context->base.release(
+        (cef_base_ref_counted_t *)default_context);
+  }
+  return is_default;
+}
+
 static char *proton_engine_bridge_new_page_instance(void) {
   char value[96];
   uint64_t sequence = g_next_page_instance++;
@@ -868,7 +890,8 @@ void proton_engine_bridge_renderer_on_context_created(
     cef_v8_context_t *context,
     cef_v8_handler_t *native_invoke_handler) {
   if (browser == NULL || frame == NULL || context == NULL ||
-      native_invoke_handler == NULL || !frame->is_main(frame)) {
+      native_invoke_handler == NULL ||
+      !proton_engine_bridge_is_default_context(frame, context)) {
     return;
   }
   proton_engine_bridge_browser_config_t *browser_config =


### PR DESCRIPTION
## Summary

- inject Proton's renderer bridge only into a main frame's default V8 context
- add `54_devtools`, a runnable example using `BrowserHandle::open_devtools()`
- add self-hosted E2E coverage for page-bridge continuity and isolated-context separation
- add a native-hosted `darwin-arm64` prebuilt workflow alongside Linux and Windows

## Root cause

Opening DevTools creates an isolated V8 context named `DevTools Performance Metrics` in the inspected main frame. Proton previously accepted every main-frame context, so this isolated context replaced the default page bridge in the browser-id registry and disposed the bridge still used by the page. The next page call then failed with `Proton bridge context has been disposed`, as observed in moonbitlang/openseek#765.

The renderer now compares the created context with `frame->get_v8_context()` and skips bridge bootstrap for isolated worlds.

## Validation

- reproduced the failure against the previous 0.1.14 runtime, then passed the same `54_devtools` regression with the rebuilt runtime
- `ctest --test-dir native/build-engine -C Debug --output-on-failure`
- `node native/scripts/verify_link_config.mjs native/dist`
- `node --test native/tests/bridge_bootstrap.test.mjs`
- `moon -C proton test native --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build 54_devtools --target native --diagnostic-limit 80`
- existing `41_app_commands` and new `54_devtools` self-hosted E2E scenarios
- real DevTools CDP check: the page bridge completed a native round-trip while the `DevTools Performance Metrics` context had no `__MoonBit__`
- `moon -C e2e check --target native --diagnostic-limit 80`
- local arm64 Release build, stripped install, 5/5 CTest, link-config verification, staged ABI verification, and tar layout inspection
- `node scripts/verify_generated.mjs`
- `moon fmt --check`
