### PR TITLE
fix(window): preserve resizability across fullscreen

### DIFF
--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -985,23 +985,31 @@ int32_t proton_engine_window_apply(
     window->always_on_top = action->value != 0;
     break;
   case PROTON_ENGINE_WINDOW_SET_RESIZABLE: {
-    LONG style = GetWindowLongW(window->hwnd, GWL_STYLE);
+    DWORD style = window->fullscreen
+                      ? window->windowed_style
+                      : (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);
     if (action->value != 0) {
       style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
     } else {
       style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
     }
-    SetLastError(0);
-    if (SetWindowLongW(window->hwnd, GWL_STYLE, style) == 0 &&
-        GetLastError() != 0) {
-      proton_engine_set_message(error, error_len,
-                                "failed to update window style");
-      return PROTON_ERR_PLATFORM;
+    if (window->fullscreen) {
+      // Fullscreen uses a temporary borderless style. Update the saved
+      // windowed style so the requested state is applied when it is restored.
+      window->windowed_style = style;
+    } else {
+      SetLastError(0);
+      if (SetWindowLongW(window->hwnd, GWL_STYLE, (LONG)style) == 0 &&
+          GetLastError() != 0) {
+        proton_engine_set_message(error, error_len,
+                                  "failed to update window style");
+        return PROTON_ERR_PLATFORM;
+      }
+      SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
+                   SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                       SWP_FRAMECHANGED);
     }
     window->resizable = action->value != 0;
-    SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
-                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
-                     SWP_FRAMECHANGED);
     break;
   }
   default:


### PR DESCRIPTION
## Summary

- update the saved Windows windowed style when resizability changes during fullscreen
- leave the temporary borderless fullscreen style unchanged
- preserve the existing immediate style refresh for non-fullscreen windows

## Platform impact

Windows only. Calling `set_resizable` during fullscreen now takes effect when the window returns to windowed mode without adding frame styles to the active fullscreen window.

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 80` (27/27)
- `moon -C proton check --target native --diagnostic-limit 80`
- `git diff --check`

A real Windows fullscreen interaction still requires Windows CI or manual platform review; the local validation host was macOS.