### PR TITLE
fix(release): install Linux native dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,11 @@ jobs:
             exit 1
           fi
 
+      - name: Install Linux native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev xvfb openbox libnotify-dev
+
       - name: Install MoonBit
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly


### PR DESCRIPTION
## Summary

- install the Linux native dependencies required by Proton release validation
- keep the publish job aligned with the Ubuntu CI build environment

## Problem

The 0.2.0 publish workflow completed CEF setup but failed before configuring credentials or publishing packages. `moon check --target native` invoked `proton/build.mjs`, and `pkg-config` could not resolve GTK 3 or X11 because the publish runner did not install Proton Linux build dependencies.

## Validation

- `moon fmt`
- `moon info`
- `git diff --check`

The previous publish attempt confirmed that CEF bootstrap now succeeds.