### PR TITLE
refactor(cli): simplify command input handling

### DIFF
--- a/cefsetup/main.mbt
+++ b/cefsetup/main.mbt
@@ -16,7 +16,7 @@ fn command() -> @argparse.Command {
 async fn run(args : ArrayView[String]) -> Int {
   let matches = @argparse.parse(command(), argv=args, env=Map([])) catch {
     error => {
-      println("error: " + error.to_string())
+      println(error.to_string())
       return 2
     }
   }

--- a/cli/build_cmd/build.mbt
+++ b/cli/build_cmd/build.mbt
@@ -141,13 +141,6 @@ pub extend RawBuildOptions with Eq::{not_equal, equal}
 pub extend RawBuildOptions with Debug::{to_repr}
 
 ///|
-priv struct BuildProjectConfig {
-  base_dir : String
-  backend : @proton_config.ProjectBackendConfig?
-  frontend : @proton_config.ProjectFrontendConfig?
-}
-
-///|
 /// Returns the declarative `proton_cli build` command specification.
 pub fn command() -> @argparse.Command {
   @argparse.Command(
@@ -231,9 +224,9 @@ async fn prepare_build(cwd : String, raw : RawBuildOptions) -> BuildInvocation {
   let (cwd, config) = load_build_project(cwd, raw)
   validate_release_config(config)
   if raw.run_frontend_build {
-    run_frontend_build(config.base_dir, config)
+    run_frontend_build(config.base_dir(), config)
   }
-  validate_release_files(config.base_dir, config)
+  validate_release_files(config.base_dir(), config)
   project_build_invocation(cwd, config, raw)
 }
 
@@ -241,7 +234,7 @@ async fn prepare_build(cwd : String, raw : RawBuildOptions) -> BuildInvocation {
 async fn load_build_project(
   cwd : String,
   raw : RawBuildOptions,
-) -> (String, BuildProjectConfig) {
+) -> (String, @proton_config.ProjectConfig) {
   let cwd = @path.Path(cwd).resolve().to_string()
   let config_path = resolve_build_config_path(cwd, raw)
   let config = load_project_config(config_path)
@@ -251,17 +244,18 @@ async fn load_build_project(
 ///|
 async fn project_build_invocation(
   cwd : String,
-  config : BuildProjectConfig,
+  config : @proton_config.ProjectConfig,
   raw : RawBuildOptions,
 ) -> BuildInvocation {
+  let backend = config.backend()
   let backend_path = resolve_backend_path(
-    config.base_dir,
-    config.backend.map(fn(backend) { backend.path() }),
+    config.base_dir(),
+    backend.map(fn(backend) { backend.path() }),
   )
   let app_package = match raw.app_package {
     Some(app_package) => app_package
     None =>
-      match config.backend {
+      match backend {
         Some(backend) => backend.app_package()
         None => default_package
       }
@@ -365,7 +359,9 @@ async fn resolve_build_config_path(
 }
 
 ///|
-async fn load_project_config(config_path : String?) -> BuildProjectConfig {
+async fn load_project_config(
+  config_path : String?,
+) -> @proton_config.ProjectConfig {
   match config_path {
     None => raise NotFound(path=None)
     Some(path) => {
@@ -378,8 +374,11 @@ async fn load_project_config(config_path : String?) -> BuildProjectConfig {
 }
 
 ///|
-async fn run_frontend_build(root : String, config : BuildProjectConfig) -> Unit {
-  match config.frontend {
+async fn run_frontend_build(
+  root : String,
+  config : @proton_config.ProjectConfig,
+) -> Unit {
+  match config.frontend() {
     None => ()
     Some(frontend) =>
       match frontend.before_build() {
@@ -445,9 +444,9 @@ async fn resolve_backend_path(root : String, backend_path : String?) -> String {
 
 ///|
 fn validate_release_config(
-  config : BuildProjectConfig,
+  config : @proton_config.ProjectConfig,
 ) -> Unit raise BuildConfigError {
-  match config.frontend {
+  match config.frontend() {
     Some(frontend) =>
       match frontend.dist() {
         Some(_) => ()
@@ -463,9 +462,9 @@ fn validate_release_config(
 ///|
 async fn validate_release_files(
   root : String,
-  config : BuildProjectConfig,
+  config : @proton_config.ProjectConfig,
 ) -> Unit {
-  match config.frontend {
+  match config.frontend() {
     Some(frontend) =>
       match frontend.dist() {
         Some(dist) => {
@@ -486,7 +485,7 @@ async fn validate_release_files(
 ///|
 async fn read_project_config(
   path : String,
-) -> BuildProjectConfig raise BuildConfigError {
+) -> @proton_config.ProjectConfig raise BuildConfigError {
   let source = @async_fs.read_file(path).text() catch {
     error =>
       raise Invalid(
@@ -497,17 +496,12 @@ async fn read_project_config(
         ),
       )
   }
-  let project = @proton_config.load_project_config_from_text(
+  @proton_config.load_project_config_from_text(
     source,
     @fsutil.path_parent(path),
     name=path,
   ) catch {
     error => raise Invalid(path~, error~)
-  }
-  BuildProjectConfig::{
-    base_dir: project.base_dir(),
-    backend: project.backend(),
-    frontend: project.frontend(),
   }
 }
 
@@ -590,23 +584,22 @@ fn moon_build_only_args(app_package : String, release : Bool) -> Array[String] {
 }
 
 ///|
+priv struct MoonBuildOutput {
+  artifacts_path : Array[String]
+} derive(FromJson)
+
+///|
 fn artifact_path_from_build_output(
   output : String,
 ) -> String raise BuildProcessError {
-  let json = @json.parse(output) catch {
+  let build_output : MoonBuildOutput = @json.from_json(@json.parse(output)) catch {
     error =>
       raise InvalidOutput(
         command="MoonBit executable build",
         detail=@debug.render(Repr(error)),
       )
   }
-  guard json is { "artifacts_path": Array(paths), .. } else {
-    raise InvalidOutput(
-      command="MoonBit executable build",
-      detail="missing artifacts_path array",
-    )
-  }
-  guard paths is [String(path)] else {
+  guard build_output.artifacts_path is [path] else {
     raise InvalidOutput(
       command="MoonBit executable build",
       detail="expected exactly one executable artifact",

--- a/cli/build_cmd/build_wbtest.mbt
+++ b/cli/build_cmd/build_wbtest.mbt
@@ -145,26 +145,26 @@ test "native Moon commands select a source-built runtime on Unix" {
 
 ///|
 test "frontend release requires dist" {
-  let config = BuildProjectConfig::{
-    base_dir: ".",
-    backend: None,
-    frontend: Some(
+  let config = @proton_config.ProjectConfig(
+    ".",
+    "com.example.test",
+    frontend=Some(
       @proton_config.ProjectFrontendConfig(before_build=Some("npm run build")),
     ),
-  }
+  )
   let error = expect_build_error_message(() => validate_release_config(config))
   assert_true(error.contains("frontend.dist is required"))
 }
 
 ///|
 async test "project resolution does not require frontend build output" {
-  let config = BuildProjectConfig::{
-    base_dir: ".",
-    backend: None,
-    frontend: Some(
+  let config = @proton_config.ProjectConfig(
+    ".",
+    "com.example.test",
+    frontend=Some(
       @proton_config.ProjectFrontendConfig(dist=Some("missing-frontend-dist")),
     ),
-  }
+  )
   let invocation = project_build_invocation(".", config, RawBuildOptions::{
     app_package: None,
     config_path: None,

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -5,11 +5,9 @@ let cli_current_version : String = "0.2.2"
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"
 
 ///|
-priv struct CliVersion {
-  major : Int
-  minor : Int
-  patch : Int
-}
+priv struct CliManifest {
+  latest_version : String
+} derive(FromJson)
 
 ///|
 fn env_flag_is_enabled(value : String) -> Bool {
@@ -28,66 +26,28 @@ fn cli_update_check_disabled() -> Bool {
 }
 
 ///|
-fn parse_cli_version_part(part : StringView) -> Int? {
-  let text = part.to_owned()
-  guard text != "" else { return None }
-  let mut value = 0
-  for ch in text {
-    guard ch.is_ascii_digit() else { return None }
-    value = value * 10 + ch.to_int() - '0'.to_int()
-  }
-  Some(value)
-}
-
-///|
-fn parse_cli_version(version : String) -> CliVersion? {
+fn parse_cli_version(version : String) -> @proton_updater.Version? {
   let core = match version.split_once("-") {
     Some((prefix, _)) => prefix.to_owned()
     None => version
   }
-  match core.split(".").collect() {
-    [major, minor, patch] =>
-      match
-        (
-          parse_cli_version_part(major),
-          parse_cli_version_part(minor),
-          parse_cli_version_part(patch),
-        ) {
-        (Some(major), Some(minor), Some(patch)) =>
-          Some(CliVersion::{ major, minor, patch, })
-        _ => None
-      }
-    _ => None
-  }
-}
-
-///|
-fn compare_cli_version(left : CliVersion, right : CliVersion) -> Int {
-  if left.major != right.major {
-    left.major.compare(right.major)
-  } else if left.minor != right.minor {
-    left.minor.compare(right.minor)
-  } else {
-    left.patch.compare(right.patch)
-  }
+  @proton_updater.Version::parse(core)
 }
 
 ///|
 fn cli_version_is_newer(candidate : String, current : String) -> Bool {
   match (parse_cli_version(candidate), parse_cli_version(current)) {
-    (Some(candidate), Some(current)) =>
-      compare_cli_version(candidate, current) > 0
+    (Some(candidate), Some(current)) => candidate.is_newer_than(current)
     _ => false
   }
 }
 
 ///|
 fn latest_version_from_manifest_text(text : String) -> String? {
-  let manifest = @json.parse(text) catch { _ => return None }
-  match manifest {
-    { "latest_version": String(version), .. } => Some(version)
-    _ => None
+  let manifest : CliManifest = @json.from_json(@json.parse(text)) catch {
+    _ => return None
   }
+  Some(manifest.latest_version)
 }
 
 ///|

--- a/cli/moon.pkg
+++ b/cli/moon.pkg
@@ -16,6 +16,7 @@ import {
   "moonbit-community/proton_cli/output",
   "moonbit-community/proton_cli/package",
   "moonbit-community/proton_cli/updater",
+  "moonbit-community/proton_updater",
 }
 
 supported_targets = "native+wasm"

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -5,10 +5,18 @@ let default_package = "app"
 let default_config_file = "proton.project.json"
 
 ///|
+priv struct UpdaterMetadataOptions {
+  base_url : String
+  published_at : String
+} derive(Debug, Eq)
+
+///|
 struct RawPackageOptions {
   app_package : String?
   config_path : String?
   package_args : @package_args.PackageArguments
+  updater_metadata : UpdaterMetadataOptions?
+  update_revision : UInt64
   release : Bool
   dry_run : Bool
 } derive(Debug, Eq)
@@ -67,10 +75,12 @@ pub fn command() -> @argparse.Command {
     @argparse.OptionArg(
       "updater-base-url",
       about="Emit update metadata with artifacts served from this https base URL",
+      requires=["updater-published-at", "updater-revision"],
     ),
     @argparse.OptionArg(
       "updater-published-at",
       about="Publication instant for the manifest fragment (YYYY-MM-DDTHH:MM:SSZ)",
+      requires=["updater-base-url"],
     ),
     @argparse.OptionArg(
       "updater-revision",
@@ -112,63 +122,55 @@ pub async fn run(cwd : String, matches : @argparse.Matches) -> Unit {
   ) catch {
     error => raise PackageConfigError::Invalid(path=config_path, error~)
   }
-  let updater_base_url = match matches.values {
-    { "updater-base-url": [base_url, ..], .. } => Some(base_url)
-    _ => None
-  }
-  let update_revision = updater_revision_from_matches(matches, updater_base_url)
-  let plan = build_package_plan(raw, config_path, project, update_revision)
+  let plan = build_package_plan(raw, config_path, project, raw.update_revision)
   print_package_plan(plan, raw.dry_run)
   if raw.dry_run {
     return
   }
   let result = execute_package_plan(plan)
-  match updater_base_url {
-    Some(base_url) =>
+  match raw.updater_metadata {
+    Some(metadata) =>
       write_updater_metadata(
         plan,
         result.artifacts(),
         result.platform(),
-        base_url,
-        match matches.values {
-          { "updater-published-at": [published_at, ..], .. } => published_at
-          _ => raise MissingPublishedAt
-        },
+        metadata.base_url,
+        metadata.published_at,
       )
     None => ()
   }
 }
 
 ///|
-fn updater_revision_from_matches(
-  matches : @argparse.Matches,
-  base_url : String?,
-) -> UInt64 raise UpdaterMetadataError {
-  match matches.values {
-    { "updater-revision": [value, ..], .. } => {
+fn parse_updater_revision(value : String?) -> UInt64 raise UpdaterMetadataError {
+  match value {
+    Some(value) => {
       let revision = @string.parse_uint64(value[:]) catch {
         _ => raise InvalidRevision(value~)
       }
       guard revision > 0UL else { raise InvalidRevision(value~) }
       revision
     }
-    _ => {
-      guard base_url is None else { raise MissingRevision }
-      0UL
-    }
+    None => 0UL
   }
 }
 
 ///|
 fn package_options_from_matches(
   matches : @argparse.Matches,
-) -> RawPackageOptions raise @packager.PackagePlanError {
+) -> RawPackageOptions raise {
   guard matches.values
     is {
       "package"? : Some(app_package)
       | (None with app_package = []),
       "config"? : Some(config_path)
       | (None with config_path = []),
+      "updater-base-url"? : Some(updater_base_url)
+      | (None with updater_base_url = []),
+      "updater-published-at"? : Some(updater_published_at)
+      | (None with updater_published_at = []),
+      "updater-revision"? : Some(updater_revision)
+      | (None with updater_revision = []),
       ..
     }
   guard matches.flags
@@ -183,6 +185,13 @@ fn package_options_from_matches(
     app_package: app_package.get(0),
     config_path: config_path.get(0),
     package_args: @package_args.from_matches(matches),
+    updater_metadata: match
+      (updater_base_url.get(0), updater_published_at.get(0)) {
+      (Some(base_url), Some(published_at)) =>
+        Some(UpdaterMetadataOptions::{ base_url, published_at, })
+      _ => None
+    },
+    update_revision: parse_updater_revision(updater_revision.get(0)),
     release,
     dry_run,
   }

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -4,11 +4,6 @@ fn parse_package_args(args : Array[String]) -> RawPackageOptions raise {
 }
 
 ///|
-fn parse_package_matches(args : Array[String]) -> @argparse.Matches raise {
-  command().parse(argv=args, env=Map([]))
-}
-
-///|
 test "parse package args accepts repeated formats and overrides" {
   let raw = parse_package_args([
     "--package", "desktop", "--format", "app", "--format", "zip", "--format", "dmg",
@@ -73,35 +68,52 @@ test "parse package args rejects unsupported format" {
 
 ///|
 test "updater revision is explicit, positive and full width" {
-  assert_eq(updater_revision_from_matches(parse_package_matches([]), None), 0UL)
+  assert_eq(parse_package_args([]).update_revision, 0UL)
   let maximum = "18446744073709551615"
-  let matches = parse_package_matches(["--updater-revision", maximum])
   assert_eq(
-    updater_revision_from_matches(matches, None),
+    parse_package_args(["--updater-revision", maximum]).update_revision,
     18446744073709551615UL,
   )
-  let no_revision = parse_package_matches([])
   try
-    ignore(
-      updater_revision_from_matches(
-        no_revision,
-        Some("https://example.com/releases"),
-      ),
-    )
+    parse_package_args(["--updater-base-url", "https://example.com/releases"])
   catch {
-    MissingRevision => ()
-    _ => abort("expected a missing updater revision")
+    error => assert_true(error.to_string().contains("updater-revision"))
   } noraise {
     _ => abort("expected the updater revision to be required")
   }
   for expected in ["0", "-1", "1.5", "not-a-number"] {
-    let invalid = parse_package_matches(["--updater-revision", expected])
-    try ignore(updater_revision_from_matches(invalid, None)) catch {
+    try parse_package_args(["--updater-revision", expected]) catch {
       InvalidRevision(value~) => assert_eq(value, expected)
       _ => abort("expected an invalid updater revision")
     } noraise {
       _ => abort("expected the updater revision to be rejected")
     }
+  }
+}
+
+///|
+test "updater metadata options form one complete value" {
+  let raw = parse_package_args([
+    "--updater-base-url", "https://example.com/releases", "--updater-published-at",
+    "2026-08-25T00:00:00Z", "--updater-revision", "42",
+  ])
+  assert_eq(
+    raw.updater_metadata,
+    Some(UpdaterMetadataOptions::{
+      base_url: "https://example.com/releases",
+      published_at: "2026-08-25T00:00:00Z",
+    }),
+  )
+  assert_eq(raw.update_revision, 42UL)
+  try
+    parse_package_args([
+      "--updater-base-url", "https://example.com/releases", "--updater-revision",
+      "42",
+    ])
+  catch {
+    error => assert_true(error.to_string().contains("updater-published-at"))
+  } noraise {
+    _ => abort("expected updater metadata to require a publication instant")
   }
 }
 

--- a/cli/version_check_wbtest.mbt
+++ b/cli/version_check_wbtest.mbt
@@ -12,19 +12,11 @@ test "update check env flag accepts common truthy and falsey values" {
 ///|
 test "parse cli semver versions" {
   match parse_cli_version("1.2.3") {
-    Some(version) => {
-      assert_eq(version.major, 1)
-      assert_eq(version.minor, 2)
-      assert_eq(version.patch, 3)
-    }
+    Some(version) => assert_eq(version.to_string(), "1.2.3")
     None => fail("expected version to parse")
   }
   match parse_cli_version("1.2.3-beta.1") {
-    Some(version) => {
-      assert_eq(version.major, 1)
-      assert_eq(version.minor, 2)
-      assert_eq(version.patch, 3)
-    }
+    Some(version) => assert_eq(version.to_string(), "1.2.3")
     None => fail("expected prerelease version to parse")
   }
   assert_true(parse_cli_version("1.2") is None)

--- a/codegen/main.mbt
+++ b/codegen/main.mbt
@@ -45,6 +45,7 @@ fn codegen_command() -> @argparse.Command {
       OptionArg(
         "identity-name",
         about="Generated binding name for --extension-identity",
+        requires=["extension-identity"],
       ),
     ],
     positionals=[
@@ -95,11 +96,6 @@ async fn generate(matches : @argparse.Matches) -> Unit {
       ..
     }
   let identity_name = identity_args.get(0)
-  if !extension_identity && identity_name is Some(_) {
-    raise CodegenCliError::Invalid(
-      message="--identity-name requires --extension-identity",
-    )
-  }
   let result = if extension_identity {
     guard inputs is [metadata_path] else {
       raise CodegenCliError::Invalid(
@@ -129,7 +125,7 @@ async fn generate(matches : @argparse.Matches) -> Unit {
 async fn run(args : ArrayView[String]) -> Int {
   let matches = @argparse.parse(codegen_command(), argv=args, env=Map([])) catch {
     error => {
-      write_stderr_line("error: " + error.to_string())
+      write_stderr_line(error.to_string())
       return 2
     }
   }

--- a/package/config.mbt
+++ b/package/config.mbt
@@ -1,0 +1,126 @@
+///|
+priv struct ConfigPayload {
+  source : String
+  destination : String
+  location : String?
+} derive(FromJson)
+
+///|
+priv struct ConfigDocumentType {
+  name : String
+  extensions : Array[String]
+  role : String?
+} derive(FromJson)
+
+///|
+priv struct PackageConfig {
+  schema_version : Int
+  executable : String?
+  product_name : String?
+  identifier : String?
+  version : String?
+  formats : Array[String]?
+  output : String?
+  payloads : Array[ConfigPayload]?
+  icons : Array[String]?
+  url_schemes : Array[String]?
+  document_types : Array[ConfigDocumentType]?
+  sign : Bool?
+  notarize : Bool?
+} derive(FromJson, Default)
+
+///|
+priv suberror PackageCommandError {
+  InvalidConfig(path~ : String, detail~ : String)
+  UnsupportedSchema(version~ : Int)
+  MissingOption(name~ : String)
+} derive(Debug)
+
+///|
+impl Show for PackageCommandError with fn output(self, logger) {
+  logger.write_string(
+    match self {
+      InvalidConfig(path~, detail~) =>
+        "invalid package config " + path + ": " + detail
+      UnsupportedSchema(version~) =>
+        "unsupported package config schema version " + version.to_string()
+      MissingOption(name~) => "missing required option --" + name
+    },
+  )
+}
+
+///|
+fn decode_package_config(
+  source : String,
+  path : String,
+) -> PackageConfig raise PackageCommandError {
+  let config : PackageConfig = @json.from_json(@json.parse(source)) catch {
+    error =>
+      raise PackageCommandError::InvalidConfig(path~, detail=error.to_string())
+  }
+  guard config.schema_version == 1 else {
+    raise PackageCommandError::UnsupportedSchema(version=config.schema_version)
+  }
+  config
+}
+
+///|
+async fn load_package_config(path : String) -> (PackageConfig, String) {
+  let absolute = @path.Path(path).resolve()
+  let source = @async_fs.read_file(absolute.to_string()).text() catch {
+    error =>
+      raise PackageCommandError::InvalidConfig(
+        path=absolute.to_string(),
+        detail=error.to_string(),
+      )
+  }
+  (
+    decode_package_config(source, absolute.to_string()),
+    absolute.dirname().to_string(),
+  )
+}
+
+///|
+fn PackageConfig::payload_specs(
+  self : PackageConfig,
+  base : String,
+) -> Array[@package.Payload] raise @package.PackagePlanError {
+  self.payloads
+  .unwrap_or([])
+  .map(payload => {
+    let location = match payload.location {
+      Some(value) => @package.PayloadLocation::parse(value)
+      None => @package.PayloadLocation::Resources
+    }
+    @package.Payload(
+      resolve_path(base, payload.source),
+      payload.destination,
+      location~,
+    )
+  })
+}
+
+///|
+fn PackageConfig::document_type_specs(
+  self : PackageConfig,
+) -> Array[@package.DocumentType] {
+  self.document_types
+  .unwrap_or([])
+  .map(document_type => {
+    @package.DocumentType(
+      document_type.name,
+      document_type.extensions,
+      role=document_type.role.unwrap_or("Viewer"),
+    )
+  })
+}
+
+///|
+fn resolve_path(base : String, value : String) -> String {
+  let path : @path.Path = value
+  if path.is_absolute() {
+    path.resolve().to_string()
+  } else {
+    @path.Path(base).join(path).resolve().to_string()
+  }
+}

--- a/package/main.mbt
+++ b/package/main.mbt
@@ -1,38 +1,4 @@
 ///|
-priv struct RawConfig {
-  executable : String?
-  product_name : String?
-  identifier : String?
-  version : String?
-  formats : Array[String]
-  output : String?
-  payloads : Array[@package.Payload]
-  icons : Array[String]
-  url_schemes : Array[String]
-  document_types : Array[@package.DocumentType]
-  sign : Bool
-  notarize : Bool
-}
-
-///|
-fn empty_config() -> RawConfig {
-  RawConfig::{
-    executable: None,
-    product_name: None,
-    identifier: None,
-    version: None,
-    formats: [],
-    output: None,
-    payloads: [],
-    icons: [],
-    url_schemes: [],
-    document_types: [],
-    sign: false,
-    notarize: false,
-  }
-}
-
-///|
 fn command() -> @argparse.Command {
   let options = [
     @argparse.OptionArg("config", about="JSON package specification"),
@@ -47,217 +13,14 @@ fn command() -> @argparse.Command {
     about="Package an already-built desktop executable",
     flags=@package_args.flags(),
     options~,
+    arg_required_else_help=true,
   )
-}
-
-///|
-fn string_field(fields : Map[String, Json], name : String) -> String? {
-  match fields.get(name) {
-    Some(String(value)) => Some(value)
-    Some(_) => abort("package config field " + name + " must be a string")
-    None => None
-  }
-}
-
-///|
-fn bool_field(fields : Map[String, Json], name : String) -> Bool {
-  match fields.get(name) {
-    Some(True) => true
-    Some(False) | None => false
-    Some(_) => abort("package config field " + name + " must be a boolean")
-  }
-}
-
-///|
-fn string_array_field(
-  fields : Map[String, Json],
-  name : String,
-) -> Array[String] {
-  match fields.get(name) {
-    None => []
-    Some(Array(values)) =>
-      values.map(fn(value) {
-        match value {
-          String(value) => value
-          _ => abort("package config field " + name + " must contain strings")
-        }
-      })
-    Some(_) => abort("package config field " + name + " must be an array")
-  }
-}
-
-///|
-fn resolve_config_path(base : String, value : String) -> String {
-  let path : @path.Path = value
-  if path.is_absolute() {
-    path.resolve().to_string()
-  } else {
-    @path.Path(base).join(path).resolve().to_string()
-  }
-}
-
-///|
-fn payloads_field(
-  fields : Map[String, Json],
-  base : String,
-) -> Array[@package.Payload] raise @package.PackagePlanError {
-  guard fields.get("payloads") is Some(Array(values)) else { return [] }
-  values.map(value => {
-    guard value is Object(payload) else {
-      abort("package config payload must be an object")
-    }
-    guard payload
-      is { "source": String(source), "destination": String(destination), .. } else {
-      abort("package config payload requires source and destination strings")
-    }
-    let location = match payload.get("location") {
-      Some(String(value)) => @package.PayloadLocation::parse(value)
-      None => @package.PayloadLocation::Resources
-      Some(_) => abort("package config payload location must be a string")
-    }
-    @package.Payload(resolve_config_path(base, source), destination, location~)
-  })
-}
-
-///|
-fn document_types_field(
-  fields : Map[String, Json],
-) -> Array[@package.DocumentType] {
-  guard fields.get("document_types") is Some(Array(values)) else { return [] }
-  values.map(fn(value) {
-    guard value is Object(document_type) else {
-      abort("package config document_type must be an object")
-    }
-    guard document_type
-      is { "name": String(name), "extensions": Array(extension_values), .. } else {
-      abort("package config document_type requires name and extensions")
-    }
-    let extensions = extension_values.map(fn(value) {
-      match value {
-        String(value) => value
-        _ => abort("document_type extensions must contain strings")
-      }
-    })
-    let role = match document_type.get("role") {
-      Some(String(role)) => role
-      None => "Viewer"
-      Some(_) => abort("document_type role must be a string")
-    }
-    @package.DocumentType(name, extensions, role~)
-  })
-}
-
-///|
-async fn read_config(path : String) -> RawConfig {
-  let absolute = @path.Path(path).resolve()
-  let text = @async_fs.read_file(absolute.to_string()).text() catch {
-    error =>
-      abort("failed to read package config: " + @debug.render(Repr(error)))
-  }
-  let json = @json.parse(text) catch {
-    error => abort("invalid package config JSON: " + @debug.render(Repr(error)))
-  }
-  guard json is Object(fields) else {
-    abort("package config root must be an object")
-  }
-  guard fields.get("schema_version") is Some(Number(1.0, ..)) else {
-    abort("package config requires schema_version 1")
-  }
-  let base = absolute.dirname().to_string()
-  RawConfig::{
-    executable: string_field(fields, "executable").map(fn(path) {
-      resolve_config_path(base, path)
-    }),
-    product_name: string_field(fields, "product_name"),
-    identifier: string_field(fields, "identifier"),
-    version: string_field(fields, "version"),
-    formats: string_array_field(fields, "formats"),
-    output: string_field(fields, "output").map(fn(path) {
-      resolve_config_path(base, path)
-    }),
-    payloads: payloads_field(fields, base),
-    icons: string_array_field(fields, "icons").map(fn(path) {
-      resolve_config_path(base, path)
-    }),
-    url_schemes: string_array_field(fields, "url_schemes"),
-    document_types: document_types_field(fields),
-    sign: bool_field(fields, "sign"),
-    notarize: bool_field(fields, "notarize"),
-  }
-}
-
-///|
-fn first(values : Map[String, Array[String]], name : String) -> String? {
-  match values.get(name) {
-    Some([value, ..]) => Some(value)
-    _ => None
-  }
-}
-
-///|
-fn required(value : String?, name : String) -> String {
-  match value {
-    Some(value) => value
-    None => abort("missing required option --" + name)
-  }
-}
-
-///|
-fn prefer(primary : String?, fallback : String?) -> String? {
-  match primary {
-    Some(value) => Some(value)
-    None => fallback
-  }
 }
 
 ///|
 async fn run(args : ArrayView[String]) -> Unit {
-  let matches = @argparse.parse(command(), argv=args, env=Map([])) catch {
-    error => abort(error.to_string())
-  }
-  let config = match first(matches.values, "config") {
-    Some(path) => read_config(path)
-    None => empty_config()
-  }
-  let arguments = @package_args.from_matches(matches)
-  let executable = prefer(
-    first(matches.values, "executable"),
-    config.executable,
-  )
-  let product_name = prefer(arguments.product_name, config.product_name)
-  let identifier = prefer(arguments.identifier, config.identifier)
-  let version = prefer(arguments.version, config.version)
-  let output = prefer(arguments.output, config.output).unwrap_or("dist")
-  let formats = if arguments.formats.length() > 0 {
-    arguments.formats
-  } else {
-    config.formats.map(value => @package.PackageFormat::parse(value))
-  }
-  let icons = if arguments.icons.length() > 0 {
-    arguments.icons
-  } else {
-    config.icons
-  }
-  let url_schemes = if arguments.url_schemes.length() > 0 {
-    arguments.url_schemes
-  } else {
-    config.url_schemes
-  }
-  let spec = @package.PackageSpec(
-    @path.Path(required(executable, "executable")).resolve().to_string(),
-    required(product_name, "product-name"),
-    required(identifier, "identifier"),
-    required(version, "version"),
-    formats,
-    @path.Path(output).resolve().to_string(),
-    payloads=config.payloads,
-    icons=icons.map(fn(path) { @path.Path(path).resolve().to_string() }),
-    url_schemes~,
-    document_types=config.document_types,
-    sign=arguments.sign || config.sign,
-    notarize=arguments.notarize || config.notarize,
-  )
-  for artifact in @package.build(spec) {
+  let matches = command().parse(argv=args, env={})
+  for artifact in @package.build(package_spec(matches)) {
     println(artifact)
   }
 }
@@ -266,7 +29,14 @@ async fn run(args : ArrayView[String]) -> Unit {
 async fn main {
   run(@env.args()[1:]) catch {
     error => {
-      println("error: " + error.to_string())
+      let message = error.to_string()
+      println(
+        if message.has_prefix("error: ") {
+          message
+        } else {
+          "error: " + message
+        },
+      )
       @sys.exit(1)
     }
   }

--- a/package/main_wbtest.mbt
+++ b/package/main_wbtest.mbt
@@ -1,0 +1,34 @@
+///|
+test "configuration decoding uses typed defaults" {
+  let config = decode_package_config("{\"schema_version\":1}", "test.json")
+  assert_eq(config.formats, None)
+  assert_eq(config.sign, None)
+}
+
+///|
+test "invalid configuration is a regular error" {
+  try
+    ignore(
+      decode_package_config(
+        "{\"schema_version\":1,\"payloads\":false}", "test.json",
+      ),
+    )
+  catch {
+    PackageCommandError::InvalidConfig(path~, ..) =>
+      inspect(path, content="test.json")
+    _ => fail("expected an invalid configuration error")
+  } noraise {
+    _ => fail("expected configuration decoding to fail")
+  }
+}
+
+///|
+test "missing merged options are regular errors" {
+  try ignore(required(None, "executable")) catch {
+    PackageCommandError::MissingOption(name~) =>
+      inspect(name, content="executable")
+    _ => fail("expected a missing option error")
+  } noraise {
+    _ => fail("expected required option validation to fail")
+  }
+}

--- a/package/moon.pkg
+++ b/package/moon.pkg
@@ -4,7 +4,6 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs" @async_fs,
   "moonbitlang/core/argparse",
-  "moonbitlang/core/debug",
   "moonbitlang/core/env",
   "moonbitlang/core/json",
   "moonbitlang/x/path",

--- a/package/spec.mbt
+++ b/package/spec.mbt
@@ -1,0 +1,72 @@
+///|
+async fn package_spec(matches : @argparse.Matches) -> @package.PackageSpec {
+  let (config, base) = match option(matches, "config") {
+    Some(path) => load_package_config(path)
+    None => ((Default::default() : PackageConfig), ".")
+  }
+  let arguments = @package_args.from_matches(matches)
+  let executable = prefer(
+    option(matches, "executable"),
+    config.executable.map(path => resolve_path(base, path)),
+  )
+  let output = prefer(
+    arguments.output,
+    config.output.map(path => resolve_path(base, path)),
+  ).unwrap_or("dist")
+  let formats = if arguments.formats.is_empty() {
+    config.formats.unwrap_or([]).map(@package.PackageFormat::parse)
+  } else {
+    arguments.formats
+  }
+  let icons = if arguments.icons.is_empty() {
+    config.icons.unwrap_or([]).map(path => resolve_path(base, path))
+  } else {
+    arguments.icons.map(path => @path.Path(path).resolve().to_string())
+  }
+  let url_schemes = if arguments.url_schemes.is_empty() {
+    config.url_schemes.unwrap_or([])
+  } else {
+    arguments.url_schemes
+  }
+  @package.PackageSpec(
+    @path.Path(required(executable, "executable")).resolve().to_string(),
+    required(
+      prefer(arguments.product_name, config.product_name),
+      "product-name",
+    ),
+    required(prefer(arguments.identifier, config.identifier), "identifier"),
+    required(prefer(arguments.version, config.version), "version"),
+    formats,
+    @path.Path(output).resolve().to_string(),
+    payloads=config.payload_specs(base),
+    icons~,
+    url_schemes~,
+    document_types=config.document_type_specs(),
+    sign=arguments.sign || config.sign.unwrap_or(false),
+    notarize=arguments.notarize || config.notarize.unwrap_or(false),
+  )
+}
+
+///|
+fn option(matches : @argparse.Matches, name : String) -> String? {
+  match matches.values.get(name) {
+    Some([value, ..]) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn prefer(primary : String?, fallback : String?) -> String? {
+  match primary {
+    Some(value) => Some(value)
+    None => fallback
+  }
+}
+
+///|
+fn required(value : String?, name : String) -> String raise PackageCommandError {
+  match value {
+    Some(value) => value
+    None => raise PackageCommandError::MissingOption(name~)
+  }
+}


### PR DESCRIPTION
## Summary

- validate standalone package input without aborting
- reuse shared version and project configuration models
- decode CLI JSON payloads through typed `FromJson` structures
- move argument dependencies into argparse and avoid duplicate error prefixes
- parse package updater options once before execution

## Validation

- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
- `moon -C codegen test lib --target wasm`
- `moon -C cefsetup check --target native --diagnostic-limit 80`
- `moon fmt --check`