### PR TITLE
feat(window): add cross-platform opacity control

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ manual review.
 programmatic `set_position` or `center` calls. It is enforced on macOS and
 Windows and follows Electron's no-op behavior on Linux. See
 `examples/64_window_movable` for a manual review.
+`WindowHandle::set_opacity` changes the whole native window and clamps values to
+the Electron-compatible `0.0..1.0` range. See `examples/65_window_opacity` for
+a manual review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:

--- a/examples/65_window_opacity/README.md
+++ b/examples/65_window_opacity/README.md
@@ -1,0 +1,31 @@
+# Window Opacity
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_opacity` API.
+
+Run it with:
+
+```sh
+moon -C examples run 65_window_opacity --target native
+```
+
+Review the complete native window:
+
+1. Place the window above another application or a high-contrast desktop area.
+2. Choose **85% opacity**, **60% opacity**, and **35% opacity**. Confirm the
+   desktop behind the native frame becomes progressively more visible.
+3. Move the slider through intermediate values and confirm the opacity changes
+   when the slider is released.
+4. Choose **100% opaque** and confirm the window returns to its original
+   appearance without restarting.
+5. Confirm the title bar, native frame, and renderer change together rather
+   than only changing the web page contents.
+
+Platform details:
+
+- macOS updates `NSWindow.alphaValue`.
+- Windows enables `WS_EX_LAYERED` and updates the frame alpha with
+  `SetLayeredWindowAttributes`.
+- Linux updates the top-level GTK widget opacity; the compositor and desktop
+  session determine the exact visual result.
+- Values are clamped to `0.0..1.0`. Headless runtimes report unsupported.

--- a/examples/65_window_opacity/main.mbt
+++ b/examples/65_window_opacity/main.mbt
@@ -1,0 +1,204 @@
+///|
+struct OpacityRequest {
+  opacity : Double
+} derive(ToJson, FromJson)
+
+///|
+pub extend OpacityRequest with ToJson::{to_json}
+
+///|
+pub extend OpacityRequest with FromJson::{from_json}
+
+///|
+struct OpacityReply {
+  applied : Bool
+  opacity : Double
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend OpacityReply with ToJson::{to_json}
+
+///|
+pub extend OpacityReply with FromJson::{from_json}
+
+///|
+let opacity_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-opacity",
+  js_namespace="windowOpacity",
+)
+
+///|
+let opacity_command : @proton_contract.Command[OpacityRequest, OpacityReply] = opacity_contract.command(
+  "set",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let opacity_state : Ref[Double] = { val: 1.0, }
+
+///|
+fn set_opacity(request : OpacityRequest) -> OpacityReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        window.set_opacity(request.opacity)
+        let bounded = if request.opacity < 0.0 {
+          0.0
+        } else if request.opacity > 1.0 {
+          1.0
+        } else {
+          request.opacity
+        }
+        opacity_state.val = bounded
+        OpacityReply::{
+          applied: true,
+          opacity: bounded,
+          message: "Native window opacity updated",
+        }
+      } catch {
+        error =>
+          OpacityReply::{
+            applied: false,
+            opacity: opacity_state.val,
+            message: "native call failed: " + error.to_string(),
+          }
+      }
+    None =>
+      OpacityReply::{
+        applied: false,
+        opacity: opacity_state.val,
+        message: "window is not ready",
+      }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(opacity_command, (_context, request) => set_opacity(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Opacity</title>
+    #|    <style>
+    #|      :root { color-scheme: light; font-family: Charter, Georgia, serif; background: #f2eee5; color: #202522; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #f2eee5; }
+    #|      button, input { font: inherit; }
+    #|      main { width: min(880px, calc(100vw - 36px)); margin: 0 auto; padding: 34px 0 48px; }
+    #|      header { display: grid; grid-template-columns: minmax(0, 1fr) 190px; gap: 32px; align-items: end; padding: 0 2px 24px; border-bottom: 1px solid #26322d; }
+    #|      .eyebrow { margin: 0 0 8px; color: #a33e2f; font: 750 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      h1 { margin: 0; font-size: 48px; line-height: .94; letter-spacing: 0; }
+    #|      .summary { max-width: 540px; margin: 16px 0 0; color: #59645f; font: 15px/1.55 Avenir Next, Segoe UI, sans-serif; }
+    #|      .meter { min-width: 190px; border-left: 5px solid #a33e2f; padding: 8px 0 6px 18px; }
+    #|      .meter small { display: block; color: #69736f; font: 700 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .meter strong { display: block; margin-top: 7px; color: #26322d; font: 700 48px/.9 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      .surface { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(270px, .9fr); border: 1px solid #768079; margin-top: 20px; background: #faf8f2; }
+    #|      .preview { position: relative; min-height: 330px; overflow: hidden; border-right: 1px solid #768079; background: #d7ddd8; }
+    #|      .preview-band { position: absolute; left: 0; right: 0; height: 33.34%; }
+    #|      .preview-band.one { top: 0; background: #c7d5cb; }
+    #|      .preview-band.two { top: 33.33%; background: #d7bbb1; }
+    #|      .preview-band.three { bottom: 0; background: #d8c894; }
+    #|      .sample { position: absolute; inset: 54px 58px; display: grid; place-items: center; border: 2px solid #26322d; background: #f8f6f0; box-shadow: 12px 12px 0 #26322d; text-align: center; }
+    #|      .sample span { display: block; color: #a33e2f; font: 750 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .sample strong { display: block; margin-top: 10px; font-size: 25px; }
+    #|      .controls { display: grid; align-content: start; gap: 24px; padding: 24px; }
+    #|      .control-label { display: flex; justify-content: space-between; gap: 12px; color: #58635e; font: 700 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      input[type="range"] { width: 100%; margin: 14px 0 0; accent-color: #a33e2f; cursor: pointer; }
+    #|      .presets { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+    #|      button { min-height: 44px; border: 1px solid #59655f; padding: 0 11px; background: #e8e4da; color: #26322d; cursor: pointer; font: 750 13px/1 Avenir Next, Segoe UI, sans-serif; }
+    #|      button:hover { border-color: #26322d; background: #dcd6c9; }
+    #|      button:focus-visible, input:focus-visible { outline: 3px solid #a33e2f55; outline-offset: 3px; }
+    #|      button.primary { border-color: #873427; background: #a33e2f; color: #fffaf5; }
+    #|      button.primary:hover { background: #873427; }
+    #|      #status { min-height: 58px; margin: 0; padding-top: 18px; border-top: 1px solid #aab1ac; color: #4a5c53; font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      @media (max-width: 700px) { header { grid-template-columns: 1fr; } .meter { width: 190px; } .surface { grid-template-columns: 1fr; } .preview { border-right: 0; border-bottom: 1px solid #768079; } }
+    #|      @media (max-width: 440px) { h1 { font-size: 39px; } .sample { inset: 58px 30px; } .presets { grid-template-columns: 1fr; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div>
+    #|          <p class="eyebrow">Native frame / manual test 65</p>
+    #|          <h1>Window opacity</h1>
+    #|          <p class="summary">Adjust the whole native window, including its frame and web contents, against the desktop behind it.</p>
+    #|        </div>
+    #|        <div class="meter"><small>Native opacity</small><strong id="meter">100%</strong></div>
+    #|      </header>
+    #|      <section class="surface">
+    #|        <div class="preview" aria-hidden="true">
+    #|          <div class="preview-band one"></div><div class="preview-band two"></div><div class="preview-band three"></div>
+    #|          <div class="sample"><div><span>Reference surface</span><strong>See the desktop through this window</strong></div></div>
+    #|        </div>
+    #|        <div class="controls">
+    #|          <div>
+    #|            <div class="control-label"><span>Opacity</span><output id="value">1.00</output></div>
+    #|            <input id="opacity" type="range" min="0.35" max="1" step="0.05" value="1" aria-label="Window opacity">
+    #|          </div>
+    #|          <div class="presets" role="group" aria-label="Opacity presets">
+    #|            <button class="primary" data-opacity="1" type="button">100% opaque</button>
+    #|            <button data-opacity="0.85" type="button">85% opacity</button>
+    #|            <button data-opacity="0.60" type="button">60% opacity</button>
+    #|            <button data-opacity="0.35" type="button">35% opacity</button>
+    #|          </div>
+    #|          <p id="status" role="status" aria-live="polite">Ready. The native window starts fully opaque.</p>
+    #|        </div>
+    #|      </section>
+    #|    </main>
+    #|    <script>
+    #|      const slider = document.querySelector("#opacity");
+    #|      const value = document.querySelector("#value");
+    #|      const meter = document.querySelector("#meter");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (opacity) => window.__MoonBit__.core.invokeOp("ext:windowOpacity/set", { opacity });
+    #|      function render(opacity, message) {
+    #|        slider.value = opacity.toFixed(2);
+    #|        value.value = opacity.toFixed(2);
+    #|        meter.textContent = `${Math.round(opacity * 100)}%`;
+    #|        status.textContent = message;
+    #|        document.querySelectorAll("[data-opacity]").forEach((button) => button.classList.toggle("primary", Number(button.dataset.opacity) === opacity));
+    #|      }
+    #|      async function setOpacity(opacity) {
+    #|        status.textContent = "Updating native window opacity...";
+    #|        try {
+    #|          const reply = await invoke(opacity);
+    #|          render(reply.opacity, reply.message);
+    #|        } catch (error) {
+    #|          status.textContent = `request failed: ${String(error)}`;
+    #|        }
+    #|      }
+    #|      slider.addEventListener("input", () => { value.value = Number(slider.value).toFixed(2); meter.textContent = `${Math.round(Number(slider.value) * 100)}%`; });
+    #|      slider.addEventListener("change", () => void setOpacity(Number(slider.value)));
+    #|      document.querySelectorAll("[data-opacity]").forEach((button) => button.addEventListener("click", () => void setOpacity(Number(button.dataset.opacity))));
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Opacity", html(), width=880, height=620, debug=true)
+  .identifier("dev.proton.window-opacity")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      opacity_state.val = 1.0
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/65_window_opacity/moon.pkg
+++ b/examples/65_window_opacity/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/65_window_opacity/pkg.generated.mbti
+++ b/examples/65_window_opacity/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/65_window_opacity"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type OpacityReply derive(ToJson, @json.FromJson)
+pub fn OpacityReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpacityReply::to_json(Self) -> Json
+
+type OpacityRequest derive(ToJson, @json.FromJson)
+pub fn OpacityRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpacityRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -110,6 +110,8 @@ moon -C examples run 01_run --target native
 - `64_window_movable`: manual Electron-style window movement control with
   native drag blocking on macOS and Windows, Linux no-op behavior, and
   programmatic movement checks.
+- `65_window_opacity`: manual Electron-style whole-window opacity review with
+  a numeric slider, presets, and native frame checks.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -94,6 +94,8 @@ Live window handles can change native frame behavior after creation. In
 particular, `WindowHandle::set_movable(false)` blocks manual movement on macOS
 and Windows while preserving programmatic placement; Linux follows Electron's
 successful no-op behavior.
+`WindowHandle::set_opacity` adjusts the complete native window, including its
+frame and renderer, with values clamped to `0.0..1.0`.
 
 ## Logging
 

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -165,6 +165,11 @@ fn RuntimeSession::window_handle(
         window.set_movable(movable)
       })
     },
+    set_window_opacity: opacity => {
+      self.control_window(id, native_id, "set opacity", window => {
+        window.set_opacity(opacity)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1170,6 +1175,19 @@ pub fn WindowHandle::set_movable(
   movable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_movable)(movable)
+}
+
+///|
+/// Sets the live native window opacity.
+///
+/// Values are clamped to the Electron-compatible `0.0..1.0` range, where
+/// `0.0` is fully transparent and `1.0` is fully opaque. Headless runtimes
+/// raise `WindowSessionError` because they have no native frame.
+pub fn WindowHandle::set_opacity(
+  self : WindowHandle,
+  opacity : Double,
+) -> Unit raise WindowSessionError {
+  (self.set_window_opacity)(opacity)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -431,6 +431,7 @@ pub struct WindowHandle {
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
+  set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -64,6 +64,7 @@ fn test_window_handle(
   flash_calls? : Array[Bool],
   resizable_calls? : Array[Bool],
   movable_calls? : Array[Bool],
+  opacity_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
   window_state? : WindowState,
@@ -105,6 +106,12 @@ fn test_window_handle(
     set_window_movable: movable => {
       match movable_calls {
         Some(calls) => calls.push(movable)
+        None => ()
+      }
+    },
+    set_window_opacity: opacity => {
+      match opacity_calls {
+        Some(calls) => calls.push(opacity)
         None => ()
       }
     },
@@ -1990,6 +1997,15 @@ test "window movable routes live capability changes through the handle" {
   window.set_movable(false)
   window.set_movable(true)
   debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window opacity routes live values through the handle" {
+  let calls : Array[Double] = []
+  let window = test_window_handle("main", 17L, opacity_calls=calls)
+  window.set_opacity(0.35)
+  window.set_opacity(1.0)
+  debug_inspect(calls, content="[0.35, 1]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -467,6 +467,12 @@ pub extern "C" fn proton_window_set_movable_ffi(
 ) -> Int = "proton_window_set_movable"
 
 ///|
+pub extern "C" fn proton_window_set_opacity_ffi(
+  window : WindowHandle,
+  opacity : Double,
+) -> Int = "proton_window_set_opacity"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -162,6 +162,8 @@ int32_t proton_window_set_maximum_size(proton_window_handle_t window,
                                        int32_t width, int32_t height);
 int32_t proton_window_set_movable(proton_window_handle_t window,
                                   int32_t movable);
+int32_t proton_window_set_opacity(proton_window_handle_t window,
+                                  double opacity);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -214,6 +214,10 @@ pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_minimum_size_ffi(WindowHandle, Int, Int) -> Int
 
+pub fn proton_window_set_movable_ffi(WindowHandle, Int) -> Int
+
+pub fn proton_window_set_opacity_ffi(WindowHandle, Double) -> Int
+
 pub fn proton_window_set_position_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_progress_bar_ffi(WindowHandle, Double) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -879,6 +879,28 @@ int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
+                                         double opacity, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(opacity)) {
+    proton_engine_set_message(error, error_len,
+                              "opacity must not be NaN");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window opacity is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  const double bounded_opacity = opacity < 0.0 ? 0.0 : (opacity > 1.0 ? 1.0 : opacity);
+  gtk_widget_set_opacity(window->window, bounded_opacity);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1232,6 +1232,28 @@ int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
+                                         double opacity, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(opacity)) {
+    proton_engine_set_message(error, error_len,
+                              "opacity must not be NaN");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window opacity is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  const double bounded_opacity = opacity < 0.0 ? 0.0 : (opacity > 1.0 ? 1.0 : opacity);
+  [window->window setAlphaValue:bounded_opacity];
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -647,6 +647,42 @@ int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
+                                         double opacity, char *error,
+                                         size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(opacity)) {
+    proton_engine_set_message(error, error_len,
+                              "opacity must not be NaN");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window opacity is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  const double bounded_opacity = opacity < 0.0 ? 0.0 : (opacity > 1.0 ? 1.0 : opacity);
+  LONG_PTR extended_style = GetWindowLongPtrW(window->hwnd, GWL_EXSTYLE);
+  SetLastError(0);
+  if (SetWindowLongPtrW(window->hwnd, GWL_EXSTYLE,
+                        extended_style | WS_EX_LAYERED) == 0 &&
+      GetLastError() != 0) {
+    proton_engine_set_message(error, error_len,
+                              "failed to enable layered window opacity");
+    return PROTON_ERR_PLATFORM;
+  }
+  if (!SetLayeredWindowAttributes(window->hwnd, 0,
+                                  (BYTE)(bounded_opacity * 255.0), LWA_ALPHA)) {
+    proton_engine_set_message(error, error_len,
+                              "failed to update window opacity");
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_hide(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1026,6 +1026,36 @@ int32_t proton_window_set_movable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_opacity(proton_window_handle_t window,
+                                  double opacity) {
+  if (isnan(opacity)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "opacity must not be NaN");
+  }
+  if (opacity < 0.0) {
+    opacity = 0.0;
+  } else if (opacity > 1.0) {
+    opacity = 1.0;
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window opacity requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_opacity(
+      slot->engine_window, opacity, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -218,6 +218,9 @@ int32_t proton_engine_window_set_maximum_size(
 int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
                                          int32_t movable, char *error,
                                          size_t error_len);
+int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
+                                         double opacity, char *error,
+                                         size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1427,6 +1427,30 @@ pub fn Window::set_movable(
 }
 
 ///|
+/// Sets the opacity of the live native window, clamped to `0.0..1.0`.
+pub fn Window::set_opacity(
+  self : Window,
+  opacity : Double,
+) -> Unit raise NativeError {
+  if opacity.is_nan() {
+    raise invalid_argument("opacity must not be NaN")
+  }
+  let bounded_opacity = if opacity < 0.0 {
+    0.0
+  } else if opacity > 1.0 {
+    1.0
+  } else {
+    opacity
+  }
+  check_status(
+    @native_ffi.proton_window_set_opacity_ffi(
+      self.live_handle(),
+      bounded_opacity,
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -188,6 +188,22 @@ test "window progress rejects NaN before native handle access" {
 }
 
 ///|
+test "window opacity rejects NaN before native handle access" {
+  let window = Window::{
+    handle: @native_ffi.window_null(),
+    id: 0L,
+    lifecycle: WindowLive,
+  }
+  try window.set_opacity(0.0 / 0.0) catch {
+    InvalidArgument(message~) =>
+      inspect(message, content="opacity must not be NaN")
+    _ => fail("expected invalid opacity")
+  } noraise {
+    _ => fail("expected invalid opacity")
+  }
+}
+
+///|
 test "runtime config preserves typed native ABI values" {
   let cache_dir = test_absolute_cache_dir()
   let runtime_config = RuntimeConfig(

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -600,6 +600,7 @@ pub struct WindowHandle {
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
+  set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -628,6 +629,7 @@ pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_movable(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_opacity(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_opacity` through the public facade and native ABI
- clamp values to `0.0..1.0` and reject NaN before native handle access
- map to `NSWindow.alphaValue`, Windows layered-window alpha, and GTK widget opacity
- add `examples/65_window_opacity` with slider and preset controls for manual review

## Platform impact

- macOS: updates the live native window alpha
- Windows: enables `WS_EX_LAYERED` and uses `SetLayeredWindowAttributes`
- Linux: updates top-level GTK widget opacity; compositor behavior remains desktop-session dependent
- Headless: returns unsupported because no native frame exists

## Validation

- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test --target native --diagnostic-limit 120` (569 passed)
- `moon -C examples check 65_window_opacity --target native --diagnostic-limit 120`
- `moon -C examples build 65_window_opacity --target native --diagnostic-limit 120`
- `moon info proton --target native`
- `moon info proton/internal/native/ffi --target native`
- `moon info examples/65_window_opacity --target native`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS launch smoke: example initialized the CEF runtime and DevTools successfully

## Manual review

Run `moon -C examples run 65_window_opacity --target native` and follow `examples/65_window_opacity/README.md`. Visual opacity changes still need manual review on macOS, Windows, and Linux.