### PR TITLE
fix(release): resume partial package publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,31 @@ run-name: publish Proton packages to Mooncakes
 on:
   workflow_dispatch:
     inputs:
-      resume_from_shell:
-        description: Publish only proton_shell, proton_ext, and proton_cli
-        type: boolean
-        default: false
+      resume_from:
+        description: First module to publish after a partial release
+        type: choice
+        default: config
+        options:
+          - config
+          - codegen
+          - contract
+          - rsa
+          - updater
+          - sys/ffi
+          - sys/shell
+          - sys/auto_launch
+          - sys/clipboard
+          - sys/global_hotkey
+          - sys/keepawake
+          - sys/microphone
+          - sys/power_monitor
+          - sys/process
+          - sys/tray
+          - client
+          - rabbita
+          - proton
+          - extensions
+          - cli
 
 permissions:
   contents: read
@@ -55,20 +76,23 @@ jobs:
 
       - name: Publish packages
         run: |
+          resume_from="${{ inputs.resume_from }}"
+          publishing=false
+
           publish_module() {
             module_dir="$1"
             module_name="$2"
+            if [ "$publishing" != "true" ]; then
+              if [ "$module_dir" != "$resume_from" ]; then
+                echo "Skipping $module_name before resume point $resume_from"
+                return
+              fi
+              publishing=true
+            fi
             echo "Publishing $module_name from $module_dir"
             moon -C "$module_dir" publish
             moon update
           }
-
-          if [ "${{ inputs.resume_from_shell }}" = "true" ]; then
-            publish_module sys/shell moonbit-community/proton_shell
-            publish_module extensions moonbit-community/proton_ext
-            publish_module cli moonbit-community/proton_cli
-            exit 0
-          fi
 
           publish_module config moonbit-community/proton_config
           publish_module codegen moonbit-community/proton_codegen

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -4,8 +4,8 @@ version = "0.1.17"
 
 import {
   "moonbitlang/async@0.20.5",
-  "moonbitlang/lexer@0.3.13",
-  "moonbitlang/parser@0.3.13",
+  "moonbitlang/lexer@0.3.14",
+  "moonbitlang/parser@0.3.14",
   "moonbitlang/x@0.4.50",
 }
 


### PR DESCRIPTION
## Summary

- update the isolated codegen package to lexer/parser 0.3.14 for the current MoonBit toolchain
- replace the shell-only publication retry with an arbitrary module resume point

## Problem

The 0.1.17 release published `proton_config` and then failed while validating the isolated `proton_codegen` archive. Its direct lexer 0.3.13 dependency still used the removed `lexscan StringView` contract. Restarting the old workflow would attempt to republish `proton_config@0.1.17`.

## Validation

- `moon fmt`
- `moon info`
- `moon -C codegen test lib --target wasm`
- isolated `moon -C codegen publish --dry-run` package extraction and check
- `node scripts/verify_release_metadata.mjs`
- `git diff --check`