### PR TITLE
refactor(extensions/notification): unify native error types

### DIFF
--- a/extensions/notification/error.mbt
+++ b/extensions/notification/error.mbt
@@ -4,7 +4,8 @@ suberror NotificationError {
   EmptyBody
   NativeCapability(error~ : @proton_native.NativeError)
   UnsupportedPlatform
-  NativeShow(error~ : @proton.NotificationDeliveryError)
+  NativeShow(error~ : @proton_native.NativeError)
+  ShowWaitInterrupted(detail~ : String)
   DeliveryFailed(message~ : String)
   NativePoll(error~ : @proton_native.NativeError)
   NativeCleanup(error~ : @proton_native.NativeError)
@@ -20,6 +21,8 @@ fn NotificationError::message(self : NotificationError) -> String {
       "native notifications are not implemented on this platform"
     NativeShow(error~) =>
       "failed to show native notification: " + error.message()
+    ShowWaitInterrupted(detail~) =>
+      "notification delivery wait was interrupted: " + detail
     DeliveryFailed(message~) =>
       "native notification was not delivered: " + message
     NativePoll(error~) =>

--- a/extensions/notification/notification_native.mbt
+++ b/extensions/notification/notification_native.mbt
@@ -20,17 +20,32 @@ async fn notification_native_show(
   let result = match payload {
     Some(payload) =>
       @proton.notification_show_and_wait(title, body, payload~) catch {
-        error => raise NativeShow(error~)
+        error => raise map_delivery_error(error)
       }
     None =>
       @proton.notification_show_and_wait(title, body) catch {
-        error => raise NativeShow(error~)
+        error => raise map_delivery_error(error)
       }
   }
   match result {
     @proton_native.NativeNotificationResult::Delivered => ()
     @proton_native.NativeNotificationResult::Failed(message) =>
       raise DeliveryFailed(message~)
+  }
+}
+
+///|
+/// Translates the facade-level `NotificationDeliveryError` into the
+/// extension's `NotificationError` so callers see a single native error type
+/// (`@proton_native.NativeError`) instead of a mix of facade and native errors.
+fn map_delivery_error(
+  error : @proton.NotificationDeliveryError,
+) -> NotificationError {
+  match error {
+    @proton.NotificationDeliveryError::Native(native_error) =>
+      NativeShow(error=native_error)
+    @proton.NotificationDeliveryError::WaitInterrupted(detail~) =>
+      ShowWaitInterrupted(detail~)
   }
 }
 


### PR DESCRIPTION
## Summary

Completes the previously deferred Step 4 from the extension P1/P2 cleanup (#100): unifying the notification extension's mixed native error types.

## Problem

`NotificationError` mixed two error sources:
- `NativeShow` carried `@proton.NotificationDeliveryError` from the facade layer
- `NativeCapability`, `NativePoll`, `NativeCleanup` carried `@proton_native.NativeError` from the low-level binding

This forced callers to handle two different native error types within one extension, inconsistent with every other extension's pattern.

## Change

Deconstruct `NotificationDeliveryError` at the boundary in `notification_native_show`:
- `Native(@native.NativeError)` → `NativeShow(error~ : @proton_native.NativeError)`
- `WaitInterrupted(detail~)` → new `ShowWaitInterrupted(detail~ : String)` variant

`NotificationError` now references only `@proton_native.NativeError` for all native failures.

## Architecture note

The `show` path still goes through `@proton.notification_show_and_wait` because the async broker (`CondVar` + `RuntimeSession` event dispatch) cannot move to `proton/native`, which does not depend on `moonbitlang/async`. The fix targets the error type inconsistency, not the call path — the mixed call path is an architectural constraint.

## Validation

```
moon fmt --check
moon check --target native --diagnostic-limit 40
moon -C extensions test -p moonbit-community/proton_ext/notification --target native
node scripts/verify_generated.mjs
```

Notification tests: 1 passed, 0 failed. Generated files: up to date.
