### PR TITLE
fix(release): update registry before CEF setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,12 +62,14 @@ jobs:
       - name: Show MoonBit version
         run: moon version --all
 
+      - name: Update MoonBit registry
+        run: moon update
+
       - name: Install CEF runtime
         run: moon -C cefsetup run . --target native
 
       - name: Validate release
         run: |
-          moon update
           moon fmt --check
           node scripts/verify_generated.mjs
           node scripts/verify_release_metadata.mjs


### PR DESCRIPTION
## Summary

- update the MoonBit registry immediately after installing the toolchain
- run CEF setup only after external dependencies can be resolved
- remove the later duplicate `moon update` from release validation

## Context

The `0.2.0` publish run failed before publishing any package because a fresh runner tried to build `proton_cefsetup` before initializing the registry index.

Failed run: https://github.com/moonbit-community/proton/actions/runs/32468439362

## Validation

- `moon update`
- `moon fmt`
- `moon info`
- `node scripts/verify_generated.mjs`
