### PR TITLE
feat(window): add macOS progress indicator

### DIFF
--- a/examples/40_event_broadcast/Readme.md
+++ b/examples/40_event_broadcast/Readme.md
@@ -1,6 +1,6 @@
 # Event Broadcast
 
-Native DLL bridge example for command-extension event broadcast.
+Source-built command-extension example for event broadcast.
 
 The page calls `window.__MoonBit__.ticker.start(payload)` and subscribes with
 `window.__MoonBit__.ticker.on("tick", listener)` / `ticker.on("done", listener)`.

--- a/examples/59_window_progress/README.md
+++ b/examples/59_window_progress/README.md
@@ -1,0 +1,27 @@
+# Window Progress
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_progress_bar` API on macOS.
+
+Run it with:
+
+```sh
+moon -C examples run 59_window_progress --target native
+```
+
+Review the application and its Dock icon:
+
+1. Move the slider to 25%, 50%, and 75%. The Dock indicator should remain
+   determinate and track each value.
+2. Choose **Indeterminate**. The Dock indicator should animate continuously.
+3. Choose **Clear**. The custom Dock indicator should disappear and the normal
+   application icon should return.
+4. Choose **Run cycle**. The indicator should advance smoothly from 0% to 100%
+   and clear when the cycle completes.
+5. Set a visible progress value and close the window. The Dock indicator should
+   be removed during window teardown.
+
+Electron value semantics are preserved: negative values clear the indicator,
+values from `0.0` through `1.0` are determinate, and values above `1.0` are
+indeterminate. macOS exposes one Dock indicator for the application, so the
+most recent window call wins and any negative value clears it.

--- a/examples/59_window_progress/main.mbt
+++ b/examples/59_window_progress/main.mbt
@@ -1,0 +1,204 @@
+///|
+struct SetProgressRequest {
+  progress : Double
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetProgressRequest with ToJson::{to_json}
+
+///|
+pub extend SetProgressRequest with FromJson::{from_json}
+
+///|
+struct SetProgressReply {
+  applied : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetProgressReply with ToJson::{to_json}
+
+///|
+pub extend SetProgressReply with FromJson::{from_json}
+
+///|
+let progress_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-progress",
+  js_namespace="windowProgress",
+)
+
+///|
+let set_progress_command : @proton_contract.Command[
+  SetProgressRequest,
+  SetProgressReply,
+] = progress_contract.command("set")
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+fn set_progress(request : SetProgressRequest) -> SetProgressReply {
+  match window_slot.val {
+    Some(window) => {
+      window.set_progress_bar(request.progress) catch {
+        error =>
+          return SetProgressReply::{
+            applied: false,
+            message: "native call failed: " + error.message(),
+          }
+      }
+      SetProgressReply::{ applied: true, message: "progress updated", }
+    }
+    None =>
+      SetProgressReply::{ applied: false, message: "window is not ready", }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(set_progress_command, (_context, request) => {
+    set_progress(request)
+  })
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Progress</title>
+    #|    <style>
+    #|      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #101216; color: #f5f7fa; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #101216; }
+    #|      button, input { font: inherit; }
+    #|      main { width: min(760px, calc(100vw - 40px)); margin: 0 auto; padding: 48px 0; }
+    #|      header { border-bottom: 1px solid #343943; padding-bottom: 24px; }
+    #|      .eyebrow { margin: 0 0 10px; color: #66d9a8; font: 700 12px/1 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; }
+    #|      h1 { margin: 0; font-size: 42px; line-height: 1.05; }
+    #|      .meter { display: grid; grid-template-columns: 116px minmax(0, 1fr); gap: 28px; align-items: center; padding: 42px 0 34px; }
+    #|      .value { display: grid; place-items: center; width: 116px; aspect-ratio: 1; border: 1px solid #4a515e; border-radius: 8px; background: #191d24; color: #7ee2b8; font: 700 28px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      .track { display: grid; gap: 15px; min-width: 0; }
+    #|      label { color: #b9c0cb; font-size: 13px; }
+    #|      input[type="range"] { width: 100%; accent-color: #22b77b; }
+    #|      .bar { height: 12px; border: 1px solid #414854; border-radius: 4px; overflow: hidden; background: #171a20; }
+    #|      .bar span { display: block; width: 35%; height: 100%; background: #22b77b; transition: width 100ms linear; }
+    #|      .commands { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; border-top: 1px solid #343943; padding-top: 24px; }
+    #|      button { min-height: 44px; border: 1px solid #4a515e; border-radius: 6px; padding: 0 14px; background: #20252d; color: #f5f7fa; cursor: pointer; }
+    #|      button:hover { border-color: #66d9a8; background: #252c34; }
+    #|      button:focus-visible, input:focus-visible { outline: 3px solid #66d9a866; outline-offset: 3px; }
+    #|      button.primary { border-color: #22b77b; background: #17885e; }
+    #|      button.primary:hover { background: #1d9c6c; }
+    #|      #status { min-height: 24px; margin: 20px 0 0; color: #9da6b3; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      @media (max-width: 560px) { main { padding-top: 28px; } h1 { font-size: 34px; } .meter { grid-template-columns: 1fr; } .commands { grid-template-columns: 1fr; } }
+    #|      @media (prefers-reduced-motion: reduce) { .bar span { transition: none; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <p class="eyebrow">Native surface / manual test 59</p>
+    #|        <h1>Window progress</h1>
+    #|      </header>
+    #|      <section class="meter">
+    #|        <output id="value" class="value" for="progress">35%</output>
+    #|        <div class="track">
+    #|          <label for="progress">Determinate progress</label>
+    #|          <input id="progress" type="range" min="0" max="100" value="35" step="1">
+    #|          <div class="bar" aria-hidden="true"><span id="fill"></span></div>
+    #|        </div>
+    #|      </section>
+    #|      <div class="commands">
+    #|        <button id="indeterminate" type="button">Indeterminate</button>
+    #|        <button id="clear" type="button">Clear</button>
+    #|        <button id="cycle" class="primary" type="button">Run cycle</button>
+    #|      </div>
+    #|      <p id="status" role="status" aria-live="polite">Ready.</p>
+    #|    </main>
+    #|    <script>
+    #|      const slider = document.querySelector("#progress");
+    #|      const value = document.querySelector("#value");
+    #|      const fill = document.querySelector("#fill");
+    #|      const status = document.querySelector("#status");
+    #|      const cycleButton = document.querySelector("#cycle");
+    #|      let cycleTimer = 0;
+    #|      const invoke = (progress) => window.__MoonBit__.core.invokeOp("ext:windowProgress/set", { progress });
+    #|      function render(percent) {
+    #|        slider.value = String(percent);
+    #|        value.textContent = `${percent}%`;
+    #|        fill.style.width = `${percent}%`;
+    #|      }
+    #|      async function apply(progress, label) {
+    #|        status.textContent = `${label}...`;
+    #|        try {
+    #|          const reply = await invoke(progress);
+    #|          status.textContent = reply.applied ? label : reply.message;
+    #|        } catch (error) {
+    #|          status.textContent = `request failed: ${String(error)}`;
+    #|        }
+    #|      }
+    #|      function stopCycle() {
+    #|        if (cycleTimer) window.clearInterval(cycleTimer);
+    #|        cycleTimer = 0;
+    #|        cycleButton.textContent = "Run cycle";
+    #|      }
+    #|      slider.addEventListener("input", () => {
+    #|        stopCycle();
+    #|        const percent = Number(slider.value);
+    #|        render(percent);
+    #|        void apply(percent / 100, `Determinate ${percent}%`);
+    #|      });
+    #|      document.querySelector("#indeterminate").addEventListener("click", () => {
+    #|        stopCycle();
+    #|        void apply(2, "Indeterminate");
+    #|      });
+    #|      document.querySelector("#clear").addEventListener("click", () => {
+    #|        stopCycle();
+    #|        void apply(-1, "Cleared");
+    #|      });
+    #|      cycleButton.addEventListener("click", () => {
+    #|        if (cycleTimer) {
+    #|          stopCycle();
+    #|          void apply(-1, "Cycle stopped and cleared");
+    #|          return;
+    #|        }
+    #|        let percent = 0;
+    #|        cycleButton.textContent = "Stop cycle";
+    #|        render(percent);
+    #|        void apply(0, "Cycle 0%");
+    #|        cycleTimer = window.setInterval(() => {
+    #|          percent += 2;
+    #|          if (percent > 100) {
+    #|            stopCycle();
+    #|            void apply(-1, "Cycle complete and cleared");
+    #|            return;
+    #|          }
+    #|          render(percent);
+    #|          void apply(percent / 100, `Cycle ${percent}%`);
+    #|        }, 100);
+    #|      });
+    #|      void apply(0.35, "Determinate 35%");
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Progress", html(), width=760, height=560, debug=true)
+  .identifier("dev.proton.window-progress")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/59_window_progress/moon.pkg
+++ b/examples/59_window_progress/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/59_window_progress/pkg.generated.mbti
+++ b/examples/59_window_progress/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/59_window_progress"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type SetProgressReply derive(ToJson, @json.FromJson)
+pub fn SetProgressReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetProgressReply::to_json(Self) -> Json
+
+type SetProgressRequest derive(ToJson, @json.FromJson)
+pub fn SetProgressRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetProgressRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -96,6 +96,8 @@ moon -C examples run 01_run --target native
 - `58_context_menu`: manual Electron-style window context menu review with
   native macOS, Windows, and Linux popups at renderer CSS-pixel coordinates,
   nested submenu items, role items, and menu command events.
+- `59_window_progress`: manual Electron-style window progress review with
+  determinate, indeterminate, cleared, and animated macOS Dock states.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -150,6 +150,11 @@ fn RuntimeSession::window_handle(
         window.set_zoom_percent(zoom_percent)
       })
     },
+    set_window_progress_bar: progress => {
+      self.control_window(id, native_id, "set progress bar", window => {
+        window.set_progress_bar(progress)
+      })
+    },
     popup_window_menu: (menu, x, y) => {
       self.control_window(id, native_id, "popup menu in", window => {
         window.popup_menu(@native.MenuBar(menus=[menu.to_native()]), x, y)
@@ -1077,6 +1082,22 @@ pub fn WindowHandle::set_zoom_percent(
   zoom_percent : Int,
 ) -> Unit raise WindowSessionError {
   (self.set_window_zoom_percent)(zoom_percent)
+}
+
+///|
+/// Sets the platform progress indicator using Electron-compatible values.
+///
+/// Pass a negative value to clear the indicator, a value from `0.0` through
+/// `1.0` for determinate progress, or a value above `1.0` for indeterminate
+/// progress. The current native implementation displays this in the macOS
+/// Dock as one application-level indicator; the most recent window call wins,
+/// and any negative value clears it. Unsupported platforms raise
+/// `WindowSessionError`.
+pub fn WindowHandle::set_progress_bar(
+  self : WindowHandle,
+  progress : Double,
+) -> Unit raise WindowSessionError {
+  (self.set_window_progress_bar)(progress)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -428,6 +428,7 @@ pub struct WindowHandle {
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
+  set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   popup_window_menu : (Menu, Int, Int) -> Unit raise WindowSessionError
   read_window_state : () -> WindowState raise WindowSessionError
   browser : BrowserHandle

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -59,6 +59,7 @@ fn test_window_handle(
   id : String,
   native_id : Int64,
   popup_calls? : Array[String],
+  progress_calls? : Array[Double],
 ) -> WindowHandle {
   let browser = BrowserHandle::{
     id,
@@ -84,6 +85,12 @@ fn test_window_handle(
     set_window_position: fn(_x, _y) {  },
     set_window_always_on_top: fn(_always_on_top) {  },
     set_window_zoom_percent: fn(_zoom_percent) {  },
+    set_window_progress_bar: progress => {
+      match progress_calls {
+        Some(calls) => calls.push(progress)
+        None => ()
+      }
+    },
     popup_window_menu: fn(menu, x, y) {
       match popup_calls {
         Some(calls) => {
@@ -1901,6 +1908,16 @@ test "window context menu routes through the public window handle" {
   let menu = Menu("Context", items=[MenuItem::separator()])
   menu.popup(window, 123, 456)
   debug_inspect(calls, content="[\"popup:Context@123,456\"]")
+}
+
+///|
+test "window progress routes Electron-compatible values through the handle" {
+  let calls : Array[Double] = []
+  let window = test_window_handle("main", 17L, progress_calls=calls)
+  window.set_progress_bar(0.42)
+  window.set_progress_bar(2.0)
+  window.set_progress_bar(-1.0)
+  debug_inspect(calls, content="[0.42, 2, -1]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -447,6 +447,12 @@ pub extern "C" fn proton_window_set_zoom_percent_ffi(
 ) -> Int = "proton_window_set_zoom_percent"
 
 ///|
+pub extern "C" fn proton_window_set_progress_bar_ffi(
+  window : WindowHandle,
+  progress : Double,
+) -> Int = "proton_window_set_progress_bar"
+
+///|
 #borrow(command_json)
 pub extern "C" fn proton_window_browser_command_json_ffi(
   window : WindowHandle,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -156,6 +156,10 @@ int32_t proton_window_set_always_on_top(proton_window_handle_t window,
                                                    int32_t always_on_top);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
+/* Matches Electron's progress value semantics: negative clears the indicator,
+   [0, 1] is determinate, and values above 1 are indeterminate. */
+int32_t proton_window_set_progress_bar(proton_window_handle_t window,
+                                       double progress);
 /* Writes the 21 integer fields of the current window state into out_fields.
    The field order is private to the matching MoonBit wrapper. */
 int32_t proton_window_get_state(proton_window_handle_t window,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -210,6 +210,8 @@ pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_position_ffi(WindowHandle, Int, Int) -> Int
 
+pub fn proton_window_set_progress_bar_ffi(WindowHandle, Double) -> Int
+
 pub fn proton_window_set_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_title_ffi(WindowHandle, Bytes) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -794,6 +794,20 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_progress_bar(
+    proton_engine_window_t *window, double progress, char *error,
+    size_t error_len) {
+  (void)progress;
+  if (window == NULL) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  proton_engine_set_message(
+      error, error_len,
+      "window progress is not implemented on Linux");
+  return PROTON_ERR_UNSUPPORTED;
+}
+
 int32_t proton_engine_window_apply(
     proton_engine_window_t *window,
     const proton_engine_window_action_t *action,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -30,6 +30,63 @@
 
 static proton_engine_window_t *g_windows = NULL;
 static uint64_t g_next_window_native_id = 1;
+static proton_engine_window_t *g_dock_progress_owner = NULL;
+static NSImageView *g_dock_progress_content = nil;
+static NSProgressIndicator *g_dock_progress_indicator = nil;
+
+static void proton_engine_dock_progress_clear(void) {
+  if (g_dock_progress_indicator != nil) {
+    [g_dock_progress_indicator stopAnimation:nil];
+  }
+  [[NSApp dockTile] setContentView:nil];
+  [g_dock_progress_indicator release];
+  [g_dock_progress_content release];
+  g_dock_progress_owner = NULL;
+  g_dock_progress_indicator = nil;
+  g_dock_progress_content = nil;
+  [[NSApp dockTile] display];
+}
+
+static int proton_engine_dock_progress_prepare(char *error,
+                                               size_t error_len) {
+  if (g_dock_progress_content != nil &&
+      g_dock_progress_indicator != nil) {
+    return 1;
+  }
+  NSDockTile *dock_tile = [NSApp dockTile];
+  if (dock_tile == nil) {
+    proton_engine_set_message(error, error_len,
+                              "application Dock tile is not available");
+    return 0;
+  }
+  NSSize tile_size = dock_tile.size;
+  if (tile_size.width <= 0.0 || tile_size.height <= 0.0) {
+    tile_size = NSMakeSize(128.0, 128.0);
+  }
+  NSImageView *content = [[NSImageView alloc]
+      initWithFrame:NSMakeRect(0.0, 0.0, tile_size.width, tile_size.height)];
+  NSProgressIndicator *indicator = [[NSProgressIndicator alloc]
+      initWithFrame:NSMakeRect(8.0, 5.0, MAX(1.0, tile_size.width - 16.0),
+                               14.0)];
+  if (content == nil || indicator == nil) {
+    [indicator release];
+    [content release];
+    proton_engine_set_message(error, error_len,
+                              "failed to create Dock progress indicator");
+    return 0;
+  }
+  content.image = [NSApp applicationIconImage];
+  content.imageScaling = NSImageScaleProportionallyUpOrDown;
+  indicator.style = NSProgressIndicatorStyleBar;
+  indicator.minValue = 0.0;
+  indicator.maxValue = 1.0;
+  indicator.displayedWhenStopped = YES;
+  [content addSubview:indicator];
+  dock_tile.contentView = content;
+  g_dock_progress_content = content;
+  g_dock_progress_indicator = indicator;
+  return 1;
+}
 
 static int32_t proton_engine_window_create_browser(
     proton_engine_window_t *window,
@@ -779,6 +836,9 @@ static void proton_engine_window_free(proton_engine_window_t *window) {
   if (window == NULL) {
     return;
   }
+  if (g_dock_progress_owner == window) {
+    proton_engine_dock_progress_clear();
+  }
   if (window->delegate != nil) {
     [window->delegate release];
     window->delegate = nil;
@@ -1079,6 +1139,46 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
     frame.size.height = height;
     [window->window setFrame:frame display:YES animate:NO];
   }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_progress_bar(
+    proton_engine_window_t *window, double progress, char *error,
+    size_t error_len) {
+  if (window == NULL) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (isnan(progress)) {
+    proton_engine_set_message(error, error_len,
+                              "progress must not be NaN");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window progress is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (progress < 0.0) {
+    proton_engine_dock_progress_clear();
+    proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+    return PROTON_OK;
+  }
+  if (!proton_engine_dock_progress_prepare(error, error_len)) {
+    return PROTON_ERR_PLATFORM;
+  }
+  g_dock_progress_owner = window;
+  if (progress > 1.0) {
+    g_dock_progress_indicator.indeterminate = YES;
+    [g_dock_progress_indicator startAnimation:nil];
+  } else {
+    [g_dock_progress_indicator stopAnimation:nil];
+    g_dock_progress_indicator.indeterminate = NO;
+    g_dock_progress_indicator.doubleValue = progress;
+  }
+  [[NSApp dockTile] display];
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -674,6 +674,20 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_progress_bar(
+    proton_engine_window_t *window, double progress, char *error,
+    size_t error_len) {
+  (void)progress;
+  if (window == NULL) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  proton_engine_set_message(
+      error, error_len,
+      "window progress is not implemented on Windows");
+  return PROTON_ERR_UNSUPPORTED;
+}
+
 int32_t proton_engine_window_apply(
     proton_engine_window_t *window,
     const proton_engine_window_action_t *action,

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -5,6 +5,7 @@
 #include "proton_internal.h"
 #include "proton_state.h"
 
+#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -936,6 +937,31 @@ int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
       .value = zoom_percent,
   };
   return proton_window_apply_action(window, &action);
+}
+
+int32_t proton_window_set_progress_bar(proton_window_handle_t window,
+                                       double progress) {
+  if (isnan(progress)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "progress must not be NaN");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window progress requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_progress_bar(
+      slot->engine_window, progress, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
 }
 
 int32_t proton_window_get_state(proton_window_handle_t window,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -208,6 +208,9 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t height,
                                       char *error,
                                       size_t error_len);
+int32_t proton_engine_window_set_progress_bar(
+    proton_engine_window_t *window, double progress, char *error,
+    size_t error_len);
 int32_t proton_engine_window_apply(
     proton_engine_window_t *window,
     const proton_engine_window_action_t *action,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1357,6 +1357,24 @@ pub fn Window::set_zoom_percent(
 }
 
 ///|
+/// Sets the platform progress indicator for this window.
+///
+/// A negative value clears the indicator, values from `0.0` through `1.0`
+/// display determinate progress, and a value above `1.0` displays an
+/// indeterminate indicator.
+pub fn Window::set_progress_bar(
+  self : Window,
+  progress : Double,
+) -> Unit raise NativeError {
+  if progress.is_nan() {
+    raise invalid_argument("progress must not be NaN")
+  }
+  check_status(
+    @native_ffi.proton_window_set_progress_bar_ffi(self.live_handle(), progress),
+  )
+}
+
+///|
 pub fn Window::state(self : Window) -> WindowState raise NativeError {
   let fields = FixedArray::make(proton_window_state_field_count, 0)
   check_status(

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -172,6 +172,22 @@ test "typed window state fields map to a snapshot" {
 }
 
 ///|
+test "window progress rejects NaN before native handle access" {
+  let window = Window::{
+    handle: @native_ffi.window_null(),
+    id: 0L,
+    lifecycle: WindowLive,
+  }
+  try window.set_progress_bar(0.0 / 0.0) catch {
+    InvalidArgument(message~) =>
+      inspect(message, content="progress must not be NaN")
+    _ => fail("expected invalid progress")
+  } noraise {
+    _ => fail("expected invalid progress")
+  }
+}
+
+///|
 test "runtime config preserves typed native ABI values" {
   let cache_dir = test_absolute_cache_dir()
   let runtime_config = RuntimeConfig(

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -567,6 +567,7 @@ pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_position(Self, Int, Int) -> Unit raise NativeError
+pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -597,6 +597,7 @@ pub struct WindowHandle {
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
+  set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   popup_window_menu : (Menu, Int, Int) -> Unit raise WindowSessionError
   read_window_state : () -> WindowState raise WindowSessionError
   browser : BrowserHandle
@@ -618,6 +619,7 @@ pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-compatible `WindowHandle::set_progress_bar(Double)` value semantics through the facade, native MoonBit wrapper, and private C ABI
- render determinate and indeterminate progress in the macOS Dock and clear it when requested or when the owning window is destroyed
- add `examples/59_window_progress` for manual review of determinate, indeterminate, clear, cycle, and teardown behavior

## Platform impact

- macOS: implemented with `NSDockTile` and `NSProgressIndicator`; the Dock indicator is application-level, so the most recent window call wins
- Windows: currently returns an explicit unsupported error
- Linux: currently returns an explicit unsupported error
- headless: returns an explicit unsupported error

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C proton check --target native --diagnostic-limit 160`
- `moon -C proton test internal/native --target native --diagnostic-limit 160` (25 passed)
- `moon -C proton test --target native --diagnostic-limit 160` (560 passed)
- `moon -C examples build --target native --diagnostic-limit 160`
- `moon -C e2e build --target native --diagnostic-limit 160`
- `moon -C e2e run test --target native --diagnostic-limit 220 -- --self-hosted`
- manual CEF renderer smoke for determinate, indeterminate, clear, and run-cycle actions

## Manual review

Run `examples/59_window_progress` on macOS and follow its README checklist while observing the Dock icon.
