### PR TITLE
fix(release): bootstrap CEF setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         run: moon update
 
       - name: Install CEF runtime
-        run: moon -C cefsetup run . --target native
+        run: PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native
 
       - name: Validate release
         run: |


### PR DESCRIPTION
## Summary

- run the publish workflow's CEF setup command with `PROTON_CEF_SETUP_BOOTSTRAP=1`
- preserve the normal installed-runtime check for every non-bootstrap build

## Context

The `0.2.0` publish workflow now initializes the registry correctly, but setup still failed because the workspace prebuild required an installed CEF runtime while compiling the executable responsible for installing that runtime.

Failed run: https://github.com/moonbit-community/proton/actions/runs/32469625919

## Validation

- `moon update`
- `PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native`
- `moon fmt`
- `moon info`
- `node scripts/verify_generated.mjs`
