### PR TITLE
fix(proton): route runtime diagnostics through xlog

### DIFF
--- a/proton/core/mbt_process_host.mbt
+++ b/proton/core/mbt_process_host.mbt
@@ -18,7 +18,11 @@ fn CommandErrorPolicy::response_message(
   if self.expose_details {
     diagnostic
   } else {
-    println("[proton] command dispatch failed: " + diagnostic)
+    // xlog keeps hidden backend details behind the process-wide handler. An
+    // application can point that handler at persistent storage without
+    // leaking the details into the renderer's deliberately generic response.
+    @xlog.error(category="command") <?
+      { "message": "command dispatch failed", "error": diagnostic }
     safe_message
   }
 }

--- a/proton/core/moon.pkg
+++ b/proton/core/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/json",
   "moonbit-community/proton/ipc",
   "moonbit-community/proton_contract",
+  "tonyfettes/xlog",
 }
 
 import {

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -403,25 +403,30 @@ fn current_permission_base_path() -> String {
 ///|
 fn App::warn_config_overrides(self : App) -> Unit {
   if self.title_overridden {
-    println("warning: Proton API App::title overrides moon.proton window.title")
+    @xlog.warn(category="config") <?
+      { "message": "Proton API App::title overrides moon.proton window.title" }
   }
   if self.size_overridden {
-    println(
-      "warning: Proton API App::size overrides moon.proton window.width/window.height",
-    )
+    @xlog.warn(category="config") <?
+      {
+        "message": "Proton API App::size overrides moon.proton window.width/window.height",
+      }
   }
   if self.titlebar_style_overridden {
-    println(
-      "warning: Proton API App::titlebar_style overrides moon.proton window.titlebar_style",
-    )
+    @xlog.warn(category="config") <?
+      {
+        "message": "Proton API App::titlebar_style overrides moon.proton window.titlebar_style",
+      }
   }
   if self.entry_overridden {
-    println("warning: Proton API App::entry_* overrides moon.proton entry")
+    @xlog.warn(category="config") <?
+      { "message": "Proton API App::entry_* overrides moon.proton entry" }
   }
   if self.debug_overridden {
-    println(
-      "warning: Proton API App::debug/debug_level overrides moon.proton debug",
-    )
+    @xlog.warn(category="config") <?
+      {
+        "message": "Proton API App::debug/debug_level overrides moon.proton debug",
+      }
   }
 }
 

--- a/proton/facade_updater.mbt
+++ b/proton/facade_updater.mbt
@@ -194,7 +194,8 @@ fn start_update_check(
     @async.sleep(update_check_delay_ms + update_check_jitter())
     let offered = channel.poll() catch {
       error => {
-        println("proton: update check failed: \{error}")
+        @xlog.error(category="update") <?
+          { "message": "update check failed", "error": "\{error}" }
         return
       }
     }
@@ -216,7 +217,11 @@ fn start_update_check(
 fn cleanup_previous_update() -> Unit {
   @native.update_cleanup_previous() catch {
     error =>
-      println("proton: previous update cleanup failed: " + error.message())
+      @xlog.error(category="update") <?
+        {
+          "message": "previous update cleanup failed",
+          "error": error.message(),
+        }
   }
 }
 

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -11,6 +11,7 @@ import {
   "moonbitlang/async@0.20.5",
   "moonbitlang/x@0.4.49",
   "moonbitlang/lexer@0.3.13",
+  "tonyfettes/xlog@0.4.0",
 }
 
 readme = "README.md"

--- a/proton/moon.pkg
+++ b/proton/moon.pkg
@@ -19,6 +19,7 @@ import {
   "moonbit-community/proton/updater",
   "moonbit-community/proton_updater",
   "moonbit-community/proton_contract",
+  "tonyfettes/xlog",
 }
 
 import {


### PR DESCRIPTION
## Summary

- route hidden command-dispatch diagnostics through the process-wide xlog handler
- replace Proton configuration and updater `println` calls with structured xlog records
- retain generic renderer-facing command errors while preserving full backend details in configured logs

## Why

GUI-launched applications may not have a useful terminal, so Proton diagnostics written with `println` can disappear. Applications such as SeekMoon already configure xlog with a persistent file handler; using the same logger keeps those failures available for support investigations.

## Validation

- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test core --target native --diagnostic-limit 80` (9/9)
- downstream OpenSeek: `moon check --target native desktop --diagnostic-limit 80`
- downstream OpenSeek: `moon build --target native desktop --diagnostic-limit 80`
- `moon -C proton info && moon -C proton fmt`
- `git diff --check`