### PR TITLE
feat(window): add cross-platform taskbar visibility control

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ Windows and follows Electron's no-op behavior on Linux. See
 `WindowHandle::set_opacity` changes the whole native window and clamps values to
 the Electron-compatible `0.0..1.0` range. See `examples/65_window_opacity` for
 a manual review.
+`WindowHandle::set_skip_taskbar` removes or restores the Windows taskbar tab;
+macOS and Linux follow Electron's no-op behavior. See
+`examples/66_window_skip_taskbar` for a manual review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:

--- a/examples/66_window_skip_taskbar/README.md
+++ b/examples/66_window_skip_taskbar/README.md
@@ -1,0 +1,28 @@
+# Window Skip Taskbar
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_skip_taskbar` API.
+
+Run it with:
+
+```sh
+moon -C examples run 66_window_skip_taskbar --target native
+```
+
+Review the operating-system window shell:
+
+1. On Windows, confirm the application starts with a normal taskbar tab.
+2. Enable **Skip taskbar** and confirm the taskbar tab disappears while the
+   native window remains open and usable.
+3. Disable **Skip taskbar** and confirm the taskbar tab returns without
+   restarting the process.
+4. Repeat the toggle several times and confirm focus, movement, resizing, and
+   close behavior remain normal.
+5. On macOS and Linux, confirm both calls succeed and the window remains usable;
+   Electron intentionally treats this API as a no-op on those platforms.
+
+Platform details:
+
+- Windows uses `ITaskbarList::DeleteTab` and `ITaskbarList::AddTab`.
+- macOS and Linux follow Electron's successful no-op behavior.
+- Headless runtimes report unsupported because there is no native window shell.

--- a/examples/66_window_skip_taskbar/main.mbt
+++ b/examples/66_window_skip_taskbar/main.mbt
@@ -1,0 +1,200 @@
+///|
+struct SkipTaskbarRequest {
+  skip : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend SkipTaskbarRequest with ToJson::{to_json}
+
+///|
+pub extend SkipTaskbarRequest with FromJson::{from_json}
+
+///|
+struct SkipTaskbarReply {
+  applied : Bool
+  skip : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend SkipTaskbarReply with ToJson::{to_json}
+
+///|
+pub extend SkipTaskbarReply with FromJson::{from_json}
+
+///|
+let taskbar_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-skip-taskbar",
+  js_namespace="windowSkipTaskbar",
+)
+
+///|
+let taskbar_command : @proton_contract.Command[
+  SkipTaskbarRequest,
+  SkipTaskbarReply,
+] = taskbar_contract.command("set")
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let skip_state : Ref[Bool] = { val: false, }
+
+///|
+fn set_skip_taskbar(request : SkipTaskbarRequest) -> SkipTaskbarReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        window.set_skip_taskbar(request.skip)
+        skip_state.val = request.skip
+        SkipTaskbarReply::{
+          applied: true,
+          skip: request.skip,
+          message: if request.skip {
+            "Taskbar omission requested"
+          } else {
+            "Taskbar presence requested"
+          },
+        }
+      } catch {
+        error =>
+          SkipTaskbarReply::{
+            applied: false,
+            skip: skip_state.val,
+            message: "native call failed: " + error.to_string(),
+          }
+      }
+    None =>
+      SkipTaskbarReply::{
+        applied: false,
+        skip: skip_state.val,
+        message: "window is not ready",
+      }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(taskbar_command, (_context, request) => {
+    set_skip_taskbar(request)
+  })
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Taskbar Visibility</title>
+    #|    <style>
+    #|      :root { color-scheme: dark; font-family: Segoe UI, Avenir Next, sans-serif; background: #171a1d; color: #edf0ef; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #171a1d; }
+    #|      button { font: inherit; }
+    #|      main { width: min(780px, calc(100vw - 36px)); margin: 0 auto; padding: 42px 0 50px; }
+    #|      header { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 28px; align-items: end; padding-bottom: 24px; border-bottom: 1px solid #51585c; }
+    #|      .eyebrow { margin: 0 0 9px; color: #63c4aa; font: 750 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; letter-spacing: 0; text-transform: uppercase; }
+    #|      h1 { margin: 0; max-width: 530px; font-size: 44px; line-height: .96; letter-spacing: 0; }
+    #|      .summary { max-width: 560px; margin: 15px 0 0; color: #a8b0b3; line-height: 1.55; }
+    #|      .tab-mark { display: grid; place-items: center; width: 118px; height: 76px; border: 1px solid #667075; background: #252a2e; color: #93e2cc; font: 750 12px/1 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      .panel { display: grid; grid-template-columns: minmax(0, 1fr) 250px; margin-top: 20px; border: 1px solid #51585c; background: #202428; }
+    #|      .visual { position: relative; min-height: 280px; border-right: 1px solid #51585c; background: #2a3034; overflow: hidden; }
+    #|      .desktop { position: absolute; inset: 30px 28px 62px; border: 1px solid #778188; background: #343c41; }
+    #|      .window-shape { position: absolute; inset: 65px 73px 100px; border: 2px solid #d8dfdc; background: #1e2326; box-shadow: 9px 9px 0 #111416; }
+    #|      .window-shape::before { content: ""; display: block; height: 27px; border-bottom: 1px solid #737d81; background: #333a3e; }
+    #|      .taskbar { position: absolute; left: 28px; right: 28px; bottom: 25px; display: flex; align-items: center; gap: 8px; height: 38px; border: 1px solid #778188; padding: 0 10px; background: #121619; }
+    #|      .start { width: 18px; height: 18px; border: 1px solid #899398; background: #353d42; }
+    #|      .app-tab { min-width: 112px; height: 24px; border-bottom: 2px solid #63c4aa; background: #30383d; transition: opacity 120ms ease; }
+    #|      .app-tab.hidden { opacity: .18; border-bottom-color: #596267; }
+    #|      .controls { display: grid; align-content: start; gap: 20px; padding: 22px; }
+    #|      .state small { display: block; color: #939da2; font: 700 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .state strong { display: block; margin-top: 8px; color: #eff4f2; font-size: 20px; }
+    #|      .switch { display: grid; grid-template-columns: 1fr auto; gap: 14px; align-items: center; border: 1px solid #596368; padding: 14px; background: #292f33; cursor: pointer; }
+    #|      .switch span { font-weight: 720; }
+    #|      .switch input { position: absolute; opacity: 0; pointer-events: none; }
+    #|      .track { position: relative; width: 44px; height: 24px; border: 1px solid #707a7f; border-radius: 12px; background: #3a4247; }
+    #|      .track::after { content: ""; position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; border-radius: 50%; background: #c7cecb; transition: transform 120ms ease; }
+    #|      .switch input:checked + .track { border-color: #57bca1; background: #286451; }
+    #|      .switch input:checked + .track::after { transform: translateX(20px); background: #f0fff9; }
+    #|      .switch:focus-within { outline: 3px solid #63c4aa55; outline-offset: 3px; }
+    #|      #status { min-height: 58px; margin: 0; padding-top: 17px; border-top: 1px solid #51585c; color: #8bdac4; font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      @media (max-width: 650px) { header { grid-template-columns: 1fr; } .tab-mark { width: 118px; } .panel { grid-template-columns: 1fr; } .visual { border-right: 0; border-bottom: 1px solid #51585c; } }
+    #|      @media (max-width: 430px) { h1 { font-size: 36px; } .window-shape { inset-inline: 48px; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div>
+    #|          <p class="eyebrow">Native shell / manual test 66</p>
+    #|          <h1>Taskbar visibility</h1>
+    #|          <p class="summary">Toggle whether the live application window asks to appear in the operating system taskbar.</p>
+    #|        </div>
+    #|        <div class="tab-mark">APP TAB</div>
+    #|      </header>
+    #|      <section class="panel">
+    #|        <div class="visual" aria-hidden="true">
+    #|          <div class="desktop"></div><div class="window-shape"></div>
+    #|          <div class="taskbar"><span class="start"></span><span id="app-tab" class="app-tab"></span></div>
+    #|        </div>
+    #|        <div class="controls">
+    #|          <div class="state"><small>Requested state</small><strong id="state">Shown in taskbar</strong></div>
+    #|          <label class="switch"><span>Skip taskbar</span><span><input id="skip" type="checkbox"><i class="track"></i></span></label>
+    #|          <p id="status" role="status" aria-live="polite">Ready. The native window starts with its normal taskbar presence.</p>
+    #|        </div>
+    #|      </section>
+    #|    </main>
+    #|    <script>
+    #|      const checkbox = document.querySelector("#skip");
+    #|      const state = document.querySelector("#state");
+    #|      const appTab = document.querySelector("#app-tab");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (skip) => window.__MoonBit__.core.invokeOp("ext:windowSkipTaskbar/set", { skip });
+    #|      function render(skip, message) {
+    #|        checkbox.checked = skip;
+    #|        state.textContent = skip ? "Omitted from taskbar" : "Shown in taskbar";
+    #|        appTab.classList.toggle("hidden", skip);
+    #|        status.textContent = message;
+    #|      }
+    #|      checkbox.addEventListener("change", async () => {
+    #|        const requested = checkbox.checked;
+    #|        status.textContent = "Updating native taskbar visibility...";
+    #|        try {
+    #|          const reply = await invoke(requested);
+    #|          render(reply.skip, reply.message);
+    #|        } catch (error) {
+    #|          checkbox.checked = !requested;
+    #|          status.textContent = `request failed: ${String(error)}`;
+    #|        }
+    #|      });
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html(
+    "Window Taskbar Visibility",
+    html(),
+    width=780,
+    height=590,
+    debug=true,
+  )
+  .identifier("dev.proton.window-skip-taskbar")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      skip_state.val = false
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/66_window_skip_taskbar/moon.pkg
+++ b/examples/66_window_skip_taskbar/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/66_window_skip_taskbar/pkg.generated.mbti
+++ b/examples/66_window_skip_taskbar/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/66_window_skip_taskbar"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type SkipTaskbarReply derive(ToJson, @json.FromJson)
+pub fn SkipTaskbarReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SkipTaskbarReply::to_json(Self) -> Json
+
+type SkipTaskbarRequest derive(ToJson, @json.FromJson)
+pub fn SkipTaskbarRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SkipTaskbarRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -112,6 +112,8 @@ moon -C examples run 01_run --target native
   programmatic movement checks.
 - `65_window_opacity`: manual Electron-style whole-window opacity review with
   a numeric slider, presets, and native frame checks.
+- `66_window_skip_taskbar`: manual Electron-style taskbar visibility review
+  with Windows taskbar tab removal and macOS/Linux no-op checks.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -96,6 +96,8 @@ and Windows while preserving programmatic placement; Linux follows Electron's
 successful no-op behavior.
 `WindowHandle::set_opacity` adjusts the complete native window, including its
 frame and renderer, with values clamped to `0.0..1.0`.
+`WindowHandle::set_skip_taskbar` controls the Windows taskbar tab while
+preserving Electron's no-op behavior on macOS and Linux.
 
 ## Logging
 

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -170,6 +170,11 @@ fn RuntimeSession::window_handle(
         window.set_opacity(opacity)
       })
     },
+    set_window_skip_taskbar: skip => {
+      self.control_window(id, native_id, "set taskbar visibility", window => {
+        window.set_skip_taskbar(skip)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1188,6 +1193,19 @@ pub fn WindowHandle::set_opacity(
   opacity : Double,
 ) -> Unit raise WindowSessionError {
   (self.set_window_opacity)(opacity)
+}
+
+///|
+/// Sets whether this live native window is omitted from the taskbar or dock.
+///
+/// Windows removes or restores the taskbar tab. macOS and Linux follow
+/// Electron and treat this as a no-op. Headless runtimes raise
+/// `WindowSessionError` because they have no native window shell.
+pub fn WindowHandle::set_skip_taskbar(
+  self : WindowHandle,
+  skip : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_skip_taskbar)(skip)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -432,6 +432,7 @@ pub struct WindowHandle {
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
+  set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -65,6 +65,7 @@ fn test_window_handle(
   resizable_calls? : Array[Bool],
   movable_calls? : Array[Bool],
   opacity_calls? : Array[Double],
+  skip_taskbar_calls? : Array[Bool],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
   window_state? : WindowState,
@@ -112,6 +113,12 @@ fn test_window_handle(
     set_window_opacity: opacity => {
       match opacity_calls {
         Some(calls) => calls.push(opacity)
+        None => ()
+      }
+    },
+    set_window_skip_taskbar: skip => {
+      match skip_taskbar_calls {
+        Some(calls) => calls.push(skip)
         None => ()
       }
     },
@@ -2006,6 +2013,15 @@ test "window opacity routes live values through the handle" {
   window.set_opacity(0.35)
   window.set_opacity(1.0)
   debug_inspect(calls, content="[0.35, 1]")
+}
+
+///|
+test "window taskbar visibility routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, skip_taskbar_calls=calls)
+  window.set_skip_taskbar(true)
+  window.set_skip_taskbar(false)
+  debug_inspect(calls, content="[true, false]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -473,6 +473,12 @@ pub extern "C" fn proton_window_set_opacity_ffi(
 ) -> Int = "proton_window_set_opacity"
 
 ///|
+pub extern "C" fn proton_window_set_skip_taskbar_ffi(
+  window : WindowHandle,
+  skip : Int,
+) -> Int = "proton_window_set_skip_taskbar"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -164,6 +164,8 @@ int32_t proton_window_set_movable(proton_window_handle_t window,
                                   int32_t movable);
 int32_t proton_window_set_opacity(proton_window_handle_t window,
                                   double opacity);
+int32_t proton_window_set_skip_taskbar(proton_window_handle_t window,
+                                       int32_t skip);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -226,6 +226,8 @@ pub fn proton_window_set_resizable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_size_ffi(WindowHandle, Int, Int) -> Int
 
+pub fn proton_window_set_skip_taskbar_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_title_ffi(WindowHandle, Bytes) -> Int
 
 pub fn proton_window_set_zoom_percent_ffi(WindowHandle, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -901,6 +901,27 @@ int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
+                                              int32_t skip, char *error,
+                                              size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (skip != 0 && skip != 1) {
+    proton_engine_set_message(error, error_len, "skip must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "taskbar visibility is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron's Linux implementation intentionally treats setSkipTaskbar as
+  // a successful no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1254,6 +1254,27 @@ int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
+                                              int32_t skip, char *error,
+                                              size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (skip != 0 && skip != 1) {
+    proton_engine_set_message(error, error_len, "skip must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "taskbar visibility is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron's macOS implementation intentionally treats setSkipTaskbar as
+  // a successful no-op because macOS has no taskbar equivalent.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -41,6 +41,7 @@
 #include <windows.h>
 #include <commctrl.h>
 #include <dwmapi.h>
+#include <shobjidl.h>
 #include <windowsx.h>
 
 #include <math.h>
@@ -678,6 +679,44 @@ int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
                                   (BYTE)(bounded_opacity * 255.0), LWA_ALPHA)) {
     proton_engine_set_message(error, error_len,
                               "failed to update window opacity");
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
+                                              int32_t skip, char *error,
+                                              size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (skip != 0 && skip != 1) {
+    proton_engine_set_message(error, error_len, "skip must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "taskbar visibility is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  ITaskbarList *taskbar = NULL;
+  HRESULT hr = CoCreateInstance(&CLSID_TaskbarList, NULL, CLSCTX_INPROC_SERVER,
+                                &IID_ITaskbarList, (void **)&taskbar);
+  if (FAILED(hr) || taskbar == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "failed to create taskbar list");
+    return PROTON_ERR_PLATFORM;
+  }
+  hr = taskbar->lpVtbl->HrInit(taskbar);
+  if (SUCCEEDED(hr)) {
+    hr = skip != 0 ? taskbar->lpVtbl->DeleteTab(taskbar, window->hwnd)
+                   : taskbar->lpVtbl->AddTab(taskbar, window->hwnd);
+  }
+  taskbar->lpVtbl->Release(taskbar);
+  if (FAILED(hr)) {
+    proton_engine_set_message(error, error_len,
+                              "failed to update taskbar visibility");
     return PROTON_ERR_PLATFORM;
   }
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1056,6 +1056,31 @@ int32_t proton_window_set_opacity(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_skip_taskbar(proton_window_handle_t window,
+                                       int32_t skip) {
+  if (skip != 0 && skip != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "skip must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "taskbar visibility requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_skip_taskbar(
+      slot->engine_window, skip, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -221,6 +221,9 @@ int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
 int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
                                          double opacity, char *error,
                                          size_t error_len);
+int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
+                                              int32_t skip, char *error,
+                                              size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1451,6 +1451,24 @@ pub fn Window::set_opacity(
 }
 
 ///|
+/// Sets whether the live native window is omitted from the taskbar or dock.
+pub fn Window::set_skip_taskbar(
+  self : Window,
+  skip : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_skip_taskbar_ffi(
+      self.live_handle(),
+      if skip {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -601,6 +601,7 @@ pub struct WindowHandle {
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
+  set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -634,6 +635,7 @@ pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionErr
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_skip_taskbar(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::show(Self) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_skip_taskbar` through the public facade and native ABI
- implement Windows taskbar tab removal/restoration with `ITaskbarList::DeleteTab/AddTab`
- match Electron's successful no-op behavior on macOS and Linux
- add `examples/66_window_skip_taskbar` for manual shell review

## Platform impact

- Windows: removes or restores the live window taskbar tab
- macOS/Linux: successful no-op, matching Electron
- Headless: returns unsupported because no native window shell exists

## Validation

- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test --target native --diagnostic-limit 120` (570 passed)
- `moon -C examples check 66_window_skip_taskbar --target native --diagnostic-limit 120`
- `moon -C examples build 66_window_skip_taskbar --target native --diagnostic-limit 120`
- `moon info proton --target native`
- `moon info proton/internal/native/ffi --target native`
- `moon info examples/66_window_skip_taskbar --target native`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS launch smoke: example initialized the CEF runtime and DevTools successfully

## Manual review

Run `moon -C examples run 66_window_skip_taskbar --target native` and follow `examples/66_window_skip_taskbar/README.md`. The actual taskbar tab removal/restoration needs Windows manual review; macOS/Linux should confirm successful no-op calls.