### PR TITLE
fix(native): support macOS windowless app lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,14 +253,25 @@ activation:
 ```moonbit
 @proton.asset("My App", "frontend/dist/index.html")
 .single_instance("com.example.my-app")
-.on_launch_input(async fn(input) noraise {
+.last_window_closed_policy(@proton.LastWindowClosedPolicy::KeepRunning)
+.on_launch_input(async fn(context, input) noraise {
   match input {
     OpenUrls(urls) => ...
     OpenFiles(paths) => ...
-    Reopen => ...
+    Reopen =>
+      if context.windows().find("main") is None {
+        ignore(context.windows().open("main")) catch {
+          _ => ()
+        }
+      }
   }
 })
 ```
+
+By default, closing the last window quits the application. Select
+`KeepRunning` for applications that should remain available in the Dock or
+system tray after their windows close. Call `context.quit()` from an
+application-lifetime callback to request an orderly shutdown.
 
 The instance coordinator is implemented on macOS, Windows, and Linux. Packaged
 macOS applications register `package.url_schemes` and `package.document_types`

--- a/docs/research/macos-window-lifecycle-tauri-electron.md
+++ b/docs/research/macos-window-lifecycle-tauri-electron.md
@@ -1,0 +1,308 @@
+# macOS Window and Application Lifecycle in Tauri and Electron
+
+Status: research note, 2026-08-24.
+
+## Scope and versions
+
+This note compares four distinct transitions on macOS:
+
+1. a user closes one window;
+2. the last window disappears;
+3. the user activates an already-running application from the Dock;
+4. the user explicitly quits the application.
+
+The distinction matters because a window is not the application. AppKit owns an
+application-wide event loop independently of any particular `NSWindow`, exposes
+`applicationShouldHandleReopen:hasVisibleWindows:` for reopening an already-running
+application, and has a separate termination protocol. In particular,
+`applicationShouldTerminateAfterLastWindowClosed:` is the delegate decision that
+would opt into terminating merely because the final window closed
+([Apple reopen delegate API](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/applicationshouldhandlereopen%28_%3Ahasvisiblewindows%3A%29?language=objc),
+[Apple last-window termination API](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/applicationshouldterminateafterlastwindowclosed%28_%3A%29?language=objc),
+[Apple `terminate:` protocol](https://developer.apple.com/documentation/appkit/nsapplication/terminate%28_%3A%29?language=objc)).
+
+The implementation references below are fixed to the latest stable releases found
+during this research:
+
+- Tauri `2.11.5`, tag `tauri-v2.11.5`, commit `7cd71369c00978a3783b6ae3e9972358abbe4ae6`
+  ([official release](https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.11.5)).
+- Tao `0.35.0`, which `tauri-runtime-wry` 2.11.5 declares as its event-loop
+  dependency
+  ([Tauri dependency declaration](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/Cargo.toml#L21),
+  [Tao tag](https://github.com/tauri-apps/tao/tree/tao-v0.35.0)).
+- Electron `43.4.1`, tag `v43.4.1`, commit `340bae15aaef12b7e96f1c857be986aa9f65c21c`
+  ([official release](https://github.com/electron/electron/releases/tag/v43.4.1)).
+
+## Executive comparison
+
+| Concern | Tauri 2.11.5 | Electron 43.4.1 |
+| --- | --- | --- |
+| Core default after the last window is destroyed | Requests application exit on every desktop platform. | Quits if the application has not installed its own `window-all-closed` listener. |
+| Official macOS-style composition | Build the `App`, handle `ExitRequested { code: None }`, call `prevent_exit`, and handle `Reopen` yourself. Tauri exposes the primitives but its shorthand does not install this policy. | Official tutorial installs `window-all-closed`, calls `app.quit()` only off macOS, and creates a new window on `activate` when none exist. |
+| Close interception | `WindowEvent::CloseRequested` with `CloseRequestApi::prevent_close()`. | `BrowserWindow` `close` event plus renderer `beforeunload`; either can cancel. |
+| Dock activation | AppKit -> Tao `Event::Reopen` -> Tauri `RunEvent::Reopen`. No automatic window creation. | AppKit -> native `Browser::Activate` -> JavaScript `app` `activate`. No automatic window creation. |
+| Graceful explicit quit | Tauri-originated `AppHandle::exit` emits `ExitRequested`, then `Exit`; cleanup runs at `Exit`. | Native and JavaScript graceful quit share `before-quit` -> close all windows -> `will-quit` -> shutdown -> `quit`. |
+
+Both frameworks therefore leave window reconstruction to application policy. Electron
+makes the native macOS pattern prominent in its official starter tutorial. Tauri has
+the necessary hooks, but its convenience `Builder::run` retains its cross-platform
+"last window means exit" default.
+
+## Tauri
+
+### Public lifecycle model
+
+Tauri separates window and application events:
+
+- `WindowEvent::CloseRequested` carries a `CloseRequestApi`, and
+  `prevent_close()` cancels that individual close request
+  ([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L97-L123)).
+- `RunEvent::ExitRequested` carries an optional code and `ExitRequestApi`; `None`
+  denotes a user-interaction request, whereas programmatic `AppHandle::exit` or
+  restart requests carry `Some(code)`
+  ([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L220-L232)).
+- macOS adds `RunEvent::Reopen { has_visible_windows }`, explicitly documented as
+  the event corresponding to AppKit's
+  `applicationShouldHandleReopen:hasVisibleWindows:`
+  ([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L275-L282),
+  [macOS API docs](https://docs.rs/tauri/2.11.5/x86_64-apple-darwin/tauri/enum.RunEvent.html#variant.Reopen)).
+
+`Builder::run(context)` is only shorthand for `build(context)?.run(|_, _| {})`.
+Consequently, a normal generated Tauri application has no lifecycle callback that
+can prevent the default last-window exit
+([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L2445-L2451)).
+
+### Close and last-window implementation chain
+
+The Wry runtime translates Tao's native close request into Tauri policy rather than
+closing blindly:
+
+1. `TaoWindowEvent::CloseRequested` calls `on_close_requested`.
+2. `on_close_requested` invokes registered window listeners and the application
+   callback with `WindowEvent::CloseRequested`.
+3. If no listener sends the prevention signal, `on_window_close` drops the native
+   window owner.
+4. On the later `TaoWindowEvent::Destroyed`, the runtime removes the window from its
+   store. When the store becomes empty, it synchronously emits
+   `RunEvent::ExitRequested { code: None }`; absent `Prevent`, it changes the event
+   loop to `ControlFlow::Exit`.
+
+The implementation is visible directly in
+[`on_close_requested`](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/src/lib.rs#L4438-L4472)
+and the
+[`Destroyed` branch](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/src/lib.rs#L4307-L4324).
+
+This establishes the actual default: on macOS, destroying the final Tauri window
+terminates the Tauri event loop unless application code prevents the resulting
+`ExitRequested`. It is not AppKit itself killing the application after the final
+window; it is Tauri's cross-platform window-store policy.
+
+Tauri's own API example shows the intended opt-out for applications that must remain
+alive without windows: it handles `ExitRequested` only when `code.is_none()` and calls
+`api.prevent_exit()`, while allowing manually requested exits carrying `Some(code)` to
+continue
+([official example](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/examples/api/src-tauri/src/lib.rs#L161-L170)).
+
+### Dock reopen implementation chain
+
+Tao installs the AppKit delegate method
+`applicationShouldHandleReopen:hasVisibleWindows:`
+([registration](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_delegate.rs#L78-L81)).
+Its implementation forwards the AppKit boolean to `AppState::reopen`
+([delegate implementation](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_delegate.rs#L206-L216)),
+which enqueues `Event::Reopen`
+([event-loop bridge](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_state.rs#L309-L317)).
+`tauri-runtime-wry` then converts that Tao event into `RunEvent::Reopen`
+([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/src/lib.rs#L4386-L4396)).
+
+No layer in that chain recreates a window. The application must either show an
+existing hidden window or construct a replacement. Tao's official reopen example
+demonstrates the latter: it drops the window on close, then creates a new one when
+`Event::Reopen` arrives with `has_visible_windows == false`
+([official example](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/examples/reopen_event.rs#L12-L44)).
+
+For this event to be useful after closing the last window, the application must first
+prevent Tauri's last-window `ExitRequested`; otherwise the event loop is already gone.
+
+### Explicit quit implementation chain
+
+For a Tauri-originated graceful exit, `AppHandle::exit(code)` asks the runtime to exit
+and documents that it emits both `RunEvent::ExitRequested` and `RunEvent::Exit`
+([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L573-L580)).
+The Wry runtime receives `Message::RequestExit(code)`, emits
+`ExitRequested { code: Some(code) }`, and changes to `ControlFlow::Exit` unless
+prevented
+([source](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/src/lib.rs#L4353-L4366)).
+Tao's eventual `LoopDestroyed` becomes Tauri `RunEvent::Exit`, after which the high
+level `App` performs cleanup
+([runtime bridge](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri-runtime-wry/src/lib.rs#L4181-L4187),
+[cleanup](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/app.rs#L1422-L1437)).
+
+At the lower Tao/AppKit boundary, version 0.35.0 registers
+`applicationWillTerminate:` and maps it directly to `AppState::exit`, which emits
+`LoopDestroyed`
+([delegate registration and callback](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_delegate.rs#L58-L65),
+[callback implementation](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_delegate.rs#L131-L135),
+[loop teardown](https://github.com/tauri-apps/tao/blob/tao-v0.35.0/src/platform_impl/macos/app_state.rs#L272-L281)).
+It does not register AppKit's preventable `applicationShouldTerminate:` delegate in
+this version. Therefore, the source-backed guarantee is strongest for
+Tauri-originated `AppHandle::exit`; it is unsafe to assume that every native AppKit
+termination route is cancellable through `ExitRequested` merely from the public enum
+name.
+
+## Electron
+
+### Core default versus official macOS composition
+
+Electron core installs an internal `window-all-closed` listener. It calls
+`app.quit()` only when that internal listener is the sole listener
+([source](https://github.com/electron/electron/blob/v43.4.1/lib/browser/init.ts#L169-L174)).
+This implements the documented rule: without an application listener, closing every
+window quits; once the application subscribes, the application owns that choice
+([API documentation](https://github.com/electron/electron/blob/v43.4.1/docs/api/app.md#L50-L59)).
+
+The official starter tutorial deliberately overrides that core default:
+
+- `window-all-closed` calls `app.quit()` only when the platform is not `darwin`;
+- on macOS, `activate` checks `BrowserWindow.getAllWindows().length` and invokes the
+  application's existing `createWindow()` function when the count is zero.
+
+Electron explicitly describes this as implementing OS conventions in application
+code rather than enforcing them invisibly in the framework
+([official tutorial](https://github.com/electron/electron/blob/v43.4.1/docs/tutorial/tutorial-2-first-app.md#L330-L373)).
+
+Thus "Electron keeps macOS applications alive after the last window" is true of the
+official starter pattern, not an unconditional native-core default.
+
+### Close and last-window implementation chain
+
+Electron routes an AppKit close through both native-window and web-content policy:
+
+1. `NSWindowDelegate.windowShouldClose` calls
+   `NotifyWindowCloseButtonClicked()` and returns `NO`, preventing AppKit from racing
+   ahead of Electron
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/ui/cocoa/electron_ns_window_delegate.mm#L411-L414)).
+2. `BaseWindow::WillCloseWindow` emits the JavaScript `close` event; a prevented event
+   cancels the operation
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/api/electron_api_base_window.cc#L155-L159)).
+3. `BrowserWindow::OnCloseButtonClicked` then dispatches renderer
+   `beforeunload`/`unload` work before closing `WebContents`
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/api/electron_api_browser_window.cc#L151-L168),
+   [API contract](https://github.com/electron/electron/blob/v43.4.1/docs/api/browser-window.md#L186-L221)).
+4. AppKit's later `windowWillClose` cleans the native view and calls
+   `NotifyWindowClosed`
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/ui/cocoa/electron_ns_window_delegate.mm#L372-L408)).
+5. `WindowList::RemoveWindow` notifies observers when the list becomes empty
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/window_list.cc#L53-L60)).
+6. If this was an ordinary close, `Browser::OnWindowAllClosed` emits the application
+   event; if an explicit quit is already underway, it continues the quit pipeline
+   instead
+   ([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/browser.cc#L285-L300)).
+
+The important ownership boundary is that closing and destroying the final
+`BrowserWindow` does not intrinsically stop Chromium's main process. The separate
+`window-all-closed` policy decides whether to call `app.quit()`.
+
+### Dock activation implementation chain
+
+Electron's AppKit delegate implements
+`applicationShouldHandleReopen:hasVisibleWindows:` and calls
+`Browser::Activate(flag)`
+([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/mac/electron_application_delegate.mm#L127-L132)).
+That reaches `App::OnActivate`, which emits JavaScript's `activate` event with the
+same visibility flag
+([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/api/electron_api_app.cc#L616-L618),
+[API documentation](https://github.com/electron/electron/blob/v43.4.1/docs/api/app.md#L144-L154)).
+
+As in Tauri, Electron does not reconstruct an application-specific window by itself.
+The official tutorial retains a reusable `createWindow()` function and calls it when
+`BrowserWindow.getAllWindows()` is empty. That is a design requirement, not merely
+sample-code style: after a true window destruction there is no live native handle to
+"show" again.
+
+### Explicit quit implementation chain
+
+Electron gives native Quit and JavaScript `app.quit()` the same graceful path. Its
+`NSApplication` subclass overrides `terminate:`—the action used by the macOS Quit
+menu—and calls `Browser::Quit()` instead of letting AppKit terminate immediately
+([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/mac/electron_application.mm#L92-L101)).
+
+`Browser::Quit()` then:
+
+1. emits preventable `before-quit`;
+2. closes all windows, allowing each window's normal close/beforeunload path to
+   cancel;
+3. after the final window is gone, emits preventable `will-quit`;
+4. shuts down the main loop and finally emits `quit` through its observer.
+
+The native control flow is implemented in
+[`Browser::Quit`](https://github.com/electron/electron/blob/v43.4.1/shell/browser/browser.cc#L113-L125),
+[`HandleBeforeQuit`, `NotifyAndShutdown`, and `OnWindowAllClosed`](https://github.com/electron/electron/blob/v43.4.1/shell/browser/browser.cc#L265-L300),
+and the JavaScript event bridge
+([source](https://github.com/electron/electron/blob/v43.4.1/shell/browser/api/electron_api_app.cc#L580-L604)).
+The public API documents the same ordering and specifically states that
+`window-all-closed` is not emitted when `Cmd+Q` or `app.quit()` initiated the close
+sequence
+([documentation](https://github.com/electron/electron/blob/v43.4.1/docs/api/app.md#L50-L91)).
+
+Electron separately exposes `app.exit()`, which immediately destroys windows and
+skips `before-quit` and `will-quit`; it is not the semantic equivalent of a normal
+macOS Quit
+([documentation](https://github.com/electron/electron/blob/v43.4.1/docs/api/app.md#L508-L525),
+[implementation](https://github.com/electron/electron/blob/v43.4.1/shell/browser/browser.cc#L127-L156)).
+
+## Implications for Proton
+
+Electron's state separation is the stronger model for Proton's reported macOS
+failure. The useful invariant is not "the process exits when the last window closes";
+it is:
+
+> Window destruction completes independently. Application shutdown starts only when
+> an explicit application-lifetime policy requests it.
+
+A minimal macOS-correct Proton design should therefore have three explicit states or
+equivalent invariants:
+
+1. **Running, with windows.** Closing a window completes the browser's native teardown
+   and removes it from the active-window registry.
+2. **Running, without windows.** The host loop, application object, and Dock presence
+   remain alive. A Dock reopen event either shows a deliberately hidden main window or
+   invokes a retained window-construction recipe.
+3. **Quitting.** Quit sets an application-level flag, asks every window/browser to
+   close, waits for their terminal close callbacks, then destroys the runtime and
+   exits. A cancelled window close cancels or defers quitting rather than leaving the
+   app half-torn-down.
+
+Tauri confirms that the event vocabulary (`CloseRequested`, `ExitRequested`,
+`Reopen`, `Exit`) is sufficient, but its default last-window transition is the wrong
+one to copy for native macOS behavior. Electron demonstrates the more important
+implementation property: normal last-window closure and explicit quit enter distinct
+branches before they converge on native window teardown.
+
+For Proton, Dock reopen must also be a reconstruction operation, not merely a focus
+operation. Once the CEF browser and its `NSWindow` are correctly destroyed, focusing
+the old handle is impossible; Proton must retain enough prepared application/window
+description to create the main window again, or expose an application callback that
+does so.
+
+## Suggested lifecycle acceptance tests
+
+The framework-level test should assert process, window, and browser lifetimes
+separately:
+
+1. Close the only macOS window through the title-bar button.
+   - The `NSWindow` and its browser reach their terminal destroyed callbacks.
+   - No DevTools/page target remains for that window.
+   - The original application PID and host event loop remain alive.
+2. Activate the same application from the Dock.
+   - A new main window and browser target appear.
+   - The PID is unchanged.
+   - Application commands and bridge events still work.
+3. Invoke Quit through the application menu or Dock menu.
+   - The graceful quit path closes all windows.
+   - Browser/helper processes terminate.
+   - The application PID exits only after runtime cleanup completes.
+4. Add a close-cancellation case.
+   - Cancelling the window close leaves the window usable.
+   - Cancelling during Quit returns the application to the running state instead of
+     leaving a permanent `quitting` flag.

--- a/examples/44_app_activation/main.mbt
+++ b/examples/44_app_activation/main.mbt
@@ -23,8 +23,14 @@ async fn main {
   .single_instance("com.example.proton.activation")
   .url_scheme("proton-example")
   .document_extension("proton-example")
-  .on_launch_input(fn(input) noraise {
+  .last_window_closed_policy(@proton.LastWindowClosedPolicy::KeepRunning)
+  .on_launch_input(async fn(context, input) noraise {
     println("activation: " + @debug.render(Repr(input)))
+    if input is Reopen && context.windows().find("main") is None {
+      ignore(context.windows().open("main")) catch {
+        error => println("failed to reopen main window: " + error.message())
+      }
+    }
   })
   .run_or_abort()
 }

--- a/examples/57_background_residency/main.mbt
+++ b/examples/57_background_residency/main.mbt
@@ -1,0 +1,50 @@
+///|
+let page =
+  #|<!doctype html>
+  #|<html>
+  #|  <head>
+  #|    <meta charset="utf-8" />
+  #|    <title>Background Residency</title>
+  #|    <style>
+  #|      body {
+  #|        max-width: 680px;
+  #|        margin: 48px auto;
+  #|        padding: 0 24px;
+  #|        font: 16px/1.6 system-ui;
+  #|        color: #17212b;
+  #|      }
+  #|      h1 { font-size: 28px; }
+  #|      code { padding: 2px 6px; background: #f3f5f7; border-radius: 4px; }
+  #|    </style>
+  #|  </head>
+  #|  <body>
+  #|    <h1>Background Residency</h1>
+  #|    <p>
+  #|      Close this window. The application process stays alive without any
+  #|      open windows.
+  #|    </p>
+  #|    <p>
+  #|      Launch the same application again to send <code>Reopen</code> to the
+  #|      existing process and create a new main window.
+  #|    </p>
+  #|    <p>
+  #|      Use the platform Quit action, or stop the development command, to end
+  #|      the background process.
+  #|    </p>
+  #|  </body>
+  #|</html>
+
+///|
+async fn main {
+  @proton.html("Background Residency", page, width=760, height=480)
+  .single_instance("com.example.proton.background-residency")
+  .last_window_closed_policy(@proton.LastWindowClosedPolicy::KeepRunning)
+  .on_launch_input(async fn(context, input) noraise {
+    if input is Reopen && context.windows().find("main") is None {
+      ignore(context.windows().open("main")) catch {
+        error => println("failed to reopen main window: " + error.message())
+      }
+    }
+  })
+  .run_or_abort()
+}

--- a/examples/57_background_residency/moon.pkg
+++ b/examples/57_background_residency/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbitlang/async",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/57_background_residency/pkg.generated.mbti
+++ b/examples/57_background_residency/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/57_background_residency"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -90,6 +90,9 @@ moon -C examples run 01_run --target native
   combining native dialogs, clipboard access, notifications, and tray menus.
 - `56_i18n`: one explicit application locale observed through MoonBit command
   context, CEF `navigator.languages`, and localized typed native menus.
+- `57_background_residency`: keeps the process alive after the last window
+  closes, then recreates the main window when a second launch delivers
+  `Reopen`; this is the lifecycle used by messaging and synchronization apps.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -75,8 +75,11 @@ Add secondary windows to the app builder:
 )
 ```
 
-The window id `"main"` is reserved for the primary window. The process exits
-when all windows have closed.
+The window id `"main"` is reserved for the primary window. By default, the
+process exits when all windows have closed. Use
+`.last_window_closed_policy(@proton.LastWindowClosedPolicy::KeepRunning)` when
+the application should remain available for Dock, protocol, document, or tray
+activation after its last window closes.
 
 ## Headless mode
 

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -338,9 +338,20 @@ pub fn App::on_update_available(
 ///|
 pub fn App::on_launch_input(
   self : App,
-  handler : async (RuntimeLaunchInput) -> Unit noraise,
+  handler : async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise,
 ) -> App {
   self.launch_input_handlers.push(handler)
+  self
+}
+
+///|
+/// Chooses whether closing the last window exits the application or leaves it
+/// running so a later launch input can open another window.
+pub fn App::last_window_closed_policy(
+  self : App,
+  policy : LastWindowClosedPolicy,
+) -> App {
+  self.last_window_closed_policy_value = policy
   self
 }
 

--- a/proton/facade_context.mbt
+++ b/proton/facade_context.mbt
@@ -4,6 +4,7 @@ pub struct ApplicationContext {
   tasks : @async.TaskGroup[Unit]
   windows : WindowManager
   locale_preferences : @locale.LocalePreferences
+  request_quit : () -> Unit
 }
 
 ///|
@@ -48,8 +49,9 @@ fn ApplicationContext::ApplicationContext(
   tasks : @async.TaskGroup[Unit],
   windows : WindowManager,
   locale_preferences : @locale.LocalePreferences,
+  request_quit? : () -> Unit = fn() {  },
 ) -> ApplicationContext {
-  ApplicationContext::{ tasks, windows, locale_preferences, }
+  ApplicationContext::{ tasks, windows, locale_preferences, request_quit, }
 }
 
 ///|
@@ -118,6 +120,16 @@ pub fn ApplicationContext::task_group(
 /// Returns the window manager owned by this running application.
 pub fn ApplicationContext::windows(self : ApplicationContext) -> WindowManager {
   self.windows
+}
+
+///|
+/// Requests an orderly application shutdown.
+///
+/// Proton closes every open window, runs configured close interception, and
+/// destroys the native runtime after all windows have closed. A denied window
+/// close cancels this quit request.
+pub fn ApplicationContext::quit(self : ApplicationContext) -> Unit {
+  (self.request_quit)()
 }
 
 ///|

--- a/proton/facade_error.mbt
+++ b/proton/facade_error.mbt
@@ -151,6 +151,7 @@ pub fn WindowSessionError::message(self : WindowSessionError) -> String {
   match self {
     UnknownWindow(id~) => "window is not declared: " + id
     AlreadyOpen(id~) => "window is already open: " + id
+    ApplicationQuitting => "the application is quitting"
     StaleWindow(id~) => "window instance is no longer active: " + id
     UnknownView(id~) => "view does not exist in its window: " + id
     AlreadyExists(id~) => "view already exists in its window: " + id

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -16,6 +16,7 @@ fn App::App(
     single_instance_identifier: None,
     explicit_locale: None,
     bridge_startup_timeout_value_ms: default_bridge_startup_timeout_ms,
+    last_window_closed_policy_value: LastWindowClosedPolicy::Quit,
     menu: None,
     url_schemes: [],
     document_extensions: [],

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -34,6 +34,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     browser_data_dir?,
     application_name=resolved.application_name,
     app_instance~,
+    last_window_closed_policy=self.last_window_closed_policy_value,
     launch_input_handlers=self.launch_input_handlers,
     planned_views=self.planned_views.map(view => (view.0, view.1.to_native())),
     window_event_handlers=self.window_event_handlers,
@@ -78,7 +79,10 @@ async fn run_manifest(
   application_name? : String = "Proton",
   app_instance? : @native.AppInstance? = None,
   planned_views? : Array[(String, @native.ViewConfig)] = [],
-  launch_input_handlers? : Array[async (RuntimeLaunchInput) -> Unit noraise] = [],
+  last_window_closed_policy? : LastWindowClosedPolicy = LastWindowClosedPolicy::Quit,
+  launch_input_handlers? : Array[
+    async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise,
+  ] = [],
   window_event_handlers? : Array[
     async (WindowHandle, WindowEvent) -> Unit noraise,
   ] = [],
@@ -286,15 +290,12 @@ async fn run_manifest(
         let session = RuntimeSession(
           runtime, locale_preferences, definitions, windows, command_host, dialog_completions,
           wakeup, forward_menu_events, bridge_enabled, launch_input_handlers, window_event_handlers,
-          window_tasks, view_event_handlers, window_close_handler, window_lifecycle_hooks,
-          lifecycle_failures, bridge_startup_timeout_ms, navigation_handler, popup_handler,
-          download_handler, certificate_handler, media_handler, download_event_handlers,
+          application_tasks, last_window_closed_policy, window_tasks, view_event_handlers,
+          window_close_handler, window_lifecycle_hooks, lifecycle_failures, bridge_startup_timeout_ms,
+          navigation_handler, popup_handler, download_handler, certificate_handler,
+          media_handler, download_event_handlers,
         )
-        let application_context = ApplicationContext(
-          application_tasks,
-          session.window_manager(),
-          locale_preferences,
-        )
+        let application_context = session.application_context()
         let application_start = application_tasks.spawn(
           () => {
             defer session.wakeup.signal.notify()

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -9,10 +9,14 @@ fn RuntimeSession::RuntimeSession(
   wakeup : RuntimeWakeup,
   forward_menu_events : Bool,
   monitor_bridge : Bool,
-  launch_input_handlers : Array[async (RuntimeLaunchInput) -> Unit noraise],
+  launch_input_handlers : Array[
+    async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise,
+  ],
   window_event_handlers : Array[
     async (WindowHandle, WindowEvent) -> Unit noraise,
   ],
+  application_tasks : @async.TaskGroup[Unit],
+  last_window_closed_policy : LastWindowClosedPolicy,
   window_tasks : @async.TaskGroup[Unit],
   view_event_handlers : Array[async (ViewHandle, ViewEvent) -> Unit noraise],
   window_close_handler : (async (WindowHandle) -> WindowCloseDecision noraise)?,
@@ -39,6 +43,8 @@ fn RuntimeSession::RuntimeSession(
     wakeup,
     forward_menu_events,
     monitor_bridge,
+    application_tasks,
+    last_window_closed_policy,
     launch_input_handlers,
     window_event_handlers,
     view_event_handlers,
@@ -58,6 +64,8 @@ fn RuntimeSession::RuntimeSession(
     certificate_handler,
     media_handler,
     download_event_handlers,
+    quit_requested: false,
+    quit_close_started: false,
   }
 }
 
@@ -69,6 +77,18 @@ fn RuntimeSession::window_manager(self : RuntimeSession) -> WindowManager {
       self.find_active_window(id).map(window => self.window_handle(window))
     },
   }
+}
+
+///|
+fn RuntimeSession::application_context(
+  self : RuntimeSession,
+) -> ApplicationContext {
+  ApplicationContext(
+    self.application_tasks,
+    self.window_manager(),
+    self.locale_preferences,
+    request_quit=() => self.request_quit(),
+  )
 }
 
 ///|
@@ -718,6 +738,9 @@ async fn RuntimeSession::request_open_window(
   self : RuntimeSession,
   id : String,
 ) -> WindowHandle raise WindowSessionError {
+  if self.quit_requested {
+    raise ApplicationQuitting
+  }
   let completion = WindowOpenCompletion()
   self.window_commands.push(Open(id, completion))
   self.wakeup.signal.notify()
@@ -777,6 +800,10 @@ fn RuntimeSession::process_window_commands(self : RuntimeSession) -> Bool {
   self.window_commands.clear()
   for command in commands {
     let Open(id, completion) = command
+    if self.quit_requested {
+      completion.fail(ApplicationQuitting)
+      continue
+    }
     let definition = match self.find_definition(id) {
       Some(definition) => definition
       None => {
@@ -1350,9 +1377,7 @@ async fn RuntimeSession::wait_for_bridge_startup(
 
 ///|
 async fn RuntimeSession::run(self : RuntimeSession) -> Unit raise AppRunError {
-  while !self.all_windows_closed() ||
-        self.window_commands.length() > 0 ||
-        self.pending_window_opens.length() > 0 {
+  while !self.quit_complete() {
     let revision = self.wakeup.revision()
     let did_work = self.pump_once(monitor_bridge=self.monitor_bridge)
     if did_work {
@@ -1422,6 +1447,9 @@ fn RuntimeSession::pump_once(
   if self.complete_resource_requests() {
     did_work = true
   }
+  if self.advance_application_lifetime() {
+    did_work = true
+  }
   did_work
 }
 
@@ -1451,6 +1479,9 @@ fn RuntimeSession::dispatch_runtime_event(
   self : RuntimeSession,
   event : @native.RuntimeEvent,
 ) -> Unit raise AppRunError {
+  if event.is_quit_requested() {
+    self.request_quit()
+  }
   self.dispatch_window_event(event)
   self.dispatch_view_event(event)
   self.dispatch_browser_event(event)
@@ -1940,6 +1971,9 @@ fn RuntimeSession::complete_window_close_requests(
             }
             if decision == Allow {
               window.state = WindowCloseRequested
+            } else if self.quit_requested {
+              self.quit_requested = false
+              self.quit_close_started = false
             }
           }
           _ => ()
@@ -2034,6 +2068,7 @@ fn RuntimeSession::dispatch_launch_input_event(
 ) -> Unit raise AppRunError {
   match event.launch_input() {
     Some(native_input) => {
+      guard !self.quit_requested else { return }
       let input = match native_input {
         @native.RuntimeLaunchInput::OpenUrls(urls) =>
           RuntimeLaunchInput::OpenUrls(urls)
@@ -2042,8 +2077,14 @@ fn RuntimeSession::dispatch_launch_input_event(
         @native.RuntimeLaunchInput::Reopen => RuntimeLaunchInput::Reopen
       }
       self.activate_for_launch_input()
+      let context = self.application_context()
       for handler in self.launch_input_handlers {
-        ignore(self.window_tasks.spawn(() => handler(input), no_wait=true))
+        ignore(
+          self.application_tasks.spawn(
+            () => handler(context, input),
+            no_wait=true,
+          ),
+        )
       }
     }
     None => ()
@@ -2317,6 +2358,65 @@ fn runtime_session_find_window_by_native_id(
 fn RuntimeSession::all_windows_closed(self : RuntimeSession) -> Bool {
   self.windows.length() > 0 &&
   self.windows.all(fn(window) { window.is_closed() })
+}
+
+///|
+fn should_quit_after_last_window(
+  policy : LastWindowClosedPolicy,
+  has_windows : Bool,
+  all_windows_closed : Bool,
+) -> Bool {
+  policy == LastWindowClosedPolicy::Quit && has_windows && all_windows_closed
+}
+
+///|
+fn RuntimeSession::request_quit(self : RuntimeSession) -> Unit {
+  if !self.quit_requested {
+    self.quit_requested = true
+    self.quit_close_started = false
+    self.wakeup.signal.notify()
+  }
+}
+
+///|
+fn RuntimeSession::advance_application_lifetime(
+  self : RuntimeSession,
+) -> Bool raise AppRunError {
+  let mut did_work = false
+  if !self.quit_requested &&
+    should_quit_after_last_window(
+      self.last_window_closed_policy,
+      self.windows.length() > 0,
+      self.all_windows_closed(),
+    ) {
+    self.request_quit()
+    did_work = true
+  }
+  if self.quit_requested && !self.quit_close_started {
+    self.quit_close_started = true
+    did_work = true
+    for running in self.windows {
+      if !running.is_active() {
+        continue
+      }
+      running.window.close() catch {
+        error => raise native_run_error("close window " + running.id, error)
+      }
+      if self.window_close_handler is None {
+        running.state = WindowCloseRequested
+      }
+    }
+  }
+  did_work
+}
+
+///|
+fn RuntimeSession::quit_complete(self : RuntimeSession) -> Bool {
+  self.quit_requested &&
+  self.windows.all(fn(window) { window.is_closed() }) &&
+  self.window_commands.length() == 0 &&
+  self.pending_window_opens.length() == 0 &&
+  self.pending_window_closes.length() == 0
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -13,6 +13,19 @@ pub extend RuntimeLaunchInput with Eq::{not_equal, equal}
 pub extend RuntimeLaunchInput with Debug::{to_repr}
 
 ///|
+/// Controls what Proton does after the last application window closes.
+pub(all) enum LastWindowClosedPolicy {
+  Quit
+  KeepRunning
+} derive(Eq, Debug)
+
+///|
+pub extend LastWindowClosedPolicy with Eq::{not_equal, equal}
+
+///|
+pub extend LastWindowClosedPolicy with Debug::{to_repr}
+
+///|
 /// High-level application facade for ordinary Proton apps.
 struct App {
   mut window : @manifest.WindowManifest
@@ -23,6 +36,7 @@ struct App {
   mut single_instance_identifier : String?
   mut explicit_locale : @locale.Locale?
   mut bridge_startup_timeout_value_ms : Int
+  mut last_window_closed_policy_value : LastWindowClosedPolicy
   mut menu : MenuBar?
   url_schemes : Array[String]
   document_extensions : Array[String]
@@ -31,7 +45,9 @@ struct App {
   extension_capabilities : Array[ExtensionCapabilityBinding]
   application_lifecycle_hooks : Array[ApplicationLifecycleHook]
   planned_views : Array[(String, ViewConfig)]
-  launch_input_handlers : Array[async (RuntimeLaunchInput) -> Unit noraise]
+  launch_input_handlers : Array[
+    async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise,
+  ]
   window_event_handlers : Array[
     async (WindowHandle, WindowEvent) -> Unit noraise,
   ]
@@ -256,7 +272,11 @@ priv struct RuntimeSession {
   wakeup : RuntimeWakeup
   forward_menu_events : Bool
   monitor_bridge : Bool
-  launch_input_handlers : Array[async (RuntimeLaunchInput) -> Unit noraise]
+  application_tasks : @async.TaskGroup[Unit]
+  last_window_closed_policy : LastWindowClosedPolicy
+  launch_input_handlers : Array[
+    async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise,
+  ]
   window_event_handlers : Array[
     async (WindowHandle, WindowEvent) -> Unit noraise,
   ]
@@ -279,6 +299,8 @@ priv struct RuntimeSession {
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
+  mut quit_requested : Bool
+  mut quit_close_started : Bool
 }
 
 ///|
@@ -589,6 +611,7 @@ pub extend DownloadEvent with Debug::{to_repr}
 pub(all) suberror WindowSessionError {
   UnknownWindow(id~ : String)
   AlreadyOpen(id~ : String)
+  ApplicationQuitting
   StaleWindow(id~ : String)
   UnknownView(id~ : String)
   AlreadyExists(id~ : String)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -98,6 +98,46 @@ fn test_manifest() -> @manifest.AppManifest {
 }
 
 ///|
+test "last-window policy defaults to quit and can keep the app running" {
+  let app = html("Lifecycle", "<html></html>")
+  assert_eq(app.last_window_closed_policy_value, LastWindowClosedPolicy::Quit)
+  let app = app.last_window_closed_policy(LastWindowClosedPolicy::KeepRunning)
+  assert_eq(
+    app.last_window_closed_policy_value,
+    LastWindowClosedPolicy::KeepRunning,
+  )
+  assert_true(
+    should_quit_after_last_window(LastWindowClosedPolicy::Quit, true, true),
+  )
+  assert_false(
+    should_quit_after_last_window(
+      LastWindowClosedPolicy::KeepRunning,
+      true,
+      true,
+    ),
+  )
+  assert_false(
+    should_quit_after_last_window(LastWindowClosedPolicy::Quit, false, true),
+  )
+}
+
+///|
+async test "application context forwards orderly quit requests" {
+  let requested = Ref(false)
+  @async.with_task_group(group => {
+    let context = ApplicationContext(
+      group,
+      test_window_manager(),
+      @locale.LocalePreferences::resolve(None, []),
+      request_quit=fn() { requested.val = true },
+    )
+    context.quit()
+    group.return_immediately(())
+  })
+  assert_true(requested.val)
+}
+
+///|
 fn test_extension_capability(
   spec : @proton_command.AppCommandExtensionSpec,
   scope? : Json = Json::empty_object(),

--- a/proton/internal/native/ffi/src/engine/cef_mac/proton_engine_cef_mac.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/proton_engine_cef_mac.m
@@ -265,7 +265,6 @@ static int g_proton_cef_initialized = 0;
 static int g_proton_cef_library_loaded = 0;
 static int g_proton_cef_runtime_active = 0;
 static char g_proton_temporary_profile_path[PROTON_ENGINE_MAX_PATH_BYTES];
-static int g_proton_app_terminating = 0;
 static int32_t g_proton_remote_debugging_port =
     PROTON_REMOTE_DEBUGGING_DISABLED;
 static proton_engine_app_t g_app;
@@ -2531,31 +2530,6 @@ static void proton_engine_window_mark_closed(proton_engine_window_t *window) {
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
 
-static int proton_engine_request_all_windows_close(void) {
-  int requested = 0;
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    if (window->closed) {
-      continue;
-    }
-    requested = 1;
-    proton_engine_window_close_views(window);
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
-      if (host != NULL) {
-        host->close_browser(host, 1);
-        host->base.release((cef_base_ref_counted_t *)host);
-        continue;
-      }
-    }
-    proton_engine_window_mark_closed(window);
-    if (window->window != nil) {
-      [window->window close];
-    }
-  }
-  return requested;
-}
-
 static void proton_engine_window_commit_appkit_close(
     proton_engine_window_t *window, NSWindow *native_window) {
   if (window == NULL || native_window == nil || window->window == nil) {
@@ -2564,9 +2538,8 @@ static void proton_engine_window_commit_appkit_close(
   proton_engine_debug_log("window_commit_close browser=%d", window->browser_id);
   window->appkit_closing = 1;
   proton_engine_window_close_views(window);
-  // Replacing the content view below releases the complete browser view tree.
-  // Clear these borrowed pointers first so deferred view close callbacks never
-  // message an AppKit object that the replacement has already deallocated.
+  // Clear borrowed child-view pointers first so deferred close callbacks never
+  // message AppKit objects released while the main browser view is detached.
   for (proton_engine_view_t *view = window->views; view != NULL;
        view = view->next) {
     view->browser_view = nil;
@@ -2575,14 +2548,20 @@ static void proton_engine_window_commit_appkit_close(
     proton_engine_bridge_pending_remove_browser(window->runtime,
                                                 window->browser_id);
   }
+  NSView *browser_view = window->browser_view;
   window->window = nil;
   window->content_view = nil;
-  window->browser_view = nil;
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 
-  // CEF completes a windowed browser close when replacing the content view
-  // destroys its CefBrowserHostView child. Keep that hierarchy intact until
-  // the replacement so CefBrowserHostView::dealloc can call WindowDestroyed.
+  // A windowed CEF browser completes close only after CefBrowserHostView is
+  // destroyed. Detach and release the host view explicitly so its dealloc can
+  // deliver WindowDestroyed; replacing the parent content view alone leaves
+  // the browser partially closed.
+  if (browser_view != nil) {
+    [browser_view removeFromSuperview];
+    [browser_view release];
+  }
+  window->browser_view = nil;
   [native_window setDelegate:nil];
   NSView *empty_content_view = [[NSView alloc] initWithFrame:NSZeroRect];
   [native_window setContentView:empty_content_view];
@@ -2748,10 +2727,9 @@ static void proton_engine_window_commit_appkit_close(
 }
 
 - (void)terminate:(id)sender {
-  (void)sender;
   proton_engine_debug_log("app_terminate");
-  g_proton_app_terminating = 1;
-  if (g_proton_cef_initialized && proton_engine_request_all_windows_close()) {
+  proton_event_t *event = proton_event_create(PROTON_EVENT_QUIT_REQUESTED);
+  if (event != NULL && proton_event_publish(event)) {
     return;
   }
   [super terminate:sender];

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -44,6 +44,7 @@ typedef enum proton_event_kind {
   PROTON_EVENT_RESOURCE_REQUESTED = 25,
   PROTON_EVENT_RESOURCE_REQUEST_CANCELLED = 26,
   PROTON_EVENT_NOTIFICATION_CLICKED = 27,
+  PROTON_EVENT_QUIT_REQUESTED = 28,
 } proton_event_kind_t;
 
 typedef struct proton_event {

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -923,6 +923,7 @@ fn decode_native_runtime_event(
           Some(require_native_event_text(event, 0, "notification click"))
         },
       )
+    28 => QuitRequested
     kind =>
       raise InvalidPayload(
         context="runtime event",

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -117,6 +117,14 @@ test "notification clicks preserve optional payloads" {
 }
 
 ///|
+test "quit request is an application-level runtime event" {
+  let event = RuntimeEvent::QuitRequested
+  assert_eq(event.event_type(), "quit_requested")
+  assert_true(event.is_quit_requested())
+  assert_eq(event.window_id(), None)
+}
+
+///|
 test "native ABI version and availability" {
   inspect(abi_version(), content="1")
 }

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -414,6 +414,7 @@ pub fn RuntimeEvent::equal(Self, Self) -> Bool
 pub fn RuntimeEvent::event_type(Self) -> String
 pub fn RuntimeEvent::has_window(Self) -> Bool
 pub fn RuntimeEvent::is_bridge_lifecycle_changed(Self) -> Bool
+pub fn RuntimeEvent::is_quit_requested(Self) -> Bool
 pub fn RuntimeEvent::is_window_closed(Self) -> Bool
 pub fn RuntimeEvent::is_window_created(Self) -> Bool
 pub fn RuntimeEvent::launch_input(Self) -> RuntimeLaunchInput?

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -172,6 +172,7 @@ enum RuntimeEvent {
   ViewEvent(Int64, Int64, NativeViewEvent)
   ResourceRequested(NativeResourceRequest)
   ResourceRequestCancelled(Int64)
+  QuitRequested
 } derive(Debug, Eq)
 
 ///|
@@ -663,6 +664,7 @@ pub fn RuntimeEvent::event_type(self : RuntimeEvent) -> String {
     ViewEvent(_, _, LoadFailed(_, _, _)) => "view_load_failed"
     ResourceRequested(_) => "resource_requested"
     ResourceRequestCancelled(_) => "resource_request_cancelled"
+    QuitRequested => "quit_requested"
   }
 }
 
@@ -693,7 +695,8 @@ pub fn RuntimeEvent::window_id(self : RuntimeEvent) -> Int64? {
     | ResourceRequestCancelled(_)
     | LaunchInput(_)
     | NotificationResult(_)
-    | NotificationClicked(_) => None
+    | NotificationClicked(_)
+    | QuitRequested => None
   }
 }
 
@@ -791,6 +794,11 @@ pub fn RuntimeEvent::is_window_created(self : RuntimeEvent) -> Bool {
 ///|
 pub fn RuntimeEvent::is_window_closed(self : RuntimeEvent) -> Bool {
   self is WindowClosed(_)
+}
+
+///|
+pub fn RuntimeEvent::is_quit_requested(self : RuntimeEvent) -> Bool {
+  self is QuitRequested
 }
 
 ///|

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -149,6 +149,7 @@ pub fn SystemLocaleError::to_string(Self) -> String
 pub(all) suberror WindowSessionError {
   UnknownWindow(id~ : String)
   AlreadyOpen(id~ : String)
+  ApplicationQuitting
   StaleWindow(id~ : String)
   UnknownView(id~ : String)
   AlreadyExists(id~ : String)
@@ -177,12 +178,13 @@ pub fn App::entry_file(Self, String) -> Self
 pub fn App::entry_html(Self, String) -> Self
 pub fn App::entry_url(Self, String) -> Self
 pub fn App::headless(Self, enabled? : Bool) -> Self
+pub fn App::last_window_closed_policy(Self, LastWindowClosedPolicy) -> Self
 pub fn App::locale(Self, @locale.Locale) -> Self
 pub fn App::menu(Self, MenuBar) -> Self
 pub fn App::on_certificate_error(Self, async (BrowserHandle, CertificateError) -> BrowserPermissionDecision noraise) -> Self
 pub fn App::on_download_event(Self, async (BrowserHandle, DownloadEvent) -> Unit noraise) -> Self
 pub fn App::on_download_request(Self, async (BrowserHandle, DownloadRequest) -> DownloadDecision noraise) -> Self
-pub fn App::on_launch_input(Self, async (RuntimeLaunchInput) -> Unit noraise) -> Self
+pub fn App::on_launch_input(Self, async (ApplicationContext, RuntimeLaunchInput) -> Unit noraise) -> Self
 pub fn App::on_media_permission_request(Self, async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise) -> Self
 pub fn App::on_navigation_request(Self, async (BrowserHandle, NavigationRequest) -> NavigationDecision noraise) -> Self
 pub fn App::on_popup_request(Self, async (BrowserHandle, PopupRequest) -> PopupDecision noraise) -> Self
@@ -205,9 +207,11 @@ pub struct ApplicationContext {
   tasks : @async.TaskGroup[Unit]
   windows : WindowManager
   locale_preferences : @locale.LocalePreferences
+  request_quit : () -> Unit
 }
 pub fn ApplicationContext::locale(Self) -> @locale.Locale
 pub fn ApplicationContext::preferred_languages(Self) -> Array[@locale.Locale]
+pub fn ApplicationContext::quit(Self) -> Unit
 pub fn ApplicationContext::task_group(Self) -> @async.TaskGroup[Unit]
 pub fn ApplicationContext::windows(Self) -> WindowManager
 
@@ -294,6 +298,14 @@ pub(all) struct DownloadRequest {
 pub fn DownloadRequest::equal(Self, Self) -> Bool
 pub fn DownloadRequest::not_equal(Self, Self) -> Bool
 pub fn DownloadRequest::to_repr(Self) -> @debug.Repr
+
+pub(all) enum LastWindowClosedPolicy {
+  Quit
+  KeepRunning
+} derive(Eq, @debug.Debug)
+pub fn LastWindowClosedPolicy::equal(Self, Self) -> Bool
+pub fn LastWindowClosedPolicy::not_equal(Self, Self) -> Bool
+pub fn LastWindowClosedPolicy::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MediaPermissionRequest {
   origin : String


### PR DESCRIPTION
## Summary

- fix the macOS CEF close path so closing a browser window completes native teardown
- add LastWindowClosedPolicy with Quit as the default and KeepRunning for background applications
- deliver launch inputs with ApplicationContext so a windowless app can recreate its main window, and expose ApplicationContext::quit for orderly shutdown
- route the macOS application Quit action through the managed runtime lifecycle
- document the Tauri and Electron lifecycle comparison and add a focused background-residency example

## Platform impact

- macOS now exits cleanly after the last window closes under the default policy, while KeepRunning applications remain active and can reopen a window from Dock or launch input
- Windows and Linux retain the same default last-window exit behavior and can opt into KeepRunning through the shared facade API

## Validation

- moon -C proton test --target native --diagnostic-limit 80
- moon -C e2e test -p moonbit-community/proton/e2e/test --target native --no-parallelize --diagnostic-limit 200
- moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted
- moon -C examples build --target native --diagnostic-limit 80
- node scripts/verify_generated.mjs
- macOS runtime smoke: close the last window, confirm the process remains under KeepRunning, launch again, and confirm the same process creates a new main window
- macOS runtime smoke: use the application Quit action and confirm the runtime and helper processes exit cleanly