### PR TITLE
feat(notification): add application badge support

### DIFF
--- a/examples/27_app_notification/app.html
+++ b/examples/27_app_notification/app.html
@@ -169,8 +169,8 @@
     <main>
       <h1>Notification as its own runtime surface.</h1>
       <p class="lead">
-        This example isolates <code>notification.show(...)</code> and its
-        activity and click event streams on macOS.
+        This example isolates <code>notification.show(...)</code>, the
+        application badge, and notification event streams on macOS.
       </p>
       <section class="layout">
         <div class="stack">
@@ -194,8 +194,14 @@
               Click payload
               <input id="notification-payload" value="standalone-example" />
             </label>
+            <label style="margin-top: 12px;">
+              Application badge count
+              <input id="notification-badge" type="number" min="0" value="3" />
+            </label>
             <div class="actions">
               <button id="show-notification">Show Notification</button>
+              <button class="secondary" id="set-badge">Set Badge</button>
+              <button class="secondary" id="clear-badge">Clear Badge</button>
               <button class="secondary" id="clear-log">Clear Log</button>
             </div>
           </article>
@@ -247,6 +253,24 @@
         } catch (error) {
           statusLine.textContent = "Notification failed: " + String(error);
         }
+      });
+
+      async function setBadge(count) {
+        try {
+          const result = await window.__MoonBit__.notification.setBadge({ count });
+          statusLine.textContent = "Application badge updated.";
+          appendEvent("notification.setBadge", result);
+        } catch (error) {
+          statusLine.textContent = "Badge update failed: " + String(error);
+        }
+      }
+
+      document.getElementById("set-badge").addEventListener("click", () => {
+        setBadge(Number(document.getElementById("notification-badge").value));
+      });
+
+      document.getElementById("clear-badge").addEventListener("click", () => {
+        setBadge(0);
       });
     </script>
   </body>

--- a/examples/27_app_notification/app.mbt
+++ b/examples/27_app_notification/app.mbt
@@ -173,8 +173,8 @@ let resource : String =
   #|    <main>
   #|      <h1>Notification as its own runtime surface.</h1>
   #|      <p class="lead">
-  #|        This example isolates <code>notification.show(...)</code> and its
-  #|        activity and click event streams on macOS.
+  #|        This example isolates <code>notification.show(...)</code>, the
+  #|        application badge, and notification event streams on macOS.
   #|      </p>
   #|      <section class="layout">
   #|        <div class="stack">
@@ -198,8 +198,14 @@ let resource : String =
   #|              Click payload
   #|              <input id="notification-payload" value="standalone-example" />
   #|            </label>
+  #|            <label style="margin-top: 12px;">
+  #|              Application badge count
+  #|              <input id="notification-badge" type="number" min="0" value="3" />
+  #|            </label>
   #|            <div class="actions">
   #|              <button id="show-notification">Show Notification</button>
+  #|              <button class="secondary" id="set-badge">Set Badge</button>
+  #|              <button class="secondary" id="clear-badge">Clear Badge</button>
   #|              <button class="secondary" id="clear-log">Clear Log</button>
   #|            </div>
   #|          </article>
@@ -251,6 +257,24 @@ let resource : String =
   #|        } catch (error) {
   #|          statusLine.textContent = "Notification failed: " + String(error);
   #|        }
+  #|      });
+  #|
+  #|      async function setBadge(count) {
+  #|        try {
+  #|          const result = await window.__MoonBit__.notification.setBadge({ count });
+  #|          statusLine.textContent = "Application badge updated.";
+  #|          appendEvent("notification.setBadge", result);
+  #|        } catch (error) {
+  #|          statusLine.textContent = "Badge update failed: " + String(error);
+  #|        }
+  #|      }
+  #|
+  #|      document.getElementById("set-badge").addEventListener("click", () => {
+  #|        setBadge(Number(document.getElementById("notification-badge").value));
+  #|      });
+  #|
+  #|      document.getElementById("clear-badge").addEventListener("click", () => {
+  #|        setBadge(0);
   #|      });
   #|    </script>
   #|  </body>

--- a/extensions/notification/contract/contract.mbt
+++ b/extensions/notification/contract/contract.mbt
@@ -38,6 +38,41 @@ pub extend NotificationReply with ToJson::{to_json}
 pub extend NotificationReply with FromJson::{from_json}
 
 ///|
+/// The absolute application badge count. Zero clears the badge.
+pub(all) struct NotificationBadgeRequest {
+  count : Int
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend NotificationBadgeRequest with Eq::{not_equal, equal}
+
+///|
+pub extend NotificationBadgeRequest with Debug::{to_repr}
+
+///|
+pub extend NotificationBadgeRequest with ToJson::{to_json}
+
+///|
+pub extend NotificationBadgeRequest with FromJson::{from_json}
+
+///|
+pub(all) struct NotificationBadgeReply {
+  count : Int
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend NotificationBadgeReply with Eq::{not_equal, equal}
+
+///|
+pub extend NotificationBadgeReply with Debug::{to_repr}
+
+///|
+pub extend NotificationBadgeReply with ToJson::{to_json}
+
+///|
+pub extend NotificationBadgeReply with FromJson::{from_json}
+
+///|
 pub(all) struct NotificationActivity {
   operation : String
   title : String?
@@ -77,6 +112,12 @@ pub extend NotificationClick with FromJson::{from_json}
 pub let show : @proton_contract.Command[NotificationRequest, NotificationReply] = extension.command(
   "show",
 )
+
+///|
+pub let set_badge : @proton_contract.Command[
+  NotificationBadgeRequest,
+  NotificationBadgeReply,
+] = extension.command("setBadge")
 
 ///|
 pub let activity : @proton_contract.Event[NotificationActivity] = extension.event(

--- a/extensions/notification/contract/pkg.generated.mbti
+++ b/extensions/notification/contract/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub let click : @proton_contract.Event[NotificationClick]
 
 pub let extension : @proton_contract.ExtensionContract
 
+pub let set_badge : @proton_contract.Command[NotificationBadgeRequest, NotificationBadgeReply]
+
 pub let show : @proton_contract.Command[NotificationRequest, NotificationReply]
 
 // Errors
@@ -29,6 +31,24 @@ pub fn NotificationActivity::from_json(Json, @json.JsonPath) -> Self raise @json
 pub fn NotificationActivity::not_equal(Self, Self) -> Bool
 pub fn NotificationActivity::to_json(Self) -> Json
 pub fn NotificationActivity::to_repr(Self) -> @debug.Repr
+
+pub(all) struct NotificationBadgeReply {
+  count : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn NotificationBadgeReply::equal(Self, Self) -> Bool
+pub fn NotificationBadgeReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn NotificationBadgeReply::not_equal(Self, Self) -> Bool
+pub fn NotificationBadgeReply::to_json(Self) -> Json
+pub fn NotificationBadgeReply::to_repr(Self) -> @debug.Repr
+
+pub(all) struct NotificationBadgeRequest {
+  count : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn NotificationBadgeRequest::equal(Self, Self) -> Bool
+pub fn NotificationBadgeRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn NotificationBadgeRequest::not_equal(Self, Self) -> Bool
+pub fn NotificationBadgeRequest::to_json(Self) -> Json
+pub fn NotificationBadgeRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct NotificationClick {
   payload : String?

--- a/extensions/notification/error.mbt
+++ b/extensions/notification/error.mbt
@@ -2,6 +2,7 @@
 /// Failures while validating or delivering native notifications.
 suberror NotificationError {
   EmptyBody
+  InvalidBadgeCount(Int)
   UnsupportedPlatform
   NativeOperation(detail~ : String)
 } derive(Debug, Eq)
@@ -19,6 +20,8 @@ pub extend NotificationError with Show::{to_string, output}
 fn NotificationError::message(self : NotificationError) -> String {
   match self {
     EmptyBody => "notification body must not be empty"
+    InvalidBadgeCount(count) =>
+      "notification badge count must be non-negative, got " + count.to_string()
     UnsupportedPlatform =>
       "native notifications are not implemented on this platform"
     NativeOperation(detail~) =>

--- a/extensions/notification/extension.g.mbt
+++ b/extensions/notification/extension.g.mbt
@@ -5,6 +5,7 @@
 pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRoute] {
   [
     show_command.contract_route(),
+    set_badge_command.contract_route(),
   ]
 }
 
@@ -15,5 +16,9 @@ pub fn register_commands(
   registrar.bind(
     show_command,
     (context, request) => show(context, request),
+  )
+  registrar.bind(
+    set_badge_command,
+    (_context, request) => set_badge(request),
   )
 }

--- a/extensions/notification/extension.mbt
+++ b/extensions/notification/extension.mbt
@@ -2,12 +2,24 @@
 let show_command = @notification_contract.show
 
 ///|
+let set_badge_command = @notification_contract.set_badge
+
+///|
 /// Rejects empty notification bodies before calling the native package.
 fn ensure_body(body : String) -> String raise NotificationError {
   if body.is_empty() {
     raise EmptyBody
   } else {
     body
+  }
+}
+
+///|
+fn ensure_badge_count(count : Int) -> Int raise NotificationError {
+  if count < 0 {
+    raise InvalidBadgeCount(count)
+  } else {
+    count
   }
 }
 
@@ -41,6 +53,19 @@ async fn show(
     level: request.level,
   })
   reply
+}
+
+///|
+/// Sets the absolute application badge count. Repeating the same value is
+/// deliberately harmless, so replicated renderer state can converge without
+/// increment/decrement races.
+#proton.command(contract=set_badge_command)
+fn set_badge(
+  request : @notification_contract.NotificationBadgeRequest,
+) -> @notification_contract.NotificationBadgeReply raise NotificationError {
+  let count = ensure_badge_count(request.count)
+  notification_native_set_badge_count(count)
+  @notification_contract.NotificationBadgeReply::{ count, }
 }
 
 ///|

--- a/extensions/notification/extension_wbtest.mbt
+++ b/extensions/notification/extension_wbtest.mbt
@@ -8,3 +8,18 @@ test "notification requires a body" {
   inspect(error.message(), content="notification body must not be empty")
   assert_eq(ensure_body("ready"), "ready")
 }
+
+///|
+test "notification badge count is absolute and non-negative" {
+  assert_eq(ensure_badge_count(0), 0)
+  assert_eq(ensure_badge_count(3), 3)
+  let error = try ensure_badge_count(-1) catch {
+    error => error
+  } noraise {
+    _ => abort("expected invalid notification badge count error")
+  }
+  inspect(
+    error.message(),
+    content="notification badge count must be non-negative, got -1",
+  )
+}

--- a/extensions/notification/notification_native.mbt
+++ b/extensions/notification/notification_native.mbt
@@ -25,6 +25,15 @@ async fn notification_native_show(
 }
 
 ///|
+fn notification_native_set_badge_count(
+  count : Int,
+) -> Unit raise NotificationError {
+  @proton.notification_set_badge_count(count) catch {
+    error => raise NativeOperation(detail=error.message())
+  }
+}
+
+///|
 fn notification_native_cleanup() -> Unit raise NotificationError {
   @proton.notification_cleanup() catch {
     error => raise NativeOperation(detail=error.message())

--- a/proton/facade_notification.mbt
+++ b/proton/facade_notification.mbt
@@ -148,6 +148,16 @@ pub fn notification_supported() -> Bool raise NotificationDeliveryError {
 
 ///|
 #doc(hidden)
+pub fn notification_set_badge_count(
+  count : Int,
+) -> Unit raise NotificationDeliveryError {
+  @native.notification_set_badge_count(count) catch {
+    error => raise NativeFailure(status=error.status(), detail=error.message())
+  }
+}
+
+///|
+#doc(hidden)
 pub fn notification_cleanup() -> Unit raise NotificationDeliveryError {
   @native.notification_cleanup() catch {
     error => raise NativeFailure(status=error.status(), detail=error.message())

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -303,6 +303,9 @@ pub extern "C" fn proton_notification_show_ffi(
 ) -> Int = "proton_notification_show"
 
 ///|
+pub extern "C" fn proton_notification_set_badge_count_ffi(count : Int) -> Int = "proton_notification_set_badge_count"
+
+///|
 pub extern "C" fn proton_notification_cleanup_ffi() -> Int = "proton_notification_cleanup"
 
 ///|

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -134,6 +134,8 @@ int32_t proton_notification_show(const char *title,
                                             const char *body,
                                             const char *payload,
                                             int32_t has_payload);
+/* Sets the absolute application badge count. Zero clears the badge. */
+int32_t proton_notification_set_badge_count(int32_t count);
 int32_t proton_notification_cleanup(void);
 
 int32_t proton_window_destroy(proton_window_handle_t window);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -102,6 +102,8 @@ pub fn proton_notification_cleanup_ffi() -> Int
 
 pub fn proton_notification_is_supported_ffi(@ref.Ref[Int]) -> Int
 
+pub fn proton_notification_set_badge_count_ffi(Int) -> Int
+
 pub fn proton_notification_show_ffi(Bytes, Bytes, Bytes, Int) -> Int
 
 pub fn proton_runtime_begin_message_dialog_ffi(RuntimeHandle, Bytes, Int, Bytes, Int, Int, @ref.Ref[Int64]) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_notification.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_notification.c
@@ -174,6 +174,16 @@ int32_t proton_engine_notification_show(const char *title_utf8,
   return PROTON_OK;
 }
 
+int32_t proton_engine_notification_set_badge_count(int32_t count,
+                                                   char *error,
+                                                   size_t error_len) {
+  (void)count;
+  proton_notification_set_message(
+      error, error_len,
+      "application badge counts are not implemented on Linux");
+  return PROTON_ERR_UNSUPPORTED;
+}
+
 int32_t proton_engine_notification_cleanup(char *error, size_t error_len) {
   (void)error;
   (void)error_len;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_notification.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_notification.m
@@ -210,7 +210,40 @@ int32_t proton_engine_notification_show(const char *title_utf8,
   return PROTON_OK;
 }
 
+static int32_t proton_notification_apply_badge_count(int32_t count,
+                                                     char *error,
+                                                     size_t error_len) {
+  @autoreleasepool {
+    NSDockTile *dock_tile = [NSApp dockTile];
+    if (dock_tile == nil) {
+      proton_notification_set_message(error, error_len,
+                                      "application Dock tile is not available");
+      return PROTON_ERR_PLATFORM;
+    }
+    [dock_tile setBadgeLabel:(count > 0)
+                                 ? [NSString stringWithFormat:@"%d", count]
+                                 : nil];
+    [dock_tile display];
+    return PROTON_OK;
+  }
+}
+
+int32_t proton_engine_notification_set_badge_count(int32_t count,
+                                                   char *error,
+                                                   size_t error_len) {
+  __block int32_t status = PROTON_OK;
+  if ([NSThread isMainThread]) {
+    status = proton_notification_apply_badge_count(count, error, error_len);
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      status = proton_notification_apply_badge_count(count, error, error_len);
+    });
+  }
+  return status;
+}
+
 int32_t proton_engine_notification_cleanup(char *error, size_t error_len) {
+  proton_engine_notification_set_badge_count(0, error, error_len);
   if (g_notification_delegate != nil) {
     UNUserNotificationCenter *center =
         [UNUserNotificationCenter currentNotificationCenter];

--- a/proton/internal/native/ffi/src/engine/cef_win/win_notification.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_notification.c
@@ -224,6 +224,16 @@ int32_t proton_engine_notification_show(const char *title_utf8,
   return PROTON_OK;
 }
 
+int32_t proton_engine_notification_set_badge_count(int32_t count,
+                                                   char *error,
+                                                   size_t error_len) {
+  (void)count;
+  proton_notification_set_message(
+      error, error_len,
+      "application badge counts are not implemented on Windows");
+  return PROTON_ERR_UNSUPPORTED;
+}
+
 int32_t proton_engine_notification_cleanup(char *error, size_t error_len) {
   (void)error;
   (void)error_len;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1584,6 +1584,17 @@ int32_t proton_notification_show(const char *title,
   return proton_set_engine_status(status, engine_error);
 }
 
+int32_t proton_notification_set_badge_count(int32_t count) {
+  if (count < 0) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "notification badge count must be non-negative");
+  }
+  char engine_error[512] = {0};
+  int32_t status = proton_engine_notification_set_badge_count(
+      count, engine_error, sizeof(engine_error));
+  return proton_set_engine_status(status, engine_error);
+}
+
 int32_t proton_notification_cleanup(void) {
   char engine_error[512] = {0};
   int32_t status =

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -174,6 +174,9 @@ int32_t proton_engine_notification_show(const char *title,
                                         int32_t has_payload,
                                         char *error,
                                         size_t error_len);
+int32_t proton_engine_notification_set_badge_count(int32_t count,
+                                                   char *error,
+                                                   size_t error_len);
 int32_t proton_engine_notification_cleanup(char *error, size_t error_len);
 
 int32_t proton_engine_window_create(

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -117,6 +117,16 @@ test "notification clicks preserve optional payloads" {
 }
 
 ///|
+test "notification badge rejects negative counts before native dispatch" {
+  let error = expect_native_error(() => notification_set_badge_count(-1))
+  match error {
+    InvalidArgument(message~) =>
+      assert_eq(message, "notification badge count must be non-negative")
+    _ => fail("expected invalid argument")
+  }
+}
+
+///|
 test "quit request is an application-level runtime event" {
   let event = RuntimeEvent::QuitRequested
   assert_eq(event.event_type(), "quit_requested")

--- a/proton/internal/native/notification.mbt
+++ b/proton/internal/native/notification.mbt
@@ -32,6 +32,17 @@ pub fn notification_show(
 }
 
 ///|
+/// Sets the absolute application badge count. Zero clears the badge.
+pub fn notification_set_badge_count(count : Int) -> Unit raise NativeError {
+  if count < 0 {
+    raise InvalidArgument(
+      message="notification badge count must be non-negative",
+    )
+  }
+  check_status(@native_ffi.proton_notification_set_badge_count_ffi(count))
+}
+
+///|
 /// Releases process-level notification hooks installed by Proton.
 pub fn notification_cleanup() -> Unit raise NativeError {
   check_status(@native_ffi.proton_notification_cleanup_ffi())

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -25,6 +25,8 @@ pub fn last_error_message() -> String
 
 pub fn notification_cleanup() -> Unit raise NativeError
 
+pub fn notification_set_badge_count(Int) -> Unit raise NativeError
+
 pub fn notification_show(String, String, payload? : String) -> Unit raise NativeError
 
 pub fn notification_supported() -> Bool raise NativeError
@@ -569,10 +571,13 @@ pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError
+pub fn Window::set_movable(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_opacity(Self, Double) -> Unit raise NativeError
 pub fn Window::set_position(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_size(Self, Int, Int) -> Unit raise NativeError
+pub fn Window::set_skip_taskbar(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError
 pub fn Window::show(Self) -> Unit raise NativeError


### PR DESCRIPTION
## Summary

- add a typed `notification.setBadge` command that sets an absolute, non-negative application badge count
- implement Dock badge updates and cleanup on macOS, with explicit unsupported errors on Windows and Linux
- extend the notification example with controls for setting and clearing the application badge

The command is intentionally absolute and idempotent so clients can derive the count from replicated state without increment/decrement races during replay or reconnect.

## Validation

- `moon fmt --check`
- `moon test extensions/notification --target native` (2/2)
- `moon test proton/internal/native --target native` (28/28)
- `moon check --target native --deny-warn`
- `node scripts/verify_generated.mjs`
- packaged macOS notification example smoke: set count to 4, verified negative counts are rejected, then cleared the badge with count 0