### PR TITLE
chore(release): bump workspace to 0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,13 @@ jobs:
       - name: Configure CEF runtime and build helper on Unix
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          runtime=$(PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native | tail -n 1)
+          runtime_output=$(PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . \
+            --target native -- --runtime-only)
+          echo "$runtime_output"
+          runtime=$(echo "$runtime_output" | tail -n 1)
           helper_bin="$RUNNER_TEMP/proton-helper"
-          moon --target-dir "$RUNNER_TEMP/proton-helper-build" install \
-            --path proton/internal/cef_process --bin "$helper_bin"
+          moon --target-dir "$RUNNER_TEMP/proton-helper-build" install --path \
+            proton/internal/cef_process --bin "$helper_bin"
           helper="$helper_bin/cef_process"
           echo "PROTON_RUNTIME_ROOT=$runtime" >> "$GITHUB_ENV"
           echo "PROTON_HELPER_PATH=$helper" >> "$GITHUB_ENV"
@@ -118,7 +121,9 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           $env:PROTON_CEF_SETUP_BOOTSTRAP = "1"
-          $runtime = moon -C cefsetup run . --target native | Select-Object -Last 1
+          $runtimeOutput = moon -C cefsetup run . --target native -- --runtime-only
+          $runtimeOutput | Write-Output
+          $runtime = $runtimeOutput | Select-Object -Last 1
           Remove-Item Env:PROTON_CEF_SETUP_BOOTSTRAP
           $helperBin = Join-Path $env:RUNNER_TEMP "proton-helper"
           $helperBuild = Join-Path $env:RUNNER_TEMP "proton-helper-build"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,8 +71,12 @@ jobs:
       - name: Update MoonBit registry
         run: moon update
 
-      - name: Install CEF runtime
-        run: PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native
+      - name: Install CEF runtime and build helper from source
+        run: |
+          PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native -- --runtime-only
+          helper_bin="$RUNNER_TEMP/proton-helper"
+          moon --target-dir "$RUNNER_TEMP/proton-helper-build" install --path \
+            proton/internal/cef_process --bin "$helper_bin"
 
       - name: Validate release
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ developer must perform them.
   runtime-selection manifests.
 
 ## Build And Test
-- `PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native`
+- `PROTON_CEF_SETUP_BOOTSTRAP=1 moon -C cefsetup run . --target native -- --runtime-only`
 - `moon install --path proton/internal/cef_process --bin <output-dir>`
 - `moon -C proton test internal/native --target native --diagnostic-limit 80`
 - `moon -C proton check --target native --diagnostic-limit 80`

--- a/bundle/moon.mod
+++ b/bundle/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_bundle"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_package@0.2.1",
-  "moonbit-community/proton_cefsetup@0.2.1",
+  "moonbit-community/proton_package@0.2.2",
+  "moonbit-community/proton_cefsetup@0.2.2",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
 }

--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cdp"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/cefsetup/main.mbt
+++ b/cefsetup/main.mbt
@@ -3,6 +3,12 @@ fn command() -> @argparse.Command {
   @argparse.Command(
     "proton_cefsetup",
     about="Install the CEF runtime and subprocess helper required by Proton",
+    flags=[
+      @argparse.FlagArg(
+        "runtime-only",
+        about="Install the CEF runtime without installing the Proton helper",
+      ),
+    ],
   )
 }
 
@@ -14,8 +20,8 @@ async fn run(args : ArrayView[String]) -> Int {
       return 2
     }
   }
-  ignore(matches)
-  try @store.setup_default() catch {
+  let runtime_only = matches.flags.get("runtime-only") == Some(true)
+  try @store.setup_default(runtime_only~) catch {
     error => {
       println("error: " + error.to_string())
       1

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cefsetup"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/cefsetup/store/cef_setup.mbt
+++ b/cefsetup/store/cef_setup.mbt
@@ -33,9 +33,11 @@ async fn install_default() -> InstalledRuntime {
 
 ///|
 /// Installs the CEF runtime and Proton helper selected by this release.
-pub async fn setup_default() -> InstalledRuntime {
+pub async fn setup_default(runtime_only? : Bool = false) -> InstalledRuntime {
   let runtime = install_default()
-  ignore(install_default_helper())
+  if !runtime_only {
+    ignore(install_default_helper())
+  }
   runtime
 }
 

--- a/cefsetup/store/pkg.generated.mbti
+++ b/cefsetup/store/pkg.generated.mbti
@@ -10,7 +10,7 @@ pub async fn resolve_default() -> InstalledRuntime
 
 pub async fn resolve_default_helper() -> String
 
-pub async fn setup_default() -> InstalledRuntime
+pub async fn setup_default(runtime_only? : Bool) -> InstalledRuntime
 
 // Errors
 

--- a/cefsetup/store/requirements.generated.mbt
+++ b/cefsetup/store/requirements.generated.mbt
@@ -3,7 +3,7 @@
 
 ///|
 pub fn release_version() -> String {
-  "0.2.1"
+  "0.2.2"
 }
 
 ///|

--- a/cli/dev/dev.mbt
+++ b/cli/dev/dev.mbt
@@ -363,7 +363,10 @@ async fn ensure_dev_installation(
 ///|
 async fn resolve_dev_installation() -> (DevRuntime, String) {
   let runtime = @cef_store.resolve_default()
-  let helper = @cef_store.resolve_default_helper()
+  let helper = match @env.get_env_var("PROTON_HELPER_PATH") {
+    Some(path) if path.trim() != "" => path
+    _ => @cef_store.resolve_default_helper()
+  }
   (
     dev_runtime_from_root(runtime.runtime_root(), "Proton runtime store"),
     helper,

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let cli_current_version : String = "0.2.1"
+let cli_current_version : String = "0.2.2"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,14 +1,14 @@
 name = "moonbit-community/proton_cli"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_bundle@0.2.1",
-  "moonbit-community/proton_config@0.2.1",
-  "moonbit-community/proton_package@0.2.1",
-  "moonbit-community/proton_cefsetup@0.2.1",
-  "moonbit-community/proton_rsa@0.2.1",
-  "moonbit-community/proton_updater@0.2.1",
+  "moonbit-community/proton_bundle@0.2.2",
+  "moonbit-community/proton_config@0.2.2",
+  "moonbit-community/proton_package@0.2.2",
+  "moonbit-community/proton_cefsetup@0.2.2",
+  "moonbit-community/proton_rsa@0.2.2",
+  "moonbit-community/proton_updater@0.2.2",
   "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.13",
   "moonbitlang/async@0.21.0",

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -1,20 +1,20 @@
 ///|
-let default_proton_version = "0.2.1"
+let default_proton_version = "0.2.2"
 
 ///|
-let default_proton_codegen_version = "0.2.1"
+let default_proton_codegen_version = "0.2.2"
 
 ///|
-let default_proton_cli_version = "0.2.1"
+let default_proton_cli_version = "0.2.2"
 
 ///|
-let default_proton_contract_version = "0.2.1"
+let default_proton_contract_version = "0.2.2"
 
 ///|
-let default_proton_client_version = "0.2.1"
+let default_proton_client_version = "0.2.2"
 
 ///|
-let default_proton_rabbita_version = "0.2.1"
+let default_proton_rabbita_version = "0.2.2"
 
 ///|
 let default_rabbita_version = "0.14.1"

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_client"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_contract@0.2.1",
+  "moonbit-community/proton_contract@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_codegen"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_config"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/contract/moon.mod
+++ b/contract/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_contract"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -1,15 +1,15 @@
 name = "moonbit-community/proton/e2e"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
-  "moonbit-community/proton_cdp@0.2.1",
-  "moonbit-community/proton@0.2.1",
-  "moonbit-community/proton_cefsetup@0.2.1",
-  "moonbit-community/proton_updater@0.2.1",
-  "moonbit-community/proton/examples@0.2.1",
+  "moonbit-community/proton_cdp@0.2.2",
+  "moonbit-community/proton@0.2.2",
+  "moonbit-community/proton_cefsetup@0.2.2",
+  "moonbit-community/proton_updater@0.2.2",
+  "moonbit-community/proton/examples@0.2.2",
 }
 
 readme = "README.md"

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton/examples"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_ext@0.2.1",
-  "moonbit-community/proton_contract@0.2.1",
-  "moonbit-community/proton@0.2.1",
+  "moonbit-community/proton_ext@0.2.2",
+  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton@0.2.2",
 }
 
 readme = "README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -1,23 +1,23 @@
 name = "moonbit-community/proton_ext"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_clipboard@0.2.1",
-  "moonbit-community/proton_tray@0.2.1",
-  "moonbit-community/proton_global_hotkey@0.2.1",
-  "moonbit-community/proton@0.2.1",
-  "moonbit-community/proton_contract@0.2.1",
-  "moonbit-community/proton_microphone@0.2.1",
-  "moonbit-community/proton_auto_launch@0.2.1",
-  "moonbit-community/proton_keepawake@0.2.1",
-  "moonbit-community/proton_power_monitor@0.2.1",
-  "moonbit-community/proton_screen_monitor@0.2.1",
-  "moonbit-community/proton_process@0.2.1",
-  "moonbit-community/proton_shell@0.2.1",
+  "moonbit-community/proton_clipboard@0.2.2",
+  "moonbit-community/proton_tray@0.2.2",
+  "moonbit-community/proton_global_hotkey@0.2.2",
+  "moonbit-community/proton@0.2.2",
+  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton_microphone@0.2.2",
+  "moonbit-community/proton_auto_launch@0.2.2",
+  "moonbit-community/proton_keepawake@0.2.2",
+  "moonbit-community/proton_power_monitor@0.2.2",
+  "moonbit-community/proton_screen_monitor@0.2.2",
+  "moonbit-community/proton_process@0.2.2",
+  "moonbit-community/proton_shell@0.2.2",
 }
 
 readme = "README.md"

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/async@0.21.0",

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
-  "moonbit-community/proton_config@0.2.1",
-  "moonbit-community/proton_contract@0.2.1",
-  "moonbit-community/proton_updater@0.2.1",
-  "moonbit-community/proton_rsa@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_config@0.2.2",
+  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton_updater@0.2.2",
+  "moonbit-community/proton_rsa@0.2.2",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.13",

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_rabbita"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_client@0.2.1",
-  "moonbit-community/proton_contract@0.2.1",
+  "moonbit-community/proton_client@0.2.2",
+  "moonbit-community/proton_contract@0.2.2",
   "moonbit-community/rabbita@0.14.1",
 }
 

--- a/rsa/moon.mod
+++ b/rsa/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_rsa"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_auto_launch"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.md"
 

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_clipboard"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_ffi"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_global_hotkey"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_keepawake"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_microphone"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/sys/power_monitor/moon.mod
+++ b/sys/power_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_power_monitor"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/sys/process/moon.mod
+++ b/sys/process/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_process"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/sys/screen_monitor/moon.mod
+++ b/sys/screen_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_screen_monitor"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_shell"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_tray"
 
-version = "0.2.1"
+version = "0.2.2"
 
 import {
-  "moonbit-community/proton_ffi@0.2.1",
+  "moonbit-community/proton_ffi@0.2.2",
 }
 
 readme = "README.mbt.md"

--- a/updater/moon.mod
+++ b/updater/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_updater"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
## Summary

- bump all workspace modules from 0.2.1 to 0.2.2
- update internal lockstep dependency requirements and CLI scaffold versions
- regenerate the embedded CEF runtime release requirement
- add a runtime-only CEF bootstrap mode for source builds
- build the subprocess helper from the checked-out workspace in CI and release validation
- let `proton_cli dev` honor an explicit `PROTON_HELPER_PATH`

## Validation

- `moon fmt --check`
- `node scripts/verify_release_metadata.mjs`
- `node scripts/verify_generated.mjs`
- `moon -C cefsetup test --target native --diagnostic-limit 80` (542/542 passed)
- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80` (73/73 passed)
- `moon -C proton check --target native --diagnostic-limit 80`
- isolated runtime-only bootstrap, local helper install, and `proton_cli doctor` smoke test
- workflow YAML parse check
- `git diff --check`

Package publication remains a separate manual workflow after merge.
