### PR TITLE
fix(cli): serialize CEF cache and runtime assembly

### DIFF
--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -33,16 +33,17 @@ async fn install_cef_root(
   platform~ : ProtonPlatform,
 ) -> Unit {
   assert_safe_install_dir(install_dir, root)
-  remove_tree(install_dir)
+  ensure_dir(@fsutil.path_parent(install_dir))
+  let staging = create_install_staging(install_dir)
   @output.info("[INFO] Installing CEF into: " + install_dir)
   try {
-    copy_tree(extracted_root, install_dir)
-    normalize_cef_runtime_layout(install_dir)
-    let missing = validate_cef_layout(install_dir, platform)
+    copy_tree(extracted_root, staging)
+    normalize_cef_runtime_layout(staging)
+    let missing = validate_cef_layout(staging, platform)
     if missing.length() > 0 {
       raise InvalidCefRoot(path=install_dir, missing~)
     }
-    let version_path = @fsutil.path_join(install_dir, "version.txt")
+    let version_path = @fsutil.path_join(staging, "version.txt")
     @async_fs.write_file(
       version_path,
       name + "\n",
@@ -54,7 +55,7 @@ async fn install_cef_root(
           detail=@debug.render(Repr(err)),
         )
     }
-    let checksum_path = @fsutil.path_join(install_dir, "sha256.txt")
+    let checksum_path = @fsutil.path_join(staging, "sha256.txt")
     @async_fs.write_file(
       checksum_path,
       sha256 + "\n",
@@ -66,9 +67,19 @@ async fn install_cef_root(
           detail=@debug.render(Repr(err)),
         )
     }
+    validate_cef_root(staging, platform)
+    remove_tree(install_dir)
+    @async_fs.rename(staging, install_dir, replace=false) catch {
+      err =>
+        raise CefFileSystemError::Copy(
+          source=staging,
+          destination=install_dir,
+          detail=@debug.render(Repr(err)),
+        )
+    }
   } catch {
     error => {
-      remove_tree(install_dir) catch {
+      remove_tree(staging) catch {
         _ => ()
       }
       raise error
@@ -193,7 +204,6 @@ async fn ensure_cef_cache(
   if cached_cef_root_is_valid(cache_dir, name, sha256, platform) {
     return cache_dir
   }
-  remove_tree(cache_dir)
   if project_cache != cache_dir &&
     cached_cef_root_is_valid(project_cache, name, sha256, platform) {
     install_cef_root(
@@ -230,10 +240,6 @@ async fn cached_cef_root_is_valid(
   guard installed_version(cache_dir) == name &&
     installed_checksum(cache_dir) == sha256 else {
     return false
-  }
-  normalize_cef_runtime_layout(cache_dir) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return false
   }
   validate_cef_root(cache_dir, platform) catch {
     error if @async.is_being_cancelled() => raise error

--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -31,11 +31,14 @@ async fn install_cef_root(
   sha256~ : String,
   root~ : String,
   platform~ : ProtonPlatform,
+  report_progress? : Bool = true,
 ) -> Unit {
   assert_safe_install_dir(install_dir, root)
   ensure_dir(@fsutil.path_parent(install_dir))
   let staging = create_install_staging(install_dir)
-  @output.info("[INFO] Installing CEF into: " + install_dir)
+  if report_progress {
+    @output.info("[INFO] Installing CEF into: " + install_dir)
+  }
   try {
     copy_tree(extracted_root, staging)
     normalize_cef_runtime_layout(staging)

--- a/cli/cef/cef_cache.mbt
+++ b/cli/cef/cef_cache.mbt
@@ -68,15 +68,7 @@ async fn install_cef_root(
         )
     }
     validate_cef_root(staging, platform)
-    remove_tree(install_dir)
-    @async_fs.rename(staging, install_dir, replace=false) catch {
-      err =>
-        raise CefFileSystemError::Copy(
-          source=staging,
-          destination=install_dir,
-          detail=@debug.render(Repr(err)),
-        )
-    }
+    replace_staged_directory(staging, install_dir)
   } catch {
     error => {
       remove_tree(staging) catch {
@@ -190,44 +182,87 @@ fn home_directory() -> String? {
 }
 
 ///|
+priv struct CefCacheLease {
+  root : String
+  lock : @async_fs.File
+}
+
+///|
+fn CefCacheLease::release(self : CefCacheLease) -> Unit {
+  self.lock.unlock()
+  self.lock.close()
+}
+
+///|
+async fn install_from_project_cache(
+  project_cache~ : String,
+  cache_dir~ : String,
+  name~ : String,
+  sha256~ : String,
+  root~ : String,
+  platform~ : ProtonPlatform,
+) -> Bool {
+  let project_lock = acquire_install_lock(project_cache)
+  defer project_lock.close()
+  defer project_lock.unlock()
+  guard cached_cef_root_is_valid(project_cache, name, sha256, platform) else {
+    return false
+  }
+  install_cef_root(
+    extracted_root=project_cache,
+    install_dir=cache_dir,
+    name~,
+    sha256~,
+    root~,
+    platform~,
+  )
+  true
+}
+
+///|
 async fn ensure_cef_cache(
   root~ : String,
   platform~ : ProtonPlatform,
   name~ : String,
   url~ : String?,
   sha256~ : String,
-) -> String {
+) -> CefCacheLease {
   let project_cache = project_cef_cache_dir(root~, platform~, name~)
   let cache_dir = global_cef_cache_dir(project_root=root, platform~, name~).unwrap_or(
     project_cache,
   )
-  if cached_cef_root_is_valid(cache_dir, name, sha256, platform) {
-    return cache_dir
-  }
-  if project_cache != cache_dir &&
-    cached_cef_root_is_valid(project_cache, name, sha256, platform) {
-    install_cef_root(
-      extracted_root=project_cache,
-      install_dir=cache_dir,
+  let lock = acquire_install_lock(cache_dir)
+  try {
+    if cached_cef_root_is_valid(cache_dir, name, sha256, platform) {
+      return { root: cache_dir, lock }
+    }
+    if project_cache != cache_dir &&
+      install_from_project_cache(
+        project_cache~,
+        cache_dir~,
+        name~,
+        sha256~,
+        root~,
+        platform~,
+      ) {
+      return { root: cache_dir, lock }
+    }
+    setup_downloaded_cef(
       name~,
+      url~,
       sha256~,
       root~,
+      install_dir=cache_dir,
       platform~,
     )
-    return cache_dir
+    { root: cache_dir, lock }
+  } catch {
+    error => {
+      lock.unlock()
+      lock.close()
+      raise error
+    }
   }
-  if project_cache != cache_dir {
-    remove_tree(project_cache)
-  }
-  setup_downloaded_cef(
-    name~,
-    url~,
-    sha256~,
-    root~,
-    install_dir=cache_dir,
-    platform~,
-  )
-  cache_dir
 }
 
 ///|

--- a/cli/cef/cef_cache_wbtest.mbt
+++ b/cli/cef/cef_cache_wbtest.mbt
@@ -36,6 +36,7 @@ async test "failed CEF installation removes incomplete cache markers" {
       sha256="a".repeat(64),
       root=project_root,
       platform~,
+      report_progress=false,
     )
     false
   } catch {
@@ -97,6 +98,7 @@ async test "successful CEF installation writes markers after validation" {
     sha256="a".repeat(64),
     root=project_root,
     platform~,
+    report_progress=false,
   )
   assert_eq(installed_version(install), "cef-test")
   assert_eq(installed_checksum(install), "a".repeat(64))
@@ -124,6 +126,7 @@ async test "failed replacement keeps the previously valid CEF cache" {
     sha256="a".repeat(64),
     root=project_root,
     platform~,
+    report_progress=false,
   )
   @async_fs.mkdir(replacement, recursive=true)
   let failed = try {
@@ -134,6 +137,7 @@ async test "failed replacement keeps the previously valid CEF cache" {
       sha256="b".repeat(64),
       root=project_root,
       platform~,
+      report_progress=false,
     )
     false
   } catch {
@@ -204,6 +208,7 @@ async test "runtime assembly rebuilds an existing truncated runtime" {
     cef_root~,
     prebuilt_root~,
     runtime_dir~,
+    report_progress=false,
   )
   let truncated = @fsutil.path_join(runtime_dir, "lib/libproton.dylib")
   @async_fs.write_file(truncated, "", create_mode=CreateOrTruncate)
@@ -213,6 +218,7 @@ async test "runtime assembly rebuilds an existing truncated runtime" {
     cef_root~,
     prebuilt_root~,
     runtime_dir~,
+    report_progress=false,
   )
   assert_true(file_is_nonempty(truncated))
   validate_runtime_dist(runtime_dir, platform)

--- a/cli/cef/cef_cache_wbtest.mbt
+++ b/cli/cef/cef_cache_wbtest.mbt
@@ -106,3 +106,140 @@ async test "successful CEF installation writes markers after validation" {
   )
   remove_tree(temp)
 }
+
+///|
+async test "failed replacement keeps the previously valid CEF cache" {
+  let temp = test_cef_cache_fixture_root()
+  let source = @fsutil.path_join(temp, "source")
+  let replacement = @fsutil.path_join(temp, "replacement")
+  let install = @fsutil.path_join(temp, "cache")
+  let project_root = @fsutil.path_join(temp, "project")
+  let platform = darwin_arm64_platform()
+  @async_fs.mkdir(source, recursive=true)
+  test_write_cef_fixture_files(source, platform)
+  install_cef_root(
+    extracted_root=source,
+    install_dir=install,
+    name="cef-test",
+    sha256="a".repeat(64),
+    root=project_root,
+    platform~,
+  )
+  @async_fs.mkdir(replacement, recursive=true)
+  let failed = try {
+    install_cef_root(
+      extracted_root=replacement,
+      install_dir=install,
+      name="cef-test-next",
+      sha256="b".repeat(64),
+      root=project_root,
+      platform~,
+    )
+    false
+  } catch {
+    InvalidCefRoot(path=_, missing=_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  assert_true(failed)
+  assert_eq(installed_version(install), "cef-test")
+  assert_eq(installed_checksum(install), "a".repeat(64))
+  validate_cef_root(install, platform)
+  remove_tree(temp)
+}
+
+///|
+async test "empty CEF artifacts are rejected as incomplete" {
+  let temp = test_cef_cache_fixture_root()
+  let cache = @fsutil.path_join(temp, "cache")
+  let platform = darwin_arm64_platform()
+  @async_fs.mkdir(cache, recursive=true)
+  for relative in installed_cef_relative_files(platform) {
+    let path = @fsutil.path_join(cache, relative)
+    @async_fs.mkdir(@fsutil.path_parent(path), recursive=true) catch {
+      _ => ()
+    }
+    @async_fs.write_file(path, "fixture", create_mode=CreateOrTruncate)
+  }
+  let empty_path = @fsutil.path_join(
+    cache,
+    installed_cef_relative_files(platform)[0],
+  )
+  @async_fs.write_file(empty_path, "", create_mode=CreateOrTruncate)
+  let missing = validate_cef_layout(cache, platform)
+  assert_true(missing.contains(empty_path))
+  remove_tree(temp)
+}
+
+///|
+async fn test_write_prebuilt_fixture_files(
+  root : String,
+  platform : ProtonPlatform,
+) -> Unit {
+  for relative in proton_prebuilt_relative_files(platform) {
+    let path = @fsutil.path_join(root, relative)
+    @async_fs.mkdir(@fsutil.path_parent(path), recursive=true) catch {
+      _ => ()
+    }
+    @async_fs.write_file(path, "prebuilt", create_mode=CreateOrTruncate)
+  }
+}
+
+///|
+async test "runtime assembly rebuilds an existing truncated runtime" {
+  let temp = test_cef_cache_fixture_root()
+  let cache_root = @fsutil.path_join(temp, "runtimes")
+  let cef_root = @fsutil.path_join(temp, "cef")
+  let prebuilt_root = @fsutil.path_join(temp, "prebuilt")
+  let runtime_dir = @fsutil.path_join(cache_root, "darwin-arm64/runtime")
+  let platform = darwin_arm64_platform()
+  @async_fs.mkdir(cef_root, recursive=true)
+  @async_fs.mkdir(prebuilt_root, recursive=true)
+  test_write_cef_fixture_files(cef_root, platform)
+  test_write_prebuilt_fixture_files(prebuilt_root, platform)
+  assemble_runtime(
+    cache_root~,
+    platform~,
+    cef_root~,
+    prebuilt_root~,
+    runtime_dir~,
+  )
+  let truncated = @fsutil.path_join(runtime_dir, "lib/libproton.dylib")
+  @async_fs.write_file(truncated, "", create_mode=CreateOrTruncate)
+  assemble_runtime(
+    cache_root~,
+    platform~,
+    cef_root~,
+    prebuilt_root~,
+    runtime_dir~,
+  )
+  assert_true(file_is_nonempty(truncated))
+  validate_runtime_dist(runtime_dir, platform)
+  remove_tree(temp)
+}
+
+///|
+async test "failed staged publish restores the previous directory" {
+  let temp = test_cef_cache_fixture_root()
+  let target = @fsutil.path_join(temp, "target")
+  let marker = @fsutil.path_join(target, "marker.txt")
+  @async_fs.mkdir(target)
+  @async_fs.write_file(marker, "previous", create_mode=CreateOrTruncate)
+  let failed = try {
+    replace_staged_directory(@fsutil.path_join(temp, "missing"), target)
+    false
+  } catch {
+    CefFileSystemError::Copy(source=_, destination=_, detail=_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  assert_true(failed)
+  assert_eq(@async_fs.read_file(marker).text(), "previous")
+  assert_eq(
+    @async_fs.readdir(temp, include_hidden=true, include_special=false),
+    ["target"],
+  )
+  remove_tree(temp)
+}

--- a/cli/cef/cef_cache_wbtest.mbt
+++ b/cli/cef/cef_cache_wbtest.mbt
@@ -243,3 +243,33 @@ async test "failed staged publish restores the previous directory" {
   )
   remove_tree(temp)
 }
+
+///|
+async test "install locks serialize access to the same cache directory" {
+  let temp = test_cef_cache_fixture_root()
+  let target = @fsutil.path_join(temp, "cache")
+  let first = acquire_install_lock(target)
+  let first_locked = Ref(true)
+  defer {
+    if first_locked.val {
+      first.unlock()
+    }
+    first.close()
+  }
+  @async.with_task_group() <| group => {
+    let acquired = Ref(false)
+    let waiter = group.spawn(() => {
+      let second = acquire_install_lock(target)
+      defer second.close()
+      defer second.unlock()
+      acquired.val = true
+    })
+    @async.sleep(50)
+    assert_false(acquired.val)
+    first.unlock()
+    first_locked.val = false
+    waiter.wait()
+    assert_true(acquired.val)
+  }
+  remove_tree(temp)
+}

--- a/cli/cef/cef_fs.mbt
+++ b/cli/cef/cef_fs.mbt
@@ -111,6 +111,48 @@ async fn ensure_dir(path : String) -> Unit {
 }
 
 ///|
+async fn acquire_install_lock(target_dir : String) -> @async_fs.File {
+  let lock_path = target_dir + ".lock"
+  ensure_dir(@fsutil.path_parent(lock_path))
+  let file = @async_fs.open(lock_path, mode=ReadWrite, create_mode=OpenOrCreate) catch {
+    err =>
+      raise CefFileSystemError::Write(
+        path=lock_path,
+        detail=@debug.render(Repr(err)),
+      )
+  }
+  file.lock(Exclusive) catch {
+    err => {
+      file.close()
+      raise CefFileSystemError::Write(
+        path=lock_path,
+        detail="failed to acquire install lock: " + @debug.render(Repr(err)),
+      )
+    }
+  }
+  file
+}
+
+///|
+async fn create_install_staging(target_dir : String) -> String {
+  let prefix = target_dir + ".staging-" + @async.now().to_string()
+  for index = 0; ; index = index + 1 {
+    let staging = prefix + "-" + index.to_string()
+    try @async_fs.mkdir(staging) catch {
+      error =>
+        if !@fsutil.path_exists(staging) {
+          raise CefFileSystemError::CreateDirectory(
+            path=staging,
+            detail=@debug.render(Repr(error)),
+          )
+        }
+    } noraise {
+      _ => return staging
+    }
+  }
+}
+
+///|
 async fn normalize_cef_runtime_layout(root : String) -> Unit {
   let release_dir = @fsutil.path_join(root, "Release")
   if !@fsutil.path_exists(release_dir) {

--- a/cli/cef/cef_fs.mbt
+++ b/cli/cef/cef_fs.mbt
@@ -115,6 +115,7 @@ async fn acquire_install_lock(target_dir : String) -> @async_fs.File {
   let lock_path = target_dir + ".lock"
   ensure_dir(@fsutil.path_parent(lock_path))
   let file = @async_fs.open(lock_path, mode=ReadWrite, create_mode=OpenOrCreate) catch {
+    error if @async.is_being_cancelled() => raise error
     err =>
       raise CefFileSystemError::Write(
         path=lock_path,
@@ -122,6 +123,10 @@ async fn acquire_install_lock(target_dir : String) -> @async_fs.File {
       )
   }
   file.lock(Exclusive) catch {
+    error if @async.is_being_cancelled() => {
+      file.close()
+      raise error
+    }
     err => {
       file.close()
       raise CefFileSystemError::Write(
@@ -148,6 +153,64 @@ async fn create_install_staging(target_dir : String) -> String {
         }
     } noraise {
       _ => return staging
+    }
+  }
+}
+
+///|
+async fn create_install_backup(target_dir : String) -> String {
+  let prefix = target_dir + ".backup-" + @async.now().to_string()
+  for index = 0; ; index = index + 1 {
+    let backup = prefix + "-" + index.to_string()
+    guard !@fsutil.path_exists(backup) else { continue }
+    return backup
+  }
+}
+
+///|
+async fn replace_staged_directory(staging : String, target : String) -> Unit {
+  let had_target = @fsutil.path_exists(target)
+  let backup = if had_target { create_install_backup(target) } else { "" }
+  if had_target {
+    @async_fs.rename(target, backup, replace=false) catch {
+      err =>
+        raise CefFileSystemError::Copy(
+          source=target,
+          destination=backup,
+          detail=@debug.render(Repr(err)),
+        )
+    }
+  }
+  try {
+    @async_fs.rename(staging, target, replace=false) catch {
+      err =>
+        raise CefFileSystemError::Copy(
+          source=staging,
+          destination=target,
+          detail=@debug.render(Repr(err)),
+        )
+    }
+  } catch {
+    error => {
+      if had_target {
+        @async_fs.rename(backup, target, replace=false) catch {
+          restore_error =>
+            raise CefFileSystemError::Copy(
+              source=backup,
+              destination=target,
+              detail="failed to restore after publish error " +
+                @debug.render(Repr(error)) +
+                ": " +
+                @debug.render(Repr(restore_error)),
+            )
+        }
+      }
+      raise error
+    }
+  }
+  if had_target {
+    remove_tree(backup) catch {
+      _ => ()
     }
   }
 }

--- a/cli/cef/cef_runtime_assembly.mbt
+++ b/cli/cef/cef_runtime_assembly.mbt
@@ -115,12 +115,10 @@ async fn assemble_runtime(
   if @fsutil.path_is_dir(runtime_dir) {
     try validate_runtime_dist(runtime_dir, platform) catch {
       error if @async.is_being_cancelled() => raise error
-      _ => remove_tree(runtime_dir)
+      _ => ()
     } noraise {
       _ => return
     }
-  } else if @fsutil.path_exists(runtime_dir) {
-    remove_tree(runtime_dir)
   }
   ensure_dir(@fsutil.path_parent(runtime_dir))
   let staging = create_runtime_staging(runtime_dir)
@@ -134,18 +132,7 @@ async fn assemble_runtime(
     }
     copy_cef_runtime(platform, cef_root, staging)
     validate_runtime_dist(staging, platform)
-    @async_fs.rename(staging, runtime_dir, replace=false) catch {
-      error => {
-        if @fsutil.path_is_dir(runtime_dir) {
-          remove_tree(staging)
-          return
-        }
-        raise CefRuntimeError::RuntimeConflict(
-          path=runtime_dir,
-          detail=@debug.render(Repr(error)),
-        )
-      }
-    }
+    replace_staged_directory(staging, runtime_dir)
   } catch {
     error => {
       remove_tree(staging) catch {

--- a/cli/cef/cef_runtime_assembly.mbt
+++ b/cli/cef/cef_runtime_assembly.mbt
@@ -107,6 +107,7 @@ async fn assemble_runtime(
   cef_root~ : String,
   prebuilt_root~ : String,
   runtime_dir~ : String,
+  report_progress? : Bool = true,
 ) -> Unit {
   assert_safe_generated_dir(runtime_dir, cache_root)
   let runtime_lock = acquire_install_lock(runtime_dir)
@@ -123,7 +124,9 @@ async fn assemble_runtime(
   ensure_dir(@fsutil.path_parent(runtime_dir))
   let staging = create_runtime_staging(runtime_dir)
   try {
-    @output.info("[INFO] Assembling Proton runtime: " + runtime_dir)
+    if report_progress {
+      @output.info("[INFO] Assembling Proton runtime: " + runtime_dir)
+    }
     copy_prebuilt_runtime(platform, prebuilt_root, staging)
     if platform.id != "win32-x64" {
       make_executable(

--- a/cli/cef/cef_runtime_assembly.mbt
+++ b/cli/cef/cef_runtime_assembly.mbt
@@ -109,8 +109,18 @@ async fn assemble_runtime(
   runtime_dir~ : String,
 ) -> Unit {
   assert_safe_generated_dir(runtime_dir, cache_root)
+  let runtime_lock = acquire_install_lock(runtime_dir)
+  defer runtime_lock.close()
+  defer runtime_lock.unlock()
   if @fsutil.path_is_dir(runtime_dir) {
-    return
+    try validate_runtime_dist(runtime_dir, platform) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => remove_tree(runtime_dir)
+    } noraise {
+      _ => return
+    }
+  } else if @fsutil.path_exists(runtime_dir) {
+    remove_tree(runtime_dir)
   }
   ensure_dir(@fsutil.path_parent(runtime_dir))
   let staging = create_runtime_staging(runtime_dir)

--- a/cli/cef/cef_setup.mbt
+++ b/cli/cef/cef_setup.mbt
@@ -85,6 +85,13 @@ async fn setup(
   let (proton_version, proton_source_hash) = prebuilt_manifest_identity(
     prebuilt_root,
   )
+  let project_cache = project_cef_cache_dir(root~, platform~, name~)
+  let cache_dir = global_cef_cache_dir(project_root=root, platform~, name~).unwrap_or(
+    project_cache,
+  )
+  let cache_lock = acquire_install_lock(cache_dir)
+  defer cache_lock.close()
+  defer cache_lock.unlock()
   let cef_root = ensure_cef_cache(root~, platform~, name~, url~, sha256~)
   let runtime_id = proton_runtime_id(proton_version, proton_source_hash, sha256)
   let global_cache_root = resolve_global_runtime_cache_root(

--- a/cli/cef/cef_setup.mbt
+++ b/cli/cef/cef_setup.mbt
@@ -85,14 +85,9 @@ async fn setup(
   let (proton_version, proton_source_hash) = prebuilt_manifest_identity(
     prebuilt_root,
   )
-  let project_cache = project_cef_cache_dir(root~, platform~, name~)
-  let cache_dir = global_cef_cache_dir(project_root=root, platform~, name~).unwrap_or(
-    project_cache,
-  )
-  let cache_lock = acquire_install_lock(cache_dir)
-  defer cache_lock.close()
-  defer cache_lock.unlock()
-  let cef_root = ensure_cef_cache(root~, platform~, name~, url~, sha256~)
+  let cef_cache = ensure_cef_cache(root~, platform~, name~, url~, sha256~)
+  defer cef_cache.release()
+  let cef_root = cef_cache.root
   let runtime_id = proton_runtime_id(proton_version, proton_source_hash, sha256)
   let global_cache_root = resolve_global_runtime_cache_root(
     project_root=root,

--- a/cli/cef/cef_validation.mbt
+++ b/cli/cef/cef_validation.mbt
@@ -23,11 +23,25 @@ async fn validate_cef_layout(
   let missing : Array[String] = []
   for relative in installed_cef_relative_files(platform) {
     let path = @fsutil.path_join(root, relative)
-    if !@fsutil.path_exists(path) {
+    if !file_is_nonempty(path) {
       missing.push(path)
     }
   }
   missing
+}
+
+///|
+async fn file_is_nonempty(path : String) -> Bool {
+  guard @fsutil.path_is_file(path) else { return false }
+  let file = @async_fs.open(path, mode=ReadOnly) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  defer file.close()
+  (file.size() > 0) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }
 }
 
 ///|
@@ -38,11 +52,20 @@ async fn validate_runtime_dist(
   let missing : Array[String] = []
   for relative in runtime_required_relative_files(platform) {
     let path = @fsutil.path_join(root, relative)
-    if !@fsutil.path_exists(path) {
+    if !runtime_path_is_valid(path) {
       missing.push(path)
     }
   }
   if missing.length() > 0 {
     raise InvalidRuntime(path=root, missing~)
+  }
+}
+
+///|
+async fn runtime_path_is_valid(path : String) -> Bool {
+  if @fsutil.path_is_dir(path) {
+    true
+  } else {
+    file_is_nonempty(path)
   }
 }

--- a/cli/cef/cef_validation.mbt
+++ b/cli/cef/cef_validation.mbt
@@ -64,7 +64,15 @@ async fn validate_runtime_dist(
 ///|
 async fn runtime_path_is_valid(path : String) -> Bool {
   if @fsutil.path_is_dir(path) {
-    true
+    let entries = @async_fs.readdir(
+      path,
+      include_hidden=true,
+      include_special=false,
+    ) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return false
+    }
+    entries.length() > 0
   } else {
     file_is_nonempty(path)
   }


### PR DESCRIPTION
## Summary

- serialize shared CEF cache assembly with an advisory cross-process lock
- build, normalize, validate, and marker-write CEF caches in staging before recoverable directory replacement
- validate existing runtimes before trusting them and protect runtime assembly with its own lock
- reject empty required artifacts and add regression coverage for rollback, truncation, and lock serialization

## Validation

- `moon fmt --check`
- `moon -C cli check --target native --diagnostic-limit 80`
- `moon -C cli check --target wasm --diagnostic-limit 80`
- `moon -C cli test -p moonbit-community/proton_cli/cef --target native --no-parallelize --diagnostic-limit 80`
- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
- `git diff --check origin/main`

No changes to `update-pr-prebuilts`.
