### PR TITLE
feat(package): add standalone desktop packager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
           moon check --target native --deny-warn
+          moon -C package test lib --target native --diagnostic-limit 80
           moon -C codegen test lib --target wasm --diagnostic-limit 80
           moon -C cdp test -p moonbit-community/proton_cdp/client --target native --diagnostic-limit 80
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
@@ -232,6 +233,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           moon check --target native --deny-warn
+          moon -C package test lib --target native --diagnostic-limit 80
           moon -C codegen test lib --target wasm --diagnostic-limit 80
           moon -C cdp test -p moonbit-community/proton_cdp/client --target native --diagnostic-limit 80
           moon -C proton test -p moonbit-community/proton/native moonbit-community/proton/updater --target native --diagnostic-limit 80

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ on:
           - contract
           - rsa
           - updater
+          - package
           - sys/ffi
           - sys/shell
           - sys/auto_launch
@@ -119,6 +120,7 @@ jobs:
           publish_module contract moonbit-community/proton_contract
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater
+          publish_module package moonbit-community/proton_package
 
           publish_module sys/ffi moonbit-community/proton_ffi
           publish_module sys/shell moonbit-community/proton_shell

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,12 @@ jobs:
             moon update
           }
 
+          if [ "$resume_from" = "package" ]; then
+            publishing=true
+            publish_module package moonbit-community/proton_package
+            exit 0
+          fi
+
           wait_for_codegen() {
             version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' codegen/moon.mod)
             if [ -z "$version" ]; then
@@ -120,7 +126,6 @@ jobs:
           publish_module contract moonbit-community/proton_contract
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater
-          publish_module package moonbit-community/proton_package
 
           publish_module sys/ffi moonbit-community/proton_ffi
           publish_module sys/shell moonbit-community/proton_shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ developer must perform them.
 - `codegen/`: `moonbit-community/proton_codegen`; WASM executable invoked through
   `moonx` by application prebuild rules, plus its reusable parser/renderer library.
 - `cli/`: `moonbit-community/proton_cli`; independent native developer CLI module.
+- `package/`: standalone `moonbit-community/proton_package` module. It packages
+  already-built executables from explicit metadata and payloads; it does not
+  discover Proton projects, invoke Moon builds, or assemble CEF runtimes.
 - `extensions/`: `moonbit-community/proton_ext`; command extensions for examples and
   applications. Platform capability extensions are backed by the bindings
   under `sys/`.
@@ -97,6 +100,7 @@ developer must perform them.
   `moon -C codegen test lib --target wasm`
 - With `.proton\runtime.json` active runtime `bin` on `PATH`:
   `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
+- `moon -C package test lib --target native --diagnostic-limit 80`
 - `moon check --target native`
 - `node scripts/verify_generated.mjs`
 - `moon -C extensions test -p moonbit-community/proton_ext moonbit-community/proton_ext/auto_launch moonbit-community/proton_ext/clipboard moonbit-community/proton_ext/dialog moonbit-community/proton_ext/fs moonbit-community/proton_ext/global_hotkey moonbit-community/proton_ext/keepawake moonbit-community/proton_ext/microphone moonbit-community/proton_ext/notification moonbit-community/proton_ext/path moonbit-community/proton_ext/shell moonbit-community/proton_ext/tray --target native`
@@ -136,7 +140,8 @@ native checks before handing off larger refactors.
 ### Release Checklist
 
 - `.github/workflows/publish.yml` publishes the dependency chain in this order:
-  `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`, `proton_updater`, the ten
+  `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`,
+  `proton_updater`, `proton_package`, the ten
   `sys` modules, `proton_client`, `proton_rabbita`, `proton`, `proton_ext`, and
   finally `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not
   published.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ developer must perform them.
 - `cli/`: `moonbit-community/proton_cli`; independent native developer CLI module.
 - `package/`: standalone `moonbit-community/proton_package` module. It packages
   already-built executables from explicit metadata and payloads; it does not
-  discover Proton projects, invoke Moon builds, or assemble CEF runtimes.
+  discover Proton projects, invoke Moon builds, or assemble CEF runtimes. It
+  has an independent version line and is excluded from the workspace lockstep
+  bump.
 - `extensions/`: `moonbit-community/proton_ext`; command extensions for examples and
   applications. Platform capability extensions are backed by the bindings
   under `sys/`.
@@ -139,17 +141,22 @@ native checks before handing off larger refactors.
 
 ### Release Checklist
 
-- `.github/workflows/publish.yml` publishes the dependency chain in this order:
+- `.github/workflows/publish.yml` publishes the lockstep dependency chain in this order:
   `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`,
-  `proton_updater`, `proton_package`, the ten
+  `proton_updater`, the ten
   `sys` modules, `proton_client`, `proton_rabbita`, `proton`, `proton_ext`, and
   finally `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not
   published.
-- All modules in `moon.work` use one lockstep version. Prepare a release only
-  through `moon run scripts/bump_version.mbtx -- patch`, `minor`, or
-  `major`; do not edit individual module versions by hand. The script discovers
-  modules through `moon.work`, updates their versions and internal requirements,
-  and refuses to run if any workspace module has drifted from the shared version.
+- `proton_package` has its own version line. Select `package` as the workflow's
+  resume point to publish only that module; the workflow exits before the
+  lockstep chain.
+- All modules in `moon.work` except the explicitly independent
+  `proton_package` use one lockstep version. Prepare a lockstep release only
+  through `moon run scripts/bump_version.mbtx -- patch`, `minor`, or `major`;
+  do not edit individual lockstep module versions by hand. The script discovers
+  modules through `moon.work`, skips independently versioned modules, updates
+  the lockstep versions and internal requirements, and refuses to run if that
+  set has drifted from the shared version.
 - Run the release checks before the first publish:
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -492,9 +492,9 @@ proton_cli package
 proton_cli package --release
 ```
 
-The package command performs a debug build by default. Pass `--release` to use
-MoonBit's release build mode, or `--no-build` to reuse an existing build from
-the selected mode. Package output is written to `dist` by default.
+The package command performs an incremental debug executable build by default.
+Pass `--release` to use MoonBit's release build mode. Package output is written
+to `dist` by default.
 Icons, resources, output targets, signing, notarization, custom URL schemes, and
 macOS document types are configured through `proton.project.json` and package command
 options.

--- a/README.md
+++ b/README.md
@@ -440,6 +440,26 @@ MBT_CDP_TARGET=9222 moon -C e2e run test --target native
 
 ## Bundle and package
 
+To package an already-built executable independently of Proton project
+discovery and runtime assembly, install `moonbit-community/proton_package`:
+
+```sh
+moon install moonbit-community/proton_package
+proton_package \
+  --executable ./build/my-app \
+  --product-name "My App" \
+  --identifier com.example.my-app \
+  --version 1.0.0 \
+  --format app \
+  --output dist
+```
+
+The same implementation is available as the
+`moonbit-community/proton_package/lib` package. `--config` accepts a reusable
+JSON specification; paths in that file are resolved relative to the file.
+
+### Proton projects
+
 The `bundle` block in `proton.project.json` enables package creation and selects its
 default targets and output directory:
 

--- a/cli/build_cmd/build.mbt
+++ b/cli/build_cmd/build.mbt
@@ -53,6 +53,7 @@ pub extend BuildPathError with Show::{to_string, output}
 pub(all) suberror BuildProcessError {
   Start(command~ : String, detail~ : String)
   Exit(command~ : String, code~ : Int)
+  InvalidOutput(command~ : String, detail~ : String)
 } derive(Debug, Eq)
 
 ///|
@@ -99,6 +100,8 @@ pub fn BuildProcessError::message(self : BuildProcessError) -> String {
   match self {
     Start(command~, detail~) => "failed to run " + command + ": " + detail
     Exit(command~, code~) => command + " exited with code " + code.to_string()
+    InvalidOutput(command~, detail~) =>
+      command + " returned invalid output: " + detail
   }
 }
 
@@ -182,25 +185,45 @@ pub async fn run(cwd : String, matches : @argparse.Matches) -> Unit {
 }
 
 ///|
-/// Runs the release build requested by the package workflow.
-pub async fn run_release(
+/// Builds the application executable requested by the package workflow and
+/// returns the artifact path reported by Moon.
+pub async fn build_executable(
   cwd : String,
   app_package : String,
   config_path : String,
-  moon_args : Array[String],
-) -> Unit {
-  validate_moon_build_args(moon_args)
-  run_with_options(cwd, RawBuildOptions::{
+  release : Bool,
+) -> String {
+  let invocation = prepare_build(cwd, RawBuildOptions::{
     app_package: Some(app_package),
     config_path: Some(config_path),
     moon_target_dir: None,
     run_frontend_build: true,
-    moon_args,
+    moon_args: [],
   })
+  run_moon_build_only(invocation.backend_path, invocation.app_package, release)
 }
 
 ///|
 async fn run_with_options(cwd : String, raw : RawBuildOptions) -> Unit {
+  let invocation = prepare_build(cwd, raw)
+  run_moon_build(
+    invocation.backend_path,
+    invocation.app_package,
+    invocation.moon_args,
+    invocation.moon_target_dir,
+  )
+}
+
+///|
+priv struct BuildInvocation {
+  backend_path : String
+  app_package : String
+  moon_target_dir : String?
+  moon_args : Array[String]
+}
+
+///|
+async fn prepare_build(cwd : String, raw : RawBuildOptions) -> BuildInvocation {
   let cwd = @path.Path(cwd).resolve().to_string()
   let root = @fsutil.find_project_root_from(cwd)
   let config_path = resolve_build_config_path(cwd, root, raw)
@@ -225,7 +248,12 @@ async fn run_with_options(cwd : String, raw : RawBuildOptions) -> Unit {
   let moon_target_dir = raw.moon_target_dir.map(path => {
     @fsutil.resolve_path(root, path)
   })
-  run_moon_build(backend_path, app_package, raw.moon_args, moon_target_dir)
+  BuildInvocation::{
+    backend_path,
+    app_package,
+    moon_target_dir,
+    moon_args: raw.moon_args,
+  }
 }
 
 ///|
@@ -547,6 +575,76 @@ fn moon_build_args_with_target_dir(
     args.push(arg)
   }
   args
+}
+
+///|
+fn moon_build_only_args(app_package : String, release : Bool) -> Array[String] {
+  [
+    "run",
+    app_package,
+    "--target",
+    "native",
+    if release {
+      "--release"
+    } else {
+      "--debug"
+    },
+    "--build-only",
+  ]
+}
+
+///|
+fn artifact_path_from_build_output(
+  output : String,
+) -> String raise BuildProcessError {
+  let json = @json.parse(output) catch {
+    error =>
+      raise InvalidOutput(
+        command="MoonBit executable build",
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard json is { "artifacts_path": Array(paths), .. } else {
+    raise InvalidOutput(
+      command="MoonBit executable build",
+      detail="missing artifacts_path array",
+    )
+  }
+  guard paths is [String(path)] else {
+    raise InvalidOutput(
+      command="MoonBit executable build",
+      detail="expected exactly one executable artifact",
+    )
+  }
+  path
+}
+
+///|
+async fn run_moon_build_only(
+  root : String,
+  app_package : String,
+  release : Bool,
+) -> String {
+  let args = moon_build_only_args(app_package, release)
+  @output.info("Building Proton executable: moon " + args.join(" "))
+  let (code, stdout) = @process.collect_stdout("moon", args, cwd=root) catch {
+    error =>
+      raise BuildProcessError::Start(
+        command="MoonBit executable build",
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  if code != 0 {
+    raise BuildProcessError::Exit(command="MoonBit executable build", code~)
+  }
+  let output = stdout.text() catch {
+    error =>
+      raise BuildProcessError::InvalidOutput(
+        command="MoonBit executable build",
+        detail="failed to decode stdout: " + @debug.render(Repr(error)),
+      )
+  }
+  artifact_path_from_build_output(output)
 }
 
 ///|

--- a/cli/build_cmd/build_wbtest.mbt
+++ b/cli/build_cmd/build_wbtest.mbt
@@ -99,6 +99,40 @@ test "moon build args prepend an isolated target directory" {
 }
 
 ///|
+test "moon build-only args select the requested build mode" {
+  @debug.assert_eq(moon_build_only_args("app", false), [
+    "run", "app", "--target", "native", "--debug", "--build-only",
+  ])
+  @debug.assert_eq(moon_build_only_args("desktop", true), [
+    "run", "desktop", "--target", "native", "--release", "--build-only",
+  ])
+}
+
+///|
+test "moon build-only output identifies one executable" {
+  assert_eq(
+    artifact_path_from_build_output(
+      "{\"artifacts_path\":[\"/tmp/build/app.exe\"]}\n",
+    ),
+    "/tmp/build/app.exe",
+  )
+}
+
+///|
+test "moon build-only output rejects missing or ambiguous artifacts" {
+  for
+    output in [
+      "{}", "{\"artifacts_path\":[]}", "{\"artifacts_path\":[\"first.exe\",\"second.exe\"]}",
+      "{\"artifacts_path\":[1]}",
+    ] {
+    let error = expect_build_error_message(() => {
+      artifact_path_from_build_output(output)
+    })
+    assert_true(error.contains("returned invalid output"))
+  }
+}
+
+///|
 test "frontend release rejects url production entry" {
   let frontend = Some(
     @proton_config.ProjectFrontendConfig::new(

--- a/cli/build_cmd/moon.pkg
+++ b/cli/build_cmd/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/async/process",
   "moonbitlang/core/argparse",
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbitlang/x/path",
 }

--- a/cli/build_cmd/pkg.generated.mbti
+++ b/cli/build_cmd/pkg.generated.mbti
@@ -8,11 +8,11 @@ import {
 }
 
 // Values
+pub async fn build_executable(String, String, String, Bool) -> String
+
 pub fn command() -> @argparse.Command
 
 pub async fn run(String, @argparse.Matches) -> Unit
-
-pub async fn run_release(String, String, String, Array[String]) -> Unit
 
 // Errors
 pub(all) suberror BuildConfigError {
@@ -41,6 +41,7 @@ pub fn BuildPathError::to_string(Self) -> String
 pub(all) suberror BuildProcessError {
   Start(command~ : String, detail~ : String)
   Exit(command~ : String, code~ : Int)
+  InvalidOutput(command~ : String, detail~ : String)
 } derive(Eq, @debug.Debug)
 pub fn BuildProcessError::equal(Self, Self) -> Bool
 pub fn BuildProcessError::message(Self) -> String

--- a/cli/package/error.mbt
+++ b/cli/package/error.mbt
@@ -192,9 +192,7 @@ pub fn PackagePlanError::message(self : PackagePlanError) -> String {
       "unsupported bundle.resources glob: " + path
     MissingInput(path~) => "package input is missing: " + path
     MissingExecutable(path~) =>
-      "package executable not found under " +
-      path +
-      "; run proton package without --no-build first"
+      "Moon reported a package executable that does not exist: " + path
     NotLaunchableMachO(path~, filetype~) =>
       "staged bundle executable " +
       path +

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -10,7 +10,6 @@ struct RawPackageOptions {
   config_path : String?
   targets : Array[String]
   output : String?
-  build : Bool
   release : Bool
   dry_run : Bool
   sign : Bool
@@ -37,7 +36,6 @@ struct PackagePlan {
   update_revision : UInt64
   targets : Array[String]
   output : String
-  build : Bool
   release : Bool
   base_dir : String
   frontend_dist : String?
@@ -93,7 +91,6 @@ pub fn command() -> @argparse.Command {
     "package",
     about="Package a Proton application",
     flags=[
-      FlagArg("no-build", about="Reuse an existing package build"),
       FlagArg("release", about="Build and package the release output"),
       FlagArg("dry-run", about="Print the resolved package plan"),
       FlagArg("sign", about="Sign the packaged application"),
@@ -221,8 +218,6 @@ fn package_options_from_matches(
     is {
       "notarize"? : Some(notarize)
       | (None with notarize = false),
-      "no-build"? : Some(no_build)
-      | (None with no_build = false),
       "release"? : Some(release)
       | (None with release = false),
       "dry-run"? : Some(dry_run)
@@ -239,7 +234,6 @@ fn package_options_from_matches(
     config_path: config_path.get(0),
     targets,
     output: output.get(0),
-    build: !no_build,
     release,
     dry_run,
     sign: sign || notarize,
@@ -412,7 +406,6 @@ async fn build_package_plan(
     update_revision,
     targets,
     output,
-    build: raw.build,
     release: raw.release,
     base_dir,
     frontend_dist,
@@ -606,8 +599,6 @@ fn print_package_plan(plan : PackagePlan, dry_run : Bool) -> Unit {
     plan.sign_binaries.join(", ")
   }
   println("  sign binaries: " + sign_binaries)
-  let build = if plan.build { "yes" } else { "no" }
-  println("  build: " + build)
   let build_mode = if plan.release { "release" } else { "debug" }
   println("  build mode: " + build_mode)
   println("  sign: " + bool_text(plan.sign))
@@ -628,13 +619,9 @@ async fn execute_package_plan(plan : PackagePlan) -> Unit {
   // Resolve the active runtime before any build work so a missing
   // `proton_cli cef setup` fails fast instead of after a full application build.
   let runtime = read_active_runtime(plan.workspace_root)
-  if plan.build {
-    run_package_build(plan)
-  }
-  let executable = match find_package_executable(plan) {
-    Some(path) => path
-    None =>
-      raise PackagePlanError::MissingExecutable(path=package_build_root(plan))
+  let executable = run_package_build(plan)
+  if !@fsutil.path_exists(executable) || !@fsutil.path_is_file(executable) {
+    raise PackagePlanError::MissingExecutable(path=executable)
   }
   match current_package_host() {
     Windows => stage_windows_portable(plan, executable, runtime)
@@ -649,59 +636,13 @@ async fn is_macos_host() -> Bool {
 }
 
 ///|
-async fn run_package_build(plan : PackagePlan) -> Unit {
-  // Keep local packaging fast by default. Distribution builds opt into the
-  // Moon release mode explicitly through `proton_cli package --release`.
-  let moon_args : Array[String] = []
-  if plan.release {
-    moon_args.push("--release")
-  }
-  @build.run_release(plan.root, plan.app_package, plan.config_path, moon_args)
-}
-
-///|
-fn package_build_root(plan : PackagePlan) -> String {
-  @fsutil.resolve_path(plan.workspace_root, "_build")
-}
-
-///|
-async fn find_package_executable(plan : PackagePlan) -> String? {
-  // `--no-build` must reuse the same build mode selected for this command.
-  let build_mode = if plan.release { "release" } else { "debug" }
-  let root = @fsutil.resolve_path(
-    package_build_root(plan),
-    "native/" + build_mode + "/build",
+async fn run_package_build(plan : PackagePlan) -> String {
+  @build.build_executable(
+    plan.root,
+    plan.app_package,
+    plan.config_path,
+    plan.release,
   )
-  let package_name = path_basename(plan.app_package)
-  find_named_file(root, package_name + ".exe")
-}
-
-///|
-async fn find_named_file(root : String, name : String) -> String? {
-  guard @fsutil.path_exists(root) else { return None }
-  if @fsutil.path_is_file(root) {
-    return if path_basename(root) == name { Some(root) } else { None }
-  }
-  // A dSYM bundle mirrors the executable basename under Resources/DWARF, but
-  // that file contains debug symbols rather than runnable Mach-O code.
-  if path_basename(root).has_suffix(".dSYM") {
-    return None
-  }
-  let entries = @async_fs.readdir(
-    root,
-    include_hidden=true,
-    include_special=false,
-  ) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  for entry in entries {
-    match find_named_file(@fsutil.resolve_path(root, entry), name) {
-      Some(path) => return Some(path)
-      None => ()
-    }
-  }
-  None
 }
 
 ///|

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -12,12 +12,11 @@ fn parse_package_matches(args : Array[String]) -> @argparse.Matches raise {
 test "parse package args accepts repeated targets and overrides" {
   let raw = parse_package_args([
     "--package", "desktop", "--target", "app", "--target", "zip", "--target", "dmg",
-    "--output", "dist", "--no-build", "--dry-run",
+    "--output", "dist", "--dry-run",
   ])
   @debug.assert_eq(raw.app_package, Some("desktop"))
   @debug.assert_eq(raw.targets, ["app", "zip", "dmg"])
   @debug.assert_eq(raw.output, Some("dist"))
-  assert_false(raw.build)
   assert_false(raw.release)
   assert_true(raw.dry_run)
 }
@@ -25,8 +24,19 @@ test "parse package args accepts repeated targets and overrides" {
 ///|
 test "parse package args enables release builds explicitly" {
   let raw = parse_package_args(["--release"])
-  assert_true(raw.build)
   assert_true(raw.release)
+}
+
+///|
+test "package no longer accepts an implicit cached executable" {
+  try parse_package_args(["--no-build"]) catch {
+    error =>
+      assert_true(
+        error.to_string().contains("unexpected argument '--no-build'"),
+      )
+  } noraise {
+    _ => abort("expected --no-build to be rejected")
+  }
 }
 
 ///|
@@ -286,7 +296,6 @@ test "macOS plist contains bundle identity and executable" {
     update_revision: 42UL,
     targets: ["app"],
     output: "dist",
-    build: false,
     release: false,
     base_dir: ".",
     frontend_dist: None,
@@ -353,7 +362,6 @@ test "macOS helper plist matches its bundle identity" {
     update_revision: 42UL,
     targets: ["app"],
     output: "dist",
-    build: false,
     release: false,
     base_dir: ".",
     frontend_dist: None,

--- a/cli/package/package_windows_wbtest.mbt
+++ b/cli/package/package_windows_wbtest.mbt
@@ -17,7 +17,6 @@ fn windows_test_plan(
     update_revision: 0UL,
     targets,
     output: @fsutil.resolve_path(root, "output with spaces"),
-    build: false,
     release: false,
     base_dir: root,
     frontend_dist: Some(@fsutil.resolve_path(root, "frontend/dist")),

--- a/extensions/power_monitor/contract/pkg.generated.mbti
+++ b/extensions/power_monitor/contract/pkg.generated.mbti
@@ -10,11 +10,25 @@ import {
 // Values
 pub let activity : @proton_contract.Event[PowerMonitorActivity]
 
+pub let drain_events : @proton_contract.Command[@proton_contract.EmptyRequest, PowerMonitorEventReply]
+
 pub let extension : @proton_contract.ExtensionContract
 
 pub let get_idle_time : @proton_contract.Command[@proton_contract.EmptyRequest, IdleTimeReply]
 
 pub let get_power_source : @proton_contract.Command[@proton_contract.EmptyRequest, PowerSourceReply]
+
+pub let lock_screen : @proton_contract.Event[PowerMonitorEventPayload]
+
+pub let on_ac : @proton_contract.Event[PowerMonitorEventPayload]
+
+pub let on_battery : @proton_contract.Event[PowerMonitorEventPayload]
+
+pub let resume_event : @proton_contract.Event[PowerMonitorEventPayload]
+
+pub let suspend : @proton_contract.Event[PowerMonitorEventPayload]
+
+pub let unlock_screen : @proton_contract.Event[PowerMonitorEventPayload]
 
 // Errors
 
@@ -36,6 +50,23 @@ pub fn PowerMonitorActivity::from_json(Json, @json.JsonPath) -> Self raise @json
 pub fn PowerMonitorActivity::not_equal(Self, Self) -> Bool
 pub fn PowerMonitorActivity::to_json(Self) -> Json
 pub fn PowerMonitorActivity::to_repr(Self) -> @debug.Repr
+
+pub(all) struct PowerMonitorEventPayload {
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn PowerMonitorEventPayload::equal(Self, Self) -> Bool
+pub fn PowerMonitorEventPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn PowerMonitorEventPayload::not_equal(Self, Self) -> Bool
+pub fn PowerMonitorEventPayload::to_json(Self) -> Json
+pub fn PowerMonitorEventPayload::to_repr(Self) -> @debug.Repr
+
+pub(all) struct PowerMonitorEventReply {
+  count : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn PowerMonitorEventReply::equal(Self, Self) -> Bool
+pub fn PowerMonitorEventReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn PowerMonitorEventReply::not_equal(Self, Self) -> Bool
+pub fn PowerMonitorEventReply::to_json(Self) -> Json
+pub fn PowerMonitorEventReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PowerSourceReply {
   source : String

--- a/moon.work
+++ b/moon.work
@@ -7,6 +7,7 @@ members = [
   "./rsa",
   "./updater",
   "./proton",
+  "./package",
   "./cli",
   "./config",
   "./examples",

--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,39 @@
+# proton_package
+
+`proton_package` packages an already-built executable with the current host's
+native tools. It does not inspect MoonBit workspaces, build source code, read
+`proton.project.json`, or assemble a Proton/CEF runtime.
+
+```sh
+proton_package \
+  --executable ./build/my-app \
+  --product-name "My App" \
+  --identifier com.example.my-app \
+  --version 1.0.0 \
+  --format app \
+  --output dist
+```
+
+For reusable configuration, pass `--config package.json`:
+
+```json
+{
+  "schema_version": 1,
+  "executable": "build/my-app",
+  "product_name": "My App",
+  "identifier": "com.example.my-app",
+  "version": "1.0.0",
+  "formats": ["app", "zip"],
+  "output": "dist",
+  "payloads": [
+    {
+      "source": "assets",
+      "destination": "assets",
+      "location": "resources"
+    }
+  ]
+}
+```
+
+Supported host-native formats are macOS `app`, `zip`, and `dmg`; Windows
+`app`, `zip`, and `nsis`; and Linux `appimage`.

--- a/package/lib/error.mbt
+++ b/package/lib/error.mbt
@@ -1,0 +1,186 @@
+///|
+pub(all) suberror PackagePlanError {
+  InvalidProductName(reason~ : String)
+  InvalidIdentifier(identifier~ : String, reason~ : String)
+  InvalidVersion(version~ : String, reason~ : String)
+  UnsupportedFormat(format~ : String)
+  UnsupportedFormatForPlatform(format~ : String, platform~ : String)
+  MissingExecutable(path~ : String)
+  MissingInput(path~ : String)
+  MissingIcon(path~ : String)
+  InvalidPayload(detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend PackagePlanError with Eq::{not_equal, equal}
+
+///|
+pub extend PackagePlanError with Debug::{to_repr}
+
+///|
+pub fn PackagePlanError::message(self : PackagePlanError) -> String {
+  match self {
+    InvalidProductName(reason~) => "invalid product_name: " + reason
+    InvalidIdentifier(identifier~, reason~) =>
+      "invalid identifier " + identifier + ": " + reason
+    InvalidVersion(version~, reason~) =>
+      "invalid version " + version + ": " + reason
+    UnsupportedFormat(format~) => "unsupported package format: " + format
+    UnsupportedFormatForPlatform(format~, platform~) =>
+      "package format " + format + " is not supported on " + platform
+    MissingExecutable(path~) => "package executable is missing: " + path
+    MissingInput(path~) => "package input is missing: " + path
+    MissingIcon(path~) => "package icon is missing: " + path
+    InvalidPayload(detail~) => "invalid package payload: " + detail
+  }
+}
+
+///|
+impl Show for PackagePlanError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub(all) suberror PackageFileSystemError {
+  CreateDirectory(path~ : String, detail~ : String)
+  Remove(path~ : String, detail~ : String)
+  Copy(source~ : String, destination~ : String, detail~ : String)
+  Read(path~ : String, detail~ : String)
+  Write(path~ : String, detail~ : String)
+  InvalidSource(path~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend PackageFileSystemError with Eq::{not_equal, equal}
+
+///|
+pub extend PackageFileSystemError with Debug::{to_repr}
+
+///|
+pub fn PackageFileSystemError::message(self : PackageFileSystemError) -> String {
+  match self {
+    CreateDirectory(path~, detail~) =>
+      "failed to create directory " + path + ": " + detail
+    Remove(path~, detail~) => "failed to remove " + path + ": " + detail
+    Copy(source~, destination~, detail~) =>
+      "failed to copy " + source + " to " + destination + ": " + detail
+    Read(path~, detail~) => "failed to read " + path + ": " + detail
+    Write(path~, detail~) => "failed to write " + path + ": " + detail
+    InvalidSource(path~) => "package input is not a file or directory: " + path
+  }
+}
+
+///|
+impl Show for PackageFileSystemError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub(all) suberror PackageToolError {
+  Start(tool~ : String, detail~ : String)
+  Exit(tool~ : String, code~ : Int, detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend PackageToolError with Eq::{not_equal, equal}
+
+///|
+pub extend PackageToolError with Debug::{to_repr}
+
+///|
+pub fn PackageToolError::message(self : PackageToolError) -> String {
+  match self {
+    Start(tool~, detail~) => "failed to run " + tool + ": " + detail
+    Exit(tool~, code~, detail~) =>
+      tool +
+      " exited with code " +
+      code.to_string() +
+      (if detail == "" { "" } else { ": " + detail })
+  }
+}
+
+///|
+impl Show for PackageToolError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub(all) suberror MacosSigningError {
+  InvalidConfiguration(detail~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+  Verification(detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend MacosSigningError with Eq::{not_equal, equal}
+
+///|
+pub extend MacosSigningError with Debug::{to_repr}
+
+///|
+pub fn MacosSigningError::message(self : MacosSigningError) -> String {
+  match self {
+    InvalidConfiguration(detail~) => detail
+    ToolFailure(stage~, detail~) => stage + " failed: " + detail
+    Verification(detail~) => "macOS signing verification failed: " + detail
+  }
+}
+
+///|
+impl Show for MacosSigningError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub(all) suberror WindowsPackagingError {
+  InvalidConfiguration(detail~ : String)
+  MissingTarget(path~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+  Verification(detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend WindowsPackagingError with Eq::{not_equal, equal}
+
+///|
+pub extend WindowsPackagingError with Debug::{to_repr}
+
+///|
+pub fn WindowsPackagingError::message(self : WindowsPackagingError) -> String {
+  match self {
+    InvalidConfiguration(detail~) => detail
+    MissingTarget(path~) => "required Windows target is missing: " + path
+    ToolFailure(stage~, detail~) => stage + " failed: " + detail
+    Verification(detail~) => "Windows package verification failed: " + detail
+  }
+}
+
+///|
+impl Show for WindowsPackagingError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub(all) suberror LinuxPackagingError {
+  InvalidConfiguration(detail~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend LinuxPackagingError with Eq::{not_equal, equal}
+
+///|
+pub extend LinuxPackagingError with Debug::{to_repr}
+
+///|
+pub fn LinuxPackagingError::message(self : LinuxPackagingError) -> String {
+  match self {
+    InvalidConfiguration(detail~) => detail
+    ToolFailure(stage~, detail~) => stage + " failed: " + detail
+  }
+}
+
+///|
+impl Show for LinuxPackagingError with fn output(self, logger) {
+  logger.write_string(self.message())
+}

--- a/package/lib/linux.mbt
+++ b/package/lib/linux.mbt
@@ -1,0 +1,128 @@
+///|
+fn linux_appdir_path(spec : PackageSpec) -> String {
+  path_join(spec.output, "." + executable_name(spec.product_name) + ".AppDir")
+}
+
+///|
+async fn linux_arch() -> String {
+  let (code, output) = @process.collect_output_merged("uname", ["-m"]) catch {
+    error =>
+      raise LinuxPackagingError::ToolFailure(
+        stage="detect architecture",
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 else {
+    raise LinuxPackagingError::ToolFailure(
+      stage="detect architecture",
+      detail="uname exited with code " + code.to_string(),
+    )
+  }
+  match (output.text() catch { _ => "" }).trim().to_owned() {
+    "x86_64" | "amd64" => "x86_64"
+    "aarch64" | "arm64" => "aarch64"
+    arch =>
+      raise LinuxPackagingError::InvalidConfiguration(
+        detail="unsupported AppImage architecture: " + arch,
+      )
+  }
+}
+
+///|
+fn linux_desktop_entry(spec : PackageSpec, name : String) -> String {
+  let prefix =
+    #|[Desktop Entry]
+    #|Type=Application
+    #|Terminal=false
+    #|Categories=Utility;
+  prefix +
+  "Name=" +
+  spec.product_name +
+  "\n" +
+  "Exec=" +
+  name +
+  "\n" +
+  "Icon=" +
+  name +
+  "\n" +
+  "X-AppImage-Version=" +
+  spec.version +
+  "\n"
+}
+
+///|
+fn linux_apprun(name : String) -> String {
+  let prefix =
+    #|#!/bin/sh
+    #|HERE="$(dirname "$(readlink -f "$0")")"
+  prefix + "exec \"$HERE/usr/bin/" + name + "\" \"$@\"\n"
+}
+
+///|
+async fn package_linux(spec : PackageSpec) -> Array[String] {
+  guard path_is_file(spec.executable) else {
+    raise PackagePlanError::MissingExecutable(path=spec.executable)
+  }
+  let icon = match first_icon(spec, ".png") {
+    Some(icon) => icon
+    None =>
+      raise LinuxPackagingError::InvalidConfiguration(
+        detail="the appimage format requires a PNG icon",
+      )
+  }
+  guard path_is_file(icon) else {
+    raise PackagePlanError::MissingIcon(path=icon)
+  }
+  let appdir = linux_appdir_path(spec)
+  remove_tree(appdir)
+  let name = executable_name(spec.product_name)
+  let bin = path_join(appdir, "usr/bin")
+  let resources = path_join(appdir, "usr/share/" + name)
+  let libraries = path_join(appdir, "usr/lib")
+  for directory in [bin, resources, libraries] {
+    ensure_dir(directory)
+  }
+  let staged_executable = path_join(bin, name)
+  copy_file(spec.executable, staged_executable)
+  @async_fs.chmod(staged_executable, 0o755)
+  copy_payloads(spec, resources, libraries, bin)
+  copy_file(icon, path_join(appdir, name + ".png"))
+  copy_file(icon, path_join(appdir, ".DirIcon"))
+  write_text(
+    path_join(appdir, name + ".desktop"),
+    linux_desktop_entry(spec, name),
+  )
+  let apprun = path_join(appdir, "AppRun")
+  write_text(apprun, linux_apprun(name))
+  @async_fs.chmod(apprun, 0o755)
+  let arch = linux_arch()
+  let destination = path_join(
+    spec.output,
+    name + "-" + spec.version + "-" + arch + ".AppImage",
+  )
+  let staging = destination + ".staging"
+  remove_tree(staging)
+  let (code, output) = @process.collect_output_merged(
+    "appimagetool",
+    ["--no-appstream", appdir, staging],
+    extra_env={ "ARCH": arch },
+  ) catch {
+    error =>
+      raise LinuxPackagingError::ToolFailure(
+        stage="create AppImage",
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 else {
+    raise LinuxPackagingError::ToolFailure(
+      stage="create AppImage",
+      detail="exit code " +
+        code.to_string() +
+        ": " +
+        (output.text() catch { _ => "non-UTF-8 output" }),
+    )
+  }
+  promote(staging, destination)
+  remove_tree(appdir)
+  [destination]
+}

--- a/package/lib/macos.mbt
+++ b/package/lib/macos.mbt
@@ -27,7 +27,8 @@ fn macos_info_plist(
 ) -> String {
   let schemes = StringBuilder::new()
   for scheme in spec.url_schemes {
-    schemes.write_string("<string>" + xml_escape(scheme) + "</string>")
+    schemes <+
+      $|<string>\{xml_escape(scheme)}</string>
   }
   let url_types = if schemes.to_string() == "" {
     ""
@@ -41,23 +42,14 @@ fn macos_info_plist(
   }
   let document_entries = StringBuilder::new()
   for document_type in spec.document_types {
-    document_entries.write_string("<dict><key>CFBundleTypeName</key><string>")
-    document_entries.write_string(xml_escape(document_type.name))
-    document_entries.write_string(
-      "</string><key>CFBundleTypeRole</key><string>",
-    )
-    document_entries.write_string(xml_escape(document_type.role))
-    document_entries.write_string(
-      "</string><key>CFBundleTypeExtensions</key><array>",
-    )
+    document_entries <+
+      $|<dict><key>CFBundleTypeName</key><string>\{xml_escape(document_type.name)}</string><key>CFBundleTypeRole</key><string>\{xml_escape(document_type.role)}</string><key>CFBundleTypeExtensions</key><array>
     for extension in document_type.extensions {
-      document_entries.write_string(
-        "<string>" + xml_escape(extension) + "</string>",
-      )
+      document_entries <+
+        $|<string>\{xml_escape(extension)}</string>
     }
-    document_entries.write_string(
-      "</array><key>LSHandlerRank</key><string>Owner</string></dict>",
-    )
+    document_entries <+
+      "</array><key>LSHandlerRank</key><string>Owner</string></dict>"
   }
   let document_types = if document_entries.to_string() == "" {
     ""

--- a/package/lib/macos.mbt
+++ b/package/lib/macos.mbt
@@ -1,0 +1,367 @@
+///|
+fn macos_staging_root(spec : PackageSpec) -> String {
+  path_join(spec.output, "." + executable_name(spec.product_name) + ".staging")
+}
+
+///|
+fn macos_app_path(spec : PackageSpec) -> String {
+  path_join(spec.output, spec.product_name + ".app")
+}
+
+///|
+fn macos_zip_path(spec : PackageSpec) -> String {
+  path_join(spec.output, spec.product_name + ".app.zip")
+}
+
+///|
+fn macos_dmg_path(spec : PackageSpec) -> String {
+  path_join(spec.output, spec.product_name + ".dmg")
+}
+
+///|
+fn macos_info_plist(
+  spec : PackageSpec,
+  executable : String,
+  short_version : String,
+  bundle_version : String,
+) -> String {
+  let schemes = StringBuilder::new()
+  for scheme in spec.url_schemes {
+    schemes.write_string("<string>" + xml_escape(scheme) + "</string>")
+  }
+  let url_types = if schemes.to_string() == "" {
+    ""
+  } else {
+    "<key>CFBundleURLTypes</key><array><dict>" +
+    "<key>CFBundleURLName</key><string>" +
+    xml_escape(spec.identifier) +
+    "</string><key>CFBundleURLSchemes</key><array>" +
+    schemes.to_string() +
+    "</array></dict></array>"
+  }
+  let document_entries = StringBuilder::new()
+  for document_type in spec.document_types {
+    document_entries.write_string("<dict><key>CFBundleTypeName</key><string>")
+    document_entries.write_string(xml_escape(document_type.name))
+    document_entries.write_string(
+      "</string><key>CFBundleTypeRole</key><string>",
+    )
+    document_entries.write_string(xml_escape(document_type.role))
+    document_entries.write_string(
+      "</string><key>CFBundleTypeExtensions</key><array>",
+    )
+    for extension in document_type.extensions {
+      document_entries.write_string(
+        "<string>" + xml_escape(extension) + "</string>",
+      )
+    }
+    document_entries.write_string(
+      "</array><key>LSHandlerRank</key><string>Owner</string></dict>",
+    )
+  }
+  let document_types = if document_entries.to_string() == "" {
+    ""
+  } else {
+    "<key>CFBundleDocumentTypes</key><array>" +
+    document_entries.to_string() +
+    "</array>"
+  }
+  let icon = match first_icon(spec, ".icns") {
+    Some(_) => "<key>CFBundleIconFile</key><string>AppIcon</string>"
+    None => ""
+  }
+  let template =
+    #|<?xml version="1.0" encoding="UTF-8"?>
+    #|<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    #|<plist version="1.0"><dict>
+    #|<key>CFBundleDisplayName</key><string>{{PRODUCT}}</string>
+    #|<key>CFBundleExecutable</key><string>{{EXECUTABLE}}</string>
+    #|<key>CFBundleIdentifier</key><string>{{IDENTIFIER}}</string>
+    #|<key>CFBundleName</key><string>{{PRODUCT}}</string>
+    #|<key>CFBundlePackageType</key><string>APPL</string>
+    #|<key>CFBundleShortVersionString</key><string>{{SHORT_VERSION}}</string>
+    #|<key>CFBundleVersion</key><string>{{BUNDLE_VERSION}}</string>
+    #|<key>LSMinimumSystemVersion</key><string>12.0</string>
+    #|<key>NSHighResolutionCapable</key><true/>
+    #|{{ICON}}{{URL_TYPES}}{{DOCUMENT_TYPES}}
+    #|</dict></plist>
+    #|
+  template
+  .replace_all(old="{{PRODUCT}}", new=xml_escape(spec.product_name))
+  .replace_all(old="{{EXECUTABLE}}", new=xml_escape(executable))
+  .replace_all(old="{{IDENTIFIER}}", new=xml_escape(spec.identifier))
+  .replace_all(old="{{SHORT_VERSION}}", new=xml_escape(short_version))
+  .replace_all(old="{{BUNDLE_VERSION}}", new=xml_escape(bundle_version))
+  .replace_all(old="{{ICON}}", new=icon)
+  .replace_all(old="{{URL_TYPES}}", new=url_types)
+  .replace_all(old="{{DOCUMENT_TYPES}}", new=document_types)
+}
+
+///|
+fn macos_versions(value : String) -> (String, String) raise PackagePlanError {
+  let value = value.trim().to_owned()
+  let core = match value.split_once("-") {
+    Some((core, _)) => core.to_owned()
+    None => value
+  }
+  let core = match core.split_once("+") {
+    Some((core, _)) => core.to_owned()
+    None => core
+  }
+  let components : Array[StringView] = core.split(".").collect()
+  guard components.length() >= 1 && components.length() <= 3 else {
+    raise InvalidVersion(
+      version=core,
+      reason="macOS version must contain one to three numeric components",
+    )
+  }
+  let normalized : Array[String] = []
+  for component in components {
+    guard component.length() > 0 else {
+      raise InvalidVersion(version=core, reason="contains an empty component")
+    }
+    for char in component {
+      guard char.is_ascii_digit() else {
+        raise InvalidVersion(version=core, reason="components must be numeric")
+      }
+    }
+    normalized.push(component.to_owned())
+  }
+  while normalized.length() < 3 {
+    normalized.push("0")
+  }
+  let short_version = normalized.join(".")
+  let bundle_version = match @env.get_env_var("PROTON_MACOS_BUILD_NUMBER") {
+    Some(value) if value.trim().to_owned() != "" => value.trim().to_owned()
+    _ => short_version
+  }
+  (short_version, bundle_version)
+}
+
+///|
+fn macos_signing_identity(spec : PackageSpec) -> String raise MacosSigningError {
+  if !spec.sign {
+    return "-"
+  }
+  match @env.get_env_var("PROTON_MACOS_SIGNING_IDENTITY") {
+    Some(identity) if identity.trim().to_owned() != "" =>
+      identity.trim().to_owned()
+    _ =>
+      raise MacosSigningError::InvalidConfiguration(
+        detail="signing requires PROTON_MACOS_SIGNING_IDENTITY",
+      )
+  }
+}
+
+///|
+async fn run_macos_tool(
+  tool : String,
+  args : Array[String],
+  stage : String,
+) -> Unit {
+  let (code, output) = @process.collect_output_merged(tool, args) catch {
+    error =>
+      raise MacosSigningError::ToolFailure(
+        stage~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 else {
+    raise MacosSigningError::ToolFailure(
+      stage~,
+      detail="exit code " +
+        code.to_string() +
+        ": " +
+        (output.text() catch { _ => "non-UTF-8 output" }),
+    )
+  }
+}
+
+///|
+async fn sign_macos_app(spec : PackageSpec, app : String) -> Unit {
+  let identity = macos_signing_identity(spec)
+  let args = ["--force", "--deep", "--sign", identity]
+  if identity != "-" {
+    args.push("--timestamp")
+    args.push("--options")
+    args.push("runtime")
+  }
+  args.push(app)
+  run_macos_tool("/usr/bin/codesign", args, "sign application")
+  run_macos_tool(
+    "/usr/bin/codesign",
+    ["--verify", "--deep", "--strict", app],
+    "verify application signature",
+  )
+}
+
+///|
+async fn create_macos_zip(app : String, destination : String) -> Unit {
+  let staging = destination + ".staging"
+  remove_tree(staging)
+  run_macos_tool(
+    "/usr/bin/ditto",
+    ["-c", "-k", "--sequesterRsrc", "--keepParent", app, staging],
+    "create application zip",
+  )
+  promote(staging, destination)
+}
+
+///|
+async fn create_macos_dmg(
+  spec : PackageSpec,
+  app : String,
+  destination : String,
+) -> Unit {
+  let root = path_join(macos_staging_root(spec), "dmg-root")
+  // hdiutil chooses its output format from the final extension.
+  let staging = destination + ".staging.dmg"
+  remove_tree(root)
+  remove_tree(staging)
+  ensure_dir(root)
+  copy_tree(app, path_join(root, spec.product_name + ".app"))
+  @async_fs.symlink(target="/Applications", path_join(root, "Applications")) catch {
+    error =>
+      raise PackageFileSystemError::Write(
+        path=root,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  run_macos_tool(
+    "/usr/bin/hdiutil",
+    [
+      "create",
+      "-volname",
+      spec.product_name,
+      "-srcfolder",
+      root,
+      "-format",
+      "UDZO",
+      "-ov",
+      staging,
+    ],
+    "create DMG",
+  )
+  if spec.sign {
+    run_macos_tool(
+      "/usr/bin/codesign",
+      [
+        "--force",
+        "--timestamp",
+        "--sign",
+        macos_signing_identity(spec),
+        staging,
+      ],
+      "sign DMG",
+    )
+    run_macos_tool(
+      "/usr/bin/codesign",
+      ["--verify", "--strict", staging],
+      "verify DMG signature",
+    )
+  }
+  run_macos_tool("/usr/bin/hdiutil", ["verify", staging], "verify DMG")
+  promote(staging, destination)
+  remove_tree(root)
+}
+
+///|
+async fn notarize_macos(
+  spec : PackageSpec,
+  app : String,
+  artifact : String,
+) -> Unit {
+  guard spec.notarize else { return }
+  let profile = match @env.get_env_var("PROTON_MACOS_NOTARY_PROFILE") {
+    Some(profile) if profile.trim().to_owned() != "" =>
+      profile.trim().to_owned()
+    _ =>
+      raise MacosSigningError::InvalidConfiguration(
+        detail="notarization requires PROTON_MACOS_NOTARY_PROFILE",
+      )
+  }
+  run_macos_tool(
+    "/usr/bin/xcrun",
+    ["notarytool", "submit", artifact, "--keychain-profile", profile, "--wait"],
+    "submit notarization",
+  )
+  run_macos_tool(
+    "/usr/bin/xcrun",
+    ["stapler", "staple", app],
+    "staple application",
+  )
+  if artifact.has_suffix(".dmg") {
+    run_macos_tool(
+      "/usr/bin/xcrun",
+      ["stapler", "staple", artifact],
+      "staple DMG",
+    )
+  }
+}
+
+///|
+async fn package_macos(spec : PackageSpec) -> Array[String] {
+  guard path_is_file(spec.executable) else {
+    raise PackagePlanError::MissingExecutable(path=spec.executable)
+  }
+  let staging_root = macos_staging_root(spec)
+  let app = path_join(staging_root, spec.product_name + ".app")
+  let contents = path_join(app, "Contents")
+  let macos = path_join(contents, "MacOS")
+  let resources = path_join(contents, "Resources")
+  let frameworks = path_join(contents, "Frameworks")
+  remove_tree(staging_root)
+  for directory in [macos, resources, frameworks] {
+    ensure_dir(directory)
+  }
+  let name = executable_name(spec.product_name)
+  let staged_executable = path_join(macos, name)
+  copy_file(spec.executable, staged_executable)
+  @async_fs.chmod(staged_executable, 0o755)
+  copy_payloads(spec, resources, frameworks, macos)
+  match first_icon(spec, ".icns") {
+    Some(icon) => copy_file(icon, path_join(resources, "AppIcon.icns"))
+    None => ()
+  }
+  let (short_version, bundle_version) = macos_versions(spec.version)
+  write_text(
+    path_join(contents, "Info.plist"),
+    macos_info_plist(spec, name, short_version, bundle_version),
+  )
+  sign_macos_app(spec, app)
+  let outputs : Array[String] = []
+  let zip = macos_zip_path(spec)
+  let dmg = macos_dmg_path(spec)
+  if spec.formats.contains(Zip) ||
+    (spec.notarize && !spec.formats.contains(Dmg)) {
+    create_macos_zip(app, zip)
+    if spec.formats.contains(Zip) {
+      outputs.push(zip)
+    }
+  }
+  if spec.formats.contains(Dmg) {
+    create_macos_dmg(spec, app, dmg)
+    outputs.push(dmg)
+  }
+  if spec.notarize {
+    notarize_macos(
+      spec,
+      app,
+      if spec.formats.contains(Dmg) {
+        dmg
+      } else {
+        zip
+      },
+    )
+    if !spec.formats.contains(Zip) && !spec.formats.contains(Dmg) {
+      remove_tree(zip)
+    }
+  }
+  if spec.formats.contains(App) {
+    let destination = macos_app_path(spec)
+    promote(app, destination)
+    outputs.push(destination)
+  }
+  remove_tree(staging_root)
+  outputs
+}

--- a/package/lib/moon.pkg
+++ b/package/lib/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async/fs" @async_fs,
+  "moonbitlang/async/process",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/env",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/x/path",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "windows_icon.c" ],
+)

--- a/package/lib/package.mbt
+++ b/package/lib/package.mbt
@@ -1,0 +1,392 @@
+///|
+priv enum PackageHost {
+  Macos
+  Windows
+  Linux
+} derive(Eq)
+
+///|
+async fn current_package_host() -> PackageHost {
+  if @path.sep == '\\' {
+    Windows
+  } else if path_exists("/System/Library/CoreServices/SystemVersion.plist") {
+    Macos
+  } else {
+    Linux
+  }
+}
+
+///|
+fn host_name(host : PackageHost) -> String {
+  match host {
+    Macos => "macOS"
+    Windows => "Windows"
+    Linux => "Linux"
+  }
+}
+
+///|
+fn format_supported(host : PackageHost, format : PackageFormat) -> Bool {
+  match (host, format) {
+    (Macos, App | Zip | Dmg) => true
+    (Windows, App | Zip | Nsis) => true
+    (Linux, AppImage) => true
+    _ => false
+  }
+}
+
+///|
+/// Packages an already-built executable using the current host's native tools.
+pub async fn build(spec : PackageSpec) -> Array[String] {
+  let spec = validate_spec(spec)
+  let host = current_package_host()
+  for format in spec.formats {
+    guard format_supported(host, format) else {
+      raise PackagePlanError::UnsupportedFormatForPlatform(
+        format=format.to_string(),
+        platform=host_name(host),
+      )
+    }
+  }
+  ensure_dir(spec.output)
+  match host {
+    Macos => package_macos(spec)
+    Windows => package_windows(spec)
+    Linux => package_linux(spec)
+  }
+}
+
+///|
+fn validate_spec(spec : PackageSpec) -> PackageSpec raise PackagePlanError {
+  let product_name = validate_product_name(spec.product_name)
+  let identifier = validate_identifier(spec.identifier)
+  let version = spec.version.trim().to_owned()
+  guard version != "" else {
+    raise InvalidVersion(version=spec.version, reason="must not be empty")
+  }
+  guard spec.formats.length() > 0 else {
+    raise UnsupportedFormat(format="no format selected")
+  }
+  for payload in spec.payloads {
+    validate_relative_destination(payload.destination)
+  }
+  PackageSpec::{ ..spec, product_name, identifier, version }
+}
+
+///|
+fn validate_product_name(value : String) -> String raise PackagePlanError {
+  let value = value.trim().to_owned()
+  guard value != "" else {
+    raise InvalidProductName(reason="value is required")
+  }
+  for char in value {
+    let code = char.to_int()
+    if code < 32 || code == 127 {
+      raise InvalidProductName(reason="contains an ASCII control character")
+    }
+    if char == '/' || char == '\\' || char == ':' {
+      raise InvalidProductName(
+        reason="contains a path-unsafe character: " + char.to_string(),
+      )
+    }
+  }
+  value
+}
+
+///|
+fn validate_identifier(value : String) -> String raise PackagePlanError {
+  let value = value.trim().to_owned()
+  let components : Array[StringView] = value.split(".").collect()
+  guard components.length() >= 2 else {
+    raise InvalidIdentifier(
+      identifier=value,
+      reason="expected a reverse-DNS bundle identifier",
+    )
+  }
+  for component in components {
+    guard component.length() > 0 else {
+      raise InvalidIdentifier(
+        identifier=value,
+        reason="contains an empty component",
+      )
+    }
+    let mut at_start = true
+    for char in component {
+      if at_start {
+        guard char.is_ascii_alphabetic() || char.is_ascii_digit() else {
+          raise InvalidIdentifier(
+            identifier=value,
+            reason="a component must start with an ASCII letter or digit",
+          )
+        }
+        at_start = false
+      }
+      guard char.is_ascii_alphabetic() || char.is_ascii_digit() || char == '-' else {
+        raise InvalidIdentifier(
+          identifier=value,
+          reason="contains an unsupported character",
+        )
+      }
+    }
+  }
+  value
+}
+
+///|
+fn validate_relative_destination(value : String) -> Unit raise PackagePlanError {
+  let normalized = value.replace_all(old="\\", new="/")
+  let path : @path.Path = normalized
+  guard normalized != "" && !path.is_absolute() else {
+    raise InvalidPayload(detail="destination must be a non-empty relative path")
+  }
+  for component in normalized.split("/") {
+    guard component != ".." else {
+      raise InvalidPayload(
+        detail="destination must stay inside its package area",
+      )
+    }
+  }
+}
+
+///|
+fn executable_name(product_name : String) -> String {
+  let mut output = ""
+  let mut previous_dash = false
+  for char in product_name.trim().to_owned().to_lower() {
+    if char.is_ascii_alphabetic() ||
+      char.is_ascii_digit() ||
+      char == '-' ||
+      char == '_' {
+      output = output + char.to_string()
+      previous_dash = false
+    } else if !previous_dash && output != "" {
+      output = output + "-"
+      previous_dash = true
+    }
+  }
+  while output.has_suffix("-") {
+    output = output
+      .unsafe_substring(start=0, end=output.length() - 1)
+      .to_string()
+  }
+  if output == "" {
+    "app"
+  } else {
+    output
+  }
+}
+
+///|
+fn first_icon(spec : PackageSpec, suffix : String) -> String? {
+  for icon in spec.icons {
+    if icon.to_lower().has_suffix(suffix) {
+      return Some(icon)
+    }
+  }
+  None
+}
+
+///|
+async fn path_exists(path : String) -> Bool {
+  @async_fs.exists(path)
+}
+
+///|
+async fn path_is_file(path : String) -> Bool {
+  path_exists(path) && @async_fs.kind(path) is Regular
+}
+
+///|
+async fn path_is_dir(path : String) -> Bool {
+  path_exists(path) && @async_fs.kind(path) is Directory
+}
+
+///|
+fn host_path(path : String) -> @path.Path {
+  if @path.sep == '\\' {
+    path.replace_all(old="/", new="\\")
+  } else {
+    path
+  }
+}
+
+///|
+fn path_join(base : String, child : String) -> String {
+  host_path(base).join(host_path(child)).to_string()
+}
+
+///|
+fn path_parent(path : String) -> String {
+  host_path(path).dirname().to_string()
+}
+
+///|
+fn resolve_path(base : String, path : String) -> String {
+  let candidate = host_path(path)
+  if candidate.is_absolute() {
+    candidate.resolve().to_string()
+  } else {
+    host_path(base).join(candidate).resolve().to_string()
+  }
+}
+
+///|
+async fn ensure_dir(path : String) -> Unit {
+  guard !path_exists(path) else { return }
+  let parent = path_parent(path)
+  if parent != path && !path_exists(parent) {
+    ensure_dir(parent)
+  }
+  @async_fs.mkdir(path) catch {
+    error => {
+      guard !path_exists(path) else { return }
+      raise PackageFileSystemError::CreateDirectory(
+        path~,
+        detail=@debug.render(Repr(error)),
+      )
+    }
+  }
+}
+
+///|
+async fn remove_tree(path : String) -> Unit {
+  guard path_exists(path) else { return }
+  if path_is_file(path) {
+    @async_fs.remove(path) catch {
+      error =>
+        raise PackageFileSystemError::Remove(
+          path~,
+          detail=@debug.render(Repr(error)),
+        )
+    }
+  } else {
+    @async_fs.rmdir(path, recursive=true) catch {
+      error =>
+        raise PackageFileSystemError::Remove(
+          path~,
+          detail=@debug.render(Repr(error)),
+        )
+    }
+  }
+}
+
+///|
+async fn copy_file(source : String, destination : String) -> Unit {
+  guard path_is_file(source) else {
+    raise PackagePlanError::MissingInput(path=source)
+  }
+  ensure_dir(path_parent(destination))
+  if current_package_host() == Macos {
+    let code = @process.run("ditto", [source, destination]) catch {
+      error =>
+        raise PackageFileSystemError::Copy(
+          source~,
+          destination~,
+          detail=@debug.render(Repr(error)),
+        )
+    }
+    guard code == 0 else {
+      raise PackageToolError::Exit(tool="ditto", code~, detail=source)
+    }
+    return
+  }
+  let data = @async_fs.read_file(source) catch {
+    error =>
+      raise PackageFileSystemError::Read(
+        path=source,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  @async_fs.write_file(destination, data, create_mode=CreateOrTruncate) catch {
+    error =>
+      raise PackageFileSystemError::Write(
+        path=destination,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+}
+
+///|
+async fn copy_tree(source : String, destination : String) -> Unit {
+  if path_is_file(source) {
+    return copy_file(source, destination)
+  }
+  guard path_is_dir(source) else {
+    raise PackageFileSystemError::InvalidSource(path=source)
+  }
+  ensure_dir(path_parent(destination))
+  let (tool, args) = match current_package_host() {
+    Windows =>
+      (
+        "robocopy",
+        [
+          source, destination, "/E", "/COPY:DAT", "/DCOPY:DAT", "/NFL", "/NDL", "/NJH",
+          "/NJS", "/NP", "/R:2", "/W:1",
+        ],
+      )
+    Macos => ("ditto", [source, destination])
+    Linux => ("cp", ["-R", source, destination])
+  }
+  let (code, _) = @process.collect_output_merged(tool, args) catch {
+    error =>
+      raise PackageFileSystemError::Copy(
+        source~,
+        destination~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 || (tool == "robocopy" && code < 8) else {
+    raise PackageToolError::Exit(tool~, code~, detail=source)
+  }
+}
+
+///|
+async fn copy_payloads(
+  spec : PackageSpec,
+  resources : String,
+  libraries : String,
+  executables : String,
+) -> Unit {
+  for payload in spec.payloads {
+    let root = match payload.location {
+      Resources => resources
+      Libraries => libraries
+      Executables => executables
+    }
+    copy_tree(payload.source, path_join(root, payload.destination))
+  }
+}
+
+///|
+async fn write_text(path : String, text : String) -> Unit {
+  ensure_dir(path_parent(path))
+  @async_fs.write_file(path, text, create_mode=CreateOrTruncate) catch {
+    error =>
+      raise PackageFileSystemError::Write(
+        path~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+}
+
+///|
+async fn promote(source : String, destination : String) -> Unit {
+  remove_tree(destination)
+  @async_fs.rename(source, destination) catch {
+    error =>
+      raise PackageFileSystemError::Copy(
+        source~,
+        destination~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+}
+
+///|
+fn xml_escape(text : String) -> String {
+  text
+  .replace_all(old="&", new="&amp;")
+  .replace_all(old="<", new="&lt;")
+  .replace_all(old=">", new="&gt;")
+  .replace_all(old="\"", new="&quot;")
+}

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -1,0 +1,32 @@
+///|
+test "package formats use stable command names" {
+  assert_eq(PackageFormat::parse("app"), App)
+  assert_eq(PackageFormat::parse("APPIMAGE"), AppImage)
+  assert_eq(PackageFormat::Dmg.to_string(), "dmg")
+}
+
+///|
+test "package identifiers require reverse-DNS form" {
+  assert_eq(validate_identifier("com.example.app"), "com.example.app")
+  let mut rejected = false
+  try validate_identifier("app") catch {
+    InvalidIdentifier(..) => rejected = true
+    _ => ()
+  } noraise {
+    _ => ()
+  }
+  assert_true(rejected)
+}
+
+///|
+test "payload destinations cannot escape their package area" {
+  validate_relative_destination("assets/icon.png")
+  let mut rejected = false
+  try validate_relative_destination("../secret") catch {
+    InvalidPayload(..) => rejected = true
+    _ => ()
+  } noraise {
+    _ => ()
+  }
+  assert_true(rejected)
+}

--- a/package/lib/pkg.generated.mbti
+++ b/package/lib/pkg.generated.mbti
@@ -1,0 +1,145 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton_package/lib"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub async fn build(PackageSpec) -> Array[String]
+
+// Errors
+pub(all) suberror LinuxPackagingError {
+  InvalidConfiguration(detail~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn LinuxPackagingError::equal(Self, Self) -> Bool
+pub fn LinuxPackagingError::message(Self) -> String
+pub fn LinuxPackagingError::not_equal(Self, Self) -> Bool
+pub fn LinuxPackagingError::to_repr(Self) -> @debug.Repr
+
+pub(all) suberror MacosSigningError {
+  InvalidConfiguration(detail~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+  Verification(detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn MacosSigningError::equal(Self, Self) -> Bool
+pub fn MacosSigningError::message(Self) -> String
+pub fn MacosSigningError::not_equal(Self, Self) -> Bool
+pub fn MacosSigningError::to_repr(Self) -> @debug.Repr
+
+pub(all) suberror PackageFileSystemError {
+  CreateDirectory(path~ : String, detail~ : String)
+  Remove(path~ : String, detail~ : String)
+  Copy(source~ : String, destination~ : String, detail~ : String)
+  Read(path~ : String, detail~ : String)
+  Write(path~ : String, detail~ : String)
+  InvalidSource(path~ : String)
+} derive(Eq, @debug.Debug)
+pub fn PackageFileSystemError::equal(Self, Self) -> Bool
+pub fn PackageFileSystemError::message(Self) -> String
+pub fn PackageFileSystemError::not_equal(Self, Self) -> Bool
+pub fn PackageFileSystemError::to_repr(Self) -> @debug.Repr
+
+pub(all) suberror PackagePlanError {
+  InvalidProductName(reason~ : String)
+  InvalidIdentifier(identifier~ : String, reason~ : String)
+  InvalidVersion(version~ : String, reason~ : String)
+  UnsupportedFormat(format~ : String)
+  UnsupportedFormatForPlatform(format~ : String, platform~ : String)
+  MissingExecutable(path~ : String)
+  MissingInput(path~ : String)
+  MissingIcon(path~ : String)
+  InvalidPayload(detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn PackagePlanError::equal(Self, Self) -> Bool
+pub fn PackagePlanError::message(Self) -> String
+pub fn PackagePlanError::not_equal(Self, Self) -> Bool
+pub fn PackagePlanError::to_repr(Self) -> @debug.Repr
+
+pub(all) suberror PackageToolError {
+  Start(tool~ : String, detail~ : String)
+  Exit(tool~ : String, code~ : Int, detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn PackageToolError::equal(Self, Self) -> Bool
+pub fn PackageToolError::message(Self) -> String
+pub fn PackageToolError::not_equal(Self, Self) -> Bool
+pub fn PackageToolError::to_repr(Self) -> @debug.Repr
+
+pub(all) suberror WindowsPackagingError {
+  InvalidConfiguration(detail~ : String)
+  MissingTarget(path~ : String)
+  ToolFailure(stage~ : String, detail~ : String)
+  Verification(detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn WindowsPackagingError::equal(Self, Self) -> Bool
+pub fn WindowsPackagingError::message(Self) -> String
+pub fn WindowsPackagingError::not_equal(Self, Self) -> Bool
+pub fn WindowsPackagingError::to_repr(Self) -> @debug.Repr
+
+// Types and methods
+pub struct DocumentType {
+  name : String
+  extensions : Array[String]
+  role : String
+} derive(Eq, @debug.Debug)
+pub fn DocumentType::equal(Self, Self) -> Bool
+pub fn DocumentType::new(String, Array[String], role? : String) -> Self
+pub fn DocumentType::not_equal(Self, Self) -> Bool
+pub fn DocumentType::to_repr(Self) -> @debug.Repr
+
+pub(all) enum PackageFormat {
+  App
+  Zip
+  Dmg
+  Nsis
+  AppImage
+} derive(Eq, @debug.Debug)
+pub fn PackageFormat::equal(Self, Self) -> Bool
+pub fn PackageFormat::not_equal(Self, Self) -> Bool
+pub fn PackageFormat::parse(String) -> Self raise PackagePlanError
+pub fn PackageFormat::to_repr(Self) -> @debug.Repr
+pub fn PackageFormat::to_string(Self) -> String
+
+pub struct PackageSpec {
+  executable : String
+  product_name : String
+  identifier : String
+  version : String
+  formats : Array[PackageFormat]
+  output : String
+  payloads : Array[Payload]
+  icons : Array[String]
+  url_schemes : Array[String]
+  document_types : Array[DocumentType]
+  sign : Bool
+  notarize : Bool
+} derive(Eq, @debug.Debug)
+pub fn PackageSpec::equal(Self, Self) -> Bool
+pub fn PackageSpec::new(String, String, String, String, Array[PackageFormat], String, payloads? : Array[Payload], icons? : Array[String], url_schemes? : Array[String], document_types? : Array[DocumentType], sign? : Bool, notarize? : Bool) -> Self
+pub fn PackageSpec::not_equal(Self, Self) -> Bool
+pub fn PackageSpec::to_repr(Self) -> @debug.Repr
+
+pub struct Payload {
+  source : String
+  destination : String
+  location : PayloadLocation
+} derive(Eq, @debug.Debug)
+pub fn Payload::equal(Self, Self) -> Bool
+pub fn Payload::new(String, String, location? : PayloadLocation) -> Self
+pub fn Payload::not_equal(Self, Self) -> Bool
+pub fn Payload::to_repr(Self) -> @debug.Repr
+
+pub(all) enum PayloadLocation {
+  Resources
+  Libraries
+  Executables
+} derive(Eq, @debug.Debug)
+pub fn PayloadLocation::equal(Self, Self) -> Bool
+pub fn PayloadLocation::not_equal(Self, Self) -> Bool
+pub fn PayloadLocation::parse(String) -> Self raise PackagePlanError
+pub fn PayloadLocation::to_repr(Self) -> @debug.Repr
+
+// Type aliases
+
+// Traits

--- a/package/lib/types.mbt
+++ b/package/lib/types.mbt
@@ -1,0 +1,166 @@
+///|
+/// A host-native package artifact.
+pub(all) enum PackageFormat {
+  App
+  Zip
+  Dmg
+  Nsis
+  AppImage
+} derive(Debug, Eq)
+
+///|
+pub extend PackageFormat with Eq::{not_equal, equal}
+
+///|
+pub extend PackageFormat with Debug::{to_repr}
+
+///|
+pub fn PackageFormat::parse(
+  value : String,
+) -> PackageFormat raise PackagePlanError {
+  match value.to_lower() {
+    "app" => App
+    "zip" => Zip
+    "dmg" => Dmg
+    "nsis" => Nsis
+    "appimage" => AppImage
+    _ => raise UnsupportedFormat(format=value)
+  }
+}
+
+///|
+pub fn PackageFormat::to_string(self : PackageFormat) -> String {
+  match self {
+    App => "app"
+    Zip => "zip"
+    Dmg => "dmg"
+    Nsis => "nsis"
+    AppImage => "appimage"
+  }
+}
+
+///|
+/// The portable destination area for an additional package payload.
+pub(all) enum PayloadLocation {
+  Resources
+  Libraries
+  Executables
+} derive(Debug, Eq)
+
+///|
+pub extend PayloadLocation with Eq::{not_equal, equal}
+
+///|
+pub extend PayloadLocation with Debug::{to_repr}
+
+///|
+pub fn PayloadLocation::parse(
+  value : String,
+) -> PayloadLocation raise PackagePlanError {
+  match value.to_lower() {
+    "resources" => Resources
+    "libraries" => Libraries
+    "executables" => Executables
+    _ => raise InvalidPayload(detail="unknown payload location: " + value)
+  }
+}
+
+///|
+/// A file or directory copied into the package.
+pub struct Payload {
+  source : String
+  destination : String
+  location : PayloadLocation
+} derive(Debug, Eq)
+
+///|
+pub extend Payload with Eq::{not_equal, equal}
+
+///|
+pub extend Payload with Debug::{to_repr}
+
+///|
+pub fn Payload::new(
+  source : String,
+  destination : String,
+  location? : PayloadLocation = Resources,
+) -> Payload {
+  Payload::{ source, destination, location }
+}
+
+///|
+/// A file association included in native application metadata.
+pub struct DocumentType {
+  name : String
+  extensions : Array[String]
+  role : String
+} derive(Debug, Eq)
+
+///|
+pub extend DocumentType with Eq::{not_equal, equal}
+
+///|
+pub extend DocumentType with Debug::{to_repr}
+
+///|
+pub fn DocumentType::new(
+  name : String,
+  extensions : Array[String],
+  role? : String = "Viewer",
+) -> DocumentType {
+  DocumentType::{ name, extensions, role }
+}
+
+///|
+/// Complete input to the host-native packager.
+pub struct PackageSpec {
+  executable : String
+  product_name : String
+  identifier : String
+  version : String
+  formats : Array[PackageFormat]
+  output : String
+  payloads : Array[Payload]
+  icons : Array[String]
+  url_schemes : Array[String]
+  document_types : Array[DocumentType]
+  sign : Bool
+  notarize : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend PackageSpec with Eq::{not_equal, equal}
+
+///|
+pub extend PackageSpec with Debug::{to_repr}
+
+///|
+pub fn PackageSpec::new(
+  executable : String,
+  product_name : String,
+  identifier : String,
+  version : String,
+  formats : Array[PackageFormat],
+  output : String,
+  payloads? : Array[Payload] = [],
+  icons? : Array[String] = [],
+  url_schemes? : Array[String] = [],
+  document_types? : Array[DocumentType] = [],
+  sign? : Bool = false,
+  notarize? : Bool = false,
+) -> PackageSpec {
+  PackageSpec::{
+    executable,
+    product_name,
+    identifier,
+    version,
+    formats,
+    output,
+    payloads,
+    icons,
+    url_schemes,
+    document_types,
+    sign: sign || notarize,
+    notarize,
+  }
+}

--- a/package/lib/windows.mbt
+++ b/package/lib/windows.mbt
@@ -1,0 +1,172 @@
+///|
+priv struct WindowsSigningConfig {
+  certificate : String
+  password : String
+  timestamp : String?
+}
+
+///|
+fn windows_app_path(spec : PackageSpec) -> String {
+  path_join(spec.output, executable_name(spec.product_name))
+}
+
+///|
+fn windows_staging_path(spec : PackageSpec) -> String {
+  path_join(spec.output, "." + executable_name(spec.product_name) + ".staging")
+}
+
+///|
+fn windows_zip_path(spec : PackageSpec) -> String {
+  path_join(spec.output, executable_name(spec.product_name) + ".zip")
+}
+
+///|
+fn windows_signing_config() -> WindowsSigningConfig raise WindowsPackagingError {
+  let certificate = match @env.get_env_var("PROTON_WINDOWS_CERTIFICATE") {
+    Some(path) if path.trim().to_owned() != "" => path.trim().to_owned()
+    _ =>
+      raise WindowsPackagingError::InvalidConfiguration(
+        detail="signing requires PROTON_WINDOWS_CERTIFICATE",
+      )
+  }
+  let timestamp = match @env.get_env_var("PROTON_WINDOWS_TIMESTAMP_URL") {
+    Some(value) if value.trim().to_owned().to_lower() == "none" => None
+    Some(value) if value.trim().to_owned() != "" =>
+      Some(value.trim().to_owned())
+    _ => Some("http://timestamp.digicert.com")
+  }
+  WindowsSigningConfig::{
+    certificate,
+    password: @env.get_env_var("PROTON_WINDOWS_CERTIFICATE_PASSWORD").unwrap_or(
+      "",
+    ),
+    timestamp,
+  }
+}
+
+///|
+async fn run_signtool(args : Array[String], stage : String) -> Unit {
+  let (code, output) = @process.collect_output_merged(
+    "signtool",
+    args,
+    no_console_window=true,
+  ) catch {
+    error =>
+      raise WindowsPackagingError::ToolFailure(
+        stage~,
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 else {
+    raise WindowsPackagingError::ToolFailure(
+      stage~,
+      detail="exit code " +
+        code.to_string() +
+        ": " +
+        (output.text() catch { _ => "non-UTF-8 output" }),
+    )
+  }
+}
+
+///|
+async fn sign_windows_executable(path : String) -> Unit {
+  let signing = windows_signing_config()
+  guard path_is_file(signing.certificate) else {
+    raise WindowsPackagingError::InvalidConfiguration(
+      detail="Windows signing certificate is missing: " + signing.certificate,
+    )
+  }
+  let args = ["sign", "/fd", "SHA256", "/f", signing.certificate]
+  if signing.password != "" {
+    args.push("/p")
+    args.push(signing.password)
+  }
+  match signing.timestamp {
+    Some(timestamp) => {
+      args.push("/tr")
+      args.push(timestamp)
+      args.push("/td")
+      args.push("SHA256")
+    }
+    None => ()
+  }
+  args.push(path)
+  run_signtool(args, "sign Windows executable")
+  run_signtool(
+    ["verify", "/pa", "/all", "/v", path],
+    "verify Windows executable",
+  )
+}
+
+///|
+async fn create_windows_zip(source : String, destination : String) -> Unit {
+  let staging = destination + ".staging"
+  remove_tree(staging)
+  let script =
+    #|& {
+    #|  $ErrorActionPreference = "Stop"
+    #|  Compress-Archive -LiteralPath $env:PROTON_PACKAGE_ZIP_SOURCE -DestinationPath $env:PROTON_PACKAGE_ZIP_DESTINATION -Force
+    #|}
+  let (code, output) = @process.collect_output_merged(
+    "powershell",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    extra_env={
+      "PROTON_PACKAGE_ZIP_SOURCE": source,
+      "PROTON_PACKAGE_ZIP_DESTINATION": staging,
+    },
+    no_console_window=true,
+  ) catch {
+    error =>
+      raise WindowsPackagingError::ToolFailure(
+        stage="create Windows zip",
+        detail=@debug.render(Repr(error)),
+      )
+  }
+  guard code == 0 else {
+    raise WindowsPackagingError::ToolFailure(
+      stage="create Windows zip",
+      detail="exit code " +
+        code.to_string() +
+        ": " +
+        (output.text() catch { _ => "non-UTF-8 output" }),
+    )
+  }
+  promote(staging, destination)
+}
+
+///|
+async fn package_windows(spec : PackageSpec) -> Array[String] {
+  guard path_is_file(spec.executable) else {
+    raise PackagePlanError::MissingExecutable(path=spec.executable)
+  }
+  let staging = windows_staging_path(spec)
+  remove_tree(staging)
+  ensure_dir(staging)
+  let name = executable_name(spec.product_name) + ".exe"
+  let staged_executable = path_join(staging, name)
+  copy_file(spec.executable, staged_executable)
+  copy_payloads(spec, path_join(staging, "Resources"), staging, staging)
+  stage_windows_icon(spec, staged_executable)
+  if spec.sign {
+    sign_windows_executable(staged_executable)
+  }
+  let outputs : Array[String] = []
+  let app = windows_app_path(spec)
+  promote(staging, app)
+  if spec.formats.contains(App) {
+    outputs.push(app)
+  }
+  if spec.formats.contains(Zip) {
+    let zip = windows_zip_path(spec)
+    create_windows_zip(app, zip)
+    outputs.push(zip)
+  }
+  if spec.formats.contains(Nsis) {
+    create_windows_installer(spec, app, false)
+    outputs.push(windows_installer_path(spec))
+  }
+  if !spec.formats.contains(App) {
+    remove_tree(app)
+  }
+  outputs
+}

--- a/package/lib/windows_icon.c
+++ b/package/lib/windows_icon.c
@@ -1,0 +1,298 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "moonbit.h"
+
+static void package_icon_error(char *buffer, int32_t buffer_length,
+                               const char *message) {
+  if (buffer == NULL || buffer_length <= 0) {
+    return;
+  }
+  snprintf(buffer, (size_t)buffer_length, "%s", message);
+}
+
+#ifdef _WIN32
+#include <windows.h>
+
+enum {
+  PACKAGE_ICON_OK = 0,
+  PACKAGE_ICON_INVALID_ARGUMENT = -1,
+  PACKAGE_ICON_IO_ERROR = -2,
+  PACKAGE_ICON_INVALID_FORMAT = -3,
+  PACKAGE_ICON_WINDOWS_ERROR = -4,
+  PACKAGE_ICON_OUT_OF_MEMORY = -5,
+};
+
+static uint16_t package_icon_u16(const uint8_t *data) {
+  return (uint16_t)(data[0] | ((uint16_t)data[1] << 8));
+}
+
+static uint32_t package_icon_u32(const uint8_t *data) {
+  return (uint32_t)data[0] | ((uint32_t)data[1] << 8) |
+         ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+}
+
+static void package_icon_write_u16(uint8_t *data, uint16_t value) {
+  data[0] = (uint8_t)(value & 0xff);
+  data[1] = (uint8_t)(value >> 8);
+}
+
+static void package_icon_write_u32(uint8_t *data, uint32_t value) {
+  data[0] = (uint8_t)(value & 0xff);
+  data[1] = (uint8_t)((value >> 8) & 0xff);
+  data[2] = (uint8_t)((value >> 16) & 0xff);
+  data[3] = (uint8_t)((value >> 24) & 0xff);
+}
+
+static void package_icon_windows_error(char *buffer, int32_t buffer_length,
+                                       const char *operation,
+                                       DWORD error_code) {
+  if (buffer == NULL || buffer_length <= 0) {
+    return;
+  }
+  wchar_t wide_message[512] = {0};
+  DWORD length = FormatMessageW(
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+      error_code, 0, wide_message,
+      (DWORD)(sizeof(wide_message) / sizeof(wide_message[0])), NULL);
+  while (length > 0 &&
+         (wide_message[length - 1] == L'\r' ||
+          wide_message[length - 1] == L'\n' ||
+          wide_message[length - 1] == L' ')) {
+    wide_message[--length] = L'\0';
+  }
+  char system_message[512 * 3] = {0};
+  if (length > 0 &&
+      WideCharToMultiByte(CP_UTF8, 0, wide_message, -1, system_message,
+                          (int)sizeof(system_message), NULL, NULL) > 0) {
+    snprintf(buffer, (size_t)buffer_length, "%s failed (Windows error %lu): %s",
+             operation, (unsigned long)error_code, system_message);
+  } else {
+    snprintf(buffer, (size_t)buffer_length, "%s failed (Windows error %lu)",
+             operation, (unsigned long)error_code);
+  }
+}
+
+static wchar_t *package_icon_utf8_path(const uint8_t *path, int32_t length,
+                                       char *error_buffer,
+                                       int32_t error_buffer_length) {
+  if (path == NULL || length <= 0) {
+    package_icon_error(error_buffer, error_buffer_length,
+                       "path must not be empty");
+    return NULL;
+  }
+  int wide_length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                        (const char *)path, length, NULL, 0);
+  if (wide_length <= 0) {
+    package_icon_windows_error(error_buffer, error_buffer_length,
+                               "decode UTF-8 path", GetLastError());
+    return NULL;
+  }
+  wchar_t *wide =
+      (wchar_t *)calloc((size_t)wide_length + 1, sizeof(wchar_t));
+  if (wide == NULL) {
+    package_icon_error(error_buffer, error_buffer_length, "out of memory");
+    return NULL;
+  }
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                          (const char *)path, length, wide,
+                          wide_length) != wide_length) {
+    DWORD error_code = GetLastError();
+    free(wide);
+    package_icon_windows_error(error_buffer, error_buffer_length,
+                               "decode UTF-8 path", error_code);
+    return NULL;
+  }
+  return wide;
+}
+
+static uint8_t *package_icon_read_file(const wchar_t *path, size_t *size,
+                                       char *error_buffer,
+                                       int32_t error_buffer_length) {
+  FILE *file = _wfopen(path, L"rb");
+  if (file == NULL) {
+    package_icon_error(error_buffer, error_buffer_length,
+                       "failed to open Windows icon file");
+    return NULL;
+  }
+  if (_fseeki64(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    package_icon_error(error_buffer, error_buffer_length,
+                       "failed to inspect Windows icon file");
+    return NULL;
+  }
+  __int64 length = _ftelli64(file);
+  if (length <= 0 || (uint64_t)length > SIZE_MAX) {
+    fclose(file);
+    package_icon_error(error_buffer, error_buffer_length,
+                       "Windows icon file is empty or too large");
+    return NULL;
+  }
+  rewind(file);
+  uint8_t *data = (uint8_t *)malloc((size_t)length);
+  if (data == NULL) {
+    fclose(file);
+    package_icon_error(error_buffer, error_buffer_length, "out of memory");
+    return NULL;
+  }
+  if (fread(data, 1, (size_t)length, file) != (size_t)length) {
+    free(data);
+    fclose(file);
+    package_icon_error(error_buffer, error_buffer_length,
+                       "failed to read Windows icon file");
+    return NULL;
+  }
+  fclose(file);
+  *size = (size_t)length;
+  return data;
+}
+
+static int package_icon_validate(const uint8_t *data, size_t size,
+                                 uint16_t *count, char *error_buffer,
+                                 int32_t error_buffer_length) {
+  if (size < 6 || package_icon_u16(data) != 0 ||
+      package_icon_u16(data + 2) != 1) {
+    package_icon_error(error_buffer, error_buffer_length,
+                       "invalid Windows ICO header");
+    return 0;
+  }
+  uint16_t image_count = package_icon_u16(data + 4);
+  if (image_count == 0 ||
+      (size_t)image_count > (SIZE_MAX - 6) / 16 ||
+      6 + (size_t)image_count * 16 > size) {
+    package_icon_error(error_buffer, error_buffer_length,
+                       "invalid Windows ICO directory");
+    return 0;
+  }
+  for (uint32_t index = 0; index < image_count; index++) {
+    const uint8_t *entry = data + 6 + (size_t)index * 16;
+    uint32_t image_size = package_icon_u32(entry + 8);
+    uint32_t image_offset = package_icon_u32(entry + 12);
+    if (image_size == 0 || image_offset > size ||
+        image_size > size - image_offset) {
+      package_icon_error(error_buffer, error_buffer_length,
+                         "Windows ICO image lies outside the file");
+      return 0;
+    }
+  }
+  *count = image_count;
+  return 1;
+}
+
+static int32_t package_icon_update_resources(
+    const wchar_t *executable, const uint8_t *icon_data, uint16_t image_count,
+    char *error_buffer, int32_t error_buffer_length) {
+  HANDLE update = BeginUpdateResourceW(executable, FALSE);
+  if (update == NULL) {
+    package_icon_windows_error(error_buffer, error_buffer_length,
+                               "BeginUpdateResourceW", GetLastError());
+    return PACKAGE_ICON_WINDOWS_ERROR;
+  }
+
+  size_t group_size = 6 + (size_t)image_count * 14;
+  uint8_t *group = (uint8_t *)calloc(group_size, 1);
+  if (group == NULL) {
+    EndUpdateResourceW(update, TRUE);
+    package_icon_error(error_buffer, error_buffer_length, "out of memory");
+    return PACKAGE_ICON_OUT_OF_MEMORY;
+  }
+  package_icon_write_u16(group + 2, 1);
+  package_icon_write_u16(group + 4, image_count);
+
+  WORD language = MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL);
+  for (uint32_t index = 0; index < image_count; index++) {
+    const uint8_t *source = icon_data + 6 + (size_t)index * 16;
+    uint8_t *target = group + 6 + (size_t)index * 14;
+    uint16_t resource_id = (uint16_t)(index + 1);
+    uint32_t image_size = package_icon_u32(source + 8);
+    uint32_t image_offset = package_icon_u32(source + 12);
+    memcpy(target, source, 8);
+    package_icon_write_u32(target + 8, image_size);
+    package_icon_write_u16(target + 12, resource_id);
+    if (!UpdateResourceW(update, RT_ICON, MAKEINTRESOURCEW(resource_id),
+                         language, (void *)(icon_data + image_offset),
+                         image_size)) {
+      DWORD error_code = GetLastError();
+      free(group);
+      EndUpdateResourceW(update, TRUE);
+      package_icon_windows_error(error_buffer, error_buffer_length,
+                                 "UpdateResourceW(RT_ICON)", error_code);
+      return PACKAGE_ICON_WINDOWS_ERROR;
+    }
+  }
+
+  if (!UpdateResourceW(update, RT_GROUP_ICON, MAKEINTRESOURCEW(1), language,
+                       group, (DWORD)group_size)) {
+    DWORD error_code = GetLastError();
+    free(group);
+    EndUpdateResourceW(update, TRUE);
+    package_icon_windows_error(error_buffer, error_buffer_length,
+                               "UpdateResourceW(RT_GROUP_ICON)", error_code);
+    return PACKAGE_ICON_WINDOWS_ERROR;
+  }
+  free(group);
+  if (!EndUpdateResourceW(update, FALSE)) {
+    package_icon_windows_error(error_buffer, error_buffer_length,
+                               "EndUpdateResourceW", GetLastError());
+    return PACKAGE_ICON_WINDOWS_ERROR;
+  }
+  return PACKAGE_ICON_OK;
+}
+#endif
+
+MOONBIT_FFI_EXPORT int32_t proton_package_set_windows_executable_icon(
+    moonbit_bytes_t executable, int32_t executable_length,
+    moonbit_bytes_t icon, int32_t icon_length, char *error_buffer,
+    int32_t error_buffer_length) {
+  package_icon_error(error_buffer, error_buffer_length, "");
+#ifdef _WIN32
+  if (executable == NULL || icon == NULL || executable_length <= 0 ||
+      icon_length <= 0) {
+    package_icon_error(error_buffer, error_buffer_length,
+                       "executable and icon paths are required");
+    return PACKAGE_ICON_INVALID_ARGUMENT;
+  }
+  wchar_t *wide_executable = package_icon_utf8_path(
+      executable, executable_length, error_buffer, error_buffer_length);
+  if (wide_executable == NULL) {
+    return PACKAGE_ICON_INVALID_ARGUMENT;
+  }
+  wchar_t *wide_icon = package_icon_utf8_path(
+      icon, icon_length, error_buffer, error_buffer_length);
+  if (wide_icon == NULL) {
+    free(wide_executable);
+    return PACKAGE_ICON_INVALID_ARGUMENT;
+  }
+  size_t icon_size = 0;
+  uint8_t *icon_data = package_icon_read_file(
+      wide_icon, &icon_size, error_buffer, error_buffer_length);
+  free(wide_icon);
+  if (icon_data == NULL) {
+    free(wide_executable);
+    return PACKAGE_ICON_IO_ERROR;
+  }
+  uint16_t image_count = 0;
+  if (!package_icon_validate(icon_data, icon_size, &image_count, error_buffer,
+                             error_buffer_length)) {
+    free(icon_data);
+    free(wide_executable);
+    return PACKAGE_ICON_INVALID_FORMAT;
+  }
+  int32_t status = package_icon_update_resources(
+      wide_executable, icon_data, image_count, error_buffer,
+      error_buffer_length);
+  free(icon_data);
+  free(wide_executable);
+  return status;
+#else
+  (void)executable;
+  (void)executable_length;
+  (void)icon;
+  (void)icon_length;
+  package_icon_error(error_buffer, error_buffer_length,
+                     "Windows icon embedding is only available on Windows");
+  return -1;
+#endif
+}

--- a/package/lib/windows_icon.mbt
+++ b/package/lib/windows_icon.mbt
@@ -1,0 +1,55 @@
+///|
+let windows_icon_error_buffer_length = 1024
+
+///|
+#borrow(executable, icon, error_buffer)
+extern "C" fn set_windows_executable_icon_ffi(
+  executable : Bytes,
+  executable_length : Int,
+  icon : Bytes,
+  icon_length : Int,
+  error_buffer : FixedArray[Byte],
+  error_buffer_length : Int,
+) -> Int = "proton_package_set_windows_executable_icon"
+
+///|
+fn first_windows_icon(icons : Array[String]) -> String? {
+  for icon in icons {
+    if icon.to_lower().has_suffix(".ico") {
+      return Some(icon)
+    }
+  }
+  None
+}
+
+///|
+async fn stage_windows_icon(spec : PackageSpec, executable : String) -> Unit {
+  guard first_windows_icon(spec.icons) is Some(icon) else { return }
+  guard path_is_file(icon) else {
+    raise PackagePlanError::MissingIcon(path=icon)
+  }
+  let executable_bytes = @utf8.encode(executable)
+  let icon_bytes = @utf8.encode(icon)
+  let error_buffer = FixedArray::make(windows_icon_error_buffer_length, b'\x00')
+  let status = set_windows_executable_icon_ffi(
+    executable_bytes,
+    executable_bytes.length(),
+    icon_bytes,
+    icon_bytes.length(),
+    error_buffer,
+    error_buffer.length(),
+  )
+  guard status == 0 else {
+    let bytes = Bytes::from_array(error_buffer)
+    let end = bytes.find(b"\x00").unwrap_or(bytes.length())
+    let detail = @utf8.decode_lossy(bytes[0:end])
+    raise WindowsPackagingError::ToolFailure(
+      stage="embed Windows application icon",
+      detail=if detail == "" {
+        "native icon writer failed with status " + status.to_string()
+      } else {
+        detail
+      },
+    )
+  }
+}

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -1,0 +1,207 @@
+// The Windows installer target. The generated NSIS script is intentionally
+// repeatable so it can replace an existing installation.
+
+///|
+/// NSIS derives the silent-install switch (`/S`) itself.
+let windows_installer_tool : String = "makensis"
+
+///|
+fn windows_installer_path(plan : PackageSpec) -> String {
+  resolve_path(plan.output, "\{executable_name(plan.product_name)}-setup.exe")
+}
+
+///|
+fn windows_installer_staging_path(plan : PackageSpec) -> String {
+  resolve_path(
+    plan.output,
+    ".\{executable_name(plan.product_name)}.staging-setup.exe",
+  )
+}
+
+///|
+fn windows_installer_script_path(plan : PackageSpec) -> String {
+  resolve_path(
+    plan.output,
+    ".\{executable_name(plan.product_name)}.installer.nsi",
+  )
+}
+
+///|
+/// The registry key holding the install location. The updater does not read
+/// it — it re-runs the installer, which resolves the location itself — but
+/// Add/Remove Programs and a manual reinstall both do.
+fn windows_installer_registry_key(plan : PackageSpec) -> String {
+  "Software\\\{plan.identifier}"
+}
+
+///|
+fn windows_uninstall_registry_key(plan : PackageSpec) -> String {
+  "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\{plan.identifier}"
+}
+
+///|
+/// `VIProductVersion` rejects anything that is not exactly four numeric
+/// fields, so a semantic version has to be padded and any pre-release suffix
+/// dropped. The human-readable version still ships in `FileVersion`.
+fn windows_installer_version_quad(version : String) -> String {
+  let digits = []
+  let current = StringBuilder::new()
+  for char in version {
+    if char.is_ascii_digit() {
+      current.write_char(char)
+    } else {
+      if current.to_string() != "" {
+        digits.push(current.to_string())
+        current.reset()
+      }
+      if char != '.' {
+        break
+      }
+    }
+  }
+  if current.to_string() != "" {
+    digits.push(current.to_string())
+  }
+  while digits.length() < 4 {
+    digits.push("0")
+  }
+  let quad = digits[:4]
+  quad.to_owned().join(".")
+}
+
+///|
+/// Escapes a value for an NSIS double-quoted string.
+///
+/// `$` opens a variable reference such as `$INSTDIR` and is doubled to stay
+/// literal; a quote is written `$\"`. The `$` pass has to run first, or it
+/// would go back over the `$` that the quote escape just introduced.
+/// Backslashes are ordinary characters here and must be left alone, otherwise
+/// every Windows path in the script breaks.
+fn windows_installer_quote(value : String) -> String {
+  value.replace_all(old="$", new="$$").replace_all(old="\"", new="$\\\"")
+}
+
+///|
+/// Renders the installer script.
+///
+/// Kept pure so the generated text is testable on any host; running
+/// `makensis` needs Windows tooling that only the packaging step has.
+fn windows_installer_script(plan : PackageSpec, source : String) -> String {
+  let product = windows_installer_quote(plan.product_name)
+  let executable = "\{executable_name(plan.product_name)}.exe"
+  let builder = StringBuilder::new()
+  builder <+
+    #|Unicode true
+    #|ManifestDPIAware true
+    #|SetCompressor /SOLID lzma
+    #|RequestExecutionLevel admin
+    #|
+    #|!include "MUI2.nsh"
+    #|
+  builder <+
+    $|Name "\{product}"
+    $|OutFile "\{windows_installer_quote(windows_installer_staging_path(plan))}"
+    $|InstallDir "$PROGRAMFILES64\\\{product}"
+    $|InstallDirRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "InstallDir"
+    $|
+    $|VIProductVersion "\{windows_installer_version_quad(plan.version)}"
+    $|VIAddVersionKey "ProductName" "\{product}"
+    $|VIAddVersionKey "FileVersion" "\{windows_installer_quote(plan.version)}"
+    $|VIAddVersionKey "ProductVersion" "\{windows_installer_quote(plan.version)}"
+    $|VIAddVersionKey "FileDescription" "\{product} Setup"
+    $|
+  builder <+
+    #|!define MUI_ABORTWARNING
+    #|!insertmacro MUI_PAGE_DIRECTORY
+    #|!insertmacro MUI_PAGE_INSTFILES
+    #|!insertmacro MUI_UNPAGE_CONFIRM
+    #|!insertmacro MUI_UNPAGE_INSTFILES
+    #|!insertmacro MUI_LANGUAGE "English"
+    #|
+    #|Section "Install"
+    #|
+  builder <+
+    $|  ; An update re-runs this installer while the application it is
+    $|  ; replacing is still running, so close it before overwriting.
+    $|  nsExec::Exec 'taskkill /F /IM "\{executable}"'
+    $|  Pop $0
+    $|  Sleep 500
+    $|
+    $|  SetOutPath "$INSTDIR"
+    $|  File /r "\{windows_installer_quote(source)}\\*.*"
+    $|  WriteUninstaller "$INSTDIR\\Uninstall.exe"
+    $|
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "InstallDir" "$INSTDIR"
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "Version" "\{windows_installer_quote(plan.version)}"
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayName" "\{product}"
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayVersion" "\{windows_installer_quote(plan.version)}"
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "UninstallString" "$\\"$INSTDIR\\Uninstall.exe$\\""
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "InstallLocation" "$INSTDIR"
+    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayIcon" "$INSTDIR\\\{executable}"
+    $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoModify" 1
+    $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoRepair" 1
+    $|
+    $|  CreateShortCut "$SMPROGRAMS\\\{product}.lnk" "$INSTDIR\\\{executable}"
+    $|SectionEnd
+    $|
+  builder <+
+    $|Section "Uninstall"
+    $|  nsExec::Exec 'taskkill /F /IM "\{executable}"'
+    $|  Pop $0
+    $|  Delete "$SMPROGRAMS\\\{product}.lnk"
+    $|  RMDir /r "$INSTDIR"
+    $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}"
+    $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
+    $|SectionEnd
+    $|
+  builder.to_string()
+}
+
+///|
+/// Builds the installer from an already-staged portable directory.
+async fn create_windows_installer(
+  plan : PackageSpec,
+  source : String,
+  announce : Bool,
+) -> Unit {
+  let installer = windows_installer_path(plan)
+  let staging = windows_installer_staging_path(plan)
+  let script = windows_installer_script_path(plan)
+  remove_tree(staging)
+  @async_fs.write_file(
+    script,
+    windows_installer_script(plan, source),
+    create_mode=CreateOrTruncate,
+  ) catch {
+    error =>
+      raise WindowsPackagingError::ToolFailure(
+        stage="write Windows installer script",
+        detail="\{script}: \{@debug.render(Repr(error))}",
+      )
+  }
+  let (code, _) = @process.collect_output_merged(windows_installer_tool, [
+    "/V2", script,
+  ]) catch {
+    _ =>
+      raise WindowsPackagingError::ToolFailure(
+        stage="create Windows installer",
+        detail="\{windows_installer_tool} is not available; install NSIS to build the installer target",
+      )
+  }
+  guard code == 0 else {
+    raise WindowsPackagingError::ToolFailure(
+      stage="create Windows installer",
+      detail="exit code \{code}",
+    )
+  }
+  guard path_exists(staging) else {
+    raise WindowsPackagingError::Verification(
+      detail="installer was not produced: \{staging}",
+    )
+  }
+  promote(staging, installer)
+  if announce {
+    println("Created installer: \{installer}")
+  }
+  ()
+}

--- a/package/main.mbt
+++ b/package/main.mbt
@@ -1,0 +1,301 @@
+///|
+priv struct RawConfig {
+  executable : String?
+  product_name : String?
+  identifier : String?
+  version : String?
+  formats : Array[String]
+  output : String?
+  payloads : Array[@package.Payload]
+  icons : Array[String]
+  url_schemes : Array[String]
+  document_types : Array[@package.DocumentType]
+  sign : Bool
+  notarize : Bool
+}
+
+///|
+fn empty_config() -> RawConfig {
+  RawConfig::{
+    executable: None,
+    product_name: None,
+    identifier: None,
+    version: None,
+    formats: [],
+    output: None,
+    payloads: [],
+    icons: [],
+    url_schemes: [],
+    document_types: [],
+    sign: false,
+    notarize: false,
+  }
+}
+
+///|
+fn command() -> @argparse.Command {
+  @argparse.Command(
+    "proton_package",
+    about="Package an already-built desktop executable",
+    flags=[
+      FlagArg("sign", about="Sign the packaged application"),
+      FlagArg("notarize", about="Sign and notarize a macOS application"),
+    ],
+    options=[
+      OptionArg("config", about="JSON package specification"),
+      OptionArg("executable", about="Already-built application executable"),
+      OptionArg("product-name", about="Application display name"),
+      OptionArg("identifier", about="Reverse-DNS application identifier"),
+      OptionArg("version", about="Application version"),
+      OptionArg(
+        "format",
+        action=Append,
+        about="Output format: app, zip, dmg, nsis, or appimage; may be repeated",
+      ),
+      OptionArg("output", about="Artifact output directory"),
+      OptionArg("icon", action=Append, about="Platform icon; may be repeated"),
+      OptionArg(
+        "url-scheme",
+        action=Append,
+        about="Registered URL scheme; may be repeated",
+      ),
+    ],
+  )
+}
+
+///|
+fn string_field(fields : Map[String, Json], name : String) -> String? {
+  match fields.get(name) {
+    Some(String(value)) => Some(value)
+    Some(_) => abort("package config field " + name + " must be a string")
+    None => None
+  }
+}
+
+///|
+fn bool_field(fields : Map[String, Json], name : String) -> Bool {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) | None => false
+    Some(_) => abort("package config field " + name + " must be a boolean")
+  }
+}
+
+///|
+fn string_array_field(
+  fields : Map[String, Json],
+  name : String,
+) -> Array[String] {
+  match fields.get(name) {
+    None => []
+    Some(Array(values)) =>
+      values.map(fn(value) {
+        match value {
+          String(value) => value
+          _ => abort("package config field " + name + " must contain strings")
+        }
+      })
+    Some(_) => abort("package config field " + name + " must be an array")
+  }
+}
+
+///|
+fn resolve_config_path(base : String, value : String) -> String {
+  let path : @path.Path = value
+  if path.is_absolute() {
+    path.resolve().to_string()
+  } else {
+    @path.Path(base).join(path).resolve().to_string()
+  }
+}
+
+///|
+fn payloads_field(
+  fields : Map[String, Json],
+  base : String,
+) -> Array[@package.Payload] raise @package.PackagePlanError {
+  guard fields.get("payloads") is Some(Array(values)) else { return [] }
+  values.map(value => {
+    guard value is Object(payload) else {
+      abort("package config payload must be an object")
+    }
+    guard payload
+      is { "source": String(source), "destination": String(destination), .. } else {
+      abort("package config payload requires source and destination strings")
+    }
+    let location = match payload.get("location") {
+      Some(String(value)) => @package.PayloadLocation::parse(value)
+      None => @package.PayloadLocation::Resources
+      Some(_) => abort("package config payload location must be a string")
+    }
+    @package.Payload::new(
+      resolve_config_path(base, source),
+      destination,
+      location~,
+    )
+  })
+}
+
+///|
+fn document_types_field(
+  fields : Map[String, Json],
+) -> Array[@package.DocumentType] {
+  guard fields.get("document_types") is Some(Array(values)) else { return [] }
+  values.map(fn(value) {
+    guard value is Object(document_type) else {
+      abort("package config document_type must be an object")
+    }
+    guard document_type
+      is { "name": String(name), "extensions": Array(extension_values), .. } else {
+      abort("package config document_type requires name and extensions")
+    }
+    let extensions = extension_values.map(fn(value) {
+      match value {
+        String(value) => value
+        _ => abort("document_type extensions must contain strings")
+      }
+    })
+    let role = match document_type.get("role") {
+      Some(String(role)) => role
+      None => "Viewer"
+      Some(_) => abort("document_type role must be a string")
+    }
+    @package.DocumentType::new(name, extensions, role~)
+  })
+}
+
+///|
+async fn read_config(path : String) -> RawConfig {
+  let absolute = @path.Path(path).resolve()
+  let text = @async_fs.read_file(absolute.to_string()).text() catch {
+    error =>
+      abort("failed to read package config: " + @debug.render(Repr(error)))
+  }
+  let json = @json.parse(text) catch {
+    error => abort("invalid package config JSON: " + @debug.render(Repr(error)))
+  }
+  guard json is Object(fields) else {
+    abort("package config root must be an object")
+  }
+  guard fields.get("schema_version") is Some(Number(1.0, ..)) else {
+    abort("package config requires schema_version 1")
+  }
+  let base = absolute.dirname().to_string()
+  RawConfig::{
+    executable: string_field(fields, "executable").map(fn(path) {
+      resolve_config_path(base, path)
+    }),
+    product_name: string_field(fields, "product_name"),
+    identifier: string_field(fields, "identifier"),
+    version: string_field(fields, "version"),
+    formats: string_array_field(fields, "formats"),
+    output: string_field(fields, "output").map(fn(path) {
+      resolve_config_path(base, path)
+    }),
+    payloads: payloads_field(fields, base),
+    icons: string_array_field(fields, "icons").map(fn(path) {
+      resolve_config_path(base, path)
+    }),
+    url_schemes: string_array_field(fields, "url_schemes"),
+    document_types: document_types_field(fields),
+    sign: bool_field(fields, "sign"),
+    notarize: bool_field(fields, "notarize"),
+  }
+}
+
+///|
+fn first(values : Map[String, Array[String]], name : String) -> String? {
+  match values.get(name) {
+    Some([value, ..]) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn values(values : Map[String, Array[String]], name : String) -> Array[String] {
+  values.get(name).unwrap_or([])
+}
+
+///|
+fn required(value : String?, name : String) -> String {
+  match value {
+    Some(value) => value
+    None => abort("missing required option --" + name)
+  }
+}
+
+///|
+fn prefer(primary : String?, fallback : String?) -> String? {
+  match primary {
+    Some(value) => Some(value)
+    None => fallback
+  }
+}
+
+///|
+async fn run(args : ArrayView[String]) -> Unit {
+  let matches = @argparse.parse(command(), argv=args, env=Map([])) catch {
+    error => abort(error.to_string())
+  }
+  let config = match first(matches.values, "config") {
+    Some(path) => read_config(path)
+    None => empty_config()
+  }
+  let executable = prefer(
+    first(matches.values, "executable"),
+    config.executable,
+  )
+  let product_name = prefer(
+    first(matches.values, "product-name"),
+    config.product_name,
+  )
+  let identifier = prefer(
+    first(matches.values, "identifier"),
+    config.identifier,
+  )
+  let version = prefer(first(matches.values, "version"), config.version)
+  let output = prefer(first(matches.values, "output"), config.output).unwrap_or(
+    "dist",
+  )
+  let format_values = values(matches.values, "format")
+  let formats = (if format_values.length() > 0 {
+    format_values
+  } else {
+    config.formats
+  }).map(value => @package.PackageFormat::parse(value))
+  let icon_values = values(matches.values, "icon")
+  let icons = if icon_values.length() > 0 { icon_values } else { config.icons }
+  let scheme_values = values(matches.values, "url-scheme")
+  let url_schemes = if scheme_values.length() > 0 {
+    scheme_values
+  } else {
+    config.url_schemes
+  }
+  let spec = @package.PackageSpec::new(
+    @path.Path(required(executable, "executable")).resolve().to_string(),
+    required(product_name, "product-name"),
+    required(identifier, "identifier"),
+    required(version, "version"),
+    formats,
+    @path.Path(output).resolve().to_string(),
+    payloads=config.payloads,
+    icons=icons.map(fn(path) { @path.Path(path).resolve().to_string() }),
+    url_schemes~,
+    document_types=config.document_types,
+    sign=matches.flags.get("sign").unwrap_or(false) || config.sign,
+    notarize=matches.flags.get("notarize").unwrap_or(false) || config.notarize,
+  )
+  for artifact in @package.build(spec) {
+    println(artifact)
+  }
+}
+
+///|
+async fn main {
+  run(@env.args()[1:]) catch {
+    error => {
+      println("error: " + error.to_string())
+      @sys.exit(1)
+    }
+  }
+}

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,0 +1,24 @@
+name = "moonbit-community/proton_package"
+
+version = "0.1.18"
+
+import {
+  "moonbitlang/async@0.20.5",
+  "moonbitlang/x@0.4.50",
+}
+
+readme = "README.md"
+
+repository = "https://github.com/moonbit-community/proton/tree/main/package"
+
+license = "Apache-2.0"
+
+keywords = [ "desktop", "package", "app", "dmg", "nsis", "appimage" ]
+
+description = "Host-native desktop application packaging library and CLI."
+
+options(
+  warn_list: "",
+  preferred_target: "native",
+  supported_targets: "native",
+)

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.1.18"
+version = "0.1.0"
 
 import {
   "moonbitlang/async@0.20.5",

--- a/package/moon.pkg
+++ b/package/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbit-community/proton_package/lib" @package,
+  "moonbitlang/async",
+  "moonbitlang/async/fs" @async_fs,
+  "moonbitlang/core/argparse",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/x/path",
+  "moonbitlang/x/sys",
+}
+
+pkgtype(kind: "executable")
+
+supported_targets = "native"

--- a/package/pkg.generated.mbti
+++ b/package/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton_package"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/proton/native/pkg.generated.mbti
+++ b/proton/native/pkg.generated.mbti
@@ -73,6 +73,7 @@ pub(all) suberror NativeError {
   InvalidPayload(context~ : String, message~ : String)
 } derive(Eq, @debug.Debug)
 pub fn NativeError::equal(Self, Self) -> Bool
+pub fn NativeError::is_invalid_state(Self) -> Bool
 pub fn NativeError::is_stale_bridge_response(Self) -> Bool
 pub fn NativeError::is_stale_browser_request(Self) -> Bool
 pub fn NativeError::is_stale_window_request(Self) -> Bool

--- a/scripts/bump_version.mbtx
+++ b/scripts/bump_version.mbtx
@@ -13,6 +13,8 @@ struct ModuleDocument {
   ast : @moon_config.Ast
 }
 
+let independently_versioned_modules = ["./package"]
+
 fn fail(message : String) -> Unit {
   println("error: " + message)
   @sys.exit(2)
@@ -115,6 +117,9 @@ async fn main {
     guard item is @moon_config.Ast::Str(member_path, ..) else {
       fail("moon.work contains a non-string member")
       return
+    }
+    guard !independently_versioned_modules.contains(member_path) else {
+      continue
     }
     let path = member_path + "/moon.mod"
     let source = @fs.read_file(path).text()

--- a/scripts/verify_release_metadata.mjs
+++ b/scripts/verify_release_metadata.mjs
@@ -106,6 +106,7 @@ const workspaceModuleManifests = [
   "contract/moon.mod",
   "rsa/moon.mod",
   "updater/moon.mod",
+  "package/moon.mod",
   "sys/auto_launch/moon.mod",
   "sys/clipboard/moon.mod",
   "sys/ffi/moon.mod",

--- a/scripts/verify_release_metadata.mjs
+++ b/scripts/verify_release_metadata.mjs
@@ -106,7 +106,6 @@ const workspaceModuleManifests = [
   "contract/moon.mod",
   "rsa/moon.mod",
   "updater/moon.mod",
-  "package/moon.mod",
   "sys/auto_launch/moon.mod",
   "sys/clipboard/moon.mod",
   "sys/ffi/moon.mod",

--- a/sys/power_monitor/pkg.generated.mbti
+++ b/sys/power_monitor/pkg.generated.mbti
@@ -23,9 +23,24 @@ pub struct PowerMonitor {
   // private fields
 }
 pub fn PowerMonitor::destroy(Self) -> Unit
+pub fn PowerMonitor::drain_events(Self) -> Array[PowerMonitorEvent]
 pub fn PowerMonitor::idle_seconds(Self) -> Int raise PowerMonitorError
 pub fn PowerMonitor::new() -> Self raise PowerMonitorError
 pub fn PowerMonitor::power_source(Self) -> PowerSourceInfo raise PowerMonitorError
+pub fn PowerMonitor::start_watching(Self) -> Unit raise PowerMonitorError
+pub fn PowerMonitor::stop_watching(Self) -> Unit raise PowerMonitorError
+
+pub enum PowerMonitorEvent {
+  Suspend
+  Resume
+  OnAC
+  OnBattery
+  LockScreen
+  UnlockScreen
+} derive(Eq, @debug.Debug)
+pub fn PowerMonitorEvent::equal(Self, Self) -> Bool
+pub fn PowerMonitorEvent::not_equal(Self, Self) -> Bool
+pub fn PowerMonitorEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum PowerSource {
   Unknown


### PR DESCRIPTION
## Summary

- add the independently published `moonbit-community/proton_package` library and CLI
- package already-built executables as host-native macOS, Windows, and Linux artifacts
- accept explicit payloads through the library API, CLI flags, or a JSON specification
- make `proton_cli package` consume executable paths reported by Moon instead of inspecting `_build`
- start `proton_package` on an independent `0.1.0` version line
- make the publish workflow's `package` resume point publish only `proton_package`

## Validation

- `moon fmt --check`
- `moon info`
- `moon -C package test lib --target native --diagnostic-limit 80`
- `moon -C cli test -p moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
- `moon check --target native --deny-warn --diagnostic-limit 100`
- `node scripts/verify_release_metadata.mjs`
- `moon -C package publish --dry-run` completed archive creation, extraction, and isolated package checking; upload was correctly rejected because local credentials belong to `Milky2018`, so the organization workflow will perform the release
- generated and verified real macOS `.app`, `.app.zip`, and `.dmg` artifacts, including payload placement, plist validation, code-sign verification, ZIP integrity, and DMG integrity

## Platform status

- macOS packaging was exercised locally with real artifacts
- Windows and Linux implementations compile but still require host-native runtime validation
