### PR TITLE
fix(e2e): keep CDP connection across reload

### DIFF
--- a/e2e/test/app_commands_probe.mbt
+++ b/e2e/test/app_commands_probe.mbt
@@ -159,7 +159,8 @@ async fn run_app_commands_full_probe(
   wait_for_native_osr_paint(native_log_path, timeout)
   assert_app_commands_probe(page)
   let queue = run_queue_full_probe(page)
-  run_reload_probe(page, target, timeout)
+  run_reload_probe(page, timeout)
+  page.close()
   page_open = false
   run_non_proton_probe(target, output_root, timeout)
   assert_native_bridge_guards(native_log_path)
@@ -382,11 +383,7 @@ async fn run_queue_full_probe(page : @client.CdpClient) -> QueueFullProbeResult 
 }
 
 ///|
-async fn run_reload_probe(
-  page : @client.CdpClient,
-  target : String,
-  timeout : Int,
-) -> Unit {
+async fn run_reload_probe(page : @client.CdpClient, timeout : Int) -> Unit {
   ignore(page.send_schema_command("Page.enable"))
   ignore(
     evaluate_json(
@@ -407,12 +404,8 @@ async fn run_reload_probe(
       false,
     ),
   )
-  ignore(page.send_cdp_command("Page.reload"))
-  page.close()
-  let reloaded_page = connect_page_matching_expression(
-    target,
-    "https://proton.localhost/",
-    false,
+  reload_page_and_wait(
+    page,
     (
       #|Boolean(
       #|  window.__MoonBit__?.core?.invokeOp &&
@@ -422,9 +415,8 @@ async fn run_reload_probe(
     "bridge after reload",
     timeout,
   )
-  defer reloaded_page.close()
   let value = evaluate_json(
-    reloaded_page,
+    page,
     (
       #|;(async () => {
       #|  const invoke = window.__MoonBit__?.core?.invokeOp;

--- a/e2e/test/cdp_eval.mbt
+++ b/e2e/test/cdp_eval.mbt
@@ -14,3 +14,22 @@ async fn evaluate_bool(
     _ => false
   }
 }
+
+///|
+async fn reload_page_and_wait(
+  page : @client.CdpClient,
+  expression : String,
+  description : String,
+  timeout : Int,
+) -> Unit {
+  page.clear_cdp_events()
+  ignore(page.send_schema_command("Page.reload", timeout_ms=timeout))
+  ignore(
+    run_e2e_operation_with_timeout(
+      timeout,
+      "Page.loadEventFired after reload",
+      () => page.recv_cdp_event(method_name="Page.loadEventFired"),
+    ),
+  )
+  wait_for_cdp_expression(page, expression, description, timeout)
+}

--- a/e2e/test/dev_extension_scenario.mbt
+++ b/e2e/test/dev_extension_scenario.mbt
@@ -123,7 +123,8 @@ async fn run_dev_extension_page_probe(
   let value = evaluate_json(page, dev_extension_probe_expression(), true)
   let result : DevExtensionProbe = decode_probe(value, "dev extension")
   assert_dev_extension_probe(result, frontend_url, value)
-  run_dev_extension_reload_probe(page, target, frontend_url, timeout)
+  run_dev_extension_reload_probe(page, frontend_url, timeout)
+  page.close()
   page_open = false
   run_dev_extension_non_proton_probe(target, output_root, timeout)
   assert_dev_extension_native_log(app.native_log_path)
@@ -297,7 +298,6 @@ fn dev_extension_production_probe_expression() -> String {
 ///|
 async fn run_dev_extension_reload_probe(
   page : @client.CdpClient,
-  target : String,
   frontend_url : String,
   timeout : Int,
 ) -> Unit {
@@ -317,12 +317,8 @@ async fn run_dev_extension_reload_probe(
       false,
     ),
   )
-  ignore(page.send_cdp_command("Page.reload"))
-  page.close()
-  let reloaded_page = connect_page_matching_expression(
-    target,
-    frontend_url,
-    true,
+  reload_page_and_wait(
+    page,
     (
       #|Boolean(
       #|  window.__MoonBit__?.ticker?.start &&
@@ -333,12 +329,7 @@ async fn run_dev_extension_reload_probe(
     "dev extension bridge after reload",
     timeout,
   )
-  defer reloaded_page.close()
-  let value = evaluate_json(
-    reloaded_page,
-    dev_extension_reload_probe_expression(),
-    true,
-  )
+  let value = evaluate_json(page, dev_extension_reload_probe_expression(), true)
   let result : DevExtensionReloadProbe = decode_probe(
     value, "dev extension reload",
   )

--- a/e2e/test/event_scenario.mbt
+++ b/e2e/test/event_scenario.mbt
@@ -157,7 +157,8 @@ async fn run_event_scenario_page_probe(
   )
   let result : EventScenarioProbe = decode_probe(value, "event broadcast")
   assert_event_scenario_probe(result, value)
-  run_event_reload_scenario_probe(page, target, timeout)
+  run_event_reload_scenario_probe(page, timeout)
+  page.close()
   page_open = false
   assert_event_scenario_native_log(app.native_log_path)
   println("MoonBit 40_event_broadcast event/reload probe passed")
@@ -216,7 +217,6 @@ fn assert_event_scenario_probe(
 ///|
 async fn run_event_reload_scenario_probe(
   page : @client.CdpClient,
-  target : String,
   timeout : Int,
 ) -> Unit {
   ignore(page.send_schema_command("Page.enable"))
@@ -239,12 +239,8 @@ async fn run_event_reload_scenario_probe(
       false,
     ),
   )
-  ignore(page.send_cdp_command("Page.reload"))
-  page.close()
-  let reloaded_page = connect_page_matching_expression(
-    target,
-    "https://proton.localhost/",
-    false,
+  reload_page_and_wait(
+    page,
     (
       #|Boolean(
       #|  window.__MoonBit__?.ticker?.start &&
@@ -255,9 +251,8 @@ async fn run_event_reload_scenario_probe(
     "event bridge after reload",
     timeout,
   )
-  defer reloaded_page.close()
   let value = evaluate_json(
-    reloaded_page,
+    page,
     (
       #|;(async () => {
       #|  window.__eventReloadProbe = [];


### PR DESCRIPTION
## Summary

- keep the existing page-level CDP WebSocket alive across `Page.reload`
- wait for the reload command response and `Page.loadEventFired` before probing the reinstalled bridge
- apply the same reload lifecycle to the app commands, event broadcast, and dev extension scenarios

## Background

The Windows job in main run [32250118352](https://github.com/moonbit-community/proton/actions/runs/32250118352) failed with `WSAECONNABORTED` while entering the `40_event_broadcast` reload probe. The previous probes sent `Page.reload` without waiting for its response, immediately closed the page WebSocket, and attempted to reconnect while navigation was still in progress. That made the test harness race CEF's Windows CDP transport.

This change removes that transport handoff instead of broadening retry classification. A page target's CDP connection remains valid across navigation, so each probe now waits on the existing connection until the new document has loaded and its Proton bridge is ready. The owning scenario closes the connection only after the reload assertions finish.

## Validation

- `moon fmt`
- `moon info`
- `moon -C e2e check --target native --diagnostic-limit 80`
- `PROTON_NATIVE_DIST=/Users/zhengyu/.codex/worktrees/8263/lepus/native/dist PROTON_BRIDGE_E2E_TIMEOUT_MS=60000 moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`
