### PR TITLE
fix(cli): allow CEF setup before frontend build

### DIFF
--- a/bundle/moon.mod
+++ b/bundle/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_bundle"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_package@0.2.0",
-  "moonbit-community/proton_cefsetup@0.2.0",
+  "moonbit-community/proton_package@0.2.1",
+  "moonbit-community/proton_cefsetup@0.2.1",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
 }

--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cdp"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cefsetup"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/cli/build_cmd/build.mbt
+++ b/cli/build_cmd/build.mbt
@@ -236,14 +236,32 @@ priv struct BuildInvocation {
 
 ///|
 async fn prepare_build(cwd : String, raw : RawBuildOptions) -> BuildInvocation {
-  let cwd = @path.Path(cwd).resolve().to_string()
-  let config_path = resolve_build_config_path(cwd, raw)
-  let config = load_project_config(config_path)
+  let (cwd, config) = load_build_project(cwd, raw)
   validate_release_config(config)
   if raw.run_frontend_build {
     run_frontend_build(config.base_dir, config)
   }
   validate_release_files(config.base_dir, config)
+  project_build_invocation(cwd, config, raw)
+}
+
+///|
+async fn load_build_project(
+  cwd : String,
+  raw : RawBuildOptions,
+) -> (String, BuildProjectConfig) {
+  let cwd = @path.Path(cwd).resolve().to_string()
+  let config_path = resolve_build_config_path(cwd, raw)
+  let config = load_project_config(config_path)
+  (cwd, config)
+}
+
+///|
+async fn project_build_invocation(
+  cwd : String,
+  config : BuildProjectConfig,
+  raw : RawBuildOptions,
+) -> BuildInvocation {
   let backend_path = resolve_backend_path(
     config.base_dir,
     config.backend.map(fn(backend) { backend.path() }),
@@ -349,13 +367,15 @@ pub async fn resolve_proton_source(
 
 ///|
 pub async fn resolve_default_project_proton_source(cwd : String) -> String {
-  let invocation = prepare_build(cwd, RawBuildOptions::{
+  let raw = RawBuildOptions::{
     app_package: None,
     config_path: None,
     moon_target_dir: None,
     run_frontend_build: false,
     moon_args: [],
-  })
+  }
+  let (cwd, config) = load_build_project(cwd, raw)
+  let invocation = project_build_invocation(cwd, config, raw)
   resolve_proton_source(invocation.backend_path, invocation.app_package)
 }
 

--- a/cli/build_cmd/build_wbtest.mbt
+++ b/cli/build_cmd/build_wbtest.mbt
@@ -188,3 +188,25 @@ test "frontend release requires dist" {
   let error = expect_build_error_message(() => validate_release_config(config))
   assert_true(error.contains("frontend.dist is required"))
 }
+
+///|
+async test "project resolution does not require frontend build output" {
+  let config = BuildProjectConfig::{
+    base_dir: ".",
+    backend: None,
+    frontend: Some(
+      @proton_config.ProjectFrontendConfig::new(
+        dist=Some("missing-frontend-dist"),
+      ),
+    ),
+  }
+  let invocation = project_build_invocation(".", config, RawBuildOptions::{
+    app_package: None,
+    config_path: None,
+    moon_target_dir: None,
+    run_frontend_build: false,
+    moon_args: [],
+  })
+  @debug.assert_eq(invocation.backend_path, ".")
+  @debug.assert_eq(invocation.app_package, default_package)
+}

--- a/cli/build_cmd/moon.pkg
+++ b/cli/build_cmd/moon.pkg
@@ -13,3 +13,7 @@ import {
 }
 
 supported_targets = "native+wasm"
+
+options(
+  wbtest_import: [ "moonbitlang/async" ],
+)

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let cli_current_version : String = "0.2.0"
+let cli_current_version : String = "0.2.1"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,14 +1,14 @@
 name = "moonbit-community/proton_cli"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_bundle@0.2.0",
-  "moonbit-community/proton_config@0.2.0",
-  "moonbit-community/proton_package@0.2.0",
-  "moonbit-community/proton_cefsetup@0.2.0",
-  "moonbit-community/proton_rsa@0.2.0",
-  "moonbit-community/proton_updater@0.2.0",
+  "moonbit-community/proton_bundle@0.2.1",
+  "moonbit-community/proton_config@0.2.1",
+  "moonbit-community/proton_package@0.2.1",
+  "moonbit-community/proton_cefsetup@0.2.1",
+  "moonbit-community/proton_rsa@0.2.1",
+  "moonbit-community/proton_updater@0.2.1",
   "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.13",
   "moonbitlang/async@0.21.0",

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -1,20 +1,20 @@
 ///|
-let default_proton_version = "0.2.0"
+let default_proton_version = "0.2.1"
 
 ///|
-let default_proton_codegen_version = "0.2.0"
+let default_proton_codegen_version = "0.2.1"
 
 ///|
-let default_proton_cli_version = "0.2.0"
+let default_proton_cli_version = "0.2.1"
 
 ///|
-let default_proton_contract_version = "0.2.0"
+let default_proton_contract_version = "0.2.1"
 
 ///|
-let default_proton_client_version = "0.2.0"
+let default_proton_client_version = "0.2.1"
 
 ///|
-let default_proton_rabbita_version = "0.2.0"
+let default_proton_rabbita_version = "0.2.1"
 
 ///|
 let default_rabbita_version = "0.14.1"

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_client"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_contract@0.2.0",
+  "moonbit-community/proton_contract@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_codegen"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_config"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/contract/moon.mod
+++ b/contract/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_contract"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -1,15 +1,15 @@
 name = "moonbit-community/proton/e2e"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
-  "moonbit-community/proton_cdp@0.2.0",
-  "moonbit-community/proton@0.2.0",
-  "moonbit-community/proton_cefsetup@0.2.0",
-  "moonbit-community/proton_updater@0.2.0",
-  "moonbit-community/proton/examples@0.2.0",
+  "moonbit-community/proton_cdp@0.2.1",
+  "moonbit-community/proton@0.2.1",
+  "moonbit-community/proton_cefsetup@0.2.1",
+  "moonbit-community/proton_updater@0.2.1",
+  "moonbit-community/proton/examples@0.2.1",
 }
 
 readme = "README.md"

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton/examples"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_ext@0.2.0",
-  "moonbit-community/proton_contract@0.2.0",
-  "moonbit-community/proton@0.2.0",
+  "moonbit-community/proton_ext@0.2.1",
+  "moonbit-community/proton_contract@0.2.1",
+  "moonbit-community/proton@0.2.1",
 }
 
 readme = "README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -1,22 +1,22 @@
 name = "moonbit-community/proton_ext"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_clipboard@0.2.0",
-  "moonbit-community/proton_tray@0.2.0",
-  "moonbit-community/proton_global_hotkey@0.2.0",
-  "moonbit-community/proton@0.2.0",
-  "moonbit-community/proton_contract@0.2.0",
-  "moonbit-community/proton_microphone@0.2.0",
-  "moonbit-community/proton_auto_launch@0.2.0",
-  "moonbit-community/proton_keepawake@0.2.0",
-  "moonbit-community/proton_power_monitor@0.2.0",
-  "moonbit-community/proton_process@0.2.0",
-  "moonbit-community/proton_shell@0.2.0",
+  "moonbit-community/proton_clipboard@0.2.1",
+  "moonbit-community/proton_tray@0.2.1",
+  "moonbit-community/proton_global_hotkey@0.2.1",
+  "moonbit-community/proton@0.2.1",
+  "moonbit-community/proton_contract@0.2.1",
+  "moonbit-community/proton_microphone@0.2.1",
+  "moonbit-community/proton_auto_launch@0.2.1",
+  "moonbit-community/proton_keepawake@0.2.1",
+  "moonbit-community/proton_power_monitor@0.2.1",
+  "moonbit-community/proton_process@0.2.1",
+  "moonbit-community/proton_shell@0.2.1",
 }
 
 readme = "README.md"

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
-  "moonbit-community/proton_config@0.2.0",
-  "moonbit-community/proton_contract@0.2.0",
-  "moonbit-community/proton_updater@0.2.0",
-  "moonbit-community/proton_rsa@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_config@0.2.1",
+  "moonbit-community/proton_contract@0.2.1",
+  "moonbit-community/proton_updater@0.2.1",
+  "moonbit-community/proton_rsa@0.2.1",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.13",

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_rabbita"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_client@0.2.0",
-  "moonbit-community/proton_contract@0.2.0",
+  "moonbit-community/proton_client@0.2.1",
+  "moonbit-community/proton_contract@0.2.1",
   "moonbit-community/rabbita@0.14.1",
 }
 

--- a/rsa/moon.mod
+++ b/rsa/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_rsa"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_auto_launch"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.md"
 

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_clipboard"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_ffi"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_global_hotkey"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_keepawake"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_microphone"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/sys/power_monitor/moon.mod
+++ b/sys/power_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_power_monitor"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/sys/process/moon.mod
+++ b/sys/process/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_process"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_shell"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_tray"
 
-version = "0.2.0"
+version = "0.2.1"
 
 import {
-  "moonbit-community/proton_ffi@0.2.0",
+  "moonbit-community/proton_ffi@0.2.1",
 }
 
 readme = "README.mbt.md"

--- a/updater/moon.mod
+++ b/updater/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_updater"
 
-version = "0.2.0"
+version = "0.2.1"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
## Summary

- separate project/backend resolution from release build validation
- allow `proton_cli cef setup` on a fresh scaffold before `frontend/dist` exists
- bump the lockstep workspace release to 0.2.1

## Background

The 0.2.0 release was published successfully, but the independent registry smoke test found that `proton_cli cef setup` failed on a fresh project because resolving the project's Proton source went through the full release-build preparation path. That path correctly requires `frontend/dist`, but CEF setup only needs the project configuration and backend package resolution.

## Validation

- `moon fmt`
- `moon info`
- `node scripts/verify_generated.mjs`
- CLI release test suite: 76 passed
- `moon -C proton check --target native --diagnostic-limit 80`
- registry-only fresh scaffold with 0.2.0 dependencies:
  - source CLI `cef setup`
  - release build
  - package dry-run
  - real macOS `.app` package
