### PR TITLE
refactor(extensions): P1/P2 cleanup across extensions and sys modules

### DIFF
--- a/cli/package/pkg.generated.mbti
+++ b/cli/package/pkg.generated.mbti
@@ -59,6 +59,7 @@ pub(all) suberror PackagePlanError {
   UnsupportedResourceGlob(path~ : String)
   MissingInput(path~ : String)
   MissingExecutable(path~ : String)
+  NotLaunchableMachO(path~ : String, filetype~ : Int)
   InputOutsideProject(path~ : String)
   MissingIcon(path~ : String)
 } derive(Eq, @debug.Debug)

--- a/contract/contract.mbt
+++ b/contract/contract.mbt
@@ -11,6 +11,14 @@ pub enum ContractScope {
 pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+/// Standard platform-support probe result, shared by extension `support` commands.
+pub(all) struct SupportReply {
+  supported : Bool
+  platform : String
+  reason : String?
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
 /// An opaque application or extension route carried by a typed descriptor.
 ///
 /// Application code does not construct routes or assemble transport names

--- a/contract/contract.mbt
+++ b/contract/contract.mbt
@@ -7,6 +7,10 @@ pub enum ContractScope {
 }
 
 ///|
+/// A request payload with no fields, shared by commands that take no input.
+pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
+
+///|
 /// An opaque application or extension route carried by a typed descriptor.
 ///
 /// Application code does not construct routes or assemble transport names

--- a/contract/moon.pkg
+++ b/contract/moon.pkg
@@ -1,3 +1,7 @@
+import {
+  "moonbitlang/core/json",
+}
+
 options(
   "is-main": false,
 )

--- a/contract/pkg.generated.mbti
+++ b/contract/pkg.generated.mbti
@@ -57,6 +57,12 @@ pub fn ExtensionContract::id(Self) -> String
 pub fn ExtensionContract::js_namespace(Self) -> String
 pub fn ExtensionContract::validate(Self) -> Unit raise ContractDefinitionError
 
+pub(all) struct SupportReply {
+  supported : Bool
+  platform : String
+  reason : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 // Type aliases
 
 // Traits

--- a/contract/pkg.generated.mbti
+++ b/contract/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbit-community/proton_contract"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 }
 
 // Values
@@ -34,6 +35,9 @@ pub struct ContractRoute {
   scope : ContractScope
   name : String
 }
+
+pub(all) struct EmptyRequest {
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub struct Event[Payload] {
   route : ContractRoute

--- a/extensions/auto_launch/auto_launch.mbt
+++ b/extensions/auto_launch/auto_launch.mbt
@@ -79,10 +79,11 @@ fn launcher_reply(
 }
 
 ///|
-fn auto_launch_support() -> @auto_launch_contract.SupportReply {
-  @auto_launch_contract.SupportReply::{
+fn auto_launch_support() -> @proton_contract.SupportReply {
+  @proton_contract.SupportReply::{
     supported: @sys_auto_launch.is_supported(),
     platform: platform_label(@sys_auto_launch.current_platform()),
+    reason: None,
   }
 }
 

--- a/extensions/auto_launch/contract/contract.mbt
+++ b/extensions/auto_launch/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct SupportRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct AutoLaunchRequest {
   name : String
   path : String?
@@ -9,12 +6,6 @@ pub(all) struct AutoLaunchRequest {
   background_arg : String?
   extra_arguments : Array[String]?
   identifier : String?
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
-pub(all) struct SupportReply {
-  supported : Bool
-  platform : String
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
@@ -41,9 +32,10 @@ pub(all) struct AutoLaunchActivity {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
-pub let support : @proton_contract.Command[SupportRequest, SupportReply] = extension.command(
-  "support",
-)
+pub let support : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  @proton_contract.SupportReply,
+] = extension.command("support")
 
 ///|
 pub let describe : @proton_contract.Command[AutoLaunchRequest, AutoLaunchReply] = extension.command(

--- a/extensions/auto_launch/contract/pkg.generated.mbti
+++ b/extensions/auto_launch/contract/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub let extension : @proton_contract.ExtensionContract
 
 pub let is_enabled : @proton_contract.Command[AutoLaunchRequest, EnabledReply]
 
-pub let support : @proton_contract.Command[SupportRequest, SupportReply]
+pub let support : @proton_contract.Command[@proton_contract.EmptyRequest, @proton_contract.SupportReply]
 
 // Errors
 
@@ -51,14 +51,6 @@ pub(all) struct EnabledReply {
 
 pub(all) struct MutationReply {
   changed : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
-pub(all) struct SupportReply {
-  supported : Bool
-  platform : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
-pub(all) struct SupportRequest {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 // Type aliases

--- a/extensions/auto_launch/extension.mbt
+++ b/extensions/auto_launch/extension.mbt
@@ -17,8 +17,8 @@ let disable_command = @auto_launch_contract.disable
 /// Returns platform support details for JavaScript callers.
 #proton.command(contract=support_command)
 fn support(
-  _request : @auto_launch_contract.SupportRequest,
-) -> @auto_launch_contract.SupportReply {
+  _request : @proton_contract.EmptyRequest,
+) -> @proton_contract.SupportReply {
   auto_launch_support()
 }
 

--- a/extensions/dialog/extension.mbt
+++ b/extensions/dialog/extension.mbt
@@ -33,6 +33,9 @@ async fn message(
   context : @proton.CommandContext,
   request : @dialog_contract.MessageRequest,
 ) -> @dialog_contract.MessageReply {
+  // The handle is sourced from `window.id()` in the dispatch path, which
+  // checks the window lifecycle and returns `proton_invalid_handle` for
+  // destroying/destroyed windows.
   let window = @native.WindowRef::unsafe_from_handle(context.window())
   emit_command_result(
     context,

--- a/extensions/global_hotkey/contract/contract.mbt
+++ b/extensions/global_hotkey/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct GlobalHotkeyRequest {
   accelerator : String
 } derive(ToJson, FromJson, Debug, Eq)
@@ -40,13 +37,14 @@ pub let unregister : @proton_contract.Command[
 ] = extension.command("unregister")
 
 ///|
-pub let list : @proton_contract.Command[EmptyRequest, GlobalHotkeyListReply] = extension.command(
-  "list",
-)
+pub let list : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  GlobalHotkeyListReply,
+] = extension.command("list")
 
 ///|
 pub let drain_triggered : @proton_contract.Command[
-  EmptyRequest,
+  @proton_contract.EmptyRequest,
   GlobalHotkeyListReply,
 ] = extension.command("drainTriggered")
 

--- a/extensions/global_hotkey/contract/pkg.generated.mbti
+++ b/extensions/global_hotkey/contract/pkg.generated.mbti
@@ -10,11 +10,11 @@ import {
 // Values
 pub let activity : @proton_contract.Event[GlobalHotkeyActivity]
 
-pub let drain_triggered : @proton_contract.Command[EmptyRequest, GlobalHotkeyListReply]
+pub let drain_triggered : @proton_contract.Command[@proton_contract.EmptyRequest, GlobalHotkeyListReply]
 
 pub let extension : @proton_contract.ExtensionContract
 
-pub let list : @proton_contract.Command[EmptyRequest, GlobalHotkeyListReply]
+pub let list : @proton_contract.Command[@proton_contract.EmptyRequest, GlobalHotkeyListReply]
 
 pub let register : @proton_contract.Command[GlobalHotkeyRequest, GlobalHotkeyReply]
 
@@ -25,9 +25,6 @@ pub let unregister : @proton_contract.Command[GlobalHotkeyRequest, GlobalHotkeyR
 // Errors
 
 // Types and methods
-pub(all) struct EmptyRequest {
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct GlobalHotkeyActivity {
   operation : String
   accelerator : String

--- a/extensions/global_hotkey/extension.mbt
+++ b/extensions/global_hotkey/extension.mbt
@@ -34,25 +34,6 @@ async fn[Reply] emit_command_result(
 }
 
 ///|
-fn trigger_poller_script() -> String {
-  (
-    #|(() => {
-    #|  const root = window.__MoonBit__;
-    #|  const globalHotkey = root && root.globalHotkey;
-    #|  if (!globalHotkey || typeof globalHotkey.drainTriggered !== "function") {
-    #|    return;
-    #|  }
-    #|  if (globalHotkey.__protonTriggerPoller) {
-    #|    return;
-    #|  }
-    #|  globalHotkey.__protonTriggerPoller = window.setInterval(() => {
-    #|    globalHotkey.drainTriggered({}).catch(() => {});
-    #|  }, 100);
-    #|})();
-  )
-}
-
-///|
 /// Registers one global hotkey from a generated app-command extension.
 #proton.command(contract=register_command)
 async fn register(
@@ -86,7 +67,7 @@ async fn unregister(
 /// Lists registered global hotkeys from a generated app-command extension.
 #proton.command(contract=list_command)
 fn list(
-  _request : @global_hotkey_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @global_hotkey_contract.GlobalHotkeyListReply raise GlobalHotkeyError {
   list_hotkeys(app_command_manager_handle())
 }
@@ -96,7 +77,7 @@ fn list(
 #proton.command(contract=drain_triggered_command)
 async fn drain_triggered(
   context : @proton.CommandContext,
-  _request : @global_hotkey_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @global_hotkey_contract.GlobalHotkeyListReply {
   let reply = drain_triggered_hotkeys(app_command_manager_handle())
   for accelerator in reply.accelerators {
@@ -113,6 +94,12 @@ pub fn extension() -> @proton_extension.Extension {
     @global_hotkey_contract.extension,
     generated_extension_command_routes(),
     fn(registrar) raise { register_commands(registrar) },
-    scripts=[trigger_poller_script()],
+    scripts=[
+      @proton_extension.poller_script(
+        js_namespace="globalHotkey",
+        drain_method="drainTriggered",
+        poller_field="__protonTriggerPoller",
+      ),
+    ],
   )
 }

--- a/extensions/keepawake/contract/contract.mbt
+++ b/extensions/keepawake/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct AcquireRequest {
   reason : String?
   scope : String?
@@ -25,14 +22,16 @@ pub let acquire : @proton_contract.Command[AcquireRequest, KeepAwakeReply] = ext
 )
 
 ///|
-pub let release : @proton_contract.Command[EmptyRequest, KeepAwakeReply] = extension.command(
-  "release",
-)
+pub let release : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  KeepAwakeReply,
+] = extension.command("release")
 
 ///|
-pub let status : @proton_contract.Command[EmptyRequest, KeepAwakeReply] = extension.command(
-  "status",
-)
+pub let status : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  KeepAwakeReply,
+] = extension.command("status")
 
 ///|
 pub let activity : @proton_contract.Event[KeepAwakeActivity] = extension.event(

--- a/extensions/keepawake/contract/pkg.generated.mbti
+++ b/extensions/keepawake/contract/pkg.generated.mbti
@@ -14,9 +14,9 @@ pub let activity : @proton_contract.Event[KeepAwakeActivity]
 
 pub let extension : @proton_contract.ExtensionContract
 
-pub let release : @proton_contract.Command[EmptyRequest, KeepAwakeReply]
+pub let release : @proton_contract.Command[@proton_contract.EmptyRequest, KeepAwakeReply]
 
-pub let status : @proton_contract.Command[EmptyRequest, KeepAwakeReply]
+pub let status : @proton_contract.Command[@proton_contract.EmptyRequest, KeepAwakeReply]
 
 // Errors
 
@@ -24,9 +24,6 @@ pub let status : @proton_contract.Command[EmptyRequest, KeepAwakeReply]
 pub(all) struct AcquireRequest {
   reason : String?
   scope : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
-pub(all) struct EmptyRequest {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct KeepAwakeActivity {

--- a/extensions/keepawake/extension.mbt
+++ b/extensions/keepawake/extension.mbt
@@ -118,7 +118,7 @@ async fn acquire_next_guard(
 #proton.command(contract=release_command)
 async fn release(
   context : @proton.CommandContext,
-  _request : @keepawake_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @keepawake_contract.KeepAwakeReply {
   match active_guard_ref.val {
     Some(active_guard) => {
@@ -138,7 +138,7 @@ async fn release(
 /// Returns the active keep-awake guard status from a generated app-command extension.
 #proton.command(contract=status_command)
 fn status(
-  _request : @keepawake_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @keepawake_contract.KeepAwakeReply {
   match active_guard_ref.val {
     Some(active_guard) =>

--- a/extensions/microphone/contract/contract.mbt
+++ b/extensions/microphone/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct ParseListingRequest {
   listing : String
 } derive(ToJson, FromJson, Debug, Eq)
@@ -51,7 +48,7 @@ pub(all) struct MicrophoneActivity {
 
 ///|
 pub let list_devices : @proton_contract.Command[
-  EmptyRequest,
+  @proton_contract.EmptyRequest,
   MicrophoneDevicesReply,
 ] = extension.command("listDevices")
 

--- a/extensions/microphone/contract/pkg.generated.mbti
+++ b/extensions/microphone/contract/pkg.generated.mbti
@@ -14,7 +14,7 @@ pub let config : @proton_contract.Command[CaptureConfigRequest, CaptureConfigRep
 
 pub let extension : @proton_contract.ExtensionContract
 
-pub let list_devices : @proton_contract.Command[EmptyRequest, MicrophoneDevicesReply]
+pub let list_devices : @proton_contract.Command[@proton_contract.EmptyRequest, MicrophoneDevicesReply]
 
 pub let parse_listing : @proton_contract.Command[ParseListingRequest, MicrophoneDevicesReply]
 
@@ -38,9 +38,6 @@ pub(all) struct CaptureConfigRequest {
   sample_format : String?
   echo_cancellation : Bool?
   noise_suppression : Bool?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
-pub(all) struct EmptyRequest {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct MicrophoneActivity {

--- a/extensions/microphone/error.mbt
+++ b/extensions/microphone/error.mbt
@@ -1,11 +1,11 @@
 ///|
 /// Invalid microphone capture configuration supplied by JavaScript.
-suberror MicrophoneConfigError {
+suberror MicrophoneError {
   UnknownSampleFormat(format~ : String)
 } derive(Debug, Eq)
 
 ///|
-fn MicrophoneConfigError::message(self : MicrophoneConfigError) -> String {
+fn MicrophoneError::message(self : MicrophoneError) -> String {
   match self {
     UnknownSampleFormat(format~) =>
       "unknown microphone sample format: " + format
@@ -13,6 +13,6 @@ fn MicrophoneConfigError::message(self : MicrophoneConfigError) -> String {
 }
 
 ///|
-impl Show for MicrophoneConfigError with fn output(self, logger) {
+impl Show for MicrophoneError with fn output(self, logger) {
   logger.write_string(self.message())
 }

--- a/extensions/microphone/extension.mbt
+++ b/extensions/microphone/extension.mbt
@@ -94,7 +94,7 @@ fn microphone_devices_reply(
 #proton.command(contract=list_devices_command)
 async fn list_devices(
   context : @proton.CommandContext,
-  _request : @microphone_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @microphone_contract.MicrophoneDevicesReply {
   let devices = @sys_microphone.MicrophoneDevice::list()
   context.emit(@microphone_contract.activity, @microphone_contract.MicrophoneActivity::{

--- a/extensions/microphone/extension.mbt
+++ b/extensions/microphone/extension.mbt
@@ -11,7 +11,7 @@ let config_command = @microphone_contract.config
 /// Converts a sample format label from JavaScript into the package enum.
 fn parse_sample_format(
   sample_format : String?,
-) -> @sys_microphone.SampleFormat? raise MicrophoneConfigError {
+) -> @sys_microphone.SampleFormat? raise MicrophoneError {
   match sample_format {
     Some("i16") => Some(I16)
     Some("u16") => Some(U16)
@@ -35,7 +35,7 @@ fn sample_format_label(format : @sys_microphone.SampleFormat) -> String {
 /// Builds and normalizes one capture config from JavaScript payload data.
 fn build_capture_config(
   payload : @microphone_contract.CaptureConfigRequest,
-) -> @sys_microphone.CaptureConfig raise MicrophoneConfigError {
+) -> @sys_microphone.CaptureConfig raise MicrophoneError {
   let sample_format = parse_sample_format(payload.sample_format).unwrap_or(F32)
   @sys_microphone.CaptureConfig::new(
     channels=payload.channels.unwrap_or(1),
@@ -119,7 +119,7 @@ fn parse_listing(
 #proton.command(contract=config_command)
 fn config(
   request : @microphone_contract.CaptureConfigRequest,
-) -> @microphone_contract.CaptureConfigReply raise MicrophoneConfigError {
+) -> @microphone_contract.CaptureConfigReply raise MicrophoneError {
   capture_config_reply(build_capture_config(request))
 }
 

--- a/extensions/microphone/pkg.generated.mbti
+++ b/extensions/microphone/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
 pub fn register_commands(@command.CommandRegistrar) -> Unit raise
 
 // Errors
-type MicrophoneConfigError derive(Eq, @debug.Debug)
+type MicrophoneError derive(Eq, @debug.Debug)
 
 // Types and methods
 

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -14,6 +14,7 @@ import {
   "moonbit-community/proton_microphone@0.1.14",
   "moonbit-community/proton_auto_launch@0.1.14",
   "moonbit-community/proton_keepawake@0.1.14",
+  "moonbit-community/proton_shell@0.1.14",
 }
 
 readme = "README.md"

--- a/extensions/notification/contract/contract.mbt
+++ b/extensions/notification/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 /// `level` is a reserved severity hint: today it is only echoed back in the
 /// activity event and is not forwarded to the native backend.
 pub(all) struct NotificationRequest {
@@ -40,7 +37,7 @@ pub let show : @proton_contract.Command[NotificationRequest, NotificationReply] 
 
 ///|
 pub let drain_clicks : @proton_contract.Command[
-  EmptyRequest,
+  @proton_contract.EmptyRequest,
   NotificationDrainReply,
 ] = extension.command("drainClicks")
 

--- a/extensions/notification/contract/pkg.generated.mbti
+++ b/extensions/notification/contract/pkg.generated.mbti
@@ -12,7 +12,7 @@ pub let activity : @proton_contract.Event[NotificationActivity]
 
 pub let click : @proton_contract.Event[NotificationClick]
 
-pub let drain_clicks : @proton_contract.Command[EmptyRequest, NotificationDrainReply]
+pub let drain_clicks : @proton_contract.Command[@proton_contract.EmptyRequest, NotificationDrainReply]
 
 pub let extension : @proton_contract.ExtensionContract
 
@@ -21,9 +21,6 @@ pub let show : @proton_contract.Command[NotificationRequest, NotificationReply]
 // Errors
 
 // Types and methods
-pub(all) struct EmptyRequest {
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct NotificationActivity {
   operation : String
   title : String?

--- a/extensions/notification/extension.mbt
+++ b/extensions/notification/extension.mbt
@@ -26,25 +26,6 @@ async fn show_notification(
 }
 
 ///|
-fn notification_click_poller_script() -> String {
-  (
-    #|(() => {
-    #|  const root = window.__MoonBit__;
-    #|  const notification = root && root.notification;
-    #|  if (!notification || typeof notification.drainClicks !== "function") {
-    #|    return;
-    #|  }
-    #|  if (notification.__protonClickPoller) {
-    #|    return;
-    #|  }
-    #|  notification.__protonClickPoller = window.setInterval(() => {
-    #|    notification.drainClicks({}).catch(() => {});
-    #|  }, 100);
-    #|})();
-  )
-}
-
-///|
 fn cleanup_notification() -> Unit raise NotificationError {
   notification_native_cleanup()
 }
@@ -70,7 +51,7 @@ async fn show(
 #proton.command(contract=drain_clicks_command)
 async fn drain_clicks(
   context : @proton.CommandContext,
-  _request : @notification_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @notification_contract.NotificationDrainReply {
   let mut count = 0
   while true {
@@ -93,7 +74,13 @@ pub fn extension() -> @proton_extension.Extension {
     @notification_contract.extension,
     generated_extension_command_routes(),
     fn(registrar) raise { register_commands(registrar) },
-    scripts=[notification_click_poller_script()],
+    scripts=[
+      @proton_extension.poller_script(
+        js_namespace="notification",
+        drain_method="drainClicks",
+        poller_field="__protonClickPoller",
+      ),
+    ],
     on_destroy=fn() raise { cleanup_notification() },
   )
 }

--- a/extensions/shell/extension.mbt
+++ b/extensions/shell/extension.mbt
@@ -5,23 +5,11 @@ let open_command = @shell_contract.open
 let reveal_item_command = @shell_contract.reveal_item
 
 ///|
-extern "C" fn is_windows_ffi() -> Bool = "extensions_shell_is_windows"
-
-///|
-#borrow(target)
-extern "C" fn open_shell_ffi(target : Bytes) -> Bool = "extensions_shell_open"
-
-///|
-#borrow(path)
-extern "C" fn reveal_item_ffi(path : Bytes) -> Bool = "extensions_shell_reveal_item"
-
-///|
 /// Verifies that the shell extension is available on the current platform.
 fn ensure_supported() -> Unit raise ShellError {
-  if is_windows_ffi() {
-    ()
-  } else {
-    raise UnsupportedPlatform
+  match @sys_shell.ensure_supported() {
+    Ok(_) => ()
+    Err(_) => raise UnsupportedPlatform
   }
 }
 
@@ -36,21 +24,6 @@ fn validate_target(value : String, label : String) -> String raise ShellError {
 }
 
 ///|
-/// Runs one native shell action and converts its result into the common reply type.
-fn run_shell_action(
-  operation : String,
-  target : String,
-  label : String,
-  launcher : (Bytes) -> Bool,
-) -> @shell_contract.ShellReply raise ShellError {
-  let target = validate_target(target, label)
-  guard launcher(@ffi.to_wstr(target)) else {
-    raise LaunchFailed(operation~, target~)
-  }
-  @shell_contract.ShellReply::{ launched: true }
-}
-
-///|
 /// Opens one target through the native shell from a generated app-command extension.
 #proton.command(contract=open_command)
 async fn open(
@@ -58,17 +31,16 @@ async fn open(
   request : @shell_contract.OpenRequest,
 ) -> @shell_contract.ShellReply {
   ensure_supported()
-  let reply = run_shell_action(
-    "open",
-    request.target,
-    "shell.open target",
-    open_shell_ffi,
-  )
+  let target = validate_target(request.target, "shell.open target")
+  match @sys_shell.open(target) {
+    Ok(_) => ()
+    Err(_) => raise LaunchFailed(operation="open", target~)
+  }
   context.emit(@shell_contract.activity, @shell_contract.ShellActivity::{
     operation: "open",
     target: request.target,
   })
-  reply
+  @shell_contract.ShellReply::{ launched: true }
 }
 
 ///|
@@ -79,17 +51,16 @@ async fn reveal_item(
   request : @shell_contract.RevealItemRequest,
 ) -> @shell_contract.ShellReply {
   ensure_supported()
-  let reply = run_shell_action(
-    "revealItem",
-    request.path,
-    "shell.revealItem path",
-    reveal_item_ffi,
-  )
+  let path = validate_target(request.path, "shell.revealItem path")
+  match @sys_shell.reveal_item(path) {
+    Ok(_) => ()
+    Err(_) => raise LaunchFailed(operation="revealItem", target=request.path)
+  }
   context.emit(@shell_contract.activity, @shell_contract.ShellActivity::{
     operation: "revealItem",
     target: request.path,
   })
-  reply
+  @shell_contract.ShellReply::{ launched: true }
 }
 
 ///|

--- a/extensions/shell/moon.pkg
+++ b/extensions/shell/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/core/json",
-  "moonbit-community/proton_ffi" @ffi,
+  "moonbit-community/proton_shell" @sys_shell,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",
@@ -16,7 +16,6 @@ supported_targets = "native"
 formatter(ignore: [ "extension.g.mbt" ])
 
 options(
-  "native-stub": [ "shell_native.c" ],
   targets: {
     "extension.g.mbt": [ "native" ],
     "extension.mbt": [ "native" ],

--- a/extensions/tray/contract/contract.mbt
+++ b/extensions/tray/contract/contract.mbt
@@ -40,13 +40,6 @@ pub(all) struct TrayReply {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
-pub(all) struct TraySupportReply {
-  supported : Bool
-  platform : String
-  reason : String?
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct TrayEventReply {
   count : Int
 } derive(ToJson, FromJson, Debug, Eq)
@@ -83,7 +76,7 @@ pub(all) struct TrayMenuItemClick {
 ///|
 pub let support : @proton_contract.Command[
   @proton_contract.EmptyRequest,
-  TraySupportReply,
+  @proton_contract.SupportReply,
 ] = extension.command("support")
 
 ///|

--- a/extensions/tray/contract/contract.mbt
+++ b/extensions/tray/contract/contract.mbt
@@ -1,7 +1,4 @@
 ///|
-pub(all) struct EmptyRequest {} derive(ToJson, FromJson, Debug, Eq)
-
-///|
 pub(all) struct TrayMenuItem {
   id : String?
   label : String?
@@ -84,9 +81,10 @@ pub(all) struct TrayMenuItemClick {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
-pub let support : @proton_contract.Command[EmptyRequest, TraySupportReply] = extension.command(
-  "support",
-)
+pub let support : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  TraySupportReply,
+] = extension.command("support")
 
 ///|
 pub let show : @proton_contract.Command[ShowRequest, TrayReply] = extension.command(
@@ -94,9 +92,10 @@ pub let show : @proton_contract.Command[ShowRequest, TrayReply] = extension.comm
 )
 
 ///|
-pub let hide : @proton_contract.Command[EmptyRequest, TrayReply] = extension.command(
-  "hide",
-)
+pub let hide : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  TrayReply,
+] = extension.command("hide")
 
 ///|
 pub let set_icon : @proton_contract.Command[SetIconRequest, TrayReply] = extension.command(
@@ -114,14 +113,16 @@ pub let set_menu : @proton_contract.Command[SetMenuRequest, TrayReply] = extensi
 )
 
 ///|
-pub let drain_events : @proton_contract.Command[EmptyRequest, TrayEventReply] = extension.command(
-  "drainEvents",
-)
+pub let drain_events : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  TrayEventReply,
+] = extension.command("drainEvents")
 
 ///|
-pub let destroy : @proton_contract.Command[EmptyRequest, TrayReply] = extension.command(
-  "destroy",
-)
+pub let destroy : @proton_contract.Command[
+  @proton_contract.EmptyRequest,
+  TrayReply,
+] = extension.command("destroy")
 
 ///|
 pub let activity : @proton_contract.Event[TrayActivity] = extension.event(

--- a/extensions/tray/contract/pkg.generated.mbti
+++ b/extensions/tray/contract/pkg.generated.mbti
@@ -12,15 +12,15 @@ pub let activity : @proton_contract.Event[TrayActivity]
 
 pub let click : @proton_contract.Event[TrayClick]
 
-pub let destroy : @proton_contract.Command[EmptyRequest, TrayReply]
+pub let destroy : @proton_contract.Command[@proton_contract.EmptyRequest, TrayReply]
 
 pub let double_click : @proton_contract.Event[TrayDoubleClick]
 
-pub let drain_events : @proton_contract.Command[EmptyRequest, TrayEventReply]
+pub let drain_events : @proton_contract.Command[@proton_contract.EmptyRequest, TrayEventReply]
 
 pub let extension : @proton_contract.ExtensionContract
 
-pub let hide : @proton_contract.Command[EmptyRequest, TrayReply]
+pub let hide : @proton_contract.Command[@proton_contract.EmptyRequest, TrayReply]
 
 pub let menu_item_click : @proton_contract.Event[TrayMenuItemClick]
 
@@ -34,14 +34,11 @@ pub let set_tooltip : @proton_contract.Command[SetTooltipRequest, TrayReply]
 
 pub let show : @proton_contract.Command[ShowRequest, TrayReply]
 
-pub let support : @proton_contract.Command[EmptyRequest, TraySupportReply]
+pub let support : @proton_contract.Command[@proton_contract.EmptyRequest, TraySupportReply]
 
 // Errors
 
 // Types and methods
-pub(all) struct EmptyRequest {
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct SetIconRequest {
   icon : Json?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)

--- a/extensions/tray/contract/pkg.generated.mbti
+++ b/extensions/tray/contract/pkg.generated.mbti
@@ -34,7 +34,7 @@ pub let set_tooltip : @proton_contract.Command[SetTooltipRequest, TrayReply]
 
 pub let show : @proton_contract.Command[ShowRequest, TrayReply]
 
-pub let support : @proton_contract.Command[@proton_contract.EmptyRequest, TraySupportReply]
+pub let support : @proton_contract.Command[@proton_contract.EmptyRequest, @proton_contract.SupportReply]
 
 // Errors
 
@@ -99,12 +99,6 @@ pub(all) struct TrayReply {
 
 pub(all) struct TrayRightClick {
   visible : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
-pub(all) struct TraySupportReply {
-  supported : Bool
-  platform : String
-  reason : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 // Type aliases

--- a/extensions/tray/extension.mbt
+++ b/extensions/tray/extension.mbt
@@ -219,25 +219,6 @@ fn destroy_tray(tray_handle : @sys_tray.Tray?) -> Unit {
 }
 
 ///|
-fn tray_event_poller_script() -> String {
-  (
-    #|(() => {
-    #|  const root = window.__MoonBit__;
-    #|  const tray = root && root.tray;
-    #|  if (!tray || typeof tray.drainEvents !== "function") {
-    #|    return;
-    #|  }
-    #|  if (tray.__protonEventPoller) {
-    #|    return;
-    #|  }
-    #|  tray.__protonEventPoller = window.setInterval(() => {
-    #|    tray.drainEvents({}).catch(() => {});
-    #|  }, 100);
-    #|})();
-  )
-}
-
-///|
 fn cleanup_tray() -> Unit {
   destroy_tray(app_command_tray_handle.val)
 }
@@ -246,7 +227,7 @@ fn cleanup_tray() -> Unit {
 /// Returns platform support details for JavaScript callers.
 #proton.command(contract=support_command)
 fn support(
-  _request : @tray_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @tray_contract.TraySupportReply {
   tray_support()
 }
@@ -288,7 +269,7 @@ async fn show(
 #proton.command(contract=hide_command)
 async fn hide(
   context : @proton.CommandContext,
-  _request : @tray_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @tray_contract.TrayReply {
   match app_command_tray_handle.val {
     None => {
@@ -360,7 +341,7 @@ async fn set_menu(
 #proton.command(contract=drain_events_command)
 async fn drain_events(
   context : @proton.CommandContext,
-  _request : @tray_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @tray_contract.TrayEventReply {
   match app_command_tray_handle.val {
     None => @tray_contract.TrayEventReply::{ count: 0 }
@@ -383,7 +364,7 @@ async fn drain_events(
 #proton.command(contract=destroy_command)
 async fn destroy(
   context : @proton.CommandContext,
-  _request : @tray_contract.EmptyRequest,
+  _request : @proton_contract.EmptyRequest,
 ) -> @tray_contract.TrayReply {
   destroy_tray(app_command_tray_handle.val)
   emit_command_activity(context, "destroy", None, None)
@@ -396,7 +377,13 @@ pub fn extension() -> @proton_extension.Extension {
     @tray_contract.extension,
     generated_extension_command_routes(),
     fn(registrar) raise { register_commands(registrar) },
-    scripts=[tray_event_poller_script()],
+    scripts=[
+      @proton_extension.poller_script(
+        js_namespace="tray",
+        drain_method="drainEvents",
+        poller_field="__protonEventPoller",
+      ),
+    ],
     on_destroy=fn() { cleanup_tray() },
   )
 }

--- a/extensions/tray/extension.mbt
+++ b/extensions/tray/extension.mbt
@@ -39,7 +39,7 @@ fn platform_label(platform : @sys_tray.Platform) -> String {
   match platform {
     Windows => "windows"
     Linux => "linux"
-    MacOS => "macos"
+    Macos => "macos"
     Unknown => "unknown"
   }
 }

--- a/extensions/tray/extension.mbt
+++ b/extensions/tray/extension.mbt
@@ -45,17 +45,13 @@ fn platform_label(platform : @sys_tray.Platform) -> String {
 }
 
 ///|
-fn tray_support() -> @tray_contract.TraySupportReply {
+fn tray_support() -> @proton_contract.SupportReply {
   let platform = platform_label(@sys_tray.current_platform())
   match @sys_tray.ensure_supported() {
     Ok(_) =>
-      @tray_contract.TraySupportReply::{
-        supported: true,
-        platform,
-        reason: None,
-      }
+      @proton_contract.SupportReply::{ supported: true, platform, reason: None }
     Err(error) =>
-      @tray_contract.TraySupportReply::{
+      @proton_contract.SupportReply::{
         supported: false,
         platform,
         reason: Some(error),
@@ -228,7 +224,7 @@ fn cleanup_tray() -> Unit {
 #proton.command(contract=support_command)
 fn support(
   _request : @proton_contract.EmptyRequest,
-) -> @tray_contract.TraySupportReply {
+) -> @proton_contract.SupportReply {
   tray_support()
 }
 

--- a/moon.work
+++ b/moon.work
@@ -17,5 +17,6 @@ members = [
   "./sys/global_hotkey",
   "./sys/keepawake",
   "./sys/microphone",
+  "./sys/shell",
   "./sys/tray",
 ]

--- a/proton/extension/extension.mbt
+++ b/proton/extension/extension.mbt
@@ -103,3 +103,53 @@ pub fn Extensions::items(self : Extensions) -> Array[Extension] {
 fn copy_extensions(items : Array[Extension]) -> Array[Extension] {
   items.map(fn(item) { item })
 }
+
+///|
+/// Builds the standard JavaScript event-poller script for an extension namespace.
+///
+/// Extensions that pump native events through a `drain*` command install this
+/// script so the renderer polls the host on a fixed interval. The script is
+/// idempotent: it exits early if the namespace or its drain method is missing,
+/// or if a poller is already registered.
+pub fn poller_script(
+  js_namespace~ : String,
+  drain_method~ : String,
+  poller_field~ : String,
+) -> String {
+  let ns = js_namespace
+  "(() => {\n" +
+  "  const root = window.__MoonBit__;\n" +
+  "  const " +
+  ns +
+  " = root && root." +
+  ns +
+  ";\n" +
+  "  if (!" +
+  ns +
+  " || typeof " +
+  ns +
+  "." +
+  drain_method +
+  " !== \"function\") {\n" +
+  "    return;\n" +
+  "  }\n" +
+  "  if (" +
+  ns +
+  "." +
+  poller_field +
+  ") {\n" +
+  "    return;\n" +
+  "  }\n" +
+  "  " +
+  ns +
+  "." +
+  poller_field +
+  " = window.setInterval(() => {\n" +
+  "    " +
+  ns +
+  "." +
+  drain_method +
+  "({}).catch(() => {});\n" +
+  "  }, 100);\n" +
+  "})();"
+}

--- a/proton/extension/pkg.generated.mbti
+++ b/proton/extension/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub fn extensions(Array[Extension]) -> Extensions
 
+pub fn poller_script(js_namespace~ : String, drain_method~ : String, poller_field~ : String) -> String
+
 pub fn typed(@proton_contract.ExtensionContract, Array[@proton_contract.ContractRoute], (@command.CommandRegistrar) -> Unit raise, scripts? : Array[String], dependencies? : Array[String], resolve_permission? : (Json, String) -> Json raise @command.PermissionScopeValidationError, on_destroy? : () -> Unit raise) -> Extension
 
 // Errors

--- a/proton/facade_bridge.mbt
+++ b/proton/facade_bridge.mbt
@@ -348,7 +348,7 @@ async fn dispatch_bridge_request_in_command_scope(
 ) -> @native.BridgeResponse {
   let request_id = request.request_id()
   let request_context = @core.AppCommandRequestContext::new(
-    request.window(),
+    window.id(),
     command_tasks,
     window_id~,
     source_origin=request.source_origin(),

--- a/sys/shell/LICENSE
+++ b/sys/shell/LICENSE
@@ -1,0 +1,187 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of
+such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as a
+whole, an original work of authorship. For the purposes of this License,
+Derivative Works shall not include works that remain separable from, or merely
+link (or bind by name) to the interfaces of, the Work and Derivative Works
+thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated
+in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed by
+their Contribution(s) alone or by combination of their Contribution(s) with
+the Work to which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+   (a) You must give any other recipients of the Work or Derivative Works a
+       copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices stating
+       that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works that You
+       distribute, all copyright, patent, trademark, and attribution notices
+       from the Source form of the Work, excluding those notices that do not
+       pertain to any part of the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its distribution,
+       then any Derivative Works that You distribute must include a readable
+       copy of the attribution notices contained within such NOTICE file,
+       excluding those notices that do not pertain to any part of the
+       Derivative Works, in at least one of the following places: within a
+       NOTICE text file distributed as part of the Derivative Works; within
+       the Source form or documentation, if provided along with the Derivative
+       Works; or, within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents of the
+       NOTICE file are for informational purposes only and do not modify the
+       License. You may add Your own attribution notices within Derivative
+       Works that You distribute, alongside or as an addendum to the NOTICE
+       text from the Work, provided that such additional attribution notices
+       cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the
+possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright 2025-2026 justjavac
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/sys/shell/ffi.mbt
+++ b/sys/shell/ffi.mbt
@@ -1,0 +1,15 @@
+///|
+/// Returns whether the native shell backend is available on the current target.
+extern "C" fn is_supported_ffi() -> Bool = "mb_shell_is_supported"
+
+///|
+/// Opens a target through the native shell. `target` must be UTF-16LE bytes
+/// with a trailing wide nul (as produced by `@ffi.to_wstr`).
+#borrow(target)
+extern "C" fn open_ffi(target : Bytes) -> Bool = "mb_shell_open"
+
+///|
+/// Reveals a filesystem item in the native file manager. `path` must be
+/// UTF-16LE bytes with a trailing wide nul (as produced by `@ffi.to_wstr`).
+#borrow(path)
+extern "C" fn reveal_item_ffi(path : Bytes) -> Bool = "mb_shell_reveal_item"

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,0 +1,23 @@
+name = "moonbit-community/proton_shell"
+
+version = "0.1.14"
+
+import {
+  "moonbit-community/proton_ffi@0.1.14",
+}
+
+repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"
+
+license = "Apache-2.0"
+
+keywords = [ "shell", "desktop", "native", "windows" ]
+
+description = "Native shell helpers for MoonBit."
+
+preferred_target = "native"
+
+source = "."
+
+options(
+  supported_targets: "+native",
+)

--- a/sys/shell/moon.pkg
+++ b/sys/shell/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbit-community/proton_ffi" @ffi,
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "shell_native.c" ],
+  targets: { "shell.mbt": [ "native" ] },
+)

--- a/sys/shell/pkg.generated.mbti
+++ b/sys/shell/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton_shell"
+
+// Values
+pub fn ensure_supported() -> Result[Unit, String]
+
+pub fn is_supported() -> Bool
+
+pub fn open(String) -> Result[Unit, String]
+
+pub fn reveal_item(String) -> Result[Unit, String]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/sys/shell/shell.mbt
+++ b/sys/shell/shell.mbt
@@ -1,0 +1,58 @@
+///|
+/// Returns the shared unsupported-platform error message.
+fn unsupported_error_message() -> String {
+  "shell package currently supports Windows native builds only"
+}
+
+///|
+/// Returns `true` when the current native target has a shell backend that
+/// this package knows how to call.
+pub fn is_supported() -> Bool {
+  is_supported_ffi()
+}
+
+///|
+/// Verifies that the current native platform is supported by this package.
+///
+/// Returns `Ok(())` on supported platforms and an explanatory `Err(String)` on
+/// unsupported targets.
+pub fn ensure_supported() -> Result[Unit, String] {
+  if is_supported() {
+    Ok(())
+  } else {
+    Err(unsupported_error_message())
+  }
+}
+
+///|
+/// Opens `target` through the native shell.
+///
+/// On Windows this calls `ShellExecuteW` with the `"open"` verb. Returns
+/// `Ok(())` on success or `Err(String)` on unsupported platforms or launch
+/// failures.
+pub fn open(target : String) -> Result[Unit, String] {
+  if !is_supported() {
+    return Err(unsupported_error_message())
+  }
+  if open_ffi(@ffi.to_wstr(target)) {
+    Ok(())
+  } else {
+    Err("shell.open failed")
+  }
+}
+
+///|
+/// Reveals `path` in the native file manager.
+///
+/// On Windows this opens Explorer with `/select,"<path>"`. Returns `Ok(())`
+/// on success or `Err(String)` on unsupported platforms or launch failures.
+pub fn reveal_item(path : String) -> Result[Unit, String] {
+  if !is_supported() {
+    return Err(unsupported_error_message())
+  }
+  if reveal_item_ffi(@ffi.to_wstr(path)) {
+    Ok(())
+  } else {
+    Err("shell.revealItem failed")
+  }
+}

--- a/sys/shell/shell_native.c
+++ b/sys/shell/shell_native.c
@@ -13,7 +13,7 @@
 #endif
 #endif
 
-MOONBIT_FFI_EXPORT int32_t extensions_shell_is_windows(void) {
+MOONBIT_FFI_EXPORT int32_t mb_shell_is_supported(void) {
 #ifdef _WIN32
   return 1;
 #else
@@ -21,7 +21,7 @@ MOONBIT_FFI_EXPORT int32_t extensions_shell_is_windows(void) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT int32_t extensions_shell_open(moonbit_bytes_t target) {
+MOONBIT_FFI_EXPORT int32_t mb_shell_open(moonbit_bytes_t target) {
 #ifdef _WIN32
   HINSTANCE result = ShellExecuteW(
       NULL, L"open", (const wchar_t *)target, NULL, NULL, SW_SHOWNORMAL);
@@ -32,7 +32,7 @@ MOONBIT_FFI_EXPORT int32_t extensions_shell_open(moonbit_bytes_t target) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT int32_t extensions_shell_reveal_item(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int32_t mb_shell_reveal_item(moonbit_bytes_t path) {
 #ifdef _WIN32
   const wchar_t *target = (const wchar_t *)path;
   size_t target_len = wcslen(target);

--- a/sys/shell/shell_test.mbt
+++ b/sys/shell/shell_test.mbt
@@ -1,0 +1,16 @@
+///|
+test "public api symbols are exported" {
+  ignore(@proton_shell.is_supported)
+  ignore(@proton_shell.ensure_supported)
+  ignore(@proton_shell.open)
+  ignore(@proton_shell.reveal_item)
+}
+
+///|
+test "ensure_supported matches platform probe" {
+  match (@proton_shell.is_supported(), @proton_shell.ensure_supported()) {
+    (true, Ok(_)) => ()
+    (false, Err(_)) => ()
+    _ => fail("ensure_supported should agree with is_supported")
+  }
+}

--- a/sys/tray/pkg.generated.mbti
+++ b/sys/tray/pkg.generated.mbti
@@ -22,7 +22,7 @@ pub fn is_supported() -> Bool
 pub enum Platform {
   Windows
   Linux
-  MacOS
+  Macos
   Unknown
 } derive(Eq, ToJson, @debug.Debug)
 pub impl Show for Platform

--- a/sys/tray/platform.mbt
+++ b/sys/tray/platform.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Desktop platform reported by the native tray backend.
 ///
-/// `Windows`, `Linux`, and `MacOS` identify a backend this package knows how to
+/// `Windows`, `Linux`, and `Macos` identify a backend this package knows how to
 /// drive. `Unknown` is returned when the native stub cannot map the host
 /// operating system to a supported variant, which typically also means tray
 /// creation will fail. Use this to branch platform-specific setup or to enrich
@@ -9,7 +9,7 @@
 pub enum Platform {
   Windows
   Linux
-  MacOS
+  Macos
   Unknown
 } derive(Debug, Eq, ToJson)
 
@@ -20,7 +20,7 @@ pub impl Show for Platform with fn output(self, logger) {
     match self {
       Windows => "Windows"
       Linux => "Linux"
-      MacOS => "MacOS"
+      Macos => "Macos"
       Unknown => "Unknown"
     },
   )
@@ -63,7 +63,7 @@ fn platform_from_tag(tag : Int) -> Platform {
   match tag {
     1 => Windows
     2 => Linux
-    3 => MacOS
+    3 => Macos
     _ => Unknown
   }
 }

--- a/sys/tray/tray_wbtest.mbt
+++ b/sys/tray/tray_wbtest.mbt
@@ -58,7 +58,7 @@ test "simulated tray lifecycle updates visible state" {
 
 ///|
 test "show can replace the tooltip inline" {
-  let tray = create_simulated_tray(tooltip="before", platform=MacOS)
+  let tray = create_simulated_tray(tooltip="before", platform=Macos)
   debug_inspect(tray.show(tooltip=Some("after")), content="Ok(true)")
   debug_inspect((tray.tooltip, tray.visible), content="(\"after\", true)")
 }
@@ -210,7 +210,7 @@ test "native hidden operations stay usable when backend is available" {
     match tray.set_menu([TrayMenuItem::normal(id="show", label="Show")]) {
       Ok(visible) => {
         match current_platform() {
-          Windows | Linux | MacOS => ()
+          Windows | Linux | Macos => ()
           Unknown => fail("expected known native tray platform")
         }
         inspect(visible, content="false")
@@ -249,7 +249,7 @@ test "native stale handles are rejected after destroy" {
 ///|
 test "native macos trays destroy out of order" {
   guard @env.get_env_var("MOONBIT_TRAY_RUN_NATIVE_TESTS") is Some("1") &&
-    current_platform() is MacOS else {
+    current_platform() is Macos else {
     inspect("skipped", content="skipped")
     return ()
   }
@@ -282,7 +282,7 @@ test "native macos trays destroy out of order" {
 ///|
 test "native macos custom icon path stays usable" {
   guard @env.get_env_var("MOONBIT_TRAY_RUN_NATIVE_TESTS") is Some("1") &&
-    current_platform() is MacOS else {
+    current_platform() is Macos else {
     inspect("skipped", content="skipped")
     return ()
   }


### PR DESCRIPTION
## Summary

This PR addresses all P1 and P2 issues found during the extension review, applied as minimal step-by-step refactors. Each commit is self-contained and independently revertable.

## Behavior changes

- **microphone**: `MicrophoneConfigError` renamed to `MicrophoneError` so the error type follows the `<Name>Error` convention used by every other extension.
- **sys/tray**: `Platform::MacOS` renamed to `Macos` to match `sys/auto_launch` and the rest of the workspace; pure rename, no logic change.
- **contract**: New shared `EmptyRequest` and `SupportReply` types in `proton_contract`, plus a shared `poller_script` helper in `proton_extension`. Removes duplicate request structs, support-reply structs, and JS poller script builders across 5 extensions (tray, global_hotkey, keepawake, notification, microphone, auto_launch).
- **sys/shell**: Shell FFI moved out of `extensions/shell` into a new `sys/shell` module (`moonbit-community/proton_shell`), matching the `sys/<pkg>/` FFI boundary used by every other platform capability. `extensions/shell` now only contains command handling and delegates native work to `@sys_shell`.
- **dialog (P1)**: The bridge dispatch path now passes `window.id()` to the command context instead of `request.window()`. `Window::id()` is sourced from the `@native.Window` resolved via `find_window_by_native_id` and verified by `is_active()`, and it returns `proton_invalid_handle` once the window enters the `Destroying`/`Destroyed` lifecycle states. This makes the `unsafe_from_handle` call in the dialog `message` command safe: the handle reaching the extension is guaranteed to come from a live, dispatch-validated `Window` rather than from untrusted request data.

No platform-specific impact beyond the sys/shell extraction (Windows-only backend, unchanged behavior).

## What is NOT included

- **Step 4 (notification native binding unification)** was scoped out. The notification extension's mixed native path needs a deeper ABI refactor that exceeds the "minimal fix" boundary agreed for this pass; it should be tracked separately.

## Validation

Rebased on `origin/main` (c22517ec) with no conflicts. Ran on Windows with the active `.proton/runtime.json` runtime `bin` on `PATH`:

```
moon fmt --check
moon check --target native --diagnostic-limit 80
moon -C proton check --target native --diagnostic-limit 80
moon -C examples build --target native --diagnostic-limit 80
node scripts/verify_generated.mjs
moon -C extensions test -p moonbit-community/proton_ext/{microphone,auto_launch,clipboard,fs,global_hotkey,keepawake,notification,path,shell,tray} --target native
moon test -p moonbit-community/proton_{ffi,auto_launch,clipboard,global_hotkey,keepawake,microphone,shell,tray} --target native
```

Extension tests: 25 passed, 0 failed. sys module tests: 127 passed, 0 failed. Generated files: up to date.

`metadata_check` and `dialog` whitebox tests were skipped locally because they require the CEF runtime DLLs to be loadable as `test.exe` (exit code `0xc0000135` when the loader cannot resolve CEF imports); CI runs them in an environment where the runtime is on `PATH`.

## Commits

1. `refactor(extensions/microphone): rename MicrophoneConfigError to MicrophoneError`
2. `refactor(sys/tray): rename Platform::MacOS to Macos for cross-module consistency`
3. `refactor(contract): share EmptyRequest and poller_script helper across extensions`
4. `refactor(sys/shell): extract shell native binding into sys/shell module`
5. `refactor(contract): share SupportReply type across tray and auto_launch extensions`
6. `fix(dialog): source window handle from validated Window::id()`
7. `chore(sys/shell): add generated pkg.generated.mbti`
