### PR TITLE
chore(cli): update Warren and harden codegen publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,8 +94,28 @@ jobs:
             moon update
           }
 
+          wait_for_codegen() {
+            version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' codegen/moon.mod)
+            if [ -z "$version" ]; then
+              echo "Could not read the proton_codegen version." >&2
+              return 1
+            fi
+            coordinate="moonbit-community/proton_codegen@$version"
+            deadline=$((SECONDS + 900))
+            echo "Waiting for $coordinate executable asset"
+            until moonx "$coordinate" --help >/dev/null 2>&1; do
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "$coordinate is still unavailable after 15 minutes." >&2
+                return 1
+              fi
+              sleep 15
+            done
+            echo "$coordinate executable asset is ready"
+          }
+
           publish_module config moonbit-community/proton_config
           publish_module codegen moonbit-community/proton_codegen
+          wait_for_codegen
           publish_module contract moonbit-community/proton_contract
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ Generated projects describe their toolchain in `proton.project.json`:
   "frontend": {
     "path": "frontend",
     "dev_url": "http://127.0.0.1:4300",
-    "before_dev": "moonx --target native moonbit-community/warren@0.2.4 dev --direct --port 4300",
-    "before_build": "moonx --target native moonbit-community/warren@0.2.4 build",
+    "before_dev": "moonx --target native moonbit-community/warren@0.2.7 dev --direct --port 4300",
+    "before_build": "moonx --target native moonbit-community/warren@0.2.7 build",
     "dist": "dist"
   },
   "entry": {

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -20,7 +20,7 @@ let default_proton_rabbita_version = "0.1.18"
 let default_rabbita_version = "0.14.1"
 
 ///|
-let default_warren_version = "0.2.4"
+let default_warren_version = "0.2.7"
 
 ///|
 /// Scaffolded backends need this directly: `async fn main` is only available to

--- a/scripts/e2e_scaffold_source_smoke.mjs
+++ b/scripts/e2e_scaffold_source_smoke.mjs
@@ -28,7 +28,7 @@ const codegenVersion = fs
   .match(/^version\s*=\s*"([^"]+)"/m)?.[1];
 assert(codegenVersion, "codegen/moon.mod is missing its version");
 const codegenCoordinate = `moonbit-community/proton_codegen@${codegenVersion}`;
-const warrenCoordinate = "moonbit-community/warren@0.2.4";
+const warrenCoordinate = "moonbit-community/warren@0.2.7";
 let appProcess = null;
 let staticServer = null;
 let succeeded = false;


### PR DESCRIPTION
## Summary

- update generated Proton projects and documentation to use Warren 0.2.7
- make the source scaffold smoke exercise the same Warren release
- block package publication until the exact proton_codegen executable can be resolved and run through moonx

## Background

Mooncakes can expose a newly published proton_codegen package before its WASM executable asset is available. Continuing the lockstep release during that interval can publish a CLI whose generated projects reference an exact codegen version that moonx cannot run yet.

The publish workflow now probes the public consumer path every 15 seconds and continues only after `moonx moonbit-community/proton_codegen@<version> --help` succeeds. The barrier also runs when resuming from a module after codegen, and fails after 15 minutes instead of publishing an unusable dependency chain.

This PR does not bump Proton to 0.1.19 or publish packages.

## Validation

- `moon fmt`
- `moon info`
- `moon -C cli test -p moonbit-community/proton_cli/new --target native --no-parallelize --diagnostic-limit 80`
- `moonx moonbit-community/proton_codegen@0.1.18 --help`
- `node scripts/e2e_scaffold_source_smoke.mjs`