### PR TITLE
fix(release): publish new system modules

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,8 @@ jobs:
           publish_module sys/global_hotkey moonbit-community/proton_global_hotkey
           publish_module sys/keepawake moonbit-community/proton_keepawake
           publish_module sys/microphone moonbit-community/proton_microphone
+          publish_module sys/power_monitor moonbit-community/proton_power_monitor
+          publish_module sys/process moonbit-community/proton_process
           publish_module sys/tray moonbit-community/proton_tray
 
           publish_module client moonbit-community/proton_client

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ developer must perform them.
 - `sys/<pkg>/`: native system capability binding modules
   (`moonbit-community/proton_auto_launch`, `moonbit-community/proton_clipboard`,
   `moonbit-community/proton_global_hotkey`, `moonbit-community/proton_keepawake`,
-  `moonbit-community/proton_microphone`, `moonbit-community/proton_shell`,
+  `moonbit-community/proton_microphone`, `moonbit-community/proton_power_monitor`,
+  `moonbit-community/proton_process`, `moonbit-community/proton_shell`,
   `moonbit-community/proton_tray`) plus the
   shared FFI helper module `moonbit-community/proton_ffi` (`sys/ffi/`). All are
   published from this repository under the Apache-2.0 license, on the workspace
@@ -135,7 +136,7 @@ native checks before handing off larger refactors.
 ### Release Checklist
 
 - `.github/workflows/publish.yml` publishes the dependency chain in this order:
-  `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`, `proton_updater`, the eight
+  `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`, `proton_updater`, the ten
   `sys` modules, `proton_client`, `proton_rabbita`, `proton`, `proton_ext`, and
   finally `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not
   published.


### PR DESCRIPTION
## Summary

- publish `proton_power_monitor` and `proton_process` before `proton_ext`
- update the maintainer module and release inventory

## Problem

The 0.1.17 workspace adds lockstep dependencies from `proton_ext` to these modules, but the publish workflow omitted them. Publishing as-is would fail when `proton_ext@0.1.17` tried to resolve unpublished dependencies.

## Validation

- `moon fmt`
- `moon info`
- `node scripts/verify_release_metadata.mjs`
- `git diff --check`