### PR TITLE
feat(window): add runtime resizable control

### DIFF
--- a/examples/61_window_resizable/README.md
+++ b/examples/61_window_resizable/README.md
@@ -1,0 +1,29 @@
+# Window Resizable
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_resizable` API.
+
+Run it with:
+
+```sh
+moon -C examples run 61_window_resizable --target native
+```
+
+Review the native window frame:
+
+1. Drag the lower-right edge and confirm the window resizes.
+2. Choose **Disable resizing**, then try the same edge gesture. The frame
+   should stay fixed.
+3. Choose **Enable resizing** and resize again without restarting the app.
+4. Repeat the checks at a narrow and a wide window size.
+5. On Windows with display scaling above 100%, confirm the frame and renderer
+   remain aligned.
+
+Platform details:
+
+- macOS adds or removes `NSWindowStyleMaskResizable` on the live `NSWindow`.
+- Windows toggles the native thick-frame/maximize styles and refreshes the
+  non-client frame; existing size hints remain in effect.
+- Linux delegates to GTK's `gtk_window_set_resizable`; the exact resize affordance
+  depends on the desktop window manager.
+- Headless runtimes report unsupported because there is no native window frame.

--- a/examples/61_window_resizable/main.mbt
+++ b/examples/61_window_resizable/main.mbt
@@ -1,0 +1,223 @@
+///|
+struct SetResizableRequest {
+  resizable : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetResizableRequest with ToJson::{to_json}
+
+///|
+pub extend SetResizableRequest with FromJson::{from_json}
+
+///|
+struct SetResizableReply {
+  applied : Bool
+  resizable : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetResizableReply with ToJson::{to_json}
+
+///|
+pub extend SetResizableReply with FromJson::{from_json}
+
+///|
+let resizable_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-resizable",
+  js_namespace="windowResizable",
+)
+
+///|
+let set_resizable_command : @proton_contract.Command[
+  SetResizableRequest,
+  SetResizableReply,
+] = resizable_contract.command("set")
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let resizable_state : Ref[Bool] = { val: true, }
+
+///|
+fn set_resizable(request : SetResizableRequest) -> SetResizableReply {
+  match window_slot.val {
+    Some(window) => {
+      window.set_resizable(request.resizable) catch {
+        error =>
+          return SetResizableReply::{
+            applied: false,
+            resizable: resizable_state.val,
+            message: "native call failed: " + error.message(),
+          }
+      }
+      resizable_state.val = request.resizable
+      SetResizableReply::{
+        applied: true,
+        resizable: request.resizable,
+        message: if request.resizable {
+          "Resizing enabled"
+        } else {
+          "Resizing disabled"
+        },
+      }
+    }
+    None =>
+      SetResizableReply::{
+        applied: false,
+        resizable: resizable_state.val,
+        message: "window is not ready",
+      }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(set_resizable_command, (_context, request) => {
+    set_resizable(request)
+  })
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Resizable</title>
+    #|    <style>
+    #|      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #0d1117; color: #eef2f7; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #0d1117; }
+    #|      button { font: inherit; }
+    #|      main { width: min(820px, calc(100vw - 40px)); margin: 0 auto; padding: 42px 0 50px; }
+    #|      header { display: flex; align-items: end; justify-content: space-between; gap: 24px; padding-bottom: 25px; border-bottom: 1px solid #2c3644; }
+    #|      .eyebrow { margin: 0 0 10px; color: #8ed8ff; font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .16em; text-transform: uppercase; }
+    #|      h1 { margin: 0; font-size: clamp(34px, 6vw, 54px); line-height: .98; letter-spacing: -.055em; }
+    #|      .summary { max-width: 520px; margin: 14px 0 0; color: #9aa9bc; line-height: 1.55; }
+    #|      .state-chip { flex: none; display: grid; gap: 6px; min-width: 156px; border: 1px solid #2d7aa3; border-radius: 12px; padding: 13px 15px; background: #102536; }
+    #|      .state-chip small { color: #76b4d1; font: 700 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .12em; text-transform: uppercase; }
+    #|      .state-chip strong { color: #d6f2ff; font-size: 17px; }
+    #|      .state-chip.off { border-color: #5a6472; background: #1b2028; }
+    #|      .state-chip.off small, .state-chip.off strong { color: #b8c1cc; }
+    #|      .layout { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(250px, .8fr); gap: 16px; margin-top: 20px; }
+    #|      .panel { border: 1px solid #2c3644; border-radius: 14px; background: #111821; overflow: hidden; }
+    #|      .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 48px; padding: 0 17px; border-bottom: 1px solid #2c3644; color: #9aa9bc; font: 650 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .05em; text-transform: uppercase; }
+    #|      .panel-head strong { color: #d8e1ec; }
+    #|      .preview { position: relative; min-height: 278px; padding: 27px; background: radial-gradient(circle at 70% 24%, #16445d 0, #142330 35%, #111821 77%); }
+    #|      .preview::after { content: ""; position: absolute; right: 0; bottom: 0; width: 72px; height: 72px; background: repeating-linear-gradient(135deg, transparent 0 7px, #8ed8ff44 8px 9px); opacity: .75; pointer-events: none; }
+    #|      .preview-copy { position: relative; z-index: 1; max-width: 410px; }
+    #|      .preview h2 { margin: 0 0 9px; font-size: 23px; letter-spacing: -.03em; }
+    #|      .preview p { margin: 0; color: #a6b7c9; line-height: 1.6; }
+    #|      .edge-note { display: inline-flex; align-items: center; gap: 8px; margin-top: 27px; color: #c8eaff; font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; text-transform: uppercase; }
+    #|      .edge-note::before { content: ">"; display: grid; place-items: center; width: 24px; height: 24px; border: 1px solid #6eb9db; border-radius: 50%; color: #8ed8ff; font-size: 15px; }
+    #|      .controls { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 9px; padding: 15px 17px; border-top: 1px solid #2c3644; }
+    #|      button { min-height: 43px; border: 1px solid #405064; border-radius: 8px; padding: 0 12px; background: #1b2531; color: #e9f3fb; cursor: pointer; font-weight: 720; }
+    #|      button:hover { border-color: #8ed8ff; background: #213546; }
+    #|      button:focus-visible { outline: 3px solid #8ed8ff66; outline-offset: 3px; }
+    #|      button.primary { border-color: #2d9bc8; background: #17678a; }
+    #|      button.primary:hover { background: #1b7ca5; }
+    #|      .review { padding: 20px; }
+    #|      .review h2 { margin: 0 0 14px; font-size: 16px; }
+    #|      .checklist { display: grid; gap: 13px; margin: 0; padding: 0; list-style: none; }
+    #|      .checklist li { position: relative; padding-left: 26px; color: #a6b7c9; font-size: 13px; line-height: 1.5; }
+    #|      .checklist li::before { content: ""; position: absolute; left: 1px; top: 5px; width: 10px; height: 10px; border: 1px solid #6eb9db; border-radius: 3px; }
+    #|      .log-title { margin-top: 21px !important; padding-top: 18px; border-top: 1px solid #2c3644; }
+    #|      #status { min-height: 34px; margin: 16px 0 0; color: #8ed8ff; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      @media (max-width: 720px) { header { align-items: start; flex-direction: column; } .state-chip { width: 100%; } .layout { grid-template-columns: 1fr; } }
+    #|      @media (max-width: 460px) { main { padding-top: 28px; } .controls { grid-template-columns: 1fr; } }
+    #|      @media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div>
+    #|          <p class="eyebrow">Native surface / manual test 61</p>
+    #|          <h1>Window<br>resizable</h1>
+    #|          <p class="summary">A small review console for Electron-style live resizing. The control changes the native frame; the web page only reports the state.</p>
+    #|        </div>
+    #|        <div id="state-chip" class="state-chip">
+    #|          <small>Native window</small>
+    #|          <strong id="state-label">Resizable</strong>
+    #|        </div>
+    #|      </header>
+    #|      <div class="layout">
+    #|        <section class="panel">
+    #|          <div class="panel-head"><strong>Window frame</strong><span>drag the lower-right edge</span></div>
+    #|          <div class="preview">
+    #|            <div class="preview-copy">
+    #|              <h2>Can the frame breathe?</h2>
+    #|              <p>Resize this application with the native border, then disable resizing and try again. Re-enable it without restarting the process.</p>
+    #|              <div class="edge-note">Resize handle is outside the page</div>
+    #|            </div>
+    #|          </div>
+    #|          <div class="controls">
+    #|            <button id="enable" class="primary" type="button">Enable resizing</button>
+    #|            <button id="disable" type="button">Disable resizing</button>
+    #|            <button id="toggle" type="button">Toggle</button>
+    #|          </div>
+    #|        </section>
+    #|        <aside class="panel review">
+    #|          <h2>Manual review</h2>
+    #|          <ul class="checklist">
+    #|            <li>Drag the lower-right edge and confirm the native window changes size.</li>
+    #|            <li>Choose <strong>Disable resizing</strong>; the edge should stop accepting a resize gesture.</li>
+    #|            <li>Choose <strong>Enable resizing</strong> and resize again without restarting.</li>
+    #|            <li>Resize while the page is narrow and wide; the content should remain usable.</li>
+    #|            <li>On Windows at display scaling above 100%, confirm the frame and page stay aligned.</li>
+    #|          </ul>
+    #|          <h2 class="log-title">Bridge status</h2>
+    #|          <p id="status" role="status" aria-live="polite">Ready. The native frame starts resizable.</p>
+    #|        </aside>
+    #|      </div>
+    #|    </main>
+    #|    <script>
+    #|      const stateChip = document.querySelector("#state-chip");
+    #|      const stateLabel = document.querySelector("#state-label");
+    #|      const status = document.querySelector("#status");
+    #|      let current = true;
+    #|      const invoke = (resizable) => window.__MoonBit__.core.invokeOp("ext:windowResizable/set", { resizable });
+    #|      function render(resizable, message) {
+    #|        current = resizable;
+    #|        stateLabel.textContent = resizable ? "Resizable" : "Fixed size";
+    #|        stateChip.classList.toggle("off", !resizable);
+    #|        status.textContent = message;
+    #|      }
+    #|      async function setResizable(resizable) {
+    #|        status.textContent = resizable ? "Enabling native resizing..." : "Disabling native resizing...";
+    #|        try {
+    #|          const reply = await invoke(resizable);
+    #|          render(reply.resizable, reply.message);
+    #|        } catch (error) {
+    #|          status.textContent = `request failed: ${String(error)}`;
+    #|        }
+    #|      }
+    #|      document.querySelector("#enable").addEventListener("click", () => void setResizable(true));
+    #|      document.querySelector("#disable").addEventListener("click", () => void setResizable(false));
+    #|      document.querySelector("#toggle").addEventListener("click", () => void setResizable(!current));
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Resizable", html(), width=820, height=620, debug=true)
+  .identifier("dev.proton.window-resizable")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      resizable_state.val = true
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/61_window_resizable/moon.pkg
+++ b/examples/61_window_resizable/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/61_window_resizable/pkg.generated.mbti
+++ b/examples/61_window_resizable/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/61_window_resizable"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type SetResizableReply derive(ToJson, @json.FromJson)
+pub fn SetResizableReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetResizableReply::to_json(Self) -> Json
+
+type SetResizableRequest derive(ToJson, @json.FromJson)
+pub fn SetResizableRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetResizableRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -101,6 +101,8 @@ moon -C examples run 01_run --target native
 - `60_window_attention`: manual Electron-style window attention review with
   macOS Dock bouncing, Windows taskbar flashing, Linux urgency hints,
   activation cancellation, and timed explicit cancellation.
+- `61_window_resizable`: manual Electron-style live window resizing review with
+  enable, disable, toggle, and cross-platform native frame checks.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -145,6 +145,11 @@ fn RuntimeSession::window_handle(
         window.set_always_on_top(always_on_top)
       })
     },
+    set_window_resizable: resizable => {
+      self.control_window(id, native_id, "set resizable", window => {
+        window.set_resizable(resizable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1079,6 +1084,19 @@ pub fn WindowHandle::set_always_on_top(
   always_on_top : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_always_on_top)(always_on_top)
+}
+
+///|
+/// Sets whether the user can manually resize this window.
+///
+/// This changes the live native window on macOS, Windows, and Linux. Existing
+/// minimum or maximum size hints remain in effect. Headless runtimes raise
+/// `WindowSessionError`.
+pub fn WindowHandle::set_resizable(
+  self : WindowHandle,
+  resizable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_resizable)(resizable)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -427,6 +427,7 @@ pub struct WindowHandle {
   set_window_fullscreen : (Bool) -> Unit raise WindowSessionError
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
+  set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -61,6 +61,7 @@ fn test_window_handle(
   popup_calls? : Array[String],
   progress_calls? : Array[Double],
   flash_calls? : Array[Bool],
+  resizable_calls? : Array[Bool],
 ) -> WindowHandle {
   let browser = BrowserHandle::{
     id,
@@ -85,6 +86,12 @@ fn test_window_handle(
     set_window_fullscreen: fn(_fullscreen) {  },
     set_window_position: fn(_x, _y) {  },
     set_window_always_on_top: fn(_always_on_top) {  },
+    set_window_resizable: resizable => {
+      match resizable_calls {
+        Some(calls) => calls.push(resizable)
+        None => ()
+      }
+    },
     set_window_zoom_percent: fn(_zoom_percent) {  },
     set_window_progress_bar: progress => {
       match progress_calls {
@@ -1934,6 +1941,15 @@ test "window attention routes Electron-compatible flags through the handle" {
   window.flash_frame(true)
   window.flash_frame(false)
   debug_inspect(calls, content="[true, false]")
+}
+
+///|
+test "window resizable routes live capability changes through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, resizable_calls=calls)
+  window.set_resizable(false)
+  window.set_resizable(true)
+  debug_inspect(calls, content="[false, true]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -441,6 +441,12 @@ pub extern "C" fn proton_window_set_always_on_top_ffi(
 ) -> Int = "proton_window_set_always_on_top"
 
 ///|
+pub extern "C" fn proton_window_set_resizable_ffi(
+  window : WindowHandle,
+  resizable : Int,
+) -> Int = "proton_window_set_resizable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -154,6 +154,8 @@ int32_t proton_window_set_position(proton_window_handle_t window,
                                               int32_t x, int32_t y);
 int32_t proton_window_set_always_on_top(proton_window_handle_t window,
                                                    int32_t always_on_top);
+int32_t proton_window_set_resizable(proton_window_handle_t window,
+                                    int32_t resizable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -214,6 +214,8 @@ pub fn proton_window_set_position_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_progress_bar_ffi(WindowHandle, Double) -> Int
 
+pub fn proton_window_set_resizable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_title_ffi(WindowHandle, Bytes) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -892,6 +892,9 @@ int32_t proton_engine_window_apply(
                               action->value != 0);
     window->always_on_top = action->value != 0;
     break;
+  case PROTON_ENGINE_WINDOW_SET_RESIZABLE:
+    gtk_window_set_resizable(GTK_WINDOW(window->window), action->value != 0);
+    break;
   default:
     proton_engine_set_message(error, error_len, "unknown window action");
     return PROTON_ERR_INVALID_ARGUMENT;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1307,6 +1307,16 @@ int32_t proton_engine_window_apply(
     window->window.level =
         action->value != 0 ? NSFloatingWindowLevel : NSNormalWindowLevel;
     break;
+  case PROTON_ENGINE_WINDOW_SET_RESIZABLE: {
+    NSWindowStyleMask style = window->window.styleMask;
+    if (action->value != 0) {
+      style |= NSWindowStyleMaskResizable;
+    } else {
+      style &= ~NSWindowStyleMaskResizable;
+    }
+    window->window.styleMask = style;
+    break;
+  }
   default:
     proton_engine_set_message(error, error_len,
                               "unknown window action");

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -77,6 +77,7 @@ struct proton_engine_window {
   int osr_popup_visible;
   cef_rect_t osr_popup_rect;
   int size_hint;
+  int resizable;
   int titlebar_overlay;
   int fullscreen;
   int always_on_top;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -120,12 +120,12 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
           handled = true;
         }
       }
-      if (window->size_hint == 1 || window->size_hint == 2) {
+      if (!window->resizable || window->size_hint == 2) {
         minmax->ptMinTrackSize.x = window->width;
         minmax->ptMinTrackSize.y = window->height;
         handled = true;
       }
-      if (window->size_hint == 1 || window->size_hint == 3) {
+      if (!window->resizable || window->size_hint == 3) {
         minmax->ptMaxTrackSize.x = window->width;
         minmax->ptMaxTrackSize.y = window->height;
         handled = true;
@@ -399,6 +399,7 @@ int32_t proton_engine_window_create(
   window->height = config.height;
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
+  window->resizable = config.size_hint != 1;
   window->titlebar_overlay = config.titlebar_overlay;
   window->zoom_percent = 100;
   window->windowed_placement.length = sizeof(WINDOWPLACEMENT);
@@ -815,6 +816,26 @@ int32_t proton_engine_window_apply(
                  SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     window->always_on_top = action->value != 0;
     break;
+  case PROTON_ENGINE_WINDOW_SET_RESIZABLE: {
+    LONG style = GetWindowLongW(window->hwnd, GWL_STYLE);
+    if (action->value != 0) {
+      style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
+    } else {
+      style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
+    }
+    SetLastError(0);
+    if (SetWindowLongW(window->hwnd, GWL_STYLE, style) == 0 &&
+        GetLastError() != 0) {
+      proton_engine_set_message(error, error_len,
+                                "failed to update window style");
+      return PROTON_ERR_PLATFORM;
+    }
+    window->resizable = action->value != 0;
+    SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                     SWP_FRAMECHANGED);
+    break;
+  }
   default:
     proton_engine_set_message(error, error_len, "unknown window action");
     return PROTON_ERR_INVALID_ARGUMENT;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -926,6 +926,19 @@ int32_t proton_window_set_always_on_top(proton_window_handle_t window,
   return proton_window_apply_action(window, &action);
 }
 
+int32_t proton_window_set_resizable(proton_window_handle_t window,
+                                    int32_t resizable) {
+  if (resizable != 0 && resizable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "resizable must be 0 or 1");
+  }
+  const proton_engine_window_action_t action = {
+      .kind = PROTON_ENGINE_WINDOW_SET_RESIZABLE,
+      .value = resizable,
+  };
+  return proton_window_apply_action(window, &action);
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -80,6 +80,7 @@ typedef enum {
   PROTON_ENGINE_WINDOW_SET_POSITION = 5,
   PROTON_ENGINE_WINDOW_SET_ALWAYS_ON_TOP = 6,
   PROTON_ENGINE_WINDOW_SET_ZOOM_PERCENT = 7,
+  PROTON_ENGINE_WINDOW_SET_RESIZABLE = 8,
 } proton_engine_window_action_kind_t;
 
 typedef struct {

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1341,6 +1341,24 @@ pub fn Window::set_always_on_top(
 }
 
 ///|
+/// Sets whether the live native window can be manually resized.
+pub fn Window::set_resizable(
+  self : Window,
+  resizable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_resizable_ffi(
+      self.live_handle(),
+      if resizable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -569,6 +569,7 @@ pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_position(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
+pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -596,6 +596,7 @@ pub struct WindowHandle {
   set_window_fullscreen : (Bool) -> Unit raise WindowSessionError
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
+  set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -622,6 +623,7 @@ pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionEr
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add `WindowHandle::set_resizable(Bool)` for live native windows
- implement the native action on macOS, Windows, and Linux while preserving configured size hints
- add `61_window_resizable` for manual enable/disable/toggle review

## Platform impact

- macOS toggles `NSWindowStyleMaskResizable`
- Windows toggles `WS_THICKFRAME | WS_MAXIMIZEBOX` and refreshes the non-client frame
- Linux uses `gtk_window_set_resizable`
- headless runtimes return unsupported through the existing native action path

## Validation

- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test internal/native --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

```sh
moon -C examples run 61_window_resizable --target native
```

Resize the window, disable resizing and retry the edge gesture, then re-enable resizing without restarting.