### PR TITLE
fix(facade): keep menu events out of closing windows

### DIFF
--- a/proton/facade_bridge.mbt
+++ b/proton/facade_bridge.mbt
@@ -249,8 +249,16 @@ fn forward_menu_command(
       None,
     ),
   ) catch {
-    error => raise native_run_error("forward menu command", error)
+    error =>
+      if !is_ignorable_menu_forward_error(error) {
+        raise native_run_error("forward menu command", error)
+      }
   }
+}
+
+///|
+fn is_ignorable_menu_forward_error(error : @native.NativeError) -> Bool {
+  error.is_invalid_state() || error.is_stale_window_request()
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -489,6 +489,39 @@ test "frontend menu event transport preserves focused window" {
 }
 
 ///|
+test "menu forwarding ignores only closing window errors" {
+  assert_true(
+    is_ignorable_menu_forward_error(
+      @native.NativeError::Status(
+        status=-3,
+        message="window is closing or destroyed",
+      ),
+    ),
+  )
+  assert_true(
+    is_ignorable_menu_forward_error(
+      @native.NativeError::Status(
+        status=-13,
+        message="window close request is no longer pending",
+      ),
+    ),
+  )
+  assert_false(
+    is_ignorable_menu_forward_error(
+      @native.NativeError::Status(
+        status=-7,
+        message="failed to send bridge event to renderer",
+      ),
+    ),
+  )
+  assert_false(
+    is_ignorable_menu_forward_error(
+      @native.NativeError::InvalidArgument(message="invalid event"),
+    ),
+  )
+}
+
+///|
 test "dev bridge page policy parses exact http origins" {
   assert_eq(
     unwrap_configuration(() => url_origin("http://localhost:5173/app")),

--- a/proton/native/native_wbtest.mbt
+++ b/proton/native/native_wbtest.mbt
@@ -313,6 +313,25 @@ test "runtime event decodes menu command payload" {
 }
 
 ///|
+test "native errors identify invalid object state" {
+  assert_true(
+    NativeError::Status(
+      status=proton_err_invalid_state,
+      message="window is closing or destroyed",
+    ).is_invalid_state(),
+  )
+  assert_false(
+    NativeError::Status(
+      status=proton_err_stale_window_request,
+      message="window close request is no longer pending",
+    ).is_invalid_state(),
+  )
+  assert_false(
+    NativeError::InvalidArgument(message="invalid state").is_invalid_state(),
+  )
+}
+
+///|
 test "runtime event decodes browser control requests" {
   let navigation = decode_runtime_event_json(
     "{\"type\":\"browser_navigation_requested\",\"window\":\"7\",\"request_id\":\"11\",\"url\":\"https://example.com/next\",\"method\":\"POST\",\"user_gesture\":true,\"redirect\":false}",

--- a/proton/native/types.mbt
+++ b/proton/native/types.mbt
@@ -36,6 +36,12 @@ pub fn NativeError::message(self : NativeError) -> String {
 }
 
 ///|
+/// Reports whether the native object is closing or has already been destroyed.
+pub fn NativeError::is_invalid_state(self : NativeError) -> Bool {
+  self.status() == proton_err_invalid_state
+}
+
+///|
 /// Reports whether a bridge response lost its renderer request while an
 /// asynchronous handler was still completing.
 pub fn NativeError::is_stale_bridge_response(self : NativeError) -> Bool {


### PR DESCRIPTION
## Summary
- classify native invalid-state errors in the public MoonBit binding
- ignore menu bridge events that race with window close or stale close requests
- keep unrelated bridge/native failures fatal
- add focused regression tests for the error classification and filtering

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test -p moonbit-community/proton moonbit-community/proton/native --target native --diagnostic-limit 80`
