### PR TITLE
fix(native): invalidate Windows headless view after load

### DIFF
--- a/proton/internal/native/ffi/src/engine/cef_win/proton_engine_cef_win.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/proton_engine_cef_win.c
@@ -2635,6 +2635,20 @@ static void CEF_CALLBACK proton_engine_on_loading_state_change(
   (void)self;
   (void)canGoBack;
   (void)canGoForward;
+  proton_engine_window_t *window =
+      proton_engine_window_from_browser_client(browser);
+  if (!isLoading && window != NULL && window->headless) {
+    // The resize notification sent during synchronous browser creation can
+    // precede compositor readiness. Invalidate after loading settles so a
+    // windowless browser reliably delivers its initial OnPaint callback.
+    cef_browser_host_t *host = browser->get_host(browser);
+    if (host != NULL) {
+      if (host->invalidate != NULL) {
+        host->invalidate(host, PET_VIEW);
+      }
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+  }
   proton_engine_verbose_log("loading_state browser=%d loading=%d",
                             proton_engine_browser_id(browser), isLoading);
 }


### PR DESCRIPTION
## Summary

- invalidate the Windows windowless browser view once loading settles
- ensure the initial OSR paint is requested after the compositor is ready
- limit the behavior to headless windows

## Platform impact

Windows only. macOS and Linux engine behavior is unchanged.

## Validation

- `moon -C proton test internal/native --target native --diagnostic-limit 80` (23/23 passed)
- `moon -C proton check --target native --diagnostic-limit 80`
- `git diff --check main...HEAD`