### PR TITLE
fix(release): decouple publishing from WASM assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,28 +107,8 @@ jobs:
             moon update
           }
 
-          wait_for_codegen() {
-            version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' codegen/moon.mod)
-            if [ -z "$version" ]; then
-              echo "Could not read the proton_codegen version." >&2
-              return 1
-            fi
-            coordinate="moonbit-community/proton_codegen@$version"
-            deadline=$((SECONDS + 900))
-            echo "Waiting for $coordinate executable asset"
-            until moonx "$coordinate" --help >/dev/null 2>&1; do
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "$coordinate is still unavailable after 15 minutes." >&2
-                return 1
-              fi
-              sleep 15
-            done
-            echo "$coordinate executable asset is ready"
-          }
-
           publish_module config moonbit-community/proton_config
           publish_module codegen moonbit-community/proton_codegen
-          wait_for_codegen
           publish_module contract moonbit-community/proton_contract
           publish_module rsa moonbit-community/proton_rsa
           publish_module updater moonbit-community/proton_updater

--- a/scripts/e2e_scaffold_source_smoke.mjs
+++ b/scripts/e2e_scaffold_source_smoke.mjs
@@ -15,7 +15,6 @@ const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "proton-scaffold-e2e-"));
 const projectDir = path.join(tempRoot, "todo");
 const frontendDir = path.join(projectDir, "frontend");
 const frontendDist = path.join(frontendDir, "dist");
-let codegenWasm;
 const codegenVersion = fs
   .readFileSync(path.join(repoRoot, "codegen", "moon.mod"), "utf8")
   .match(/^version\s*=\s*"([^"]+)"/m)?.[1];
@@ -71,16 +70,6 @@ function run(command, args, options = {}) {
     fail(`${command} exited with status ${result.status}${output}`);
   }
   return `${result.stdout ?? ""}${result.stderr ?? ""}`;
-}
-
-function buildArtifact(args) {
-  const output = run("moon", args, { capture: true });
-  const artifacts = JSON.parse(output).artifacts_path;
-  assert(
-    Array.isArray(artifacts) && artifacts.length === 1,
-    `expected one Moon artifact, received: ${output}`,
-  );
-  return artifacts[0];
 }
 
 function runtimeEnv(extra = {}) {
@@ -160,37 +149,17 @@ function verifyGeneratedTree() {
   );
 }
 
-function installLocalMoonxShim() {
-  codegenWasm = buildArtifact([
-    "run",
-    "codegen",
-    "--target",
-    "wasm",
-    "--build-only",
-  ]);
-  const binDir = path.join(tempRoot, "bin");
-  fs.mkdirSync(binDir);
-  const shim = path.join(binDir, "moonx");
-  const realMoonx = run("which", ["moonx"], { capture: true }).trim();
-  fs.writeFileSync(
-    shim,
-    `#!/usr/bin/env node
-const { spawnSync } = require("node:child_process");
-const expected = ${JSON.stringify(codegenCoordinate)};
-if (process.argv[2] === expected) {
-  const result = spawnSync("moonrun", [${JSON.stringify(codegenWasm)}, ...process.argv.slice(3)], {
-    stdio: "inherit",
-  });
-  process.exit(result.status ?? 1);
-}
-const result = spawnSync(${JSON.stringify(realMoonx)}, process.argv.slice(2), {
-  stdio: "inherit",
-});
-process.exit(result.status ?? 1);
-`,
+function useLocalCodegenPackage() {
+  const backendModPath = path.join(projectDir, "backend", "moon.mod");
+  const source = fs.readFileSync(backendModPath, "utf8");
+  const localCommand = `moon runwasm '${path.join(repoRoot, "codegen")}'`;
+  const updated = source.replace(`moonx ${codegenCoordinate}`, localCommand);
+  assert(updated !== source, "generated backend is missing the codegen command");
+  assert(
+    !updated.includes(`moonx ${codegenCoordinate}`),
+    "generated backend contains multiple codegen commands",
   );
-  fs.chmodSync(shim, 0o755);
-  process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  fs.writeFileSync(backendModPath, updated);
 }
 
 function verifySourceSmokeCodegen() {
@@ -201,8 +170,9 @@ function verifySourceSmokeCodegen() {
     "commands.g.mbt",
   );
   const fresh = path.join(tempRoot, "commands.fresh.mbt");
-  run("moonrun", [
-    codegenWasm,
+  run("moon", [
+    "runwasm",
+    path.join(repoRoot, "codegen"),
     path.join(projectDir, "backend", "todo", "commands.mbt"),
     "-o",
     fresh,
@@ -781,7 +751,7 @@ async function main() {
   ]);
   verifyGeneratedTree();
   run("moon", ["fmt", "--check"], { cwd: projectDir });
-  installLocalMoonxShim();
+  useLocalCodegenPackage();
   connectLocalSourceModules();
   localCli(["-C", projectDir, "cef", "setup"]);
 


### PR DESCRIPTION
## Summary

- validate scaffold codegen with `moon runwasm` against the local `codegen` package
- remove the temporary `moonx` shim and direct `_build` artifact handling
- stop blocking source package publication on Mooncakes' asynchronous WASM asset queue

## Background

The 0.2.1 publish run successfully published `proton_config` and `proton_codegen`, then timed out because the Mooncakes executable asset remained queued for more than 15 minutes. Source package publication and release correctness must not depend on that external asynchronous build queue.

## Validation

- `moon fmt`
- `moon info`
- `moon -C codegen test lib --target wasm` (6 passed)
- `moon runwasm codegen --help`
- source scaffold generated code through the local package and completed release build and macOS app packaging

The full local scaffold lifecycle probe later hit the existing intermittent packaged-app close timeout; no process from the failed probe remained.
