### PR TITLE
feat(window): add cross-platform movable control

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ clear a constraint. See `examples/62_window_size_limits` for a manual review.
 `WindowHandle::center` places a live window in the work area of its current
 monitor while preserving its size. See `examples/63_window_center` for a
 manual review.
+`WindowHandle::set_movable` controls manual title-bar movement without blocking
+programmatic `set_position` or `center` calls. It is enforced on macOS and
+Windows and follows Electron's no-op behavior on Linux. See
+`examples/64_window_movable` for a manual review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:

--- a/examples/64_window_movable/README.md
+++ b/examples/64_window_movable/README.md
@@ -1,0 +1,31 @@
+# Window Movable
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_movable` API.
+
+Run it with:
+
+```sh
+moon -C examples run 64_window_movable --target native
+```
+
+Review the native window frame:
+
+1. Drag the native title bar and confirm the window starts movable.
+2. Choose **Disable manual movement**, then repeat the same title-bar gesture.
+   The frame should stay fixed on macOS and Windows.
+3. While movement is disabled, choose **Programmatic nudge** and **Center
+   window**. Both operations should still move the frame.
+4. Choose **Enable manual movement** and confirm title-bar dragging works again
+   without restarting the process.
+5. Watch the reported position to distinguish a blocked manual drag from a
+   successful programmatic move.
+
+Platform details:
+
+- macOS calls `NSWindow.setMovable` on the live window.
+- Windows blocks interactive movement in `WM_MOVING`; programmatic placement
+  through `SetWindowPos` remains available.
+- Linux follows Electron's intentional no-op behavior. Calls succeed, but the
+  desktop window manager can still move the window.
+- Headless runtimes report unsupported because they have no native frame.

--- a/examples/64_window_movable/main.mbt
+++ b/examples/64_window_movable/main.mbt
@@ -1,0 +1,259 @@
+///|
+struct MovableRequest {
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend MovableRequest with ToJson::{to_json}
+
+///|
+pub extend MovableRequest with FromJson::{from_json}
+
+///|
+struct MovableReply {
+  applied : Bool
+  movable : Bool
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend MovableReply with ToJson::{to_json}
+
+///|
+pub extend MovableReply with FromJson::{from_json}
+
+///|
+let movable_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-movable",
+  js_namespace="windowMovable",
+)
+
+///|
+let movable_command : @proton_contract.Command[MovableRequest, MovableReply] = movable_contract.command(
+  "run",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let movable_state : Ref[Bool] = { val: true, }
+
+///|
+fn snapshot(
+  window : @proton.WindowHandle,
+  applied : Bool,
+  message : String,
+) -> MovableReply raise {
+  let state = window.state()
+  MovableReply::{
+    applied,
+    movable: movable_state.val,
+    x: state.x,
+    y: state.y,
+    width: state.width,
+    height: state.height,
+    message,
+  }
+}
+
+///|
+fn failed_reply(message : String) -> MovableReply {
+  MovableReply::{
+    applied: false,
+    movable: movable_state.val,
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    message,
+  }
+}
+
+///|
+fn run_action(request : MovableRequest) -> MovableReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        match request.action {
+          "disable" => {
+            window.set_movable(false)
+            movable_state.val = false
+            snapshot(window, true, "Manual title-bar movement disabled")
+          }
+          "enable" => {
+            window.set_movable(true)
+            movable_state.val = true
+            snapshot(window, true, "Manual title-bar movement enabled")
+          }
+          "nudge" => {
+            let state = window.state()
+            window.set_position(state.x + 48, state.y + 32)
+            snapshot(
+              window, true, "Moved programmatically by +48, +32 while the manual setting stayed unchanged",
+            )
+          }
+          "center" => {
+            window.center()
+            snapshot(window, true, "Centered programmatically")
+          }
+          "read" => snapshot(window, true, "Read current native geometry")
+          _ =>
+            failed_reply(
+              "action must be disable, enable, nudge, center, or read",
+            )
+        }
+      } catch {
+        error => failed_reply("native call failed: " + error.to_string())
+      }
+    None => failed_reply("window is not ready")
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(movable_command, (_context, request) => run_action(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Movable</title>
+    #|    <style>
+    #|      :root { color-scheme: light; font-family: Avenir Next, Avenir, Segoe UI, sans-serif; background: #dce5e1; color: #12211d; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #dce5e1; }
+    #|      button { font: inherit; }
+    #|      main { width: min(930px, calc(100vw - 40px)); margin: 0 auto; padding: 36px 0 48px; }
+    #|      header { display: grid; grid-template-columns: minmax(0, 1fr) 230px; gap: 34px; align-items: end; padding: 0 4px 24px; border-bottom: 2px solid #19332b; }
+    #|      .eyebrow { margin: 0 0 9px; color: #17614c; font: 750 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      h1 { margin: 0; font: 750 46px/.92 Georgia, Times New Roman, serif; letter-spacing: 0; }
+    #|      .summary { max-width: 600px; margin: 18px 0 0; color: #40554e; line-height: 1.55; }
+    #|      .drag-ticket { position: relative; border: 2px solid #19332b; padding: 17px 18px 15px; background: #eff4f1; box-shadow: 7px 7px 0 #19332b; }
+    #|      .drag-ticket::before { content: "<->"; display: block; color: #d14f34; font: 800 28px/1 Georgia, serif; }
+    #|      .drag-ticket small { display: block; margin-top: 11px; color: #52675f; font: 700 10px/1.3 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      .drag-ticket strong { display: block; margin-top: 5px; font-size: 16px; }
+    #|      .layout { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(280px, .8fr); gap: 18px; margin-top: 20px; }
+    #|      .panel { border: 1px solid #80968d; background: #f5f7f5cc; backdrop-filter: blur(12px); }
+    #|      .panel-head { display: flex; justify-content: space-between; gap: 12px; min-height: 48px; padding: 0 17px; align-items: center; border-bottom: 1px solid #9bada6; color: #52675f; font: 700 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      .panel-head strong { color: #183a30; }
+    #|      .stage { position: relative; min-height: 244px; padding: 26px; overflow: hidden; background-image: linear-gradient(#9bb0a733 1px, transparent 1px), linear-gradient(90deg, #9bb0a733 1px, transparent 1px); background-size: 28px 28px; }
+    #|      .frame { position: absolute; inset: 46px 60px 48px 48px; border: 2px solid #19332b; background: #f8faf8; box-shadow: 12px 12px 0 #92a9a0; }
+    #|      .frame-bar { display: flex; align-items: center; gap: 7px; height: 36px; padding: 0 12px; border-bottom: 2px solid #19332b; background: #d5e1dc; }
+    #|      .frame-bar i { width: 9px; height: 9px; border: 1px solid #19332b; border-radius: 50%; background: #d14f34; }
+    #|      .frame-bar i:nth-child(2) { background: #e9b84d; }
+    #|      .frame-bar i:nth-child(3) { background: #4a9b78; }
+    #|      .frame-copy { display: grid; place-items: center; min-height: 118px; padding: 18px; text-align: center; }
+    #|      .frame-copy strong { color: #19332b; font: 740 17px/1.25 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      .frame-copy span { display: block; margin-top: 8px; color: #5e736b; font-size: 12px; }
+    #|      .controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; padding: 16px 17px; border-top: 1px solid #9bada6; }
+    #|      button { min-height: 44px; border: 1px solid #526d63; padding: 0 12px; background: #e5ece8; color: #17382e; cursor: pointer; font-weight: 750; }
+    #|      button:hover { background: #d5e3dd; border-color: #19332b; }
+    #|      button:focus-visible { outline: 3px solid #d14f3466; outline-offset: 3px; }
+    #|      button.primary { border-color: #b53d27; background: #d14f34; color: #fff8f3; }
+    #|      button.primary:hover { background: #b9432d; }
+    #|      .review { display: grid; align-content: start; gap: 18px; padding: 20px; }
+    #|      .state { display: grid; grid-template-columns: 1fr auto; gap: 13px; align-items: center; padding-bottom: 17px; border-bottom: 1px solid #9bada6; }
+    #|      .state small { color: #60746d; font: 700 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      .state strong { display: block; margin-top: 6px; font-size: 19px; }
+    #|      .lamp { width: 18px; height: 18px; border: 2px solid #19332b; border-radius: 50%; background: #4a9b78; box-shadow: 0 0 0 5px #4a9b7830; }
+    #|      .lamp.locked { background: #d14f34; box-shadow: 0 0 0 5px #d14f3430; }
+    #|      .geometry { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+    #|      .geometry div { border-left: 3px solid #4a9b78; padding-left: 9px; }
+    #|      .geometry small { display: block; color: #60746d; font: 700 9px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .geometry strong { display: block; margin-top: 5px; font: 750 13px/1.2 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      #status { min-height: 52px; margin: 0; padding-top: 16px; border-top: 1px solid #9bada6; color: #17614c; font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      @media (max-width: 760px) { header { grid-template-columns: 1fr; } .drag-ticket { width: min(100%, 300px); } .layout { grid-template-columns: 1fr; } }
+    #|      @media (max-width: 480px) { main { padding-top: 26px; } h1 { font-size: 38px; } .controls { grid-template-columns: 1fr; } .frame { inset: 42px 26px 42px 26px; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div>
+    #|          <p class="eyebrow">Native frame / manual test 64</p>
+    #|          <h1>Hold the<br>window still.</h1>
+    #|          <p class="summary">Disable only the user's title-bar drag gesture, then prove programmatic placement remains available. This matches Electron's platform behavior.</p>
+    #|        </div>
+    #|        <div class="drag-ticket"><small>Review gesture</small><strong>Drag the real title bar, not this page.</strong></div>
+    #|      </header>
+    #|      <div class="layout">
+    #|        <section class="panel">
+    #|          <div class="panel-head"><strong>Movement lab</strong><span>native frame outside renderer</span></div>
+    #|          <div class="stage" aria-hidden="true">
+    #|            <div class="frame">
+    #|              <div class="frame-bar"><i></i><i></i><i></i></div>
+    #|              <div class="frame-copy"><div><strong id="diagram-state">MANUAL MOVE: ENABLED</strong><span>Programmatic move always remains enabled</span></div></div>
+    #|            </div>
+    #|          </div>
+    #|          <div class="controls">
+    #|            <button id="disable" class="primary" type="button">Disable manual movement</button>
+    #|            <button id="enable" type="button">Enable manual movement</button>
+    #|            <button id="nudge" type="button">Programmatic nudge</button>
+    #|            <button id="center" type="button">Center window</button>
+    #|          </div>
+    #|        </section>
+    #|        <aside class="panel review">
+    #|          <div class="state"><div><small>Manual title-bar drag</small><strong id="state-label">Enabled</strong></div><span id="lamp" class="lamp"></span></div>
+    #|          <div class="geometry"><div><small>Position</small><strong id="position">--</strong></div><div><small>Size</small><strong id="size">--</strong></div></div>
+    #|          <p id="status" role="status" aria-live="polite">Ready. Manual movement starts enabled.</p>
+    #|        </aside>
+    #|      </div>
+    #|    </main>
+    #|    <script>
+    #|      const stateLabel = document.querySelector("#state-label");
+    #|      const diagramState = document.querySelector("#diagram-state");
+    #|      const lamp = document.querySelector("#lamp");
+    #|      const position = document.querySelector("#position");
+    #|      const size = document.querySelector("#size");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (action) => window.__MoonBit__.core.invokeOp("ext:windowMovable/run", { action });
+    #|      function render(reply) {
+    #|        stateLabel.textContent = reply.movable ? "Enabled" : "Disabled";
+    #|        diagramState.textContent = `MANUAL MOVE: ${reply.movable ? "ENABLED" : "DISABLED"}`;
+    #|        lamp.classList.toggle("locked", !reply.movable);
+    #|        position.textContent = `${reply.x}, ${reply.y}`;
+    #|        size.textContent = `${reply.width} x ${reply.height}`;
+    #|        status.textContent = reply.message;
+    #|      }
+    #|      async function run(action) {
+    #|        status.textContent = `Running ${action}...`;
+    #|        try { render(await invoke(action)); }
+    #|        catch (error) { status.textContent = `request failed: ${String(error)}`; }
+    #|      }
+    #|      document.querySelector("#disable").addEventListener("click", () => void run("disable"));
+    #|      document.querySelector("#enable").addEventListener("click", () => void run("enable"));
+    #|      document.querySelector("#nudge").addEventListener("click", () => void run("nudge"));
+    #|      document.querySelector("#center").addEventListener("click", () => void run("center"));
+    #|      void run("read");
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Movable", html(), width=930, height=700, debug=true)
+  .identifier("dev.proton.window-movable")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      movable_state.val = true
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/64_window_movable/moon.pkg
+++ b/examples/64_window_movable/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/64_window_movable/pkg.generated.mbti
+++ b/examples/64_window_movable/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/64_window_movable"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type MovableReply derive(ToJson, @json.FromJson)
+pub fn MovableReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MovableReply::to_json(Self) -> Json
+
+type MovableRequest derive(ToJson, @json.FromJson)
+pub fn MovableRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MovableRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -107,6 +107,9 @@ moon -C examples run 01_run --target native
   size review with live constraint updates and clear operations.
 - `63_window_center`: manual Electron-style window centering review using the
   current monitor work area and native frame size.
+- `64_window_movable`: manual Electron-style window movement control with
+  native drag blocking on macOS and Windows, Linux no-op behavior, and
+  programmatic movement checks.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -90,6 +90,11 @@ process exits when all windows have closed. Use
 the application should remain available for Dock, protocol, document, or tray
 activation after its last window closes.
 
+Live window handles can change native frame behavior after creation. In
+particular, `WindowHandle::set_movable(false)` blocks manual movement on macOS
+and Windows while preserving programmatic placement; Linux follows Electron's
+successful no-op behavior.
+
 ## Logging
 
 Use `tonyfettes/xlog@0.4.1` directly for application logs. Proton configures the

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -160,6 +160,11 @@ fn RuntimeSession::window_handle(
         window.set_maximum_size(width, height)
       })
     },
+    set_window_movable: movable => {
+      self.control_window(id, native_id, "set movable", window => {
+        window.set_movable(movable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1151,6 +1156,20 @@ pub fn WindowHandle::set_maximum_size(
   height : Int,
 ) -> Unit raise WindowSessionError {
   (self.set_window_maximum_size)(width, height)
+}
+
+///|
+/// Sets whether the user can move this live native window.
+///
+/// macOS and Windows prevent manual frame movement when `movable` is false;
+/// programmatic `set_position` and `center` calls remain available. Linux
+/// follows Electron and treats this as a no-op. Headless runtimes raise
+/// `WindowSessionError` because they have no native frame.
+pub fn WindowHandle::set_movable(
+  self : WindowHandle,
+  movable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_movable)(movable)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -430,6 +430,7 @@ pub struct WindowHandle {
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -63,6 +63,7 @@ fn test_window_handle(
   progress_calls? : Array[Double],
   flash_calls? : Array[Bool],
   resizable_calls? : Array[Bool],
+  movable_calls? : Array[Bool],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
   window_state? : WindowState,
@@ -98,6 +99,12 @@ fn test_window_handle(
     set_window_resizable: resizable => {
       match resizable_calls {
         Some(calls) => calls.push(resizable)
+        None => ()
+      }
+    },
+    set_window_movable: movable => {
+      match movable_calls {
+        Some(calls) => calls.push(movable)
         None => ()
       }
     },
@@ -1973,6 +1980,15 @@ test "window resizable routes live capability changes through the handle" {
   let window = test_window_handle("main", 17L, resizable_calls=calls)
   window.set_resizable(false)
   window.set_resizable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window movable routes live capability changes through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, movable_calls=calls)
+  window.set_movable(false)
+  window.set_movable(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -461,6 +461,12 @@ pub extern "C" fn proton_window_set_maximum_size_ffi(
 ) -> Int = "proton_window_set_maximum_size"
 
 ///|
+pub extern "C" fn proton_window_set_movable_ffi(
+  window : WindowHandle,
+  movable : Int,
+) -> Int = "proton_window_set_movable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -160,6 +160,8 @@ int32_t proton_window_set_minimum_size(proton_window_handle_t window,
                                        int32_t width, int32_t height);
 int32_t proton_window_set_maximum_size(proton_window_handle_t window,
                                        int32_t width, int32_t height);
+int32_t proton_window_set_movable(proton_window_handle_t window,
+                                  int32_t movable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -857,6 +857,28 @@ int32_t proton_engine_window_set_maximum_size(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
+                                         int32_t movable, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (movable != 0 && movable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "movable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window movement is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron's Linux backend intentionally treats setMovable as a no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1210,6 +1210,28 @@ int32_t proton_engine_window_set_maximum_size(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
+                                         int32_t movable, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (movable != 0 && movable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "movable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window movement is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  [window->window setMovable:movable != 0];
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -78,6 +78,7 @@ struct proton_engine_window {
   cef_rect_t osr_popup_rect;
   int size_hint;
   int resizable;
+  int movable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -192,6 +192,14 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
                                        PROTON_WAIT_PLATFORM);
     }
     return 0;
+  case WM_MOVING:
+    if (window != NULL && !window->movable) {
+      // Electron blocks manual frame movement by restoring the current rect.
+      // Programmatic SetWindowPos calls do not enter this message path.
+      GetWindowRect(hwnd, (RECT *)lparam);
+      return TRUE;
+    }
+    break;
   case WM_MOVE:
   case WM_DISPLAYCHANGE:
   case WM_THEMECHANGED:
@@ -410,6 +418,7 @@ int32_t proton_engine_window_create(
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
   window->resizable = config.size_hint != 1;
+  window->movable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -613,6 +622,28 @@ int32_t proton_engine_window_set_maximum_size(
   }
   window->max_width = width;
   window->max_height = height;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
+                                         int32_t movable, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (movable != 0 && movable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "movable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window movement is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->movable = movable;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1001,6 +1001,31 @@ int32_t proton_window_set_maximum_size(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_movable(proton_window_handle_t window,
+                                  int32_t movable) {
+  if (movable != 0 && movable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "movable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window movement requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_movable(
+      slot->engine_window, movable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -215,6 +215,9 @@ int32_t proton_engine_window_set_minimum_size(
 int32_t proton_engine_window_set_maximum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len);
+int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
+                                         int32_t movable, char *error,
+                                         size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1409,6 +1409,24 @@ pub fn Window::set_maximum_size(
 }
 
 ///|
+/// Sets whether the user can move the live native window.
+pub fn Window::set_movable(
+  self : Window,
+  movable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_movable_ffi(
+      self.live_handle(),
+      if movable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -599,6 +599,7 @@ pub struct WindowHandle {
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -626,6 +627,7 @@ pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionEr
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_movable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_movable` through the public facade and native ABI
- enforce manual movement control with `NSWindow.setMovable` on macOS and `WM_MOVING` on Windows
- match Electron's intentional Linux no-op while keeping headless unsupported
- add `examples/64_window_movable` for manual review of drag blocking and programmatic movement

## Platform impact

- macOS: toggles the live `NSWindow` movable property
- Windows: blocks interactive movement while preserving programmatic `SetWindowPos` calls
- Linux: succeeds as an Electron-compatible no-op
- Headless: returns unsupported because no native frame exists

## Validation

- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test --target native --diagnostic-limit 120` (567 passed)
- `moon -C examples check 64_window_movable --target native --diagnostic-limit 120`
- `moon -C examples build 64_window_movable --target native --diagnostic-limit 120`
- `moon info proton --target native`
- `moon info examples/64_window_movable --target native`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS launch smoke: example initialized the CEF runtime and DevTools successfully

## Manual review

Run `moon -C examples run 64_window_movable --target native` and follow `examples/64_window_movable/README.md`. Interactive title-bar dragging still needs manual review.