### PR TITLE
fix(release): update moon config parser

### DIFF
--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -7,7 +7,7 @@ import {
   "moonbit-community/proton_rsa@0.1.16",
   "moonbit-community/proton_updater@0.1.16",
   "moonbitlang/x@0.4.49",
-  "moonbitlang/moon_config@0.3.5",
+  "moonbitlang/moon_config@0.3.13",
   "moonbitlang/async@0.20.5",
 }
 

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_config"
 version = "0.1.16"
 
 import {
-  "moonbitlang/moon_config@0.3.5",
+  "moonbitlang/moon_config@0.3.13",
   "moonbitlang/x@0.4.49",
 }
 


### PR DESCRIPTION
## Summary

- update `moonbitlang/moon_config` from 0.3.5 to 0.3.13 in `proton_config` and `proton_cli`
- ensure independently packaged modules resolve `moonbitlang/lexer@0.3.14`, which is compatible with the current MoonBit nightly

## Why

The 0.1.16 publish workflow failed while validating the extracted `proton_config` package. Workspace validation selected a newer transitive lexer, but the independently packaged module resolved the declared `moon_config@0.3.5` and its incompatible `lexer@0.3.5`, producing lexscan parse errors. No package was uploaded by the failed run.

## Validation

- `moon update`
- `moon fmt`
- `moon info`
- `moon -C config test --target native --diagnostic-limit 80`
- extracted `proton_config` publish package check with `moon_config@0.3.13` and `lexer@0.3.14`
- full scoped CLI native test suite with `PROTON_NATIVE_DIST=native/dist`: 172/172
