### PR TITLE
feat(window): add runtime minimum and maximum size constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ See `examples/48_titlebar_overlay` for a cross-platform overlay layout example.
 The primary entry constructors accept `resizable=false` for a fixed window.
 Secondary windows can select `WindowSizeHint::Unconstrained`, `Fixed`, `Min`,
 or `Max`; minimum and maximum hints constrain resizing relative to the
-configured width and height.
+configured width and height. A running `WindowHandle` can also update those
+constraints with `set_minimum_size` and `set_maximum_size`; pass `(0, 0)` to
+clear a constraint. See `examples/62_window_size_limits` for a manual review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:

--- a/examples/62_window_size_limits/README.md
+++ b/examples/62_window_size_limits/README.md
@@ -1,0 +1,30 @@
+# Window Size Limits
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_minimum_size` and `WindowHandle::set_maximum_size` APIs.
+
+Run it with:
+
+```sh
+moon -C examples run 62_window_size_limits --target native
+```
+
+Review the native window frame:
+
+1. Set the minimum to `480 x 360`, then drag a corner smaller.
+2. Set the maximum to `1100 x 760`, then drag a corner larger.
+3. Clear each constraint independently and confirm the other remains active.
+4. On Windows with display scaling above 100%, confirm the native frame obeys
+   the same limits.
+
+Platform details:
+
+- macOS updates the window content minimum and maximum sizes.
+- Windows applies the limits through `WM_GETMINMAXINFO` and preserves the
+  independent `set_resizable` state.
+- Linux updates GTK geometry hints; the exact resize affordance depends on
+  the desktop window manager.
+- Headless runtimes report unsupported because they have no native frame.
+
+Passing `(0, 0)` clears a constraint. Both dimensions must be positive when a
+constraint is set, and minimum/maximum pairs may not conflict.

--- a/examples/62_window_size_limits/main.mbt
+++ b/examples/62_window_size_limits/main.mbt
@@ -1,0 +1,232 @@
+///|
+struct SetLimitRequest {
+  kind : String
+  width : Int
+  height : Int
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetLimitRequest with ToJson::{to_json}
+
+///|
+pub extend SetLimitRequest with FromJson::{from_json}
+
+///|
+struct SetLimitReply {
+  applied : Bool
+  minimum : String
+  maximum : String
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend SetLimitReply with ToJson::{to_json}
+
+///|
+pub extend SetLimitReply with FromJson::{from_json}
+
+///|
+let limits_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-size-limits",
+  js_namespace="windowSizeLimits",
+)
+
+///|
+let set_limit_command : @proton_contract.Command[SetLimitRequest, SetLimitReply] = limits_contract.command(
+  "set",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let minimum_limit : Ref[(Int, Int)] = { val: (0, 0), }
+
+///|
+let maximum_limit : Ref[(Int, Int)] = { val: (0, 0), }
+
+///|
+fn format_limit(limit : (Int, Int)) -> String {
+  let (width, height) = limit
+  if width == 0 && height == 0 {
+    "none"
+  } else {
+    width.to_string() + " x " + height.to_string()
+  }
+}
+
+///|
+fn set_limit(request : SetLimitRequest) -> SetLimitReply {
+  match window_slot.val {
+    Some(window) => {
+      if request.kind != "minimum" && request.kind != "maximum" {
+        return SetLimitReply::{
+          applied: false,
+          minimum: format_limit(minimum_limit.val),
+          maximum: format_limit(maximum_limit.val),
+          message: "kind must be minimum or maximum",
+        }
+      }
+      try {
+        match request.kind {
+          "minimum" => {
+            window.set_minimum_size(request.width, request.height)
+            minimum_limit.val = (request.width, request.height)
+          }
+          "maximum" => {
+            window.set_maximum_size(request.width, request.height)
+            maximum_limit.val = (request.width, request.height)
+          }
+          _ => ()
+        }
+        SetLimitReply::{
+          applied: true,
+          minimum: format_limit(minimum_limit.val),
+          maximum: format_limit(maximum_limit.val),
+          message: request.kind + " constraint updated",
+        }
+      } catch {
+        error =>
+          SetLimitReply::{
+            applied: false,
+            minimum: format_limit(minimum_limit.val),
+            maximum: format_limit(maximum_limit.val),
+            message: error.message(),
+          }
+      }
+    }
+    None =>
+      SetLimitReply::{
+        applied: false,
+        minimum: format_limit(minimum_limit.val),
+        maximum: format_limit(maximum_limit.val),
+        message: "window is not ready",
+      }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(set_limit_command, (_context, request) => set_limit(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Size Limits</title>
+    #|    <style>
+    #|      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #11100f; color: #f3eee8; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #11100f; }
+    #|      button { font: inherit; }
+    #|      main { width: min(850px, calc(100vw - 40px)); margin: 0 auto; padding: 42px 0 50px; }
+    #|      header { padding-bottom: 24px; border-bottom: 1px solid #403930; }
+    #|      .eyebrow { margin: 0 0 10px; color: #e7ad64; font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .16em; text-transform: uppercase; }
+    #|      h1 { margin: 0; max-width: 620px; font-size: clamp(34px, 6vw, 54px); line-height: .98; letter-spacing: -.055em; }
+    #|      .summary { max-width: 620px; margin: 14px 0 0; color: #b5a99d; line-height: 1.55; }
+    #|      .limits { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 13px; margin-top: 20px; }
+    #|      .limit { border: 1px solid #594b3f; border-radius: 10px; padding: 17px; background: #1a1714; }
+    #|      .limit small { display: block; color: #ae9a87; font: 700 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .12em; text-transform: uppercase; }
+    #|      .limit strong { display: block; margin-top: 9px; color: #ffe2b5; font: 700 24px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      .layout { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(260px, .8fr); gap: 16px; margin-top: 16px; }
+    #|      .panel { border: 1px solid #403930; border-radius: 14px; background: #171411; overflow: hidden; }
+    #|      .panel-head { display: flex; justify-content: space-between; gap: 12px; min-height: 48px; padding: 0 17px; align-items: center; border-bottom: 1px solid #403930; color: #b5a99d; font: 650 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; }
+    #|      .surface { min-height: 250px; padding: 27px; background: radial-gradient(circle at 70% 25%, #54351d 0, #2c2118 37%, #171411 76%); }
+    #|      .surface h2 { margin: 0 0 9px; font-size: 23px; letter-spacing: -.03em; }
+    #|      .surface p { max-width: 410px; margin: 0; color: #c6b8aa; line-height: 1.6; }
+    #|      .controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; padding: 15px 17px; border-top: 1px solid #403930; }
+    #|      button { min-height: 43px; border: 1px solid #6b5745; border-radius: 8px; padding: 0 12px; background: #282019; color: #f5eadf; cursor: pointer; font-weight: 720; }
+    #|      button:hover { border-color: #e7ad64; background: #372719; }
+    #|      button:focus-visible { outline: 3px solid #e7ad6466; outline-offset: 3px; }
+    #|      button.primary { border-color: #b97b37; background: #794b1e; }
+    #|      button.primary:hover { background: #95602a; }
+    #|      .review { padding: 20px; }
+    #|      .review h2 { margin: 0 0 14px; font-size: 16px; }
+    #|      .checklist { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; }
+    #|      .checklist li { position: relative; padding-left: 25px; color: #c6b8aa; font-size: 13px; line-height: 1.5; }
+    #|      .checklist li::before { content: ""; position: absolute; left: 1px; top: 5px; width: 10px; height: 10px; border: 1px solid #d19350; border-radius: 3px; }
+    #|      #status { min-height: 35px; margin: 18px 0 0; color: #e7ad64; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      @media (max-width: 720px) { .layout { grid-template-columns: 1fr; } }
+    #|      @media (max-width: 480px) { main { padding-top: 28px; } .limits, .controls { grid-template-columns: 1fr; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <p class="eyebrow">Native surface / manual test 62</p>
+    #|        <h1>Window size limits</h1>
+    #|        <p class="summary">Set live minimum and maximum bounds, resize against each edge, then clear both constraints without restarting the native window.</p>
+    #|      </header>
+    #|      <section class="limits">
+    #|        <div class="limit"><small>Minimum size</small><strong id="minimum">none</strong></div>
+    #|        <div class="limit"><small>Maximum size</small><strong id="maximum">none</strong></div>
+    #|      </section>
+    #|      <div class="layout">
+    #|        <section class="panel">
+    #|          <div class="panel-head"><strong>Window frame</strong><span>drag any edge</span></div>
+    #|          <div class="surface"><h2>Constraints live outside the page</h2><p>The buttons below update the native frame. The renderer only mirrors the values returned by the typed command.</p></div>
+    #|          <div class="controls">
+    #|            <button id="min" class="primary" type="button">Minimum 480 x 360</button>
+    #|            <button id="clear-min" type="button">Clear minimum</button>
+    #|            <button id="max" class="primary" type="button">Maximum 1100 x 760</button>
+    #|            <button id="clear-max" type="button">Clear maximum</button>
+    #|          </div>
+    #|        </section>
+    #|        <aside class="panel review">
+    #|          <h2>Manual review</h2>
+    #|          <ul class="checklist">
+    #|            <li>Set the minimum, then drag the lower-left corner smaller. The window should stop at 480 x 360.</li>
+    #|            <li>Set the maximum, then drag the upper-right corner larger. The window should stop at 1100 x 760.</li>
+    #|            <li>Clear each constraint independently and confirm the other one remains active.</li>
+    #|            <li>On Windows above 100% display scaling, confirm the native frame obeys the same bounds.</li>
+    #|            <li>On Linux, the exact resize affordance depends on the desktop window manager.</li>
+    #|          </ul>
+    #|          <p id="status" role="status" aria-live="polite">Ready. No live size constraints are set.</p>
+    #|        </aside>
+    #|      </div>
+    #|    </main>
+    #|    <script>
+    #|      const minimum = document.querySelector("#minimum");
+    #|      const maximum = document.querySelector("#maximum");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (kind, width, height) => window.__MoonBit__.core.invokeOp("ext:windowSizeLimits/set", { kind, width, height });
+    #|      function render(reply) {
+    #|        minimum.textContent = reply.minimum;
+    #|        maximum.textContent = reply.maximum;
+    #|        status.textContent = reply.message;
+    #|      }
+    #|      async function setLimit(kind, width, height) {
+    #|        status.textContent = `Updating ${kind} constraint...`;
+    #|        try { render(await invoke(kind, width, height)); }
+    #|        catch (error) { status.textContent = `request failed: ${String(error)}`; }
+    #|      }
+    #|      document.querySelector("#min").addEventListener("click", () => void setLimit("minimum", 480, 360));
+    #|      document.querySelector("#clear-min").addEventListener("click", () => void setLimit("minimum", 0, 0));
+    #|      document.querySelector("#max").addEventListener("click", () => void setLimit("maximum", 1100, 760));
+    #|      document.querySelector("#clear-max").addEventListener("click", () => void setLimit("maximum", 0, 0));
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Size Limits", html(), width=850, height=640, debug=true)
+  .identifier("dev.proton.window-size-limits")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/62_window_size_limits/moon.pkg
+++ b/examples/62_window_size_limits/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/62_window_size_limits/pkg.generated.mbti
+++ b/examples/62_window_size_limits/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/62_window_size_limits"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type SetLimitReply derive(ToJson, @json.FromJson)
+pub fn SetLimitReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetLimitReply::to_json(Self) -> Json
+
+type SetLimitRequest derive(ToJson, @json.FromJson)
+pub fn SetLimitRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SetLimitRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -103,6 +103,8 @@ moon -C examples run 01_run --target native
   activation cancellation, and timed explicit cancellation.
 - `61_window_resizable`: manual Electron-style live window resizing review with
   enable, disable, toggle, and cross-platform native frame checks.
+- `62_window_size_limits`: manual Electron-style minimum and maximum window
+  size review with live constraint updates and clear operations.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -150,6 +150,16 @@ fn RuntimeSession::window_handle(
         window.set_resizable(resizable)
       })
     },
+    set_window_minimum_size: (width, height) => {
+      self.control_window(id, native_id, "set minimum size", window => {
+        window.set_minimum_size(width, height)
+      })
+    },
+    set_window_maximum_size: (width, height) => {
+      self.control_window(id, native_id, "set maximum size", window => {
+        window.set_maximum_size(width, height)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1097,6 +1107,34 @@ pub fn WindowHandle::set_resizable(
   resizable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_resizable)(resizable)
+}
+
+///|
+/// Sets the minimum live native window size.
+///
+/// Both dimensions must be positive, or both must be zero to clear the
+/// constraint. Existing maximum size and resizable state remain unchanged.
+/// Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_minimum_size(
+  self : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Unit raise WindowSessionError {
+  (self.set_window_minimum_size)(width, height)
+}
+
+///|
+/// Sets the maximum live native window size.
+///
+/// Both dimensions must be positive, or both must be zero to clear the
+/// constraint. Existing minimum size and resizable state remain unchanged.
+/// Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_maximum_size(
+  self : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Unit raise WindowSessionError {
+  (self.set_window_maximum_size)(width, height)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -428,6 +428,8 @@ pub struct WindowHandle {
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
+  set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -62,6 +62,8 @@ fn test_window_handle(
   progress_calls? : Array[Double],
   flash_calls? : Array[Bool],
   resizable_calls? : Array[Bool],
+  minimum_size_calls? : Array[(Int, Int)],
+  maximum_size_calls? : Array[(Int, Int)],
 ) -> WindowHandle {
   let browser = BrowserHandle::{
     id,
@@ -89,6 +91,18 @@ fn test_window_handle(
     set_window_resizable: resizable => {
       match resizable_calls {
         Some(calls) => calls.push(resizable)
+        None => ()
+      }
+    },
+    set_window_minimum_size: (width, height) => {
+      match minimum_size_calls {
+        Some(calls) => calls.push((width, height))
+        None => ()
+      }
+    },
+    set_window_maximum_size: (width, height) => {
+      match maximum_size_calls {
+        Some(calls) => calls.push((width, height))
         None => ()
       }
     },
@@ -1950,6 +1964,24 @@ test "window resizable routes live capability changes through the handle" {
   window.set_resizable(false)
   window.set_resizable(true)
   debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window size limits route live constraints through the handle" {
+  let minimum_calls : Array[(Int, Int)] = []
+  let maximum_calls : Array[(Int, Int)] = []
+  let window = test_window_handle(
+    "main",
+    17L,
+    minimum_size_calls=minimum_calls,
+    maximum_size_calls=maximum_calls,
+  )
+  window.set_minimum_size(640, 480)
+  window.set_minimum_size(0, 0)
+  window.set_maximum_size(1280, 900)
+  window.set_maximum_size(0, 0)
+  debug_inspect(minimum_calls, content="[(640, 480), (0, 0)]")
+  debug_inspect(maximum_calls, content="[(1280, 900), (0, 0)]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -447,6 +447,20 @@ pub extern "C" fn proton_window_set_resizable_ffi(
 ) -> Int = "proton_window_set_resizable"
 
 ///|
+pub extern "C" fn proton_window_set_minimum_size_ffi(
+  window : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Int = "proton_window_set_minimum_size"
+
+///|
+pub extern "C" fn proton_window_set_maximum_size_ffi(
+  window : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Int = "proton_window_set_maximum_size"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -156,6 +156,10 @@ int32_t proton_window_set_always_on_top(proton_window_handle_t window,
                                                    int32_t always_on_top);
 int32_t proton_window_set_resizable(proton_window_handle_t window,
                                     int32_t resizable);
+int32_t proton_window_set_minimum_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height);
+int32_t proton_window_set_maximum_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -210,6 +210,10 @@ pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int
+
+pub fn proton_window_set_minimum_size_ffi(WindowHandle, Int, Int) -> Int
+
 pub fn proton_window_set_position_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_progress_bar_ffi(WindowHandle, Double) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -93,6 +93,10 @@ struct proton_engine_window {
   proton_engine_bridge_lifecycle_t bridge_lifecycle;
   int width;
   int height;
+  int min_width;
+  int min_height;
+  int max_width;
+  int max_height;
   int headless;
   int headless_hidden;
   int osr_popup_visible;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -50,6 +50,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+static void proton_engine_apply_size_constraints(
+    proton_engine_window_t *window) {
+  if (window == NULL || window->window == NULL || window->headless) {
+    return;
+  }
+  GdkGeometry geometry = {0};
+  GdkWindowHints hints = 0;
+  if (window->min_width > 0) {
+    geometry.min_width = window->min_width;
+    geometry.min_height = window->min_height;
+    hints = (GdkWindowHints)(hints | GDK_HINT_MIN_SIZE);
+  }
+  if (window->max_width > 0) {
+    geometry.max_width = window->max_width;
+    geometry.max_height = window->max_height;
+    hints = (GdkWindowHints)(hints | GDK_HINT_MAX_SIZE);
+  }
+  gtk_window_set_geometry_hints(GTK_WINDOW(window->window), NULL,
+                                hints == 0 ? NULL : &geometry, hints);
+}
+
 static gboolean proton_engine_on_window_delete(GtkWidget *widget,
                                                GdkEvent *event,
                                                gpointer user_data) {
@@ -409,6 +430,10 @@ int32_t proton_engine_window_create(
   window->public_window_id = config.public_window;
   window->width = config.width;
   window->height = config.height;
+  window->min_width = config.size_hint == 2 ? config.width : 0;
+  window->min_height = config.size_hint == 2 ? config.height : 0;
+  window->max_width = config.size_hint == 3 ? config.width : 0;
+  window->max_height = config.size_hint == 3 ? config.height : 0;
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
   window->titlebar_overlay = config.titlebar_overlay;
@@ -478,20 +503,8 @@ int32_t proton_engine_window_create(
                                 config.height);
     if (config.size_hint == 1) {
       gtk_window_set_resizable(GTK_WINDOW(window->window), FALSE);
-    } else if (config.size_hint == 2 || config.size_hint == 3) {
-      GdkGeometry geometry = {0};
-      GdkWindowHints hints = config.size_hint == 2 ? GDK_HINT_MIN_SIZE
-                                                   : GDK_HINT_MAX_SIZE;
-      if (config.size_hint == 2) {
-        geometry.min_width = config.width;
-        geometry.min_height = config.height;
-      } else {
-        geometry.max_width = config.width;
-        geometry.max_height = config.height;
-      }
-      gtk_window_set_geometry_hints(GTK_WINDOW(window->window), NULL,
-                                    &geometry, hints);
     }
+    proton_engine_apply_size_constraints(window);
     if (window->titlebar_overlay) {
       gtk_window_set_decorated(GTK_WINDOW(window->window), FALSE);
       window->overlay = gtk_overlay_new();
@@ -791,6 +804,56 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   } else {
     gtk_window_resize(GTK_WINDOW(window->window), width, height);
   }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_minimum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->max_width > 0 &&
+      (width > window->max_width || height > window->max_height)) {
+    proton_engine_set_message(error, error_len,
+                              "minimum size exceeds maximum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->min_width = width;
+  window->min_height = height;
+  proton_engine_apply_size_constraints(window);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_maximum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->min_width > 0 &&
+      (width < window->min_width || height < window->min_height)) {
+    proton_engine_set_message(error, error_len,
+                              "maximum size is below minimum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->max_width = width;
+  window->max_height = height;
+  proton_engine_apply_size_constraints(window);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -156,6 +156,10 @@ struct proton_engine_window {
   uint64_t native_id;
   int width;
   int height;
+  int min_width;
+  int min_height;
+  int max_width;
+  int max_height;
   int zoom_percent;
   NSInteger attention_request_id;
   int headless;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -34,6 +34,21 @@ static proton_engine_window_t *g_dock_progress_owner = NULL;
 static NSImageView *g_dock_progress_content = nil;
 static NSProgressIndicator *g_dock_progress_indicator = nil;
 
+static void proton_engine_apply_size_constraints(
+    proton_engine_window_t *window) {
+  if (window == NULL || window->window == nil) {
+    return;
+  }
+  [window->window
+      setContentMinSize:window->min_width > 0
+                        ? NSMakeSize(window->min_width, window->min_height)
+                        : NSZeroSize];
+  [window->window
+      setContentMaxSize:window->max_width > 0
+                        ? NSMakeSize(window->max_width, window->max_height)
+                        : NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX)];
+}
+
 static void proton_engine_dock_progress_clear(void) {
   if (g_dock_progress_indicator != nil) {
     [g_dock_progress_indicator stopAnimation:nil];
@@ -718,6 +733,10 @@ int32_t proton_engine_window_create(
   }
   window->width = config.width;
   window->height = config.height;
+  window->min_width = config.size_hint == 2 ? config.width : 0;
+  window->min_height = config.size_hint == 2 ? config.height : 0;
+  window->max_width = config.size_hint == 3 ? config.width : 0;
+  window->max_height = config.size_hint == 3 ? config.height : 0;
   window->zoom_percent = 100;
   window->headless = runtime->headless;
   window->bridge_config_json =
@@ -781,12 +800,7 @@ int32_t proton_engine_window_create(
     [window->window setRestorable:NO];
     [window->window disableSnapshotRestoration];
     [window->window setTitle:title != nil ? title : @"Proton"];
-    NSSize configured_size = NSMakeSize(config.width, config.height);
-    if (config.size_hint == 2) {
-      [window->window setContentMinSize:configured_size];
-    } else if (config.size_hint == 3) {
-      [window->window setContentMaxSize:configured_size];
-    }
+    proton_engine_apply_size_constraints(window);
     if (config.titlebar_overlay) {
       [window->window setTitleVisibility:NSWindowTitleHidden];
       [window->window setTitlebarAppearsTransparent:YES];
@@ -1143,6 +1157,56 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
     frame.size.height = height;
     [window->window setFrame:frame display:YES animate:NO];
   }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_minimum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->max_width > 0 &&
+      (width > window->max_width || height > window->max_height)) {
+    proton_engine_set_message(error, error_len,
+                              "minimum size exceeds maximum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->min_width = width;
+  window->min_height = height;
+  proton_engine_apply_size_constraints(window);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_maximum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->min_width > 0 &&
+      (width < window->min_width || height < window->min_height)) {
+    proton_engine_set_message(error, error_len,
+                              "maximum size is below minimum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->max_width = width;
+  window->max_height = height;
+  proton_engine_apply_size_constraints(window);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -78,6 +78,10 @@ struct proton_engine_window {
   cef_rect_t osr_popup_rect;
   int size_hint;
   int resizable;
+  int min_width;
+  int min_height;
+  int max_width;
+  int max_height;
   int titlebar_overlay;
   int fullscreen;
   int always_on_top;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -120,12 +120,22 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
           handled = true;
         }
       }
-      if (!window->resizable || window->size_hint == 2) {
+      if (!window->resizable) {
         minmax->ptMinTrackSize.x = window->width;
         minmax->ptMinTrackSize.y = window->height;
         handled = true;
       }
-      if (!window->resizable || window->size_hint == 3) {
+      if (window->resizable && window->min_width > 0) {
+        minmax->ptMinTrackSize.x = window->min_width;
+        minmax->ptMinTrackSize.y = window->min_height;
+        handled = true;
+      }
+      if (window->resizable && window->max_width > 0) {
+        minmax->ptMaxTrackSize.x = window->max_width;
+        minmax->ptMaxTrackSize.y = window->max_height;
+        handled = true;
+      }
+      if (!window->resizable) {
         minmax->ptMaxTrackSize.x = window->width;
         minmax->ptMaxTrackSize.y = window->height;
         handled = true;
@@ -400,6 +410,10 @@ int32_t proton_engine_window_create(
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
   window->resizable = config.size_hint != 1;
+  window->min_width = config.size_hint == 2 ? config.width : 0;
+  window->min_height = config.size_hint == 2 ? config.height : 0;
+  window->max_width = config.size_hint == 3 ? config.width : 0;
+  window->max_height = config.size_hint == 3 ? config.height : 0;
   window->titlebar_overlay = config.titlebar_overlay;
   window->zoom_percent = 100;
   window->windowed_placement.length = sizeof(WINDOWPLACEMENT);
@@ -551,6 +565,54 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   } else {
     ShowWindow(window->hwnd, SW_SHOW);
   }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_minimum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->max_width > 0 &&
+      (width > window->max_width || height > window->max_height)) {
+    proton_engine_set_message(error, error_len,
+                              "minimum size exceeds maximum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->min_width = width;
+  window->min_height = height;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_maximum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window size constraints are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (width > 0 && window->min_width > 0 &&
+      (width < window->min_width || height < window->min_height)) {
+    proton_engine_set_message(error, error_len,
+                              "maximum size is below minimum size");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  window->max_width = width;
+  window->max_height = height;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -939,6 +939,68 @@ int32_t proton_window_set_resizable(proton_window_handle_t window,
   return proton_window_apply_action(window, &action);
 }
 
+static int32_t proton_validate_size_constraint(int32_t width, int32_t height,
+                                               const char *name) {
+  if ((width == 0 && height == 0) || (width > 0 && height > 0)) {
+    return PROTON_OK;
+  }
+  char message[128];
+  snprintf(message, sizeof(message),
+           "%s size must use two positive dimensions or (0, 0) to clear",
+           name);
+  return proton_set_error(PROTON_ERR_INVALID_ARGUMENT, message);
+}
+
+int32_t proton_window_set_minimum_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height) {
+  int32_t status = proton_validate_size_constraint(width, height, "minimum");
+  if (status != PROTON_OK) {
+    return status;
+  }
+  proton_window_slot_t *slot = NULL;
+  status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window size constraints require native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_minimum_size(
+      slot->engine_window, width, height, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_set_maximum_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height) {
+  int32_t status = proton_validate_size_constraint(width, height, "maximum");
+  if (status != PROTON_OK) {
+    return status;
+  }
+  proton_window_slot_t *slot = NULL;
+  status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window size constraints require native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_maximum_size(
+      slot->engine_window, width, height, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -209,6 +209,12 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t height,
                                       char *error,
                                       size_t error_len);
+int32_t proton_engine_window_set_minimum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len);
+int32_t proton_engine_window_set_maximum_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -223,6 +223,22 @@ fn window_size_hint_code(value : WindowSizeHint) -> Int {
 }
 
 ///|
+fn validate_size_constraint(
+  width : Int,
+  height : Int,
+  name : String,
+) -> Unit raise NativeError {
+  if width == 0 && height == 0 {
+    return
+  }
+  if width <= 0 || height <= 0 {
+    raise invalid_argument(
+      name + " size must use two positive dimensions or (0, 0) to clear",
+    )
+  }
+}
+
+///|
 fn browser_policy_code(value : BrowserPolicyMode) -> Int {
   match value {
     Allow => 0
@@ -1354,6 +1370,40 @@ pub fn Window::set_resizable(
       } else {
         0
       },
+    ),
+  )
+}
+
+///|
+/// Sets the minimum live native window size. `(0, 0)` clears the constraint.
+pub fn Window::set_minimum_size(
+  self : Window,
+  width : Int,
+  height : Int,
+) -> Unit raise NativeError {
+  validate_size_constraint(width, height, "minimum")
+  check_status(
+    @native_ffi.proton_window_set_minimum_size_ffi(
+      self.live_handle(),
+      width,
+      height,
+    ),
+  )
+}
+
+///|
+/// Sets the maximum live native window size. `(0, 0)` clears the constraint.
+pub fn Window::set_maximum_size(
+  self : Window,
+  width : Int,
+  height : Int,
+) -> Unit raise NativeError {
+  validate_size_constraint(width, height, "maximum")
+  check_status(
+    @native_ffi.proton_window_set_maximum_size_ffi(
+      self.live_handle(),
+      width,
+      height,
     ),
   )
 }

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -263,6 +263,16 @@ test "window config preserves typed native ABI values" {
 }
 
 ///|
+test "size constraints accept positive pairs and the clear pair" {
+  validate_size_constraint(640, 480, "minimum")
+  validate_size_constraint(0, 0, "maximum")
+  let error = expect_native_error(() => {
+    validate_size_constraint(0, 480, "minimum")
+  })
+  assert_true(error.message().contains("two positive dimensions"))
+}
+
+///|
 test "bridge config retains typed renderer policy" {
   let bridge_config = BridgeConfig(grants=[
     BridgeGrantConfig("app", ops=["ext:app/ping"]),

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -567,6 +567,8 @@ pub fn Window::restore(Self) -> Unit raise NativeError
 pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
+pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_position(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -597,6 +597,8 @@ pub struct WindowHandle {
   set_window_position : (Int, Int) -> Unit raise WindowSessionError
   set_window_always_on_top : (Bool) -> Unit raise WindowSessionError
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
+  set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -621,6 +623,8 @@ pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_minimum_size` and `set_maximum_size` APIs
- keep minimum and maximum constraints independent; `(0, 0)` clears either constraint
- implement native enforcement on macOS, Windows, and Linux
- add `examples/62_window_size_limits` for manual native-frame review

## Validation

- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test internal/native --target native --diagnostic-limit 120`
- `moon -C proton test --target native --diagnostic-limit 120`
- `moon -C examples check 62_window_size_limits --target native --diagnostic-limit 120`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

Run on macOS:

```sh
moon -C examples run 62_window_size_limits --target native
```

Set and clear both constraints, then resize the native frame against each edge. Windows and Linux implementations are included and covered by CI; the example README records platform-specific review notes.
