### PR TITLE
feat(window): add Electron-style work-area centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ or `Max`; minimum and maximum hints constrain resizing relative to the
 configured width and height. A running `WindowHandle` can also update those
 constraints with `set_minimum_size` and `set_maximum_size`; pass `(0, 0)` to
 clear a constraint. See `examples/62_window_size_limits` for a manual review.
+`WindowHandle::center` places a live window in the work area of its current
+monitor while preserving its size. See `examples/63_window_center` for a
+manual review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:
@@ -189,7 +192,9 @@ template without creating it; `WindowManager::open` creates a fresh concrete
 instance when the application needs it. `WindowHandle` supports show, hide,
 focus, close, title, size, position, minimize, maximize, restore, fullscreen,
 always-on-top, zoom, and a `WindowState` snapshot containing the current
-monitor, work area, scale factor, focus, and theme.
+monitor, work area, scale factor, focus, and theme. `WindowHandle::center`
+centers a live window within that monitor's work area without changing its
+size.
 
 Window state and close requests are delivered by the managed runtime session:
 

--- a/examples/63_window_center/README.md
+++ b/examples/63_window_center/README.md
@@ -1,0 +1,26 @@
+# Window Center
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::center` API.
+
+Run it with:
+
+```sh
+moon -C examples run 63_window_center --target native
+```
+
+Review the native window frame:
+
+1. Move and resize the window so its position and size are easy to recognize.
+2. Click **Center window** and confirm the frame moves to the center of the
+   current monitor's work area, not the full monitor bounds.
+3. Move the window to another display, then center it again. The reported
+   monitor and work-area coordinates should change with the window.
+4. Resize the window, center it again, and confirm the new frame size is
+   preserved while only the position changes.
+5. On Windows with display scaling above 100%, confirm the native frame and
+   reported coordinates remain consistent.
+
+The API uses the existing native window state snapshot and position operation;
+no second runtime path or platform-specific centering ABI is introduced.
+Headless runtimes cannot be centered because they have no native frame.

--- a/examples/63_window_center/main.mbt
+++ b/examples/63_window_center/main.mbt
@@ -1,0 +1,248 @@
+///|
+struct CenterRequest {
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend CenterRequest with ToJson::{to_json}
+
+///|
+pub extend CenterRequest with FromJson::{from_json}
+
+///|
+struct CenterReply {
+  applied : Bool
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+  monitor_x : Int
+  monitor_y : Int
+  monitor_width : Int
+  monitor_height : Int
+  work_x : Int
+  work_y : Int
+  work_width : Int
+  work_height : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend CenterReply with ToJson::{to_json}
+
+///|
+pub extend CenterReply with FromJson::{from_json}
+
+///|
+let center_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-center",
+  js_namespace="windowCenter",
+)
+
+///|
+let center_command : @proton_contract.Command[CenterRequest, CenterReply] = center_contract.command(
+  "run",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+fn snapshot(
+  window : @proton.WindowHandle,
+  message : String,
+) -> CenterReply raise {
+  let state = window.state()
+  let monitor = state.monitor
+  CenterReply::{
+    applied: true,
+    x: state.x,
+    y: state.y,
+    width: state.width,
+    height: state.height,
+    monitor_x: monitor.x,
+    monitor_y: monitor.y,
+    monitor_width: monitor.width,
+    monitor_height: monitor.height,
+    work_x: monitor.work_x,
+    work_y: monitor.work_y,
+    work_width: monitor.work_width,
+    work_height: monitor.work_height,
+    message,
+  }
+}
+
+///|
+fn failed_reply(message : String) -> CenterReply {
+  CenterReply::{
+    applied: false,
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    monitor_x: 0,
+    monitor_y: 0,
+    monitor_width: 0,
+    monitor_height: 0,
+    work_x: 0,
+    work_y: 0,
+    work_width: 0,
+    work_height: 0,
+    message,
+  }
+}
+
+///|
+fn center_window(request : CenterRequest) -> CenterReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        match request.action {
+          "center" => {
+            window.center()
+            snapshot(window, "Window centered in the current work area")
+          }
+          "read" => snapshot(window, "Read current native window state")
+          _ => failed_reply("action must be center or read")
+        }
+      } catch {
+        error => failed_reply(error.to_string())
+      }
+    None => failed_reply("window is not ready")
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(center_command, (_context, request) => center_window(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Center</title>
+    #|    <style>
+    #|      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #121416; color: #f0f3f5; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #121416; }
+    #|      button { font: inherit; }
+    #|      main { width: min(860px, calc(100vw - 40px)); margin: 0 auto; padding: 42px 0 50px; }
+    #|      header { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 28px; align-items: end; padding-bottom: 25px; border-bottom: 1px solid #3a4147; }
+    #|      .eyebrow { margin: 0 0 10px; color: #6fb6e8; font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .16em; text-transform: uppercase; }
+    #|      h1 { margin: 0; max-width: 560px; font-size: clamp(34px, 6vw, 54px); line-height: .98; letter-spacing: -.055em; }
+    #|      .summary { max-width: 570px; margin: 14px 0 0; color: #a9b2b9; line-height: 1.55; }
+    #|      .crosshair { display: grid; place-items: center; width: 112px; aspect-ratio: 1; border: 1px solid #72c58c; border-radius: 50%; background: #18251d; color: #b7ecc5; font: 700 26px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      .crosshair::before { content: "+"; }
+    #|      .layout { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(260px, .85fr); gap: 16px; margin-top: 20px; }
+    #|      .panel { border: 1px solid #3a4147; border-radius: 8px; background: #181b1e; overflow: hidden; }
+    #|      .panel-head { display: flex; justify-content: space-between; gap: 12px; min-height: 48px; padding: 0 17px; align-items: center; border-bottom: 1px solid #3a4147; color: #aeb6bc; font: 650 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; }
+    #|      .surface { min-height: 235px; padding: 27px; background: #1c2023; }
+    #|      .coordinates { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px 16px; }
+    #|      .coordinate { border-left: 2px solid #72c58c; padding-left: 10px; }
+    #|      .coordinate.monitor { border-color: #e2a953; }
+    #|      .coordinate.work { border-color: #6fb6e8; }
+    #|      .coordinate small { display: block; color: #98a3aa; font: 700 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .11em; text-transform: uppercase; }
+    #|      .coordinate strong { display: block; margin-top: 6px; color: #eef3f5; font: 700 17px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      .controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; padding: 15px 17px; border-top: 1px solid #3a4147; }
+    #|      button { min-height: 43px; border: 1px solid #59636b; border-radius: 7px; padding: 0 12px; background: #252a2e; color: #f0f3f5; cursor: pointer; font-weight: 720; }
+    #|      button:hover { border-color: #6fb6e8; background: #29343c; }
+    #|      button:focus-visible { outline: 3px solid #6fb6e866; outline-offset: 3px; }
+    #|      button.primary { border-color: #72c58c; background: #28643b; }
+    #|      button.primary:hover { background: #337c4b; }
+    #|      .readout { display: grid; align-content: start; gap: 18px; padding: 20px; }
+    #|      .readout h2 { margin: 0; font-size: 16px; }
+    #|      .legend { display: grid; gap: 11px; margin: 0; padding: 0; list-style: none; }
+    #|      .legend li { display: grid; grid-template-columns: 10px minmax(0, 1fr); gap: 10px; align-items: center; color: #b7c0c6; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      .legend span { width: 10px; height: 10px; border-radius: 50%; background: #72c58c; }
+    #|      .legend .monitor-key { background: #e2a953; }
+    #|      .legend .work-key { background: #6fb6e8; }
+    #|      #status { min-height: 54px; margin: 0; padding-top: 17px; border-top: 1px solid #3a4147; color: #8bcdf5; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #|      @media (max-width: 720px) { header { grid-template-columns: 1fr; } .crosshair { width: 76px; } .layout { grid-template-columns: 1fr; } }
+    #|      @media (max-width: 480px) { main { padding-top: 28px; } .coordinates, .controls { grid-template-columns: 1fr; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div>
+    #|          <p class="eyebrow">Native surface / manual test 63</p>
+    #|          <h1>Center the frame</h1>
+    #|          <p class="summary">Place the native window in the current display's usable work area. The page reports the frame and monitor geometry returned by the runtime.</p>
+    #|        </div>
+    #|        <div class="crosshair" aria-hidden="true"></div>
+    #|      </header>
+    #|      <div class="layout">
+    #|        <section class="panel">
+    #|          <div class="panel-head"><strong>Native geometry</strong><span>live snapshot</span></div>
+    #|          <div class="surface">
+    #|            <div class="coordinates">
+    #|              <div class="coordinate"><small>Window position</small><strong id="position">--</strong></div>
+    #|              <div class="coordinate"><small>Window size</small><strong id="size">--</strong></div>
+    #|              <div class="coordinate monitor"><small>Monitor</small><strong id="monitor">--</strong></div>
+    #|              <div class="coordinate work"><small>Work area</small><strong id="work">--</strong></div>
+    #|            </div>
+    #|          </div>
+    #|          <div class="controls">
+    #|            <button id="center" class="primary" type="button">Center window</button>
+    #|            <button id="read" type="button">Read geometry</button>
+    #|          </div>
+    #|        </section>
+    #|        <aside class="panel readout">
+    #|          <h2>Geometry key</h2>
+    #|          <ul class="legend">
+    #|            <li><span></span><strong>Window frame</strong></li>
+    #|            <li><span class="monitor-key"></span><strong>Current monitor</strong></li>
+    #|            <li><span class="work-key"></span><strong>Usable work area</strong></li>
+    #|          </ul>
+    #|          <p id="status" role="status" aria-live="polite">Ready. Read the current native geometry.</p>
+    #|        </aside>
+    #|      </div>
+    #|    </main>
+    #|    <script>
+    #|      const position = document.querySelector("#position");
+    #|      const size = document.querySelector("#size");
+    #|      const monitor = document.querySelector("#monitor");
+    #|      const work = document.querySelector("#work");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (action) => window.__MoonBit__.core.invokeOp("ext:windowCenter/run", { action });
+    #|      function render(reply) {
+    #|        position.textContent = `${reply.x}, ${reply.y}`;
+    #|        size.textContent = `${reply.width} x ${reply.height}`;
+    #|        monitor.textContent = `${reply.monitor_width} x ${reply.monitor_height} @ ${reply.monitor_x}, ${reply.monitor_y}`;
+    #|        work.textContent = `${reply.work_width} x ${reply.work_height} @ ${reply.work_x}, ${reply.work_y}`;
+    #|        status.textContent = reply.message;
+    #|      }
+    #|      async function run(action) {
+    #|        status.textContent = action === "center" ? "Centering the native frame..." : "Reading native geometry...";
+    #|        try { render(await invoke(action)); }
+    #|        catch (error) { status.textContent = `request failed: ${String(error)}`; }
+    #|      }
+    #|      document.querySelector("#center").addEventListener("click", () => void run("center"));
+    #|      document.querySelector("#read").addEventListener("click", () => void run("read"));
+    #|      void run("read");
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Center", html(), width=860, height=650, debug=true)
+  .identifier("dev.proton.window-center")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/63_window_center/moon.pkg
+++ b/examples/63_window_center/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/63_window_center/pkg.generated.mbti
+++ b/examples/63_window_center/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/63_window_center"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type CenterReply derive(ToJson, @json.FromJson)
+pub fn CenterReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CenterReply::to_json(Self) -> Json
+
+type CenterRequest derive(ToJson, @json.FromJson)
+pub fn CenterRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CenterRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -105,6 +105,8 @@ moon -C examples run 01_run --target native
   enable, disable, toggle, and cross-platform native frame checks.
 - `62_window_size_limits`: manual Electron-style minimum and maximum window
   size review with live constraint updates and clear operations.
+- `63_window_center`: manual Electron-style window centering review using the
+  current monitor work area and native frame size.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1089,6 +1089,22 @@ pub fn WindowHandle::set_position(
 }
 
 ///|
+/// Centers the window in the work area of the monitor containing it.
+///
+/// The current native frame size is preserved. Work-area coordinates exclude
+/// taskbars, docks, and other reserved desktop regions, and use Proton's
+/// top-left coordinate convention on every platform.
+pub fn WindowHandle::center(
+  self : WindowHandle,
+) -> Unit raise WindowSessionError {
+  let state = self.state()
+  let monitor = state.monitor
+  let x = monitor.work_x + (monitor.work_width - state.width) / 2
+  let y = monitor.work_y + (monitor.work_height - state.height) / 2
+  self.set_position(x, y)
+}
+
+///|
 pub fn WindowHandle::set_always_on_top(
   self : WindowHandle,
   always_on_top : Bool,

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -58,12 +58,14 @@ fn test_window_manager() -> WindowManager {
 fn test_window_handle(
   id : String,
   native_id : Int64,
+  position_calls? : Array[(Int, Int)],
   popup_calls? : Array[String],
   progress_calls? : Array[Double],
   flash_calls? : Array[Bool],
   resizable_calls? : Array[Bool],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
+  window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
     id,
@@ -86,7 +88,12 @@ fn test_window_handle(
     maximize_window: fn() {  },
     restore_window: fn() {  },
     set_window_fullscreen: fn(_fullscreen) {  },
-    set_window_position: fn(_x, _y) {  },
+    set_window_position: (x, y) => {
+      match position_calls {
+        Some(calls) => calls.push((x, y))
+        None => ()
+      }
+    },
     set_window_always_on_top: fn(_always_on_top) {  },
     set_window_resizable: resizable => {
       match resizable_calls {
@@ -129,7 +136,10 @@ fn test_window_handle(
         None => ()
       }
     },
-    read_window_state: fn() { abort("test window state is not available") },
+    read_window_state: match window_state {
+      Some(state) => fn() { state }
+      None => fn() { abort("test window state is not available") }
+    },
     browser,
     add_view: fn(_id, _config) { abort("test views are not available") },
     remove_view: fn(_id) { abort("test views are not available") },
@@ -1964,6 +1974,38 @@ test "window resizable routes live capability changes through the handle" {
   window.set_resizable(false)
   window.set_resizable(true)
   debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window center uses the current monitor work area and frame size" {
+  let position_calls : Array[(Int, Int)] = []
+  let window = test_window_handle("main", 17L, position_calls~, window_state=WindowState::{
+    x: 120,
+    y: 80,
+    width: 800,
+    height: 600,
+    monitor: WindowMonitor::{
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+      work_x: 0,
+      work_y: 24,
+      work_width: 1920,
+      work_height: 1032,
+      scale_factor_percent: 100,
+    },
+    zoom_percent: 100,
+    visible: true,
+    focused: true,
+    minimized: false,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: "system",
+  })
+  window.center()
+  debug_inspect(position_calls, content="[(560, 240)]")
 }
 
 ///|

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -612,6 +612,7 @@ pub struct WindowHandle {
 }
 pub fn WindowHandle::add_view(Self, String, ViewConfig) -> ViewHandle raise WindowSessionError
 pub fn WindowHandle::browser(Self) -> BrowserHandle
+pub fn WindowHandle::center(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::close(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::flash_frame(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::focus(Self) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary
- add `WindowHandle::center()` using the current monitor work area
- preserve the native frame size and reuse existing position/state paths across platforms
- add `examples/63_window_center` for manual review

## Validation
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test --target native --diagnostic-limit 120` (566 passed)
- `moon -C examples check 63_window_center --target native --diagnostic-limit 120`
- `moon -C examples build --target native --diagnostic-limit 80`
- macOS native launch attempted locally; CI covers Linux and Windows native builds.