### PR TITLE
fix(proton): allocate remote debugging ports dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ so CDP can be enabled separately for end-to-end tests. Native menus, dialogs,
 and titlebar overlay are unavailable in this mode. Linux still requires an
 X11 display; use Xvfb in display-less CI jobs.
 
+Development and explicit debug mode use an ephemeral remote-debugging port by
+default, and CEF prints the selected WebSocket endpoint to stderr. Set
+`PROTON_REMOTE_DEBUGGING_PORT` to `0` to request the same behavior explicitly,
+or to a value from `1024` through `65535` when a fixed port is required.
+
 ## Frontend projects
 
 Generated projects describe their toolchain in `proton.project.json`:

--- a/proton/facade_entry.mbt
+++ b/proton/facade_entry.mbt
@@ -149,22 +149,43 @@ fn debug_level_from_bool(enabled : Bool) -> Int {
 }
 
 ///|
-fn debug_port(debug : Int) -> Int {
-  if debug > 0 {
-    match @env.get_env_var("PROTON_REMOTE_DEBUGGING_PORT") {
-      Some(value) => {
-        let port = @string.parse_int(value[:]) catch { _ => 9222 }
-        if port > 0 {
-          port
-        } else {
-          9222
-        }
-      }
-      None => 9222
-    }
-  } else {
-    0
+fn resolve_remote_debugging(
+  debug : Int,
+  configured_port : String?,
+) -> @native.RemoteDebugging raise AppConfigurationError {
+  guard debug > 0 else { return @native.RemoteDebugging::Disabled }
+  let value = match configured_port {
+    Some(value) => value.trim().to_owned()
+    None => ""
   }
+  guard value != "" else { return @native.RemoteDebugging::Ephemeral }
+  let port = @string.parse_int(value[:]) catch {
+    _ =>
+      raise InvalidSetting(
+        name="PROTON_REMOTE_DEBUGGING_PORT",
+        message="must be 0 or an integer between 1024 and 65535",
+      )
+  }
+  if port == 0 {
+    @native.RemoteDebugging::Ephemeral
+  } else if port >= 1024 && port <= 65535 {
+    @native.RemoteDebugging::Fixed(port)
+  } else {
+    raise InvalidSetting(
+      name="PROTON_REMOTE_DEBUGGING_PORT",
+      message="must be 0 or an integer between 1024 and 65535",
+    )
+  }
+}
+
+///|
+fn remote_debugging(
+  debug : Int,
+) -> @native.RemoteDebugging raise AppConfigurationError {
+  resolve_remote_debugging(
+    debug,
+    @env.get_env_var("PROTON_REMOTE_DEBUGGING_PORT"),
+  )
 }
 
 ///|

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -122,12 +122,15 @@ async fn run_manifest(
   lifecycle.begin_starting()
   let forward_menu_events = menu is Some(_)
   let catalog = framework_catalog(locale_preferences)
+  let remote_debugging = remote_debugging(manifest.debug) catch {
+    error => raise ConfigurationError(error)
+  }
   let runtime = @native.Runtime::new(
     config=@native.RuntimeConfig::bundled(
       cache_dir?=browser_data_dir,
       locale=locale_preferences.chromium_locale(),
       accept_languages=locale_preferences.accept_languages(),
-      remote_debugging_port=debug_port(manifest.debug),
+      remote_debugging~,
       headless~,
     ).with_framework_dialog_labels(catalog.dialog_ok, catalog.dialog_cancel),
   ) catch {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -243,6 +243,38 @@ test "bridge startup timeout is finite and configurable" {
 }
 
 ///|
+test "debug mode uses an ephemeral endpoint unless a fixed port is explicit" {
+  assert_eq(
+    resolve_remote_debugging(0, None),
+    @native.RemoteDebugging::Disabled,
+  )
+  assert_eq(
+    resolve_remote_debugging(1, None),
+    @native.RemoteDebugging::Ephemeral,
+  )
+  assert_eq(
+    resolve_remote_debugging(1, Some("0")),
+    @native.RemoteDebugging::Ephemeral,
+  )
+  assert_eq(
+    resolve_remote_debugging(1, Some(" 9333 ")),
+    @native.RemoteDebugging::Fixed(9333),
+  )
+}
+
+///|
+test "debug mode rejects invalid fixed ports instead of falling back" {
+  for value in ["invalid", "-1", "1023", "65536"] {
+    try ignore(resolve_remote_debugging(1, Some(value))) catch {
+      InvalidSetting(name="PROTON_REMOTE_DEBUGGING_PORT", ..) => ()
+      _ => fail("expected an invalid remote debugging port")
+    } noraise {
+      _ => fail("expected an invalid remote debugging port")
+    }
+  }
+}
+
+///|
 test "headless mode defaults off and is configurable" {
   let default_app = html("Test", "<html></html>")
   assert_false(default_app.headless_value)

--- a/proton/internal/native/ffi/src/engine/cef_linux/proton_engine_cef_linux.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/proton_engine_cef_linux.c
@@ -285,6 +285,8 @@ static int g_proton_cef_initialized = 0;
 static int g_proton_cef_runtime_active = 0;
 static char g_proton_temporary_profile_path[PROTON_ENGINE_MAX_PATH_BYTES];
 static char g_proton_engine_locale[PROTON_ENGINE_MAX_PATH_BYTES];
+static int32_t g_proton_remote_debugging_port =
+    PROTON_REMOTE_DEBUGGING_DISABLED;
 static proton_engine_app_t g_app;
 static proton_engine_browser_process_handler_t g_browser_process_handler;
 static proton_engine_render_process_handler_t g_render_process_handler;
@@ -1074,6 +1076,12 @@ static void CEF_CALLBACK proton_engine_on_before_command_line_processing(
       g_proton_engine_locale[0] != '\0') {
     proton_engine_append_switch_with_value(command_line, "lang",
                                            g_proton_engine_locale);
+  }
+  if (proton_engine_process_type_is_browser(process_type) &&
+      g_proton_remote_debugging_port ==
+          PROTON_REMOTE_DEBUGGING_EPHEMERAL) {
+    proton_engine_append_switch_with_value(command_line,
+                                           "remote-debugging-port", "0");
   }
   proton_engine_append_switch(command_line, "disable-gpu");
   proton_engine_append_switch(command_line, "in-process-gpu");
@@ -3282,6 +3290,7 @@ int32_t proton_engine_runtime_create(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_runtime_config_t config = *input_config;
+  g_proton_remote_debugging_port = config.remote_debugging_port;
 
   int temporary_profile = config.cache_dir[0] == '\0';
   if (temporary_profile) {
@@ -3334,7 +3343,9 @@ int32_t proton_engine_runtime_create(
   settings.external_message_pump = 1;
   settings.windowless_rendering_enabled = config.headless;
   settings.log_severity = proton_engine_cef_log_severity_from_env();
-  settings.remote_debugging_port = config.remote_debugging_port;
+  settings.remote_debugging_port = config.remote_debugging_port > 0
+                                       ? config.remote_debugging_port
+                                       : PROTON_REMOTE_DEBUGGING_DISABLED;
   settings.persist_session_cookies = config.persist_session_cookies;
   proton_engine_set_string(&settings.browser_subprocess_path,
                            config.helper_path);

--- a/proton/internal/native/ffi/src/engine/cef_mac/proton_engine_cef_mac.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/proton_engine_cef_mac.m
@@ -266,6 +266,8 @@ static int g_proton_cef_library_loaded = 0;
 static int g_proton_cef_runtime_active = 0;
 static char g_proton_temporary_profile_path[PROTON_ENGINE_MAX_PATH_BYTES];
 static int g_proton_app_terminating = 0;
+static int32_t g_proton_remote_debugging_port =
+    PROTON_REMOTE_DEBUGGING_DISABLED;
 static proton_engine_app_t g_app;
 static proton_engine_browser_process_handler_t g_browser_process_handler;
 static proton_engine_render_process_handler_t g_render_process_handler;
@@ -1172,7 +1174,12 @@ static void proton_engine_on_before_command_line_processing(
     const cef_string_t *process_type,
     cef_command_line_t *command_line) {
   (void)self;
-  (void)process_type;
+  if ((process_type == NULL || process_type->length == 0) &&
+      g_proton_remote_debugging_port ==
+          PROTON_REMOTE_DEBUGGING_EPHEMERAL) {
+    proton_engine_append_switch_with_value(command_line,
+                                           "remote-debugging-port", "0");
+  }
   proton_engine_append_switch(command_line, "disable-background-networking");
   proton_engine_append_switch(command_line, "disable-component-update");
   proton_engine_append_switch(command_line, "disable-domain-reliability");
@@ -2860,6 +2867,7 @@ int32_t proton_engine_runtime_create(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_runtime_config_t config = *input_config;
+  g_proton_remote_debugging_port = config.remote_debugging_port;
 
   int temporary_profile = config.cache_dir[0] == '\0';
   if (temporary_profile) {
@@ -2901,7 +2909,9 @@ int32_t proton_engine_runtime_create(
   settings.external_message_pump = 1;
   settings.windowless_rendering_enabled = config.headless;
   settings.log_severity = proton_engine_cef_log_severity_from_env();
-  settings.remote_debugging_port = config.remote_debugging_port;
+  settings.remote_debugging_port = config.remote_debugging_port > 0
+                                       ? config.remote_debugging_port
+                                       : PROTON_REMOTE_DEBUGGING_DISABLED;
   settings.persist_session_cookies = config.persist_session_cookies;
   proton_engine_set_string(&settings.browser_subprocess_path,
                            config.helper_path);

--- a/proton/internal/native/ffi/src/engine/cef_win/proton_engine_cef_win.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/proton_engine_cef_win.c
@@ -263,6 +263,8 @@ static int g_proton_engine_multi_threaded_message_loop = 0;
 static int g_proton_engine_app_initialized = 0;
 static int g_proton_engine_factory_initialized = 0;
 static int g_proton_engine_window_lock_initialized = 0;
+static int32_t g_proton_remote_debugging_port =
+    PROTON_REMOTE_DEBUGGING_DISABLED;
 static proton_engine_app_t g_proton_engine_app;
 static proton_engine_browser_process_handler_t
     g_proton_engine_browser_process_handler;
@@ -1453,6 +1455,12 @@ static void proton_engine_on_before_command_line_processing(
   (void)process_type;
   if (command_line == NULL) {
     return;
+  }
+  if ((process_type == NULL || process_type->length == 0) &&
+      g_proton_remote_debugging_port ==
+          PROTON_REMOTE_DEBUGGING_EPHEMERAL) {
+    proton_engine_append_switch_with_value(command_line,
+                                           "remote-debugging-port", "0");
   }
   proton_engine_append_switch(command_line, "disable-gpu");
   // A bare --disable-gpu still launches a GPU process for SwiftShader, and
@@ -3026,6 +3034,7 @@ int32_t proton_engine_runtime_create(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_runtime_config_t config = *input_config;
+  g_proton_remote_debugging_port = config.remote_debugging_port;
   int temporary_profile = config.cache_dir[0] == '\0';
   if (temporary_profile) {
     if (!proton_profile_storage_create_temporary(
@@ -3052,7 +3061,9 @@ int32_t proton_engine_runtime_create(
   settings.windowless_rendering_enabled = config.headless;
   settings.log_severity = proton_engine_cef_log_severity_from_env();
   g_proton_engine_multi_threaded_message_loop = 0;
-  settings.remote_debugging_port = config.remote_debugging_port;
+  settings.remote_debugging_port = config.remote_debugging_port > 0
+                                       ? config.remote_debugging_port
+                                       : PROTON_REMOTE_DEBUGGING_DISABLED;
   settings.persist_session_cookies = config.persist_session_cookies;
 
   if (settings.external_message_pump &&

--- a/proton/internal/native/ffi/src/proton_config.c
+++ b/proton/internal/native/ffi/src/proton_config.c
@@ -673,10 +673,13 @@ int32_t proton_config_prepare_runtime(
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                             "runtime config output is required");
   }
-  if (remote_debugging_port < 0 || remote_debugging_port > 65535) {
+  if (remote_debugging_port != PROTON_REMOTE_DEBUGGING_EPHEMERAL &&
+      remote_debugging_port != PROTON_REMOTE_DEBUGGING_DISABLED &&
+      (remote_debugging_port < 1024 || remote_debugging_port > 65535)) {
     return proton_set_error(
         PROTON_ERR_INVALID_ARGUMENT,
-        "runtime remote_debugging_port must be between 0 and 65535");
+        "runtime remote debugging must be disabled, ephemeral, or use a port "
+        "between 1024 and 65535");
   }
   if (cache_dir != NULL && cache_dir[0] != '\0' &&
       !proton_path_is_absolute(cache_dir)) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -16,6 +16,11 @@ typedef struct proton_engine_view proton_engine_view_t;
 #define PROTON_ENGINE_MAX_URL_BYTES 131072
 #define PROTON_ENGINE_MAX_LABEL_BYTES 256
 
+enum {
+  PROTON_REMOTE_DEBUGGING_EPHEMERAL = -1,
+  PROTON_REMOTE_DEBUGGING_DISABLED = 0,
+};
+
 typedef struct {
   char runtime_root[PROTON_ENGINE_MAX_PATH_BYTES];
   char helper_path[PROTON_ENGINE_MAX_PATH_BYTES];

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -370,11 +370,22 @@ fn runtime_config_languages(values : Array[String]) -> Bytes {
 }
 
 ///|
+fn runtime_config_remote_debugging(value : RemoteDebugging) -> Int {
+  match value {
+    Disabled => 0
+    Ephemeral => -1
+    Fixed(port) => port
+  }
+}
+
+///|
 fn validate_runtime_config(config : RuntimeConfig) -> Unit raise NativeError {
-  if config.remote_debugging_port < 0 || config.remote_debugging_port > 65535 {
-    raise invalid_argument(
-      "runtime remote_debugging_port must be between 0 and 65535",
-    )
+  match config.remote_debugging {
+    Fixed(port) if port < 1024 || port > 65535 =>
+      raise invalid_argument(
+        "runtime fixed remote debugging port must be between 1024 and 65535",
+      )
+    _ => ()
   }
   match config.cache_dir {
     Some(cache_dir) => {
@@ -413,7 +424,7 @@ pub fn execute_process(
     runtime_config_languages(config.accept_languages),
     runtime_config_string(config.framework_dialog_ok_label),
     runtime_config_string(config.framework_dialog_cancel_label),
-    config.remote_debugging_port,
+    runtime_config_remote_debugging(config.remote_debugging),
     runtime_config_bool(config.headless),
     runtime_config_bool(config.persist_session_cookies),
     out_exit_code,
@@ -445,7 +456,7 @@ pub fn Runtime::new(
     runtime_config_languages(config.accept_languages),
     runtime_config_string(config.framework_dialog_ok_label),
     runtime_config_string(config.framework_dialog_cancel_label),
-    config.remote_debugging_port,
+    runtime_config_remote_debugging(config.remote_debugging),
     runtime_config_bool(config.headless),
     runtime_config_bool(config.persist_session_cookies),
     out_runtime,

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -174,6 +174,7 @@ test "runtime config preserves typed native ABI values" {
       @locale.Locale::parse("zh-CN"),
       @locale.Locale::parse("en-US"),
     ],
+    remote_debugging=RemoteDebugging::Ephemeral,
     headless=true,
   )
   assert_eq(runtime_config.helper_path, Some("cef_process.exe"))
@@ -184,6 +185,7 @@ test "runtime config preserves typed native ABI values" {
   assert_eq(runtime_config.accept_languages, ["zh-CN", "en-US"])
   assert_eq(runtime_config.framework_dialog_ok_label, Some("OK"))
   assert_eq(runtime_config.framework_dialog_cancel_label, Some("Cancel"))
+  assert_eq(runtime_config.remote_debugging, RemoteDebugging::Ephemeral)
   let bundled = RuntimeConfig::bundled(cache_dir~)
   assert_true(bundled.use_bundled)
   assert_eq(bundled.runtime_root, None)
@@ -194,6 +196,19 @@ test "runtime config preserves typed native ABI values" {
   assert_false(
     RuntimeConfig::new(persist_session_cookies=false).persist_session_cookies,
   )
+}
+
+///|
+test "remote debugging modes have distinct native encodings" {
+  assert_eq(runtime_config_remote_debugging(RemoteDebugging::Disabled), 0)
+  assert_eq(runtime_config_remote_debugging(RemoteDebugging::Ephemeral), -1)
+  assert_eq(runtime_config_remote_debugging(RemoteDebugging::Fixed(9333)), 9333)
+  let error = expect_native_error(() => {
+    validate_runtime_config(
+      RuntimeConfig::bundled(remote_debugging=RemoteDebugging::Fixed(1023)),
+    )
+  })
+  assert_true(error.message().contains("between 1024 and 65535"))
 }
 
 ///|

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -378,6 +378,15 @@ pub fn ProcessResult::equal(Self, Self) -> Bool
 pub fn ProcessResult::not_equal(Self, Self) -> Bool
 pub fn ProcessResult::to_repr(Self) -> @debug.Repr
 
+pub(all) enum RemoteDebugging {
+  Disabled
+  Ephemeral
+  Fixed(Int)
+} derive(Eq, @debug.Debug)
+pub fn RemoteDebugging::equal(Self, Self) -> Bool
+pub fn RemoteDebugging::not_equal(Self, Self) -> Bool
+pub fn RemoteDebugging::to_repr(Self) -> @debug.Repr
+
 type Runtime
 pub fn Runtime::begin_message_dialog(Self, String?, String, DialogLevel) -> Int64 raise NativeError
 pub fn Runtime::complete_resource_request(Self, Int64, Int, String, Bytes) -> Unit raise NativeError
@@ -388,9 +397,9 @@ pub fn Runtime::respond_bridge_request(Self, BridgeResponse) -> Unit raise Nativ
 pub fn Runtime::set_menu(Self, MenuBar) -> Unit raise NativeError
 
 type RuntimeConfig derive(Eq, @debug.Debug)
-pub fn RuntimeConfig::bundled(helper_path? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging_port? : Int, headless? : Bool, persist_session_cookies? : Bool) -> Self
+pub fn RuntimeConfig::bundled(helper_path? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, persist_session_cookies? : Bool) -> Self
 pub fn RuntimeConfig::equal(Self, Self) -> Bool
-pub fn RuntimeConfig::new(runtime_root? : String, helper_path? : String, resources_dir? : String, locales_dir? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging_port? : Int, headless? : Bool, persist_session_cookies? : Bool) -> Self
+pub fn RuntimeConfig::new(runtime_root? : String, helper_path? : String, resources_dir? : String, locales_dir? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, persist_session_cookies? : Bool) -> Self
 pub fn RuntimeConfig::not_equal(Self, Self) -> Bool
 pub fn RuntimeConfig::to_repr(Self) -> @debug.Repr
 

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -1115,6 +1115,20 @@ pub fn bridge_permission_grants_supported() -> Bool {
 }
 
 ///|
+/// Controls whether and where CEF exposes its remote debugging endpoint.
+pub(all) enum RemoteDebugging {
+  Disabled
+  Ephemeral
+  Fixed(Int)
+} derive(Debug, Eq)
+
+///|
+pub extend RemoteDebugging with Eq::{not_equal, equal}
+
+///|
+pub extend RemoteDebugging with Debug::{to_repr}
+
+///|
 struct RuntimeConfig {
   use_bundled : Bool
   headless : Bool
@@ -1128,7 +1142,7 @@ struct RuntimeConfig {
   accept_languages : Array[String]
   framework_dialog_ok_label : String?
   framework_dialog_cancel_label : String?
-  remote_debugging_port : Int
+  remote_debugging : RemoteDebugging
 } derive(Debug, Eq)
 
 ///|
@@ -1174,7 +1188,7 @@ pub fn RuntimeConfig::new(
   cache_dir? : String,
   locale? : @locale.Locale,
   accept_languages? : Array[@locale.Locale] = [],
-  remote_debugging_port? : Int = 0,
+  remote_debugging? : RemoteDebugging = Disabled,
   headless? : Bool = false,
   persist_session_cookies? : Bool = true,
 ) -> RuntimeConfig {
@@ -1191,7 +1205,7 @@ pub fn RuntimeConfig::new(
     accept_languages: accept_languages.map(value => value.to_string()),
     framework_dialog_ok_label: Some("OK"),
     framework_dialog_cancel_label: Some("Cancel"),
-    remote_debugging_port,
+    remote_debugging,
   }
 }
 
@@ -1206,7 +1220,7 @@ pub fn RuntimeConfig::bundled(
   cache_dir? : String,
   locale? : @locale.Locale,
   accept_languages? : Array[@locale.Locale] = [],
-  remote_debugging_port? : Int = 0,
+  remote_debugging? : RemoteDebugging = Disabled,
   headless? : Bool = false,
   persist_session_cookies? : Bool = true,
 ) -> RuntimeConfig {
@@ -1223,7 +1237,7 @@ pub fn RuntimeConfig::bundled(
     accept_languages: accept_languages.map(value => value.to_string()),
     framework_dialog_ok_label: Some("OK"),
     framework_dialog_cancel_label: Some("Cancel"),
-    remote_debugging_port,
+    remote_debugging,
   }
 }
 
@@ -1274,7 +1288,7 @@ pub fn RuntimeConfig::with_framework_dialog_labels(
     accept_languages: self.accept_languages,
     framework_dialog_ok_label: Some(ok),
     framework_dialog_cancel_label: Some(cancel),
-    remote_debugging_port: self.remote_debugging_port,
+    remote_debugging: self.remote_debugging,
   }
 }
 


### PR DESCRIPTION
## Background

Proton enabled CEF remote debugging on port `9222` by default in development and debug mode. When multiple Proton applications ran at the same time, or another process already owned that port, Chromium could bind a different address family or fail to expose the expected endpoint. Tooling could then connect to the wrong application even though both applications remained running.

## Changes

- model remote debugging as explicit `Disabled`, `Ephemeral`, and `Fixed(port)` modes
- use Chromium's ephemeral-port allocation by default in development and debug mode
- treat `PROTON_REMOTE_DEBUGGING_PORT=0` as an explicit ephemeral-port request
- accept fixed ports only in the `1024..65535` range and report invalid configuration instead of falling back to `9222`
- pass ephemeral mode through CEF's `--remote-debugging-port=0` browser-process switch
- keep the native contract consistent across macOS, Windows, and Linux
- document the updated debugging-port behavior

This deliberately avoids preflight port probing and retry logic. Such checks have a stage/use race and cannot reserve the socket for CEF; delegating allocation to Chromium is the reliable default.

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 80` (22/22)
- `moon -C proton test --target native --diagnostic-limit 80` (529/529)
- `moon -C examples build --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- launched two macOS Proton examples while another application occupied `9222`; the examples received distinct ports (`54582` and `54607`) and exposed separate CDP browser endpoints

Windows and Linux receive the same implementation and compile-time contract, but the live multi-process verification was performed on macOS.
