### PR TITLE
fix(native): support Linux startup and application menus

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -39,6 +39,7 @@ if(PROTON_WITH_ENGINE)
     set(PROTON_APP_RUNNER_SOURCE src/app_runner_linux.c)
     set(PROTON_ENGINE_SOURCES
       src/engine/cef_linux/proton_engine_cef_linux.c
+      src/engine/cef_linux/proton_linux_menu.c
       src/engine/cef_linux/proton_linux_titlebar.c
     )
   else()
@@ -511,6 +512,25 @@ if(BUILD_TESTING)
   endif()
 
   if(UNIX AND NOT APPLE)
+    if(PROTON_WITH_ENGINE)
+      add_executable(proton_linux_menu_test
+        tests/proton_linux_menu_test.c
+        src/engine/cef_linux/proton_linux_menu.c
+        src/proton_json.c
+      )
+      target_include_directories(proton_linux_menu_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/engine/cef_linux
+      )
+      target_link_libraries(proton_linux_menu_test PRIVATE
+        PkgConfig::PROTON_GTK3
+      )
+      set_target_properties(proton_linux_menu_test PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON
+      )
+      add_test(NAME proton_linux_menu_test COMMAND proton_linux_menu_test)
+    endif()
+
     add_executable(proton_linux_titlebar_test
       tests/proton_linux_titlebar_test.c
       src/engine/cef_linux/proton_linux_titlebar.c

--- a/native/README.md
+++ b/native/README.md
@@ -200,6 +200,14 @@ CEF GTK/X11 embedding path, and manually keeps the CEF X11 child sized to the
 GTK content allocation. The current Linux engine intentionally forces X11, so
 WSLg uses this behavior through XWayland; native Wayland is not yet supported.
 
+Linux application menu definitions are rendered as a GTK menu bar in every
+runtime window. Command items enqueue the same `menu_command` runtime events as
+macOS, including the window that owns the activated menu. Role items map to GTK
+window actions or the focused CEF frame's edit commands, and menu key
+equivalents are installed as GTK accelerators. The standard application menu is
+always present; Edit and Window menus are supplied when the definition does not
+replace them.
+
 `proton_cli cef setup` runtime assembly is wired for Windows, macOS Apple
 Silicon, and Linux. The setup command verifies the pinned SHA-256 of the
 default CEF archive; custom `--name` or `--url` downloads require a matching

--- a/native/src/engine/cef_linux/proton_engine_cef_linux.c
+++ b/native/src/engine/cef_linux/proton_engine_cef_linux.c
@@ -5,6 +5,7 @@
 #include "../../app_runner.h"
 #include "../../proton_engine.h"
 #include "../../proton_json.h"
+#include "proton_linux_menu.h"
 #include "proton_linux_titlebar.h"
 
 #ifndef OS_LINUX
@@ -79,6 +80,8 @@
 #define PROTON_ENGINE_MAX_BRIDGE_BYTES 1048576
 #define PROTON_ENGINE_MAX_BRIDGE_OP_BYTES 128
 #define PROTON_ENGINE_CLOSE_DRAIN_LIMIT 5000
+#define PROTON_ENGINE_MAX_MENU_COMMANDS 32
+#define PROTON_ENGINE_MAX_MENU_COMMAND_BYTES 256
 
 enum {
   PROTON_X11_MOVERESIZE_SIZE_TOP_LEFT = 0,
@@ -93,6 +96,11 @@ enum {
 };
 
 typedef struct proton_engine_client proton_engine_client_t;
+
+typedef struct {
+  char command_id[PROTON_ENGINE_MAX_MENU_COMMAND_BYTES];
+  proton_window_id_t focused_window;
+} proton_engine_menu_command_t;
 
 struct proton_engine_runtime {
   int owns_cef_runtime;
@@ -109,6 +117,12 @@ struct proton_engine_runtime {
   size_t bridge_cancellation_count;
   pthread_mutex_t bridge_lock;
   int bridge_lock_initialized;
+  proton_linux_menu_bar_t *menu_definition;
+  proton_engine_menu_command_t menu_commands[PROTON_ENGINE_MAX_MENU_COMMANDS];
+  size_t menu_command_head;
+  size_t menu_command_count;
+  pthread_mutex_t menu_lock;
+  int menu_lock_initialized;
   int wake_read_fd;
   int wake_write_fd;
 };
@@ -116,6 +130,9 @@ struct proton_engine_runtime {
 struct proton_engine_window {
   proton_engine_runtime_t *runtime;
   GtkWidget *window;
+  GtkWidget *root_box;
+  GtkWidget *menu_bar;
+  GtkAccelGroup *menu_accel_group;
   GtkWidget *overlay;
   GtkWidget *browser_host;
   GtkWidget *overlay_controls;
@@ -347,11 +364,17 @@ static GdkFilterReturn proton_engine_x11_event_filter(GdkXEvent *xevent,
                                                        GdkEvent *event,
                                                        gpointer user_data);
 static void proton_engine_complete_managed_shutdown_if_ready(void);
+static int32_t proton_engine_window_install_menu(
+    proton_engine_window_t *window,
+    const proton_linux_menu_bar_t *menu_definition,
+    char *error,
+    size_t error_len);
 
 typedef enum {
   PROTON_ENGINE_UI_RUNTIME_CREATE = 0,
   PROTON_ENGINE_UI_RUNTIME_RESPOND_BRIDGE,
   PROTON_ENGINE_UI_RUNTIME_SET_WAKEUP_FD,
+  PROTON_ENGINE_UI_RUNTIME_SET_MENU,
   PROTON_ENGINE_UI_WINDOW_CREATE,
   PROTON_ENGINE_UI_WINDOW_DESTROY,
   PROTON_ENGINE_UI_WINDOW_SHOW,
@@ -419,6 +442,9 @@ static int32_t proton_engine_execute_ui_call(void *raw_call) {
   case PROTON_ENGINE_UI_RUNTIME_SET_WAKEUP_FD:
     return proton_engine_runtime_set_wakeup_fd(
         call->runtime, call->first_int, call->error, call->error_len);
+  case PROTON_ENGINE_UI_RUNTIME_SET_MENU:
+    return proton_engine_runtime_set_menu_json(
+        call->runtime, call->text, call->error, call->error_len);
   case PROTON_ENGINE_UI_WINDOW_CREATE:
     return proton_engine_window_create_json(
         call->runtime, call->text, (proton_engine_window_t **)call->output,
@@ -1003,6 +1029,10 @@ static void proton_engine_window_free_storage(proton_engine_window_t *window) {
     return;
   }
   pthread_mutex_lock(&g_window_lock);
+  if (window->menu_accel_group != NULL) {
+    g_object_unref(window->menu_accel_group);
+    window->menu_accel_group = NULL;
+  }
   proton_engine_window_free_views(window);
   free(window->client);
   free(window->html_url);
@@ -1095,6 +1125,19 @@ static void proton_engine_runtime_bridge_unlock(
     proton_engine_runtime_t *runtime) {
   if (runtime != NULL && runtime->bridge_lock_initialized) {
     pthread_mutex_unlock(&runtime->bridge_lock);
+  }
+}
+
+static void proton_engine_runtime_dispose_menu(
+    proton_engine_runtime_t *runtime) {
+  if (runtime == NULL) {
+    return;
+  }
+  proton_linux_menu_bar_destroy(runtime->menu_definition);
+  runtime->menu_definition = NULL;
+  if (runtime->menu_lock_initialized) {
+    pthread_mutex_destroy(&runtime->menu_lock);
+    runtime->menu_lock_initialized = 0;
   }
 }
 
@@ -2840,8 +2883,14 @@ static void proton_engine_on_window_destroy(GtkWidget *widget,
   proton_engine_window_t *window = (proton_engine_window_t *)user_data;
   if (window != NULL) {
     window->window = NULL;
+    window->root_box = NULL;
+    window->menu_bar = NULL;
     window->browser_host = NULL;
     window->overlay_controls = NULL;
+    if (window->menu_accel_group != NULL) {
+      g_object_unref(window->menu_accel_group);
+      window->menu_accel_group = NULL;
+    }
     proton_engine_overlay_release_input_windows(window);
   }
   if (window != NULL && !window->closed) {
@@ -3930,10 +3979,14 @@ int32_t proton_engine_runtime_create_json(const char *config_json,
   if (pthread_mutex_init(&runtime->bridge_lock, NULL) == 0) {
     runtime->bridge_lock_initialized = 1;
   }
+  if (pthread_mutex_init(&runtime->menu_lock, NULL) == 0) {
+    runtime->menu_lock_initialized = 1;
+  }
   if (!proton_engine_setup_wait_source(runtime, error, error_len)) {
     if (runtime->bridge_lock_initialized) {
       pthread_mutex_destroy(&runtime->bridge_lock);
     }
+    proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     return PROTON_ERR_PLATFORM;
   }
@@ -3974,6 +4027,7 @@ int32_t proton_engine_runtime_create_json(const char *config_json,
       pthread_mutex_destroy(&runtime->bridge_lock);
       runtime->bridge_lock_initialized = 0;
     }
+    proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
     proton_engine_set_message(error, error_len, "cef_initialize failed");
@@ -3992,6 +4046,7 @@ int32_t proton_engine_runtime_create_json(const char *config_json,
       pthread_mutex_destroy(&runtime->bridge_lock);
       runtime->bridge_lock_initialized = 0;
     }
+    proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
     return PROTON_ERR_PLATFORM;
@@ -4008,6 +4063,7 @@ int32_t proton_engine_runtime_create_json(const char *config_json,
       pthread_mutex_destroy(&runtime->bridge_lock);
       runtime->bridge_lock_initialized = 0;
     }
+    proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
     g_proton_cef_runtime_active = 0;
@@ -4143,6 +4199,7 @@ static int32_t proton_engine_finish_managed_runtime_destroy(
     pthread_mutex_destroy(&runtime->bridge_lock);
     runtime->bridge_lock_initialized = 0;
   }
+  proton_engine_runtime_dispose_menu(runtime);
   proton_engine_clear_wakeup_fd();
   if (g_active_runtime == runtime) {
     g_active_runtime = NULL;
@@ -4230,6 +4287,7 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
     pthread_mutex_destroy(&runtime->bridge_lock);
     runtime->bridge_lock_initialized = 0;
   }
+  proton_engine_runtime_dispose_menu(runtime);
   if (g_active_runtime == runtime) {
     g_active_runtime = NULL;
   }
@@ -4494,16 +4552,225 @@ int32_t proton_engine_runtime_next_wakeup_delay_ms(
   return PROTON_ERR_UNSUPPORTED;
 }
 
-// TODO: Implement app menu rendering and command events on Linux.
+static void proton_engine_menu_reset_commands(
+    proton_engine_runtime_t *runtime) {
+  if (runtime == NULL || !runtime->menu_lock_initialized) {
+    return;
+  }
+  pthread_mutex_lock(&runtime->menu_lock);
+  runtime->menu_command_head = 0;
+  runtime->menu_command_count = 0;
+  pthread_mutex_unlock(&runtime->menu_lock);
+}
+
+static void proton_engine_menu_enqueue_command(
+    proton_engine_runtime_t *runtime,
+    const char *command_id,
+    proton_window_id_t focused_window) {
+  if (runtime == NULL || !runtime->menu_lock_initialized ||
+      command_id == NULL ||
+      strlen(command_id) >= PROTON_ENGINE_MAX_MENU_COMMAND_BYTES) {
+    return;
+  }
+  int inserted = 0;
+  pthread_mutex_lock(&runtime->menu_lock);
+  if (runtime->menu_command_count < PROTON_ENGINE_MAX_MENU_COMMANDS) {
+    const size_t index =
+        (runtime->menu_command_head + runtime->menu_command_count) %
+        PROTON_ENGINE_MAX_MENU_COMMANDS;
+    snprintf(runtime->menu_commands[index].command_id,
+             sizeof(runtime->menu_commands[index].command_id), "%s",
+             command_id);
+    runtime->menu_commands[index].focused_window = focused_window;
+    runtime->menu_command_count++;
+    inserted = 1;
+  }
+  pthread_mutex_unlock(&runtime->menu_lock);
+  if (inserted) {
+    proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+  }
+}
+
+static void proton_engine_menu_command_activated(const char *command_id,
+                                                 void *user_data) {
+  proton_engine_window_t *window = (proton_engine_window_t *)user_data;
+  if (window == NULL || window->runtime == NULL) {
+    return;
+  }
+  proton_engine_menu_enqueue_command(window->runtime, command_id,
+                                     window->public_window_id);
+}
+
+static void proton_engine_menu_apply_edit_role(
+    proton_engine_window_t *window,
+    const char *role) {
+  if (window == NULL || window->browser == NULL || role == NULL) {
+    return;
+  }
+  cef_frame_t *frame =
+      window->browser->get_focused_frame != NULL
+          ? window->browser->get_focused_frame(window->browser)
+          : NULL;
+  if (frame == NULL) {
+    frame = window->browser->get_main_frame(window->browser);
+  }
+  if (frame == NULL) {
+    return;
+  }
+  if (strcmp(role, "undo") == 0) {
+    frame->undo(frame);
+  } else if (strcmp(role, "redo") == 0) {
+    frame->redo(frame);
+  } else if (strcmp(role, "cut") == 0) {
+    frame->cut(frame);
+  } else if (strcmp(role, "copy") == 0) {
+    frame->copy(frame);
+  } else if (strcmp(role, "paste") == 0) {
+    frame->paste(frame);
+  } else if (strcmp(role, "select_all") == 0) {
+    frame->select_all(frame);
+  }
+  frame->base.release((cef_base_ref_counted_t *)frame);
+}
+
+static void proton_engine_menu_role_activated(const char *role,
+                                              void *user_data) {
+  proton_engine_window_t *window = (proton_engine_window_t *)user_data;
+  if (window == NULL || window->runtime == NULL || role == NULL) {
+    return;
+  }
+  if (strcmp(role, "quit") == 0) {
+    for (proton_engine_window_t *candidate = g_windows; candidate != NULL;
+         candidate = candidate->next) {
+      if (candidate->runtime == window->runtime &&
+          candidate->window != NULL) {
+        gtk_window_close(GTK_WINDOW(candidate->window));
+      }
+    }
+  } else if (strcmp(role, "hide") == 0) {
+    if (window->window != NULL) {
+      gtk_widget_hide(window->window);
+    }
+  } else if (strcmp(role, "hide_others") == 0) {
+    for (proton_engine_window_t *candidate = g_windows; candidate != NULL;
+         candidate = candidate->next) {
+      if (candidate != window && candidate->runtime == window->runtime &&
+          candidate->window != NULL) {
+        gtk_widget_hide(candidate->window);
+      }
+    }
+  } else if (strcmp(role, "show_all") == 0) {
+    for (proton_engine_window_t *candidate = g_windows; candidate != NULL;
+         candidate = candidate->next) {
+      if (candidate->runtime == window->runtime &&
+          candidate->window != NULL) {
+        gtk_widget_show_all(candidate->window);
+      }
+    }
+  } else if (strcmp(role, "close") == 0) {
+    if (window->window != NULL) {
+      gtk_window_close(GTK_WINDOW(window->window));
+    }
+  } else if (strcmp(role, "minimize") == 0) {
+    if (window->window != NULL) {
+      gtk_window_iconify(GTK_WINDOW(window->window));
+    }
+  } else if (strcmp(role, "zoom") == 0) {
+    proton_engine_overlay_toggle_maximize(window);
+  } else {
+    proton_engine_menu_apply_edit_role(window, role);
+  }
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+}
+
+static int32_t proton_engine_window_install_menu(
+    proton_engine_window_t *window,
+    const proton_linux_menu_bar_t *menu_definition,
+    char *error,
+    size_t error_len) {
+  if (window == NULL || window->window == NULL || window->root_box == NULL ||
+      menu_definition == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "window and menu definition are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  GtkAccelGroup *accelerators = gtk_accel_group_new();
+  if (accelerators == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "failed to create menu accelerators");
+    return PROTON_ERR_PLATFORM;
+  }
+  GtkWidget *menu_bar = proton_linux_menu_bar_create_widget(
+      menu_definition, accelerators, proton_engine_menu_command_activated,
+      proton_engine_menu_role_activated, window, error, error_len);
+  if (menu_bar == NULL) {
+    g_object_unref(accelerators);
+    return PROTON_ERR_PLATFORM;
+  }
+
+  if (window->menu_accel_group != NULL) {
+    gtk_window_remove_accel_group(GTK_WINDOW(window->window),
+                                  window->menu_accel_group);
+    g_object_unref(window->menu_accel_group);
+  }
+  if (window->menu_bar != NULL) {
+    gtk_widget_destroy(window->menu_bar);
+  }
+  window->menu_bar = menu_bar;
+  window->menu_accel_group = accelerators;
+  gtk_window_add_accel_group(GTK_WINDOW(window->window), accelerators);
+  gtk_box_pack_start(GTK_BOX(window->root_box), menu_bar, FALSE, FALSE, 0);
+  gtk_box_reorder_child(GTK_BOX(window->root_box), menu_bar, 0);
+  gtk_widget_show_all(menu_bar);
+  proton_engine_sync_browser_bounds(window);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_runtime_set_menu_json(proton_engine_runtime_t *runtime,
                                             const char *menu_json,
                                             char *error,
                                             size_t error_len) {
-  (void)runtime;
-  (void)menu_json;
-  proton_engine_set_message(error, error_len,
-                            "native app menus are not implemented on Linux");
-  return PROTON_ERR_UNSUPPORTED;
+  if (proton_app_runner_is_active() &&
+      !proton_app_runner_is_ui_thread()) {
+    proton_engine_ui_call_t call = {
+        .operation = PROTON_ENGINE_UI_RUNTIME_SET_MENU,
+        .runtime = runtime,
+        .text = menu_json,
+        .error = error,
+        .error_len = error_len,
+    };
+    return proton_engine_dispatch_ui_call(&call);
+  }
+  if (runtime == NULL || !g_proton_cef_initialized) {
+    proton_engine_set_message(error, error_len, "runtime is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  if (runtime->headless) {
+    proton_engine_set_message(error, error_len,
+                              "native menus are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  proton_linux_menu_bar_t *menu_definition =
+      proton_linux_menu_bar_parse(menu_json, error, error_len);
+  if (menu_definition == NULL) {
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  for (proton_engine_window_t *window = g_windows; window != NULL;
+       window = window->next) {
+    if (window->runtime != runtime || window->window == NULL) {
+      continue;
+    }
+    const int32_t status = proton_engine_window_install_menu(
+        window, menu_definition, error, error_len);
+    if (status != PROTON_OK) {
+      proton_linux_menu_bar_destroy(menu_definition);
+      return status;
+    }
+  }
+  proton_linux_menu_bar_destroy(runtime->menu_definition);
+  runtime->menu_definition = menu_definition;
+  proton_engine_menu_reset_commands(runtime);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_runtime_poll_bridge_request_json(
@@ -4816,6 +5083,17 @@ int32_t proton_engine_window_create_json(proton_engine_runtime_t *runtime,
       proton_engine_set_message(error, error_len, "window creation failed");
       return PROTON_ERR_PLATFORM;
     }
+    window->root_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    if (window->root_box == NULL) {
+      gtk_widget_destroy(window->window);
+      free(window->client);
+      proton_browser_session_destroy(window->browser_session);
+      free(window->bridge_config_json);
+      free(window);
+      proton_engine_set_message(error, error_len,
+                                "window root container creation failed");
+      return PROTON_ERR_PLATFORM;
+    }
     proton_engine_use_default_x11_visual(window->window);
     gtk_window_set_title(GTK_WINDOW(window->window),
                          config.title[0] != '\0' ? config.title : "Proton");
@@ -4875,9 +5153,24 @@ int32_t proton_engine_window_create_json(proton_engine_runtime_t *runtime,
                                   "overlay window controls creation failed");
         return PROTON_ERR_PLATFORM;
       }
-      gtk_container_add(GTK_CONTAINER(window->window), window->overlay);
+      gtk_box_pack_end(GTK_BOX(window->root_box), window->overlay, TRUE, TRUE,
+                       0);
     } else {
-      gtk_container_add(GTK_CONTAINER(window->window), window->browser_host);
+      gtk_box_pack_end(GTK_BOX(window->root_box), window->browser_host, TRUE,
+                       TRUE, 0);
+    }
+    gtk_container_add(GTK_CONTAINER(window->window), window->root_box);
+    if (runtime->menu_definition != NULL) {
+      status = proton_engine_window_install_menu(
+          window, runtime->menu_definition, error, error_len);
+      if (status != PROTON_OK) {
+        gtk_widget_destroy(window->window);
+        free(window->client);
+        proton_browser_session_destroy(window->browser_session);
+        free(window->bridge_config_json);
+        free(window);
+        return status;
+      }
     }
     g_signal_connect(window->window, "delete-event",
                      G_CALLBACK(proton_engine_on_window_delete), window);
@@ -5941,21 +6234,37 @@ int32_t proton_engine_window_poll_dialog_result(
                             "async native dialog extension is not implemented on Linux");
   return PROTON_ERR_UNSUPPORTED;
 }
-// TODO: Drain Linux menu commands once the native menu backend is implemented.
 int32_t proton_engine_take_menu_command(
     proton_engine_runtime_t *runtime,
     char *buffer,
     size_t buffer_len,
     proton_window_id_t *out_focused_window,
     int32_t *out_present) {
-  (void)runtime;
-  (void)buffer;
-  (void)buffer_len;
   if (out_focused_window == NULL || out_present == NULL) {
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   *out_focused_window = PROTON_INVALID_HANDLE;
   *out_present = 0;
+  if (runtime == NULL || !runtime->menu_lock_initialized) {
+    return PROTON_OK;
+  }
+  pthread_mutex_lock(&runtime->menu_lock);
+  if (runtime->menu_command_count > 0) {
+    const proton_engine_menu_command_t *command =
+        &runtime->menu_commands[runtime->menu_command_head];
+    const size_t command_len = strlen(command->command_id);
+    if (buffer == NULL || buffer_len <= command_len) {
+      pthread_mutex_unlock(&runtime->menu_lock);
+      return PROTON_ERR_BUFFER_TOO_SMALL;
+    }
+    memcpy(buffer, command->command_id, command_len + 1);
+    *out_focused_window = command->focused_window;
+    runtime->menu_command_head =
+        (runtime->menu_command_head + 1) % PROTON_ENGINE_MAX_MENU_COMMANDS;
+    runtime->menu_command_count--;
+    *out_present = 1;
+  }
+  pthread_mutex_unlock(&runtime->menu_lock);
   return PROTON_OK;
 }
 

--- a/native/src/engine/cef_linux/proton_engine_cef_linux.c
+++ b/native/src/engine/cef_linux/proton_engine_cef_linux.c
@@ -902,6 +902,20 @@ static void proton_engine_append_switch(cef_command_line_t *command_line,
   cef_string_clear(&switch_name);
 }
 
+static void proton_engine_append_switch_with_value(
+    cef_command_line_t *command_line,
+    const char *name,
+    const char *value) {
+  cef_string_t switch_name = {0};
+  cef_string_t switch_value = {0};
+  proton_engine_set_string(&switch_name, name);
+  proton_engine_set_string(&switch_value, value);
+  command_line->append_switch_with_value(command_line, &switch_name,
+                                         &switch_value);
+  cef_string_clear(&switch_name);
+  cef_string_clear(&switch_value);
+}
+
 #define PROTON_ENGINE_REF_INCREMENT(refs) \
   atomic_fetch_add_explicit(&(refs)->refs, 1, memory_order_relaxed)
 #define PROTON_ENGINE_REF_DECREMENT(refs) \
@@ -1486,6 +1500,11 @@ static void CEF_CALLBACK proton_engine_on_before_command_line_processing(
     proton_engine_append_switch(command_line, "no-zygote");
     proton_engine_debug_log("managed_browser_no_zygote");
   }
+  /* The Linux window host embeds CEF into GTK/X11. Keep Chromium's Ozone
+   * backend on X11 as well; selecting Wayland here initializes GDK before
+   * proton_engine_ensure_gtk can apply its X11-only constraint. */
+  proton_engine_append_switch_with_value(command_line, "ozone-platform",
+                                         "x11");
   proton_engine_append_switch(command_line, "disable-gpu");
   proton_engine_append_switch(command_line, "in-process-gpu");
   // On Xvfb-based CI displays Chromium's occlusion tracking can mark the

--- a/native/src/engine/cef_linux/proton_linux_menu.c
+++ b/native/src/engine/cef_linux/proton_linux_menu.c
@@ -1,0 +1,751 @@
+#include "proton_linux_menu.h"
+
+#include "../../proton_json.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+  PROTON_LINUX_MENU_ITEM_COMMAND = 0,
+  PROTON_LINUX_MENU_ITEM_SEPARATOR,
+  PROTON_LINUX_MENU_ITEM_ROLE,
+} proton_linux_menu_item_kind_t;
+
+typedef struct {
+  proton_linux_menu_item_kind_t kind;
+  char *id;
+  char *label;
+  char *key;
+  char *role;
+} proton_linux_menu_item_t;
+
+typedef struct {
+  char *label;
+  proton_linux_menu_item_t *items;
+  size_t item_count;
+} proton_linux_menu_t;
+
+struct proton_linux_menu_bar {
+  proton_linux_menu_t *menus;
+  size_t menu_count;
+};
+
+typedef struct {
+  proton_linux_menu_command_callback_t command_callback;
+  proton_linux_menu_role_callback_t role_callback;
+  void *user_data;
+  char *value;
+  int is_command;
+} proton_linux_menu_activation_t;
+
+typedef struct {
+  const proton_json_doc_t *doc;
+  proton_linux_menu_t *menu;
+  char *error;
+  size_t error_len;
+} proton_linux_menu_item_parse_t;
+
+typedef struct {
+  const proton_json_doc_t *doc;
+  proton_linux_menu_bar_t *menu_bar;
+  char *error;
+  size_t error_len;
+} proton_linux_menu_parse_t;
+
+static void proton_linux_menu_set_message(char *error,
+                                          size_t error_len,
+                                          const char *message) {
+  if (error != NULL && error_len > 0) {
+    snprintf(error, error_len, "%s", message != NULL ? message : "");
+  }
+}
+
+static int proton_linux_menu_role_supported(const char *role) {
+  static const char *roles[] = {
+      "quit",   "hide", "hide_others", "show_all", "close",
+      "minimize", "zoom", "undo",        "redo",     "cut",
+      "copy",   "paste", "select_all",
+  };
+  if (role == NULL) {
+    return 0;
+  }
+  for (size_t index = 0; index < sizeof(roles) / sizeof(roles[0]); index++) {
+    if (strcmp(role, roles[index]) == 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static void proton_linux_menu_item_dispose(proton_linux_menu_item_t *item) {
+  if (item == NULL) {
+    return;
+  }
+  free(item->id);
+  free(item->label);
+  free(item->key);
+  free(item->role);
+  memset(item, 0, sizeof(*item));
+}
+
+static void proton_linux_menu_dispose(proton_linux_menu_t *menu) {
+  if (menu == NULL) {
+    return;
+  }
+  for (size_t index = 0; index < menu->item_count; index++) {
+    proton_linux_menu_item_dispose(&menu->items[index]);
+  }
+  free(menu->items);
+  free(menu->label);
+  memset(menu, 0, sizeof(*menu));
+}
+
+void proton_linux_menu_bar_destroy(proton_linux_menu_bar_t *menu_bar) {
+  if (menu_bar == NULL) {
+    return;
+  }
+  for (size_t index = 0; index < menu_bar->menu_count; index++) {
+    proton_linux_menu_dispose(&menu_bar->menus[index]);
+  }
+  free(menu_bar->menus);
+  free(menu_bar);
+}
+
+static char *proton_linux_menu_optional_string(const proton_json_doc_t *doc,
+                                               proton_json_value_t object,
+                                               const char *field,
+                                               int *out_valid) {
+  proton_json_value_t value;
+  if (!proton_json_object_get(doc, object, field, &value)) {
+    return NULL;
+  }
+  char *text = proton_json_copy_string(doc, value);
+  if (text == NULL) {
+    *out_valid = 0;
+  }
+  return text;
+}
+
+static int proton_linux_menu_append_item(proton_linux_menu_t *menu,
+                                         proton_linux_menu_item_t item) {
+  proton_linux_menu_item_t *items =
+      (proton_linux_menu_item_t *)realloc(
+          menu->items, (menu->item_count + 1) * sizeof(*items));
+  if (items == NULL) {
+    return 0;
+  }
+  menu->items = items;
+  menu->items[menu->item_count++] = item;
+  return 1;
+}
+
+static bool proton_linux_menu_parse_item(proton_json_value_t value,
+                                         void *user_data) {
+  proton_linux_menu_item_parse_t *parse =
+      (proton_linux_menu_item_parse_t *)user_data;
+  if (!proton_json_is_object(parse->doc, value)) {
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu item must be an object");
+    return false;
+  }
+  proton_json_value_t kind_value;
+  char kind[32] = {0};
+  if (!proton_json_object_get(parse->doc, value, "kind", &kind_value) ||
+      !proton_json_read_string(parse->doc, kind_value, kind, sizeof(kind))) {
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu item requires kind");
+    return false;
+  }
+
+  proton_linux_menu_item_t item = {0};
+  int valid = 1;
+  item.key =
+      proton_linux_menu_optional_string(parse->doc, value, "key", &valid);
+  if (!valid) {
+    proton_linux_menu_item_dispose(&item);
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu item key must be a string");
+    return false;
+  }
+
+  if (strcmp(kind, "separator") == 0) {
+    item.kind = PROTON_LINUX_MENU_ITEM_SEPARATOR;
+  } else if (strcmp(kind, "command") == 0) {
+    item.kind = PROTON_LINUX_MENU_ITEM_COMMAND;
+    item.id =
+        proton_linux_menu_optional_string(parse->doc, value, "id", &valid);
+    item.label = proton_linux_menu_optional_string(parse->doc, value, "label",
+                                                   &valid);
+    if (!valid || item.id == NULL || item.label == NULL) {
+      proton_linux_menu_item_dispose(&item);
+      proton_linux_menu_set_message(parse->error, parse->error_len,
+                                    "menu command requires label and id");
+      return false;
+    }
+  } else if (strcmp(kind, "role") == 0) {
+    item.kind = PROTON_LINUX_MENU_ITEM_ROLE;
+    item.role =
+        proton_linux_menu_optional_string(parse->doc, value, "role", &valid);
+    item.label = proton_linux_menu_optional_string(parse->doc, value, "label",
+                                                   &valid);
+    if (!valid || !proton_linux_menu_role_supported(item.role)) {
+      proton_linux_menu_item_dispose(&item);
+      proton_linux_menu_set_message(parse->error, parse->error_len,
+                                    "menu role is unsupported");
+      return false;
+    }
+  } else {
+    proton_linux_menu_item_dispose(&item);
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu item kind is unsupported");
+    return false;
+  }
+
+  if (!proton_linux_menu_append_item(parse->menu, item)) {
+    proton_linux_menu_item_dispose(&item);
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "failed to allocate menu item");
+    return false;
+  }
+  return true;
+}
+
+static int proton_linux_menu_append_menu(proton_linux_menu_bar_t *menu_bar,
+                                         proton_linux_menu_t menu) {
+  proton_linux_menu_t *menus = (proton_linux_menu_t *)realloc(
+      menu_bar->menus, (menu_bar->menu_count + 1) * sizeof(*menus));
+  if (menus == NULL) {
+    return 0;
+  }
+  menu_bar->menus = menus;
+  menu_bar->menus[menu_bar->menu_count++] = menu;
+  return 1;
+}
+
+static bool proton_linux_menu_parse_menu(proton_json_value_t value,
+                                         void *user_data) {
+  proton_linux_menu_parse_t *parse = (proton_linux_menu_parse_t *)user_data;
+  if (!proton_json_is_object(parse->doc, value)) {
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu definition must be an object");
+    return false;
+  }
+  proton_json_value_t label_value;
+  proton_json_value_t items_value;
+  if (!proton_json_object_get(parse->doc, value, "label", &label_value) ||
+      !proton_json_object_get(parse->doc, value, "items", &items_value) ||
+      !proton_json_is_array(parse->doc, items_value)) {
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu requires label and items");
+    return false;
+  }
+
+  proton_linux_menu_t menu = {0};
+  menu.label = proton_json_copy_string(parse->doc, label_value);
+  if (menu.label == NULL) {
+    proton_linux_menu_dispose(&menu);
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "menu requires label and items");
+    return false;
+  }
+  proton_linux_menu_item_parse_t item_parse = {
+      .doc = parse->doc,
+      .menu = &menu,
+      .error = parse->error,
+      .error_len = parse->error_len,
+  };
+  if (!proton_json_array_each(parse->doc, items_value,
+                              proton_linux_menu_parse_item, &item_parse)) {
+    proton_linux_menu_dispose(&menu);
+    return false;
+  }
+  if (!proton_linux_menu_append_menu(parse->menu_bar, menu)) {
+    proton_linux_menu_dispose(&menu);
+    proton_linux_menu_set_message(parse->error, parse->error_len,
+                                  "failed to allocate menu definition");
+    return false;
+  }
+  return true;
+}
+
+proton_linux_menu_bar_t *proton_linux_menu_bar_parse(const char *menu_json,
+                                                     char *error,
+                                                     size_t error_len) {
+  if (menu_json == NULL) {
+    proton_linux_menu_set_message(error, error_len, "menu_json is required");
+    return NULL;
+  }
+  proton_json_doc_t doc = {0};
+  proton_json_value_t root;
+  proton_json_value_t menus;
+  if (!proton_json_parse(&doc, menu_json) ||
+      !proton_json_root_object(&doc, &root)) {
+    proton_json_dispose(&doc);
+    proton_linux_menu_set_message(error, error_len,
+                                  "menu config must be a JSON object");
+    return NULL;
+  }
+  if (!proton_json_object_get(&doc, root, "menus", &menus) ||
+      !proton_json_is_array(&doc, menus)) {
+    proton_json_dispose(&doc);
+    proton_linux_menu_set_message(error, error_len,
+                                  "menu config requires menus array");
+    return NULL;
+  }
+
+  proton_linux_menu_bar_t *menu_bar =
+      (proton_linux_menu_bar_t *)calloc(1, sizeof(*menu_bar));
+  if (menu_bar == NULL) {
+    proton_json_dispose(&doc);
+    proton_linux_menu_set_message(error, error_len,
+                                  "failed to allocate menu config");
+    return NULL;
+  }
+  proton_linux_menu_parse_t parse = {
+      .doc = &doc,
+      .menu_bar = menu_bar,
+      .error = error,
+      .error_len = error_len,
+  };
+  if (!proton_json_array_each(&doc, menus, proton_linux_menu_parse_menu,
+                              &parse)) {
+    proton_json_dispose(&doc);
+    proton_linux_menu_bar_destroy(menu_bar);
+    return NULL;
+  }
+  proton_json_dispose(&doc);
+  return menu_bar;
+}
+
+static int proton_linux_menu_label_equal(const char *left,
+                                         const char *right) {
+  return left != NULL && right != NULL && g_ascii_strcasecmp(left, right) == 0;
+}
+
+static int proton_linux_menu_has_label(
+    const proton_linux_menu_bar_t *menu_bar,
+    const char *label) {
+  for (size_t index = 0; index < menu_bar->menu_count; index++) {
+    if (proton_linux_menu_label_equal(menu_bar->menus[index].label, label)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static const char *proton_linux_menu_application_name(void) {
+  const char *name = g_get_application_name();
+  if (name == NULL || name[0] == '\0') {
+    name = g_get_prgname();
+  }
+  return name != NULL && name[0] != '\0' ? name : "Proton";
+}
+
+static const char *proton_linux_menu_role_label(const char *role,
+                                                const char *app_name) {
+  if (strcmp(role, "quit") == 0) {
+    return "Quit";
+  }
+  if (strcmp(role, "hide") == 0) {
+    return "Hide";
+  }
+  if (strcmp(role, "hide_others") == 0) {
+    return "Hide Others";
+  }
+  if (strcmp(role, "show_all") == 0) {
+    return "Show All";
+  }
+  if (strcmp(role, "close") == 0) {
+    return "Close";
+  }
+  if (strcmp(role, "minimize") == 0) {
+    return "Minimize";
+  }
+  if (strcmp(role, "zoom") == 0) {
+    return "Zoom";
+  }
+  if (strcmp(role, "undo") == 0) {
+    return "Undo";
+  }
+  if (strcmp(role, "redo") == 0) {
+    return "Redo";
+  }
+  if (strcmp(role, "cut") == 0) {
+    return "Cut";
+  }
+  if (strcmp(role, "copy") == 0) {
+    return "Copy";
+  }
+  if (strcmp(role, "paste") == 0) {
+    return "Paste";
+  }
+  if (strcmp(role, "select_all") == 0) {
+    return "Select All";
+  }
+  return app_name;
+}
+
+static const char *proton_linux_menu_role_key(const char *role) {
+  if (strcmp(role, "quit") == 0) {
+    return "q";
+  }
+  if (strcmp(role, "hide") == 0 || strcmp(role, "hide_others") == 0) {
+    return "h";
+  }
+  if (strcmp(role, "close") == 0) {
+    return "w";
+  }
+  if (strcmp(role, "minimize") == 0) {
+    return "m";
+  }
+  if (strcmp(role, "undo") == 0) {
+    return "z";
+  }
+  if (strcmp(role, "redo") == 0) {
+    return "Z";
+  }
+  if (strcmp(role, "cut") == 0) {
+    return "x";
+  }
+  if (strcmp(role, "copy") == 0) {
+    return "c";
+  }
+  if (strcmp(role, "paste") == 0) {
+    return "v";
+  }
+  if (strcmp(role, "select_all") == 0) {
+    return "a";
+  }
+  return "";
+}
+
+static void proton_linux_menu_activation_destroy(gpointer data) {
+  proton_linux_menu_activation_t *activation =
+      (proton_linux_menu_activation_t *)data;
+  if (activation != NULL) {
+    free(activation->value);
+    free(activation);
+  }
+}
+
+static void proton_linux_menu_activate(GtkMenuItem *item, gpointer user_data) {
+  (void)item;
+  proton_linux_menu_activation_t *activation =
+      (proton_linux_menu_activation_t *)user_data;
+  if (activation == NULL) {
+    return;
+  }
+  if (activation->is_command) {
+    activation->command_callback(activation->value, activation->user_data);
+  } else {
+    activation->role_callback(activation->value, activation->user_data);
+  }
+}
+
+static int proton_linux_menu_bind_activation(
+    GtkWidget *item,
+    const char *value,
+    int is_command,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  proton_linux_menu_activation_t *activation =
+      (proton_linux_menu_activation_t *)calloc(1, sizeof(*activation));
+  if (activation == NULL) {
+    return 0;
+  }
+  activation->value = strdup(value);
+  if (activation->value == NULL) {
+    free(activation);
+    return 0;
+  }
+  activation->command_callback = command_callback;
+  activation->role_callback = role_callback;
+  activation->user_data = user_data;
+  activation->is_command = is_command;
+  g_object_set_data_full(G_OBJECT(item), "proton-menu-activation", activation,
+                         proton_linux_menu_activation_destroy);
+  g_signal_connect(item, "activate", G_CALLBACK(proton_linux_menu_activate),
+                   activation);
+  return 1;
+}
+
+static void proton_linux_menu_add_accelerator(GtkWidget *item,
+                                              GtkAccelGroup *accelerators,
+                                              const char *key,
+                                              GdkModifierType extra_modifiers) {
+  if (item == NULL || accelerators == NULL || key == NULL || key[0] == '\0') {
+    return;
+  }
+  char specification[128];
+  if (key[1] == '\0' && isupper((unsigned char)key[0])) {
+    snprintf(specification, sizeof(specification), "<Primary><Shift>%c",
+             tolower((unsigned char)key[0]));
+  } else {
+    snprintf(specification, sizeof(specification), "<Primary>%s", key);
+  }
+  guint accelerator_key = 0;
+  GdkModifierType modifiers = 0;
+  gtk_accelerator_parse(specification, &accelerator_key, &modifiers);
+  if (accelerator_key != 0) {
+    gtk_widget_add_accelerator(item, "activate", accelerators,
+                               accelerator_key, modifiers | extra_modifiers,
+                               GTK_ACCEL_VISIBLE);
+  }
+}
+
+static GtkWidget *proton_linux_menu_create_action_item(
+    const char *label,
+    const char *value,
+    const char *key,
+    int is_command,
+    GdkModifierType extra_modifiers,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  GtkWidget *item = gtk_menu_item_new_with_label(label);
+  if (item == NULL ||
+      !proton_linux_menu_bind_activation(
+          item, value, is_command, command_callback, role_callback,
+          user_data)) {
+    if (item != NULL) {
+      gtk_widget_destroy(item);
+    }
+    return NULL;
+  }
+  proton_linux_menu_add_accelerator(item, accelerators, key,
+                                    extra_modifiers);
+  return item;
+}
+
+static int proton_linux_menu_append_role(
+    GtkWidget *menu,
+    const char *role,
+    const char *label,
+    const char *key,
+    const char *app_name,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  GtkWidget *item = proton_linux_menu_create_action_item(
+      label != NULL ? label : proton_linux_menu_role_label(role, app_name),
+      role, key != NULL ? key : proton_linux_menu_role_key(role), 0,
+      strcmp(role, "hide_others") == 0 ? GDK_MOD1_MASK : 0, accelerators,
+      command_callback, role_callback, user_data);
+  if (item == NULL) {
+    return 0;
+  }
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
+  return 1;
+}
+
+static GtkWidget *proton_linux_menu_create_custom_menu(
+    const proton_linux_menu_t *definition,
+    const char *app_name,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  GtkWidget *menu = gtk_menu_new();
+  if (menu == NULL) {
+    return NULL;
+  }
+  for (size_t index = 0; index < definition->item_count; index++) {
+    const proton_linux_menu_item_t *definition_item =
+        &definition->items[index];
+    GtkWidget *item = NULL;
+    if (definition_item->kind == PROTON_LINUX_MENU_ITEM_SEPARATOR) {
+      item = gtk_separator_menu_item_new();
+    } else if (definition_item->kind == PROTON_LINUX_MENU_ITEM_COMMAND) {
+      item = proton_linux_menu_create_action_item(
+          definition_item->label, definition_item->id, definition_item->key,
+          1, 0, accelerators, command_callback, role_callback, user_data);
+    } else if (!proton_linux_menu_append_role(
+                   menu, definition_item->role, definition_item->label,
+                   definition_item->key, app_name, accelerators,
+                   command_callback, role_callback, user_data)) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    } else {
+      continue;
+    }
+    if (item == NULL) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    }
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
+  }
+  return menu;
+}
+
+static int proton_linux_menu_append_top_level(GtkWidget *menu_bar,
+                                              const char *label,
+                                              GtkWidget *menu) {
+  GtkWidget *item = gtk_menu_item_new_with_label(label);
+  if (item == NULL) {
+    gtk_widget_destroy(menu);
+    return 0;
+  }
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), menu);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), item);
+  return 1;
+}
+
+static GtkWidget *proton_linux_menu_create_app_menu(
+    const char *app_name,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  static const char *roles[] = {"hide", "hide_others", "show_all"};
+  GtkWidget *menu = gtk_menu_new();
+  if (menu == NULL) {
+    return NULL;
+  }
+  for (size_t index = 0; index < sizeof(roles) / sizeof(roles[0]); index++) {
+    if (!proton_linux_menu_append_role(
+            menu, roles[index], NULL, NULL, app_name, accelerators,
+            command_callback, role_callback, user_data)) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    }
+  }
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+  if (!proton_linux_menu_append_role(
+          menu, "quit", NULL, NULL, app_name, accelerators, command_callback,
+          role_callback, user_data)) {
+    gtk_widget_destroy(menu);
+    return NULL;
+  }
+  return menu;
+}
+
+static GtkWidget *proton_linux_menu_create_edit_menu(
+    const char *app_name,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  static const char *first_roles[] = {"undo", "redo"};
+  static const char *second_roles[] = {"cut", "copy", "paste", "select_all"};
+  GtkWidget *menu = gtk_menu_new();
+  if (menu == NULL) {
+    return NULL;
+  }
+  for (size_t index = 0;
+       index < sizeof(first_roles) / sizeof(first_roles[0]); index++) {
+    if (!proton_linux_menu_append_role(
+            menu, first_roles[index], NULL, NULL, app_name, accelerators,
+            command_callback, role_callback, user_data)) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    }
+  }
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+  for (size_t index = 0;
+       index < sizeof(second_roles) / sizeof(second_roles[0]); index++) {
+    if (!proton_linux_menu_append_role(
+            menu, second_roles[index], NULL, NULL, app_name, accelerators,
+            command_callback, role_callback, user_data)) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    }
+  }
+  return menu;
+}
+
+static GtkWidget *proton_linux_menu_create_window_menu(
+    const char *app_name,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data) {
+  static const char *roles[] = {"minimize", "zoom", "close"};
+  GtkWidget *menu = gtk_menu_new();
+  if (menu == NULL) {
+    return NULL;
+  }
+  for (size_t index = 0; index < sizeof(roles) / sizeof(roles[0]); index++) {
+    if (!proton_linux_menu_append_role(
+            menu, roles[index], NULL, NULL, app_name, accelerators,
+            command_callback, role_callback, user_data)) {
+      gtk_widget_destroy(menu);
+      return NULL;
+    }
+  }
+  return menu;
+}
+
+GtkWidget *proton_linux_menu_bar_create_widget(
+    const proton_linux_menu_bar_t *menu_bar,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data,
+    char *error,
+    size_t error_len) {
+  if (menu_bar == NULL || command_callback == NULL || role_callback == NULL) {
+    proton_linux_menu_set_message(error, error_len,
+                                  "menu widget callbacks are required");
+    return NULL;
+  }
+  const char *app_name = proton_linux_menu_application_name();
+  GtkWidget *widget = gtk_menu_bar_new();
+  if (widget == NULL) {
+    proton_linux_menu_set_message(error, error_len,
+                                  "failed to create menu bar widget");
+    return NULL;
+  }
+
+  GtkWidget *app_menu = proton_linux_menu_create_app_menu(
+      app_name, accelerators, command_callback, role_callback, user_data);
+  if (app_menu == NULL ||
+      !proton_linux_menu_append_top_level(widget, app_name, app_menu)) {
+    gtk_widget_destroy(widget);
+    proton_linux_menu_set_message(error, error_len,
+                                  "failed to create application menu");
+    return NULL;
+  }
+
+  for (size_t index = 0; index < menu_bar->menu_count; index++) {
+    const proton_linux_menu_t *definition = &menu_bar->menus[index];
+    GtkWidget *menu = proton_linux_menu_create_custom_menu(
+        definition, app_name, accelerators, command_callback, role_callback,
+        user_data);
+    if (menu == NULL || !proton_linux_menu_append_top_level(
+                            widget, definition->label, menu)) {
+      gtk_widget_destroy(widget);
+      proton_linux_menu_set_message(error, error_len,
+                                    "failed to create custom menu");
+      return NULL;
+    }
+  }
+
+  if (!proton_linux_menu_has_label(menu_bar, "Edit")) {
+    GtkWidget *edit_menu = proton_linux_menu_create_edit_menu(
+        app_name, accelerators, command_callback, role_callback, user_data);
+    if (edit_menu == NULL ||
+        !proton_linux_menu_append_top_level(widget, "Edit", edit_menu)) {
+      gtk_widget_destroy(widget);
+      proton_linux_menu_set_message(error, error_len,
+                                    "failed to create edit menu");
+      return NULL;
+    }
+  }
+  if (!proton_linux_menu_has_label(menu_bar, "Window")) {
+    GtkWidget *window_menu = proton_linux_menu_create_window_menu(
+        app_name, accelerators, command_callback, role_callback, user_data);
+    if (window_menu == NULL ||
+        !proton_linux_menu_append_top_level(widget, "Window", window_menu)) {
+      gtk_widget_destroy(widget);
+      proton_linux_menu_set_message(error, error_len,
+                                    "failed to create window menu");
+      return NULL;
+    }
+  }
+  return widget;
+}

--- a/native/src/engine/cef_linux/proton_linux_menu.h
+++ b/native/src/engine/cef_linux/proton_linux_menu.h
@@ -1,0 +1,29 @@
+#ifndef PROTON_LINUX_MENU_H
+#define PROTON_LINUX_MENU_H
+
+#include <gtk/gtk.h>
+
+#include <stddef.h>
+
+typedef struct proton_linux_menu_bar proton_linux_menu_bar_t;
+
+typedef void (*proton_linux_menu_command_callback_t)(const char *command_id,
+                                                     void *user_data);
+typedef void (*proton_linux_menu_role_callback_t)(const char *role,
+                                                  void *user_data);
+
+proton_linux_menu_bar_t *proton_linux_menu_bar_parse(const char *menu_json,
+                                                     char *error,
+                                                     size_t error_len);
+void proton_linux_menu_bar_destroy(proton_linux_menu_bar_t *menu_bar);
+
+GtkWidget *proton_linux_menu_bar_create_widget(
+    const proton_linux_menu_bar_t *menu_bar,
+    GtkAccelGroup *accelerators,
+    proton_linux_menu_command_callback_t command_callback,
+    proton_linux_menu_role_callback_t role_callback,
+    void *user_data,
+    char *error,
+    size_t error_len);
+
+#endif

--- a/native/tests/proton_linux_menu_test.c
+++ b/native/tests/proton_linux_menu_test.c
@@ -1,0 +1,149 @@
+#include "proton_linux_menu.h"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+  char command[64];
+  char role[64];
+} activation_state_t;
+
+static void command_activated(const char *command_id, void *user_data) {
+  activation_state_t *state = (activation_state_t *)user_data;
+  snprintf(state->command, sizeof(state->command), "%s", command_id);
+}
+
+static void role_activated(const char *role, void *user_data) {
+  activation_state_t *state = (activation_state_t *)user_data;
+  snprintf(state->role, sizeof(state->role), "%s", role);
+}
+
+static int expect_valid(const char *name, const char *json) {
+  char error[256] = {0};
+  proton_linux_menu_bar_t *menu =
+      proton_linux_menu_bar_parse(json, error, sizeof(error));
+  if (menu == NULL) {
+    fprintf(stderr, "%s should be valid: %s\n", name, error);
+    return 1;
+  }
+  proton_linux_menu_bar_destroy(menu);
+  return 0;
+}
+
+static int expect_invalid(const char *name,
+                          const char *json,
+                          const char *message) {
+  char error[256] = {0};
+  proton_linux_menu_bar_t *menu =
+      proton_linux_menu_bar_parse(json, error, sizeof(error));
+  if (menu != NULL) {
+    proton_linux_menu_bar_destroy(menu);
+    fprintf(stderr, "%s should be invalid\n", name);
+    return 1;
+  }
+  if (strstr(error, message) == NULL) {
+    fprintf(stderr, "%s expected error containing %s, got %s\n", name,
+            message, error);
+    return 1;
+  }
+  return 0;
+}
+
+static int expect_widget_accelerator(void) {
+  char error[256] = {0};
+  proton_linux_menu_bar_t *definition = proton_linux_menu_bar_parse(
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"Smoke\","
+      "\"items\":[{\"kind\":\"command\",\"id\":\"smoke.command\","
+      "\"label\":\"Smoke Command\",\"key\":\"s\"}]}]}",
+      error, sizeof(error));
+  if (definition == NULL) {
+    fprintf(stderr, "widget menu should parse: %s\n", error);
+    return 1;
+  }
+
+  activation_state_t state = {0};
+  GtkAccelGroup *accelerators = gtk_accel_group_new();
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *menu = proton_linux_menu_bar_create_widget(
+      definition, accelerators, command_activated, role_activated, &state,
+      error, sizeof(error));
+  if (menu == NULL) {
+    fprintf(stderr, "widget menu should build: %s\n", error);
+    gtk_widget_destroy(window);
+    g_object_unref(accelerators);
+    proton_linux_menu_bar_destroy(definition);
+    return 1;
+  }
+  gtk_window_add_accel_group(GTK_WINDOW(window), accelerators);
+  gtk_container_add(GTK_CONTAINER(window), menu);
+  gtk_widget_show_all(window);
+  while (gtk_events_pending()) {
+    gtk_main_iteration();
+  }
+  const gboolean command_was_activated = gtk_accel_groups_activate(
+      G_OBJECT(window), GDK_KEY_s, GDK_CONTROL_MASK);
+  int failed = !command_was_activated ||
+               strcmp(state.command, "smoke.command") != 0;
+  if (!command_was_activated ||
+      strcmp(state.command, "smoke.command") != 0) {
+    fprintf(stderr, "Ctrl+S should activate smoke.command, got %s\n",
+            state.command);
+  }
+  const gboolean role_was_activated = gtk_accel_groups_activate(
+      G_OBJECT(window), GDK_KEY_w, GDK_CONTROL_MASK);
+  if (!role_was_activated || strcmp(state.role, "close") != 0) {
+    fprintf(stderr, "Ctrl+W should activate close, got %s\n", state.role);
+    failed = 1;
+  }
+  state.role[0] = '\0';
+  const gboolean hide_others_was_activated = gtk_accel_groups_activate(
+      G_OBJECT(window), GDK_KEY_h, GDK_CONTROL_MASK | GDK_MOD1_MASK);
+  if (!hide_others_was_activated || strcmp(state.role, "hide_others") != 0) {
+    fprintf(stderr, "Ctrl+Alt+H should activate hide_others, got %s\n",
+            state.role);
+    failed = 1;
+  }
+  gtk_widget_destroy(window);
+  g_object_unref(accelerators);
+  proton_linux_menu_bar_destroy(definition);
+  return failed;
+}
+
+int main(int argc, char **argv) {
+  int failures = 0;
+  failures += expect_valid(
+      "commands separators and roles",
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"Developer\","
+      "\"items\":[{\"kind\":\"command\",\"id\":\"devtools\","
+      "\"label\":\"Open DevTools\",\"key\":\"d\"},"
+      "{\"kind\":\"separator\"},{\"kind\":\"role\","
+      "\"role\":\"close\"}]}]}");
+  failures += expect_valid("empty custom menu set",
+                           "{\"abi_version\":1,\"menus\":[]}");
+  failures += expect_valid(
+      "empty labels match macOS menu semantics",
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"\","
+      "\"items\":[{\"kind\":\"command\",\"id\":\"\","
+      "\"label\":\"\"}]}]}");
+  failures += expect_invalid(
+      "missing command id",
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"File\","
+      "\"items\":[{\"kind\":\"command\",\"label\":\"Open\"}]}]}",
+      "requires label and id");
+  failures += expect_invalid(
+      "unsupported role",
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"File\","
+      "\"items\":[{\"kind\":\"role\",\"role\":\"explode\"}]}]}",
+      "role is unsupported");
+  failures += expect_invalid(
+      "non-array items",
+      "{\"abi_version\":1,\"menus\":[{\"label\":\"File\","
+      "\"items\":{}}]}",
+      "requires label and items");
+  if (gtk_init_check(&argc, &argv)) {
+    failures += expect_widget_accelerator();
+  } else {
+    fprintf(stderr, "GTK display unavailable; skipping widget accelerator test\n");
+  }
+  return failures == 0 ? 0 : 1;
+}

--- a/native/tests/proton_smoke.c
+++ b/native/tests/proton_smoke.c
@@ -366,6 +366,7 @@ static int32_t g_app_entry_wakeup_delay_status = PROTON_ERR_NOT_INITIALIZED;
 static int32_t g_app_entry_wakeup_status = PROTON_ERR_NOT_INITIALIZED;
 static int g_app_entry_first_wakeup = 0;
 static int g_app_entry_second_wakeup = 0;
+static int32_t g_app_entry_menu_status = PROTON_ERR_NOT_INITIALIZED;
 static int32_t g_app_entry_window_create_status = PROTON_ERR_NOT_INITIALIZED;
 static int32_t g_app_entry_window_show_status = PROTON_ERR_NOT_INITIALIZED;
 static int32_t g_app_entry_close_interception_status =
@@ -629,6 +630,13 @@ static void smoke_app_entry(void) {
     } else {
       g_app_entry_wakeup_status = PROTON_ERR_PLATFORM;
     }
+#endif
+#if defined(__linux__)
+    g_app_entry_menu_status = proton_runtime_set_menu_json(
+        runtime,
+        "{\"abi_version\":1,\"menus\":[{\"label\":\"Smoke\","
+        "\"items\":[{\"kind\":\"command\",\"id\":\"smoke.command\","
+        "\"label\":\"Smoke Command\",\"key\":\"s\"}]}]}");
 #endif
     proton_window_id_t window = PROTON_INVALID_HANDLE;
     g_app_entry_window_create_status = proton_window_create_json(
@@ -2015,6 +2023,12 @@ int main(int argc, char **argv) {
     if (!g_app_entry_first_wakeup || !g_app_entry_second_wakeup) {
       return fail("app_run wakeup source lost a consecutive notification");
     }
+#if defined(__linux__)
+    if (expect_status("app_run native menu", g_app_entry_menu_status,
+                      PROTON_OK)) {
+      return 1;
+    }
+#endif
     if (expect_status("app_run window create",
                       g_app_entry_window_create_status, PROTON_OK) ||
         expect_status("app_run window show", g_app_entry_window_show_status,


### PR DESCRIPTION
## Summary

- keep Chromium's Linux Ozone backend on X11 to match Proton's GTK/X11 CEF embedding path
- render Proton application menu definitions as a native GTK menu bar on Linux
- deliver custom menu commands through the existing `menu_command` runtime event channel
- map standard menu roles to GTK window actions and focused-frame CEF editing commands

## Root cause

On a Wayland desktop, CEF selected Wayland and initialized the process-global GDK display before Proton initialized GTK. Proton's current Linux window implementation embeds the CEF child through X11, so the later X11 display check failed and runtime creation returned without opening a window.

After startup was fixed, OpenSeek still exited because its menu setup reached Proton's unimplemented Linux `proton_engine_runtime_set_menu_json` stub and received `PROTON_ERR_UNSUPPORTED`.

## Implementation

`--ozone-platform=x11` keeps CEF and GTK on the same backend. Native Wayland embedding is still out of scope; Wayland sessions run Proton through XWayland, while direct X11 sessions retain their existing path.

Linux menu JSON is parsed into an owned definition and rendered into each GTK top-level window. Custom commands are queued with the owning window ID, roles invoke GTK/CEF operations, and key equivalents use GTK accelerator groups. Updating a runtime menu replaces the widgets and accelerators on existing windows; later windows inherit the current definition.

## Impact

Linux Proton applications can start from both X11 and Wayland sessions, and applications such as OpenSeek can install and use their existing menu definitions instead of exiting during startup.

## Validation

- `cmake --build desktop/target/proton-native/build --config Release`
- `ctest --test-dir desktop/target/proton-native/build --output-on-failure` (8/8 passed, including menu, managed-runner, and overlay smoke tests)
- ABI-only native CMake configure and build with `PROTON_WITH_ENGINE=OFF`
- `moon -C desktop/lepus info && moon -C desktop/lepus fmt --check`
- `moon run ./desktop/package/dev` remained running with the menu installed; the verification process was then stopped manually
