### PR TITLE
test(release): decouple registry smoke from WASM assets

### DIFF
--- a/scripts/e2e_scaffold_registry_smoke.mjs
+++ b/scripts/e2e_scaffold_registry_smoke.mjs
@@ -100,13 +100,18 @@ function verifyGeneratedDependencies() {
   if (!backend.includes(codegen)) {
     throw new Error(`backend/moon.mod is missing ${codegen}`);
   }
-  const generatedCommands = path.join(
-    projectDir,
-    "backend/todo/commands.g.mbt",
-  );
-  if (!fs.existsSync(generatedCommands)) {
-    throw new Error("Moon prebuild did not generate backend/todo/commands.g.mbt");
+}
+
+function useLocalCodegenPackage() {
+  const backendModPath = path.join(projectDir, "backend", "moon.mod");
+  const source = fs.readFileSync(backendModPath, "utf8");
+  const coordinate = `moonx moonbit-community/proton_codegen@${moduleVersion("codegen/moon.mod")}`;
+  const localCommand = `moon runwasm '${path.join(repoRoot, "codegen")}'`;
+  const updated = source.replace(coordinate, localCommand);
+  if (updated === source || updated.includes(coordinate)) {
+    throw new Error("could not select the local codegen package");
   }
+  fs.writeFileSync(backendModPath, updated);
 }
 
 try {
@@ -122,13 +127,18 @@ try {
     "registry_smoke",
     "--identifier",
     "dev.proton.registry-smoke",
+    "--no-check",
     "--no-git",
     "-y",
   ]);
   verifyGeneratedDependencies();
+  useLocalCodegenPackage();
   run("moon", ["check", "--target", "js,native", "--diagnostic-limit", "80"], {
     cwd: projectDir,
   });
+  if (!fs.existsSync(path.join(projectDir, "backend/todo/commands.g.mbt"))) {
+    throw new Error("Moon prebuild did not generate backend/todo/commands.g.mbt");
+  }
   succeeded = true;
   console.log("Registry scaffold smoke passed.");
 } finally {


### PR DESCRIPTION
## Summary

- scaffold with `--no-check` during registry validation
- verify the published CLI's original generated dependencies and codegen rule
- replace only the temporary project's codegen command with `moon runwasm` against the checkout package
- assert that the subsequent explicit `moon check` generates `commands.g.mbt`

## Validation

- installed `moonbit-community/proton_cli@0.2.1` from Mooncakes
- verified `proton_cli 0.2.1`
- `moon fmt`
- `moon info`
- `node scripts/e2e_scaffold_registry_smoke.mjs`
