### PR TITLE
fix(cli): avoid poisoning invalid CEF cache

### DIFF
--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -35,29 +35,45 @@ async fn install_cef_root(
   assert_safe_install_dir(install_dir, root)
   remove_tree(install_dir)
   @output.info("[INFO] Installing CEF into: " + install_dir)
-  copy_tree(extracted_root, install_dir)
-  normalize_cef_runtime_layout(install_dir)
-  let version_path = @fsutil.path_join(install_dir, "version.txt")
-  @async_fs.write_file(version_path, name + "\n", create_mode=CreateOrTruncate) catch {
-    err =>
-      raise CefFileSystemError::Write(
-        path=version_path,
-        detail=@debug.render(Repr(err)),
-      )
+  try {
+    copy_tree(extracted_root, install_dir)
+    normalize_cef_runtime_layout(install_dir)
+    let missing = validate_cef_layout(install_dir, platform)
+    if missing.length() > 0 {
+      raise InvalidCefRoot(path=install_dir, missing~)
+    }
+    let version_path = @fsutil.path_join(install_dir, "version.txt")
+    @async_fs.write_file(
+      version_path,
+      name + "\n",
+      create_mode=CreateOrTruncate,
+    ) catch {
+      err =>
+        raise CefFileSystemError::Write(
+          path=version_path,
+          detail=@debug.render(Repr(err)),
+        )
+    }
+    let checksum_path = @fsutil.path_join(install_dir, "sha256.txt")
+    @async_fs.write_file(
+      checksum_path,
+      sha256 + "\n",
+      create_mode=CreateOrTruncate,
+    ) catch {
+      err =>
+        raise CefFileSystemError::Write(
+          path=checksum_path,
+          detail=@debug.render(Repr(err)),
+        )
+    }
+  } catch {
+    error => {
+      remove_tree(install_dir) catch {
+        _ => ()
+      }
+      raise error
+    }
   }
-  let checksum_path = @fsutil.path_join(install_dir, "sha256.txt")
-  @async_fs.write_file(
-    checksum_path,
-    sha256 + "\n",
-    create_mode=CreateOrTruncate,
-  ) catch {
-    err =>
-      raise CefFileSystemError::Write(
-        path=checksum_path,
-        detail=@debug.render(Repr(err)),
-      )
-  }
-  validate_cef_root(install_dir, platform)
 }
 
 ///|
@@ -174,14 +190,12 @@ async fn ensure_cef_cache(
   let cache_dir = global_cef_cache_dir(project_root=root, platform~, name~).unwrap_or(
     project_cache,
   )
-  if installed_version(cache_dir) == name &&
-    installed_checksum(cache_dir) == sha256 {
-    normalize_cef_runtime_layout(cache_dir)
+  if cached_cef_root_is_valid(cache_dir, name, sha256, platform) {
     return cache_dir
   }
+  remove_tree(cache_dir)
   if project_cache != cache_dir &&
-    installed_version(project_cache) == name &&
-    installed_checksum(project_cache) == sha256 {
+    cached_cef_root_is_valid(project_cache, name, sha256, platform) {
     install_cef_root(
       extracted_root=project_cache,
       install_dir=cache_dir,
@@ -192,6 +206,9 @@ async fn ensure_cef_cache(
     )
     return cache_dir
   }
+  if project_cache != cache_dir {
+    remove_tree(project_cache)
+  }
   setup_downloaded_cef(
     name~,
     url~,
@@ -201,6 +218,28 @@ async fn ensure_cef_cache(
     platform~,
   )
   cache_dir
+}
+
+///|
+async fn cached_cef_root_is_valid(
+  cache_dir : String,
+  name : String,
+  sha256 : String,
+  platform : ProtonPlatform,
+) -> Bool {
+  guard installed_version(cache_dir) == name &&
+    installed_checksum(cache_dir) == sha256 else {
+    return false
+  }
+  normalize_cef_runtime_layout(cache_dir) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  validate_cef_root(cache_dir, platform) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  true
 }
 
 ///|

--- a/cli/cef/cef_cache_wbtest.mbt
+++ b/cli/cef/cef_cache_wbtest.mbt
@@ -1,0 +1,108 @@
+///|
+async fn test_cef_cache_fixture_root() -> String {
+  @async_fs.tmpdir(prefix="proton-cef-cache-test-") catch {
+    error => abort(@debug.render(Repr(error)))
+  }
+}
+
+///|
+async fn test_write_cef_fixture_files(
+  root : String,
+  platform : ProtonPlatform,
+) -> Unit {
+  for relative in installed_cef_relative_files(platform) {
+    let path = @fsutil.path_join(root, relative)
+    let parent = @fsutil.path_parent(path)
+    if !@fsutil.path_exists(parent) {
+      @async_fs.mkdir(parent, recursive=true)
+    }
+    @async_fs.write_file(path, "fixture", create_mode=CreateOrTruncate)
+  }
+}
+
+///|
+async test "failed CEF installation removes incomplete cache markers" {
+  let temp = test_cef_cache_fixture_root()
+  let source = @fsutil.path_join(temp, "source")
+  let install = @fsutil.path_join(temp, "cache")
+  let project_root = @fsutil.path_join(temp, "project")
+  @async_fs.mkdir(source, recursive=true)
+  let platform = darwin_arm64_platform()
+  let failed = try {
+    install_cef_root(
+      extracted_root=source,
+      install_dir=install,
+      name="cef-test",
+      sha256="a".repeat(64),
+      root=project_root,
+      platform~,
+    )
+    false
+  } catch {
+    InvalidCefRoot(path~, missing~) => {
+      assert_eq(path, install)
+      assert_true(missing.length() > 0)
+      assert_false(
+        @fsutil.path_exists(@fsutil.path_join(install, "version.txt")),
+      )
+      assert_false(
+        @fsutil.path_exists(@fsutil.path_join(install, "sha256.txt")),
+      )
+      assert_false(@fsutil.path_exists(install))
+      true
+    }
+    _ => false
+  } noraise {
+    _ => false
+  }
+  assert_true(failed)
+  remove_tree(temp)
+}
+
+///|
+async test "CEF cache validation rejects marker-only directories" {
+  let temp = test_cef_cache_fixture_root()
+  let cache = @fsutil.path_join(temp, "cache")
+  @async_fs.mkdir(cache, recursive=true)
+  @async_fs.write_file(
+    @fsutil.path_join(cache, "version.txt"),
+    "cef-test\n",
+    create_mode=CreateOrTruncate,
+  )
+  @async_fs.write_file(
+    @fsutil.path_join(cache, "sha256.txt"),
+    "a".repeat(64) + "\n",
+    create_mode=CreateOrTruncate,
+  )
+  let platform = darwin_arm64_platform()
+  assert_false(
+    cached_cef_root_is_valid(cache, "cef-test", "a".repeat(64), platform),
+  )
+  remove_tree(temp)
+}
+
+///|
+async test "successful CEF installation writes markers after validation" {
+  let temp = test_cef_cache_fixture_root()
+  let source = @fsutil.path_join(temp, "source")
+  let install = @fsutil.path_join(temp, "cache")
+  let project_root = @fsutil.path_join(temp, "project")
+  @async_fs.mkdir(source, recursive=true)
+  let platform = darwin_arm64_platform()
+  test_write_cef_fixture_files(source, platform)
+  install_cef_root(
+    extracted_root=source,
+    install_dir=install,
+    name="cef-test",
+    sha256="a".repeat(64),
+    root=project_root,
+    platform~,
+  )
+  assert_eq(installed_version(install), "cef-test")
+  assert_eq(installed_checksum(install), "a".repeat(64))
+  validate_cef_root(install, platform)
+  assert_true(
+    cached_cef_root_is_valid(install, "cef-test", "a".repeat(64), platform),
+  )
+  remove_tree(temp)
+}

--- a/cli/cef/cef_validation.mbt
+++ b/cli/cef/cef_validation.mbt
@@ -5,13 +5,7 @@ async fn has_source_cef_files(root : String, platform : ProtonPlatform) -> Bool 
 
 ///|
 async fn validate_cef_root(root : String, platform : ProtonPlatform) -> Unit {
-  let missing : Array[String] = []
-  for relative in installed_cef_relative_files(platform) {
-    let path = @fsutil.path_join(root, relative)
-    if !@fsutil.path_exists(path) {
-      missing.push(path)
-    }
-  }
+  let missing = validate_cef_layout(root, platform)
   let version_path = @fsutil.path_join(root, "version.txt")
   if !@fsutil.path_exists(version_path) {
     missing.push(version_path)
@@ -19,6 +13,21 @@ async fn validate_cef_root(root : String, platform : ProtonPlatform) -> Unit {
   if missing.length() > 0 {
     raise InvalidCefRoot(path=root, missing~)
   }
+}
+
+///|
+async fn validate_cef_layout(
+  root : String,
+  platform : ProtonPlatform,
+) -> Array[String] {
+  let missing : Array[String] = []
+  for relative in installed_cef_relative_files(platform) {
+    let path = @fsutil.path_join(root, relative)
+    if !@fsutil.path_exists(path) {
+      missing.push(path)
+    }
+  }
+  missing
 }
 
 ///|


### PR DESCRIPTION
## Summary

- validate the extracted CEF layout before writing cache markers
- remove incomplete or invalid cache directories instead of treating marker-only directories as cache hits
- require marker values and the complete platform layout on cache reuse
- add filesystem-backed regression tests for failed, marker-only, and successful installs

## Platform impact

Applies to `proton_cli cef setup` on supported Windows, Linux, and macOS CEF layouts. No public MoonBit API changes.

## Validation

- `moon fmt --check`
- `moon -C cli check --target native --diagnostic-limit 80`
- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
- `moon -C cli info --target native`
- `git diff origin/main...HEAD --check`

`update-pr-prebuilts` was not modified.