### PR TITLE
fix(release): publish shell package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ run-name: publish Proton packages to Mooncakes
 
 on:
   workflow_dispatch:
+    inputs:
+      resume_from_shell:
+        description: Publish only proton_shell, proton_ext, and proton_cli
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -58,12 +63,20 @@ jobs:
             moon update
           }
 
+          if [ "${{ inputs.resume_from_shell }}" = "true" ]; then
+            publish_module sys/shell moonbit-community/proton_shell
+            publish_module extensions moonbit-community/proton_ext
+            publish_module cli moonbit-community/proton_cli
+            exit 0
+          fi
+
           publish_module config moonbit-community/proton_config
           publish_module contract moonbit-community/proton_contract
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater
 
           publish_module sys/ffi moonbit-community/proton_ffi
+          publish_module sys/shell moonbit-community/proton_shell
           publish_module sys/auto_launch moonbit-community/proton_auto_launch
           publish_module sys/clipboard moonbit-community/proton_clipboard
           publish_module sys/global_hotkey moonbit-community/proton_global_hotkey
@@ -74,6 +87,7 @@ jobs:
           publish_module client moonbit-community/proton_client
           publish_module rabbita moonbit-community/proton_rabbita
           publish_module proton moonbit-community/proton
+
           publish_module extensions moonbit-community/proton_ext
           publish_module cli moonbit-community/proton_cli
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ developer must perform them.
 - `sys/<pkg>/`: native system capability binding modules
   (`moonbit-community/proton_auto_launch`, `moonbit-community/proton_clipboard`,
   `moonbit-community/proton_global_hotkey`, `moonbit-community/proton_keepawake`,
-  `moonbit-community/proton_microphone`, `moonbit-community/proton_tray`) plus the
+  `moonbit-community/proton_microphone`, `moonbit-community/proton_shell`,
+  `moonbit-community/proton_tray`) plus the
   shared FFI helper module `moonbit-community/proton_ffi` (`sys/ffi/`). All are
   published from this repository under the Apache-2.0 license, on the workspace
   version shared by every module. They carry the `proton_` prefix because that
@@ -130,7 +131,7 @@ native checks before handing off larger refactors.
 ### Release Checklist
 
 - `.github/workflows/publish.yml` publishes the dependency chain in this order:
-  `proton_config`, `proton_contract`, `proton_rsa`, `proton_updater`, the seven
+  `proton_config`, `proton_contract`, `proton_rsa`, `proton_updater`, the eight
   `sys` modules, `proton_client`, `proton_rabbita`, `proton`, `proton_ext`, and
   finally `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not
   published.


### PR DESCRIPTION
## Summary

- add `moonbit-community/proton_shell` to the normal dependency-ordered publish chain
- add a `resume_from_shell` workflow input for recovering the partially published 0.1.15 release
- synchronize the maintainer module count and package list

## Root cause

The 0.1.15 publish run omitted `proton_shell`, so the extracted `proton_ext` package could not resolve its registry dependency. Fourteen preceding modules had already been published, which made restarting the workflow from the beginning unsafe.

## Validation

- parsed `.github/workflows/publish.yml` as YAML
- checked the embedded publish script with `bash -n`
- simulated normal and recovery publish order with a stubbed `moon` command
- `node scripts/verify_release_metadata.mjs`
- `git diff --check`