### PR TITLE
refactor: remove compatibility fallbacks and prepare 0.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ on:
           - rsa
           - updater
           - cefsetup
-          - bundle
           - package
           - sys/ffi
           - sys/shell
@@ -31,6 +30,7 @@ on:
           - client
           - rabbita
           - proton
+          - bundle
           - extensions
           - cli
 
@@ -100,12 +100,6 @@ jobs:
             moon update
           }
 
-          if [ "$resume_from" = "package" ]; then
-            publishing=true
-            publish_module package moonbit-community/proton_package
-            exit 0
-          fi
-
           wait_for_codegen() {
             version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' codegen/moon.mod)
             if [ -z "$version" ]; then
@@ -132,6 +126,7 @@ jobs:
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater
           publish_module cefsetup moonbit-community/proton_cefsetup
+          publish_module package moonbit-community/proton_package
 
           publish_module sys/ffi moonbit-community/proton_ffi
           publish_module sys/shell moonbit-community/proton_shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,7 @@ developer must perform them.
 - `cli/`: `moonbit-community/proton_cli`; independent native developer CLI module.
 - `package/`: standalone `moonbit-community/proton_package` module. It packages
   already-built executables from explicit metadata and payloads; it does not
-  discover Proton projects, invoke Moon builds, or assemble CEF runtimes. It
-  has an independent version line and is excluded from the workspace lockstep
-  bump.
+  discover Proton projects, invoke Moon builds, or assemble CEF runtimes.
 - `cefsetup/`: `moonbit-community/proton_cefsetup`; its root executable installs
   the CEF release selected by the module version. The `store` package owns the
   CEF requirements and immutable user-wide installation store.
@@ -119,19 +117,14 @@ native checks before handing off larger refactors.
 
 - `.github/workflows/publish.yml` publishes the lockstep dependency chain in this order:
   `proton_config`, `proton_codegen`, `proton_contract`, `proton_rsa`,
-  `proton_updater`, `proton_cefsetup`, the ten `sys` modules, `proton_client`,
-  `proton_rabbita`, `proton`, `proton_bundle`, `proton_ext`, and finally
-  `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not published.
-- `proton_package` has its own version line. Select `package` as the workflow's
-  resume point to publish only that module; the workflow exits before the
-  lockstep chain.
-- All modules in `moon.work` except the explicitly independent
-  `proton_package` use one lockstep version. Prepare a lockstep release only
+  `proton_updater`, `proton_cefsetup`, `proton_package`, the ten `sys` modules,
+  `proton_client`, `proton_rabbita`, `proton`, `proton_bundle`, `proton_ext`,
+  and finally `proton_cli`. The `cdp`, `examples`, and `e2e` modules are not published.
+- All modules in `moon.work` use one lockstep version. Prepare a lockstep release only
   through `moon run scripts/bump_version.mbtx -- patch`, `minor`, or `major`;
   do not edit individual lockstep module versions by hand. The script discovers
-  modules through `moon.work`, skips independently versioned modules, updates
-  the lockstep versions and internal requirements, and refuses to run if that
-  set has drifted from the shared version.
+  modules through `moon.work`, updates the lockstep versions and internal
+  requirements, and refuses to run if that set has drifted from the shared version.
 - Run the release checks before the first publish:
 
   ```sh

--- a/bundle/moon.mod
+++ b/bundle/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_bundle"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_package@0.1.18",
-  "moonbit-community/proton_cefsetup@0.1.19",
+  "moonbit-community/proton_package@0.2.0",
+  "moonbit-community/proton_cefsetup@0.2.0",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
 }

--- a/bundle/moon.mod
+++ b/bundle/moon.mod
@@ -5,8 +5,8 @@ version = "0.1.19"
 import {
   "moonbit-community/proton_package@0.1.18",
   "moonbit-community/proton_cefsetup@0.1.19",
-  "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/async@0.21.0",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.md"

--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cdp"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -5,8 +5,8 @@ version = "0.1.19"
 readme = "README.mbt.md"
 
 import {
-  "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/async@0.21.0",
+  "moonbitlang/x@0.5.1",
 }
 
 repository = "https://github.com/moonbit-community/proton"

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_cefsetup"
 version = "0.1.19"
 
 import {
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
 }
 

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.19"
 
 import {
   "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.md"

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cefsetup"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/cefsetup/store/paths.mbt
+++ b/cefsetup/store/paths.mbt
@@ -22,57 +22,42 @@ async fn path_is_file(path : String) -> Bool {
 }
 
 ///|
-fn host_path(path : String) -> @path.Path {
-  if @path.sep == '\\' {
-    path.replace_all(old="/", new="\\")
-  } else {
-    path
-  }
-}
-
-///|
 fn path_join(base : String, child : String) -> String {
-  if base == "" {
-    child
-  } else if child == "" {
-    base
-  } else {
-    host_path(base).join(host_path(child)).to_string()
-  }
+  let base : @path.Path = base
+  base.join(child).to_string()
 }
 
 ///|
 fn path_parent(path : String) -> String {
-  host_path(path).dirname().to_string()
+  let path : @path.Path = path
+  path.dirname().to_string()
 }
 
 ///|
 fn path_is_absolute(path : String) -> Bool {
-  host_path(path).is_absolute()
+  let path : @path.Path = path
+  path.is_absolute()
 }
 
 ///|
 fn resolve_path(base : String, path : String) -> String {
-  let candidate = host_path(path)
+  let candidate : @path.Path = path
   if candidate.is_absolute() {
     candidate.resolve().to_string()
   } else {
-    host_path(base).join(candidate).resolve().to_string()
+    let base : @path.Path = base
+    base.join(candidate).resolve().to_string()
   }
 }
 
 ///|
 fn home_directory() -> String? {
-  let primary = if @path.sep == '\\' { "USERPROFILE" } else { "HOME" }
-  let fallback = if @path.sep == '\\' { "HOME" } else { "USERPROFILE" }
-  for name in [primary, fallback] {
-    match @env.get_env_var(name) {
-      Some(value) if value.trim().to_owned() != "" =>
-        return Some(value.trim().to_owned())
-      _ => ()
-    }
+  let name = if @path.sep == '\\' { "USERPROFILE" } else { "HOME" }
+  match @env.get_env_var(name) {
+    Some(value) if value.trim().to_owned() != "" =>
+      Some(value.trim().to_owned())
+    _ => None
   }
-  None
 }
 
 ///|

--- a/cli/dev/dev.mbt
+++ b/cli/dev/dev.mbt
@@ -110,14 +110,9 @@ pub async fn run(cwd : String, matches : @argparse.Matches) -> Unit {
   let raw = dev_options_from_matches(matches)
   let cwd = @path.Path(cwd).resolve().to_string()
   let config_path = resolve_dev_config_path(cwd, raw)
-  let project_config = load_dev_project_config(config_path)
-  let frontend_config = match project_config {
-    Some(config) => config.frontend()
-    None => None
-  }
-  let project_base = project_config
-    .map(fn(config) { config.base_dir() })
-    .unwrap_or(cwd)
+  let project_config = read_dev_project_config(config_path)
+  let frontend_config = project_config.frontend()
+  let project_base = project_config.base_dir()
   let frontend_url : String? = match raw.url {
     Some(url) => Some(url)
     None =>
@@ -159,10 +154,7 @@ pub async fn run(cwd : String, matches : @argparse.Matches) -> Unit {
     frontend_path,
     managed_frontend_command is Some(_),
   )
-  let backend = match project_config {
-    Some(config) => config.backend()
-    None => None
-  }
+  let backend = project_config.backend()
   let backend_path = resolve_backend_path(
     project_base,
     backend.map(fn(config) { config.path() }),
@@ -326,33 +318,13 @@ async fn resolve_backend_path(root : String, backend_path : String?) -> String {
 }
 
 ///|
-async fn resolve_dev_config_path(cwd : String, raw : RawDevOptions) -> String? {
-  match raw.config_path {
-    Some(path) => Some(@fsutil.resolve_path(cwd, path))
-    None => {
-      let cwd_config = @fsutil.path_join(cwd, default_config_file)
-      if @fsutil.path_exists(cwd_config) {
-        Some(cwd_config)
-      } else {
-        None
-      }
-    }
+async fn resolve_dev_config_path(cwd : String, raw : RawDevOptions) -> String {
+  let path = match raw.config_path {
+    Some(path) => @fsutil.resolve_path(cwd, path)
+    None => @fsutil.path_join(cwd, default_config_file)
   }
-}
-
-///|
-async fn load_dev_project_config(
-  config_path : String?,
-) -> @proton_config.ProjectConfig? {
-  match config_path {
-    None => None
-    Some(path) => {
-      if !@fsutil.path_exists(path) {
-        raise NotFound(path~)
-      }
-      Some(read_dev_project_config(path))
-    }
-  }
+  guard @fsutil.path_exists(path) else { raise NotFound(path~) }
+  path
 }
 
 ///|

--- a/cli/dev/dev_wbtest.mbt
+++ b/cli/dev/dev_wbtest.mbt
@@ -49,6 +49,19 @@ test "parse dev args accepts an isolated Moon target directory" {
 }
 
 ///|
+async test "dev requires a project config" {
+  let root = @async_fs.tmpdir(prefix="proton-dev-config-")
+  defer (@async_fs.rmdir(root, recursive=true) catch { _ => () })
+  try resolve_dev_config_path(root, parse_dev_args([])) catch {
+    DevConfigError::NotFound(path~) =>
+      @debug.assert_eq(path, @fsutil.path_join(root, default_config_file))
+    _ => abort("expected missing project config error")
+  } noraise {
+    _ => abort("expected missing project config to fail")
+  }
+}
+
+///|
 test "dev frontend does not inherit the injected CEF preload" {
   let app_env = {
     "LD_PRELOAD": "libcef.so" + path_list_separator() + "existing-preload.so",

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let cli_current_version : String = "0.1.19"
+let cli_current_version : String = "0.2.0"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -9,9 +9,9 @@ import {
   "moonbit-community/proton_cefsetup@0.1.19",
   "moonbit-community/proton_rsa@0.1.19",
   "moonbit-community/proton_updater@0.1.19",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.13",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
 }
 
 readme = "README.md"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,14 +1,14 @@
 name = "moonbit-community/proton_cli"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_bundle@0.1.19",
-  "moonbit-community/proton_config@0.1.19",
-  "moonbit-community/proton_package@0.1.18",
-  "moonbit-community/proton_cefsetup@0.1.19",
-  "moonbit-community/proton_rsa@0.1.19",
-  "moonbit-community/proton_updater@0.1.19",
+  "moonbit-community/proton_bundle@0.2.0",
+  "moonbit-community/proton_config@0.2.0",
+  "moonbit-community/proton_package@0.2.0",
+  "moonbit-community/proton_cefsetup@0.2.0",
+  "moonbit-community/proton_rsa@0.2.0",
+  "moonbit-community/proton_updater@0.2.0",
   "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.13",
   "moonbitlang/async@0.21.0",

--- a/cli/new/new_project.mbt
+++ b/cli/new/new_project.mbt
@@ -247,7 +247,7 @@ async fn create_project(
   let mut staging_dir = ""
   let reserve_rollback_failures : Array[String] = []
   errdefer {
-    @async.protect_from_cancel(resume_on_cancel=true, () => {
+    @async.protect_from_cancel(() => {
       remove_transaction_tree(staging_dir, reserve_rollback_failures)
     })
     if reserve_rollback_failures.length() > 0 {
@@ -265,7 +265,7 @@ async fn create_project(
   })
   let rollback_failures : Array[String] = []
   errdefer {
-    @async.protect_from_cancel(resume_on_cancel=true, () => {
+    @async.protect_from_cancel(() => {
       remove_transaction_tree(staging_dir, rollback_failures)
       if target_existed && !@fsutil.path_exists(options.resolved_target_dir) {
         restore_empty_target(options.resolved_target_dir, rollback_failures)

--- a/cli/new/templates.generated.mbt
+++ b/cli/new/templates.generated.mbt
@@ -797,6 +797,7 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|- `shared/` contains the target-neutral typed application contract.
           #|- `frontend/` is a JavaScript Rabbita module owned by Warren.
           #|- `backend/` is a native Proton module.
+          #|- `proton.project.json` is required by `proton_cli dev`, `build`, and `package`.
           #|- Keep command and event names in `shared/todo_contract.mbt`.
           #|- The Moon prebuild rule regenerates the typed bridge through
           #|  `moonx moonbit-community/proton_codegen`; do not invoke codegen from application
@@ -836,8 +837,8 @@ fn generated_template_specs() -> Array[TemplateSpec] {
           #|proton_cli dev
           #|```
           #|
-          #|`dev` starts Warren in `frontend/`, waits for the development URL, then runs
-          #|`backend/app`.
+          #|`dev` reads the required `proton.project.json`, starts Warren in `frontend/`,
+          #|waits for the development URL, then runs `backend/app`.
           #|
           #|## Build
           #|

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -25,7 +25,7 @@ let default_warren_version = "0.2.7"
 ///|
 /// Scaffolded backends need this directly: `async fn main` is only available to
 /// a package that imports `moonbitlang/async`.
-let default_async_version = "0.20.3"
+let default_async_version = "0.21.0"
 
 ///|
 priv struct TemplateContext {

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -1,20 +1,20 @@
 ///|
-let default_proton_version = "0.1.19"
+let default_proton_version = "0.2.0"
 
 ///|
-let default_proton_codegen_version = "0.1.19"
+let default_proton_codegen_version = "0.2.0"
 
 ///|
-let default_proton_cli_version = "0.1.19"
+let default_proton_cli_version = "0.2.0"
 
 ///|
-let default_proton_contract_version = "0.1.19"
+let default_proton_contract_version = "0.2.0"
 
 ///|
-let default_proton_client_version = "0.1.19"
+let default_proton_client_version = "0.2.0"
 
 ///|
-let default_proton_rabbita_version = "0.1.19"
+let default_proton_rabbita_version = "0.2.0"
 
 ///|
 let default_rabbita_version = "0.14.1"

--- a/cli/new/templates/todo/files/AGENTS.md.mtpl
+++ b/cli/new/templates/todo/files/AGENTS.md.mtpl
@@ -17,6 +17,7 @@ This is a MoonBit Proton native desktop app.
 - `shared/` contains the target-neutral typed application contract.
 - `frontend/` is a JavaScript Rabbita module owned by Warren.
 - `backend/` is a native Proton module.
+- `proton.project.json` is required by `proton_cli dev`, `build`, and `package`.
 - Keep command and event names in `shared/todo_contract.mbt`.
 - The Moon prebuild rule regenerates the typed bridge through
   `moonx moonbit-community/proton_codegen`; do not invoke codegen from application

--- a/cli/new/templates/todo/files/README.md.mtpl
+++ b/cli/new/templates/todo/files/README.md.mtpl
@@ -25,8 +25,8 @@ moon check --target js,native --diagnostic-limit 80
 proton_cli dev
 ```
 
-`dev` starts Warren in `frontend/`, waits for the development URL, then runs
-`backend/app`.
+`dev` reads the required `proton.project.json`, starts Warren in `frontend/`,
+waits for the development URL, then runs `backend/app`.
 
 ## Build
 

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_client"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_contract@0.1.19",
+  "moonbit-community/proton_contract@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_client"
 version = "0.1.19"
 
 import {
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbit-community/proton_contract@0.1.19",
 }
 

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_codegen"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -3,10 +3,10 @@ name = "moonbit-community/proton_codegen"
 version = "0.1.19"
 
 import {
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbitlang/lexer@0.3.14",
   "moonbitlang/parser@0.3.14",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.md"

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_config"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_config"
 version = "0.1.19"
 
 import {
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
 }
 
 repository = "https://github.com/moonbit-community/proton"

--- a/contract/moon.mod
+++ b/contract/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_contract"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -94,10 +94,9 @@ Rules:
 - Platform keys reuse the identifiers Proton already uses everywhere else:
   `darwin-arm64`, `darwin-x64`, `win32-x64`, `linux-x64`. Introducing a second
   naming scheme for the same concept would be a defect.
-- `kind` is `"full"` in version 1. It is the extension point: `"layered"` and
-  `"delta"` can be added later, and a client that does not understand a `kind`
-  treats that platform entry as unavailable rather than failing the whole
-  manifest.
+- `kind` must be `"full"`. Other values are invalid for this schema version.
+  Adding another artifact form requires a new schema and an implementation that
+  validates it explicitly.
 - `sha256` and `signature` are hexadecimal, matching the key format. One
   encoding throughout means one strict decoder rather than two.
 - `sha256` is for integrity and resumable download bookkeeping. It is **not** a

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -3,8 +3,8 @@ name = "moonbit-community/proton/e2e"
 version = "0.1.19"
 
 import {
-  "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/async@0.21.0",
+  "moonbitlang/x@0.5.1",
   "moonbit-community/proton_cdp@0.1.19",
   "moonbit-community/proton@0.1.19",
   "moonbit-community/proton_cefsetup@0.1.19",

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -1,15 +1,15 @@
 name = "moonbit-community/proton/e2e"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
-  "moonbit-community/proton_cdp@0.1.19",
-  "moonbit-community/proton@0.1.19",
-  "moonbit-community/proton_cefsetup@0.1.19",
-  "moonbit-community/proton_updater@0.1.19",
-  "moonbit-community/proton/examples@0.1.19",
+  "moonbit-community/proton_cdp@0.2.0",
+  "moonbit-community/proton@0.2.0",
+  "moonbit-community/proton_cefsetup@0.2.0",
+  "moonbit-community/proton_updater@0.2.0",
+  "moonbit-community/proton/examples@0.2.0",
 }
 
 readme = "README.md"

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -3,8 +3,8 @@ name = "moonbit-community/proton/examples"
 version = "0.1.19"
 
 import {
-  "moonbitlang/x@0.4.50",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/x@0.5.1",
+  "moonbitlang/async@0.21.0",
   "moonbit-community/proton_ext@0.1.19",
   "moonbit-community/proton_contract@0.1.19",
   "moonbit-community/proton@0.1.19",

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton/examples"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_ext@0.1.19",
-  "moonbit-community/proton_contract@0.1.19",
-  "moonbit-community/proton@0.1.19",
+  "moonbit-community/proton_ext@0.2.0",
+  "moonbit-community/proton_contract@0.2.0",
+  "moonbit-community/proton@0.2.0",
 }
 
 readme = "README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -4,8 +4,8 @@ version = "0.1.19"
 
 import {
   "moonbit-community/proton_ffi@0.1.19",
-  "moonbitlang/x@0.4.50",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/x@0.5.1",
+  "moonbitlang/async@0.21.0",
   "moonbit-community/proton_clipboard@0.1.19",
   "moonbit-community/proton_tray@0.1.19",
   "moonbit-community/proton_global_hotkey@0.1.19",

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -1,22 +1,22 @@
 name = "moonbit-community/proton_ext"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_clipboard@0.1.19",
-  "moonbit-community/proton_tray@0.1.19",
-  "moonbit-community/proton_global_hotkey@0.1.19",
-  "moonbit-community/proton@0.1.19",
-  "moonbit-community/proton_contract@0.1.19",
-  "moonbit-community/proton_microphone@0.1.19",
-  "moonbit-community/proton_auto_launch@0.1.19",
-  "moonbit-community/proton_keepawake@0.1.19",
-  "moonbit-community/proton_power_monitor@0.1.19",
-  "moonbit-community/proton_process@0.1.19",
-  "moonbit-community/proton_shell@0.1.19",
+  "moonbit-community/proton_clipboard@0.2.0",
+  "moonbit-community/proton_tray@0.2.0",
+  "moonbit-community/proton_global_hotkey@0.2.0",
+  "moonbit-community/proton@0.2.0",
+  "moonbit-community/proton_contract@0.2.0",
+  "moonbit-community/proton_microphone@0.2.0",
+  "moonbit-community/proton_auto_launch@0.2.0",
+  "moonbit-community/proton_keepawake@0.2.0",
+  "moonbit-community/proton_power_monitor@0.2.0",
+  "moonbit-community/proton_process@0.2.0",
+  "moonbit-community/proton_shell@0.2.0",
 }
 
 readme = "README.md"

--- a/extensions/net/extension.mbt
+++ b/extensions/net/extension.mbt
@@ -38,6 +38,28 @@ fn split_url(url : String) -> (String, String) raise NetError {
 }
 
 ///|
+fn request_headers(
+  headers : Map[String, String],
+) -> Map[@http.CaseInsensitiveString, String] {
+  let result : Map[@http.CaseInsensitiveString, String] = Map([])
+  for name, value in headers {
+    result[name] = value
+  }
+  result
+}
+
+///|
+fn response_headers(
+  headers : Map[@http.CaseInsensitiveString, String],
+) -> Map[String, String] {
+  let result : Map[String, String] = Map([])
+  for name, value in headers {
+    result[name.to_string()] = value
+  }
+  result
+}
+
+///|
 /// Makes an HTTP request and returns the response.
 #proton.command(contract=request_command)
 async fn do_request(
@@ -45,7 +67,7 @@ async fn do_request(
   request : @net_contract.Request,
 ) -> @net_contract.Response {
   let meth = parse_method(request.http_method)
-  let headers = request.headers
+  let headers = request_headers(request.headers)
   let body_bytes = request.body.map(fn(s) { @utf8.encode(s) }).unwrap_or(b"")
   // Use top-level functions for GET/POST/PUT (they handle full URL parsing).
   // Use Client for DELETE, PATCH, HEAD, OPTIONS (need URL split + path).
@@ -81,7 +103,7 @@ async fn do_request(
   @net_contract.Response::{
     status: response.code,
     status_text: response.reason,
-    headers: response.headers,
+    headers: response_headers(response.headers),
     body: @utf8.decode_lossy(data.binary()),
   }
 }

--- a/extensions/net/extension_wbtest.mbt
+++ b/extensions/net/extension_wbtest.mbt
@@ -1,0 +1,13 @@
+///|
+test "request headers use case-insensitive keys" {
+  let headers = request_headers({ "Content-Type": "application/json" })
+  assert_eq(headers.get("content-type"), Some("application/json"))
+}
+
+///|
+test "response headers preserve their original spelling" {
+  let native : Map[@http.CaseInsensitiveString, String] = {
+    "Content-Type": "application/json",
+  }
+  assert_eq(response_headers(native), { "Content-Type": "application/json" })
+}

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.1.18"
+version = "0.2.0"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -3,8 +3,8 @@ name = "moonbit-community/proton_package"
 version = "0.1.18"
 
 import {
-  "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/async@0.21.0",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.md"

--- a/proton/facade_context.mbt
+++ b/proton/facade_context.mbt
@@ -176,7 +176,7 @@ async fn start_application_lifecycle_hooks(
         )
     }
     group.add_defer(async fn() {
-      @async.protect_from_cancel(activation.shutdown, resume_on_cancel=true) catch {
+      @async.protect_from_cancel(activation.shutdown) catch {
         error =>
           cleanup_failures.push(
             LifecycleHook(
@@ -203,7 +203,7 @@ async fn start_window_lifecycle_hooks(
         )
     }
     group.add_defer(async fn() {
-      @async.protect_from_cancel(activation.close, resume_on_cancel=true) catch {
+      @async.protect_from_cancel(activation.close) catch {
         error =>
           cleanup_failures.push(
             LifecycleHook(

--- a/proton/facade_notification.mbt
+++ b/proton/facade_notification.mbt
@@ -127,10 +127,7 @@ pub async fn notification_show_and_wait(
     error => raise NativeFailure(status=error.status(), detail=error.message())
   }
   if waits_for_result {
-    let result = @async.protect_from_cancel(
-      take_notification_result,
-      resume_on_cancel=true,
-    ) catch {
+    let result = @async.protect_from_cancel(take_notification_result) catch {
       error => raise WaitInterrupted(detail=@debug.render(Repr(error)))
     }
     match result {

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -8,8 +8,8 @@ import {
   "moonbit-community/proton_contract@0.1.19",
   "moonbit-community/proton_updater@0.1.19",
   "moonbit-community/proton_rsa@0.1.19",
-  "moonbitlang/async@0.20.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/async@0.21.0",
+  "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.13",
 }
 

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
-  "moonbit-community/proton_config@0.1.19",
-  "moonbit-community/proton_contract@0.1.19",
-  "moonbit-community/proton_updater@0.1.19",
-  "moonbit-community/proton_rsa@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_config@0.2.0",
+  "moonbit-community/proton_contract@0.2.0",
+  "moonbit-community/proton_updater@0.2.0",
+  "moonbit-community/proton_rsa@0.2.0",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.13",

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_rabbita"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_client@0.1.19",
-  "moonbit-community/proton_contract@0.1.19",
+  "moonbit-community/proton_client@0.2.0",
+  "moonbit-community/proton_contract@0.2.0",
   "moonbit-community/rabbita@0.14.1",
 }
 

--- a/rsa/moon.mod
+++ b/rsa/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_rsa"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/scripts/bump_version.mbtx
+++ b/scripts/bump_version.mbtx
@@ -13,8 +13,6 @@ struct ModuleDocument {
   ast : @moon_config.Ast
 }
 
-let independently_versioned_modules : ReadOnlyArray[String] = ["./package"]
-
 fn fail(message : String) -> Unit {
   println("error: " + message)
   @sys.exit(2)
@@ -117,9 +115,6 @@ async fn main {
     guard item is @moon_config.Ast::Str(member_path, ..) else {
       fail("moon.work contains a non-string member")
       return
-    }
-    guard !independently_versioned_modules.contains(member_path) else {
-      continue
     }
     let path = member_path + "/moon.mod"
     let source = @fs.read_file(path).text()

--- a/scripts/bump_version.mbtx
+++ b/scripts/bump_version.mbtx
@@ -4,7 +4,7 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/moon_config",
-  "moonbitlang/x@0.4.43/sys",
+  "moonbitlang/x@0.5.1/sys",
 }
 
 struct ModuleDocument {

--- a/scripts/verify_release_metadata.mjs
+++ b/scripts/verify_release_metadata.mjs
@@ -84,6 +84,7 @@ const workspaceModuleManifests = [
   "rsa/moon.mod",
   "updater/moon.mod",
   "cefsetup/moon.mod",
+  "package/moon.mod",
   "bundle/moon.mod",
   "sys/auto_launch/moon.mod",
   "sys/clipboard/moon.mod",

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_auto_launch"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.md"
 

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_clipboard"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -3,7 +3,7 @@ name = "moonbit-community/proton_ffi"
 version = "0.1.19"
 
 import {
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.mbt.md"

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_ffi"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_global_hotkey"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_keepawake"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_microphone"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/sys/power_monitor/moon.mod
+++ b/sys/power_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_power_monitor"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/sys/process/moon.mod
+++ b/sys/process/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_process"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_shell"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_tray"
 
-version = "0.1.19"
+version = "0.2.0"
 
 import {
-  "moonbit-community/proton_ffi@0.1.19",
+  "moonbit-community/proton_ffi@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/updater/README.mbt.md
+++ b/updater/README.mbt.md
@@ -28,15 +28,9 @@ match manifest.platform("darwin-arm64") {
 }
 ```
 
-`schema_version` must be exactly `2`, and unknown fields are an error rather
-than something to skip — the same discipline Proton's structured native
-runtime configs follow, so that a typo in a release manifest fails
-loudly instead of silently omitting whatever it was meant to say.
-
-One case deliberately does **not** fail: a platform entry whose `kind` this
-client does not implement is treated as no update on offer. Failing the whole
-document would let a newer release format lock every older client out of every
-platform at once, including the platforms it could still have served.
+`schema_version` must be exactly `2`, `kind` must be `"full"`, and unknown
+fields are errors. A release manifest is one strict protocol document: invalid
+or unsupported content fails loudly instead of being treated as no update.
 
 ## Ordering
 

--- a/updater/manifest.mbt
+++ b/updater/manifest.mbt
@@ -82,10 +82,6 @@ pub fn Manifest::notes_url(self : Manifest) -> String? {
 
 ///|
 /// Returns the update offered for one platform identifier, if any.
-///
-/// A platform that is absent, or whose entry names a `kind` this client does
-/// not implement, has no update on offer. Neither is an error: a manifest may
-/// legitimately describe artifacts that a older client cannot install.
 pub fn Manifest::platform(
   self : Manifest,
   platform : String,
@@ -213,13 +209,10 @@ fn parse_platforms(
   }
   let platforms : Map[String, PlatformUpdate] = Map([])
   for name, platform_json in entries {
-    match parse_platform(platform_json, "manifest.platforms.\{name}") {
-      Some(update) => platforms[name] = update
-      // An unrecognised `kind` means this client cannot install that artifact,
-      // not that the manifest is broken. Failing the whole document would let a
-      // newer release format lock every older client out of every platform.
-      None => ()
-    }
+    platforms[name] = parse_platform(
+      platform_json,
+      "manifest.platforms.\{name}",
+    )
   }
   platforms
 }
@@ -228,14 +221,16 @@ fn parse_platforms(
 fn parse_platform(
   json : Json,
   path : String,
-) -> PlatformUpdate? raise ManifestError {
+) -> PlatformUpdate raise ManifestError {
   guard json is Object(fields) else { raise NotAnObject(path~) }
   for key, _ in fields {
     guard key is ("kind" | "url" | "size" | "sha256" | "signature") else {
       raise UnknownField(path="\{path}.\{key}")
     }
   }
-  guard required_string(fields, "kind", path) is "full" else { return None }
+  guard required_string(fields, "kind", path) is "full" else {
+    raise InvalidField(path="\{path}.kind", expectation="must be \"full\"")
+  }
   let url = required_string(fields, "url", path)
   guard url.has_prefix("https://") else {
     raise InvalidField(path="\{path}.url", expectation="must be an https URL")
@@ -260,7 +255,7 @@ fn parse_platform(
       expectation="must be an even number of hexadecimal characters",
     )
   }
-  Some(PlatformUpdate::{ url, size, sha256_hex, signature_hex })
+  PlatformUpdate::{ url, size, sha256_hex, signature_hex }
 }
 
 ///|

--- a/updater/manifest_wbtest.mbt
+++ b/updater/manifest_wbtest.mbt
@@ -115,18 +115,20 @@ test "rejects an invalid release revision" {
 }
 
 ///|
-test "treats an unimplemented artifact kind as nothing on offer" {
+test "rejects an unimplemented artifact kind" {
   let text = manifest_json(
     (
       $|{"darwin-arm64":{"kind":"delta","url":"https://example.com/app.patch",
       $| "size":16,"sha256":"\{sample_sha256}","signature":"abcd"}}
     ),
   )
-  let manifest = Manifest::parse(text)
-  // The document decodes; this client simply has no update to install. Failing
-  // the whole manifest would let a newer release format lock older clients out.
-  assert_eq(manifest.platforms(), [])
-  assert_eq(manifest.platform("darwin-arm64"), None)
+  assert_eq(
+    parse_failure(text),
+    InvalidField(
+      path="manifest.platforms.darwin-arm64.kind",
+      expectation="must be \"full\"",
+    ),
+  )
 }
 
 ///|

--- a/updater/moon.mod
+++ b/updater/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_updater"
 
-version = "0.1.19"
+version = "0.2.0"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
## Summary

- remove the remaining configuration and updater compatibility fallbacks: `proton_cli dev` now requires `proton.project.json`, updater manifests accept only the current full-artifact model, and CEF store paths use the current path API directly
- update the workspace to `moonbitlang/async@0.21.0` and `moonbitlang/x@0.5.1`, including the HTTP header and cancellation API migrations
- bump the lockstep workspace release to `0.2.0`
- bring `proton_package` into the lockstep version and normal publish chain instead of maintaining a separate release line
- update scaffold metadata, generated templates, release validation, and maintainer documentation

## Validation

- `moon fmt`
- `moon info`
- `node scripts/verify_generated.mjs`
- `moon check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 80`
- `moon -C updater test --target native --diagnostic-limit 80`
- `moon -C cefsetup test store --target native --diagnostic-limit 80`
- `moon -C package test lib --target native --diagnostic-limit 80`
- `moon -C bundle test --target native --diagnostic-limit 80`
- `moon -C extensions test -p moonbit-community/proton_ext/net --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
