### PR TITLE
feat(window): add interactive aspect ratio control

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ a manual review.
 `WindowHandle::set_skip_taskbar` removes or restores the Windows taskbar tab;
 macOS and Linux follow Electron's no-op behavior. See
 `examples/66_window_skip_taskbar` for a manual review.
+`WindowHandle::set_aspect_ratio` constrains interactive resizing while leaving
+programmatic `set_size` calls unconstrained, matching Electron's API. Pass
+`0.0` to clear the ratio. See `examples/67_window_aspect_ratio` for a manual
+review.
 
 The typed facade can own additional windows without replacing Proton's bridge
 pump:

--- a/examples/67_window_aspect_ratio/README.md
+++ b/examples/67_window_aspect_ratio/README.md
@@ -1,0 +1,32 @@
+# Window Aspect Ratio
+
+This is a manual review example for Proton's Electron-style
+`WindowHandle::set_aspect_ratio` API.
+
+Run it with:
+
+```sh
+moon -C examples run 67_window_aspect_ratio --target native
+```
+
+Review the native window frame:
+
+1. Choose **16:9**, then drag each native edge and corner. The live frame
+   should preserve the ratio while the user resizes it.
+2. Choose **1:1** and confirm the frame becomes square during interactive
+   resizing.
+3. Choose **Programmatic 900 x 500** while a ratio is active. The window
+   should take the requested size even though it is not 16:9 or 1:1.
+4. Choose **Clear ratio**, then confirm freeform interactive resizing works
+   again without restarting the process.
+5. Repeat the checks at a non-100% display scale where available.
+
+Platform details:
+
+- macOS uses the native content aspect-ratio constraint.
+- Windows adjusts `WM_SIZING` rectangles for all eight resize directions.
+- Linux updates GTK geometry aspect hints; the exact resize affordance depends
+  on the desktop window manager.
+- Headless runtimes report unsupported because they have no native frame.
+- Passing `0.0` clears the ratio. Programmatic `set_size` is intentionally not
+  constrained, matching Electron's `setAspectRatio` behavior.

--- a/examples/67_window_aspect_ratio/main.mbt
+++ b/examples/67_window_aspect_ratio/main.mbt
@@ -1,0 +1,185 @@
+///|
+struct AspectRequest {
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend AspectRequest with ToJson::{to_json}
+
+///|
+pub extend AspectRequest with FromJson::{from_json}
+
+///|
+struct AspectReply {
+  applied : Bool
+  ratio : Double
+  width : Int
+  height : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend AspectReply with ToJson::{to_json}
+
+///|
+pub extend AspectReply with FromJson::{from_json}
+
+///|
+let aspect_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-aspect-ratio",
+  js_namespace="windowAspectRatio",
+)
+
+///|
+let aspect_command : @proton_contract.Command[AspectRequest, AspectReply] = aspect_contract.command(
+  "set",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let ratio_state : Ref[Double] = { val: 0.0, }
+
+///|
+fn reply(
+  window : @proton.WindowHandle,
+  applied : Bool,
+  message : String,
+) -> AspectReply raise {
+  let state = window.state()
+  AspectReply::{
+    applied,
+    ratio: ratio_state.val,
+    width: state.width,
+    height: state.height,
+    message,
+  }
+}
+
+///|
+fn failed_reply(message : String) -> AspectReply {
+  AspectReply::{
+    applied: false,
+    ratio: ratio_state.val,
+    width: 0,
+    height: 0,
+    message,
+  }
+}
+
+///|
+fn set_ratio(request : AspectRequest) -> AspectReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        match request.action {
+          "wide" => {
+            window.set_aspect_ratio(16.0 / 9.0)
+            ratio_state.val = 16.0 / 9.0
+            reply(window, true, "Interactive resize ratio set to 16:9")
+          }
+          "square" => {
+            window.set_aspect_ratio(1.0)
+            ratio_state.val = 1.0
+            reply(window, true, "Interactive resize ratio set to 1:1")
+          }
+          "clear" => {
+            window.set_aspect_ratio(0.0)
+            ratio_state.val = 0.0
+            reply(window, true, "Interactive resize ratio cleared")
+          }
+          "programmatic" => {
+            window.set_size(900, 500)
+            reply(window, true, "Programmatic set_size(900, 500) applied")
+          }
+          _ => failed_reply("unknown action")
+        }
+      } catch {
+        error => failed_reply(error.to_string())
+      }
+    None => failed_reply("window is not ready")
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(aspect_command, (_context, request) => set_ratio(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|  <head>
+    #|    <meta charset="utf-8">
+    #|    <meta name="viewport" content="width=device-width, initial-scale=1">
+    #|    <title>Window Aspect Ratio</title>
+    #|    <style>
+    #|      :root { color-scheme: light; font-family: ui-sans-serif, system-ui, sans-serif; background: #edf1f4; color: #17232d; }
+    #|      * { box-sizing: border-box; }
+    #|      body { margin: 0; min-height: 100vh; background: #edf1f4; }
+    #|      main { width: min(900px, calc(100vw - 36px)); margin: 0 auto; padding: 34px 0 44px; }
+    #|      header { display: flex; justify-content: space-between; gap: 24px; align-items: end; padding-bottom: 22px; border-bottom: 1px solid #82909a; }
+    #|      .eyebrow { margin: 0 0 9px; color: #16677a; font: 750 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      h1 { margin: 0; font-size: 44px; line-height: .96; letter-spacing: 0; }
+    #|      .summary { max-width: 580px; margin: 14px 0 0; color: #50616c; line-height: 1.5; }
+    #|      .ratio { min-width: 145px; border-left: 5px solid #d56b32; padding: 8px 0 7px 16px; }
+    #|      .ratio small { display: block; color: #5d6e78; font: 750 10px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .ratio strong { display: block; margin-top: 8px; color: #16677a; font: 750 28px/1 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      .surface { display: grid; grid-template-columns: minmax(0, 1fr) 280px; margin-top: 20px; border: 1px solid #82909a; background: #f8fafb; }
+    #|      .preview { min-height: 390px; display: grid; place-items: center; border-right: 1px solid #82909a; background: repeating-linear-gradient(135deg, #e3ebef 0, #e3ebef 12px, #d8e3e8 12px, #d8e3e8 24px); }
+    #|      .frame { width: min(72%, 430px); aspect-ratio: 16 / 9; display: grid; place-items: center; border: 3px solid #17232d; background: #ffffffcc; box-shadow: 12px 12px 0 #16677a; text-align: center; }
+    #|      .frame span { display: block; color: #d56b32; font: 750 11px/1 ui-monospace, SFMono-Regular, Consolas, monospace; text-transform: uppercase; }
+    #|      .frame strong { display: block; margin-top: 9px; font-size: 22px; }
+    #|      .controls { display: grid; align-content: start; gap: 12px; padding: 22px; }
+    #|      .controls h2 { margin: 0 0 6px; font-size: 16px; }
+    #|      button { min-height: 44px; border: 1px solid #63737d; padding: 0 12px; background: #e4ebee; color: #17232d; cursor: pointer; font: 700 13px/1 ui-sans-serif, system-ui, sans-serif; }
+    #|      button:hover { border-color: #16677a; background: #d5e5e9; }
+    #|      button.primary { border-color: #16677a; background: #16677a; color: #ffffff; }
+    #|      button.primary:hover { background: #105466; }
+    #|      #status { min-height: 64px; margin: 6px 0 0; padding-top: 15px; border-top: 1px solid #bbc5ca; color: #50616c; font: 12px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
+    #|      @media (max-width: 700px) { header { display: block; } .ratio { width: 145px; margin-top: 18px; } .surface { grid-template-columns: 1fr; } .preview { min-height: 280px; border-right: 0; border-bottom: 1px solid #82909a; } }
+    #|      @media (max-width: 440px) { h1 { font-size: 37px; } .frame { width: 78%; } }
+    #|    </style>
+    #|  </head>
+    #|  <body>
+    #|    <main>
+    #|      <header>
+    #|        <div><p class="eyebrow">Native frame / manual test 67</p><h1>Window aspect ratio</h1><p class="summary">Constrain interactive native resizing while keeping programmatic size changes explicit.</p></div>
+    #|        <div class="ratio"><small>Active ratio</small><strong id="ratio">freeform</strong></div>
+    #|      </header>
+    #|      <section class="surface">
+    #|        <div class="preview"><div class="frame"><div><span>Resize the native frame</span><strong>Ratio lives outside the page</strong></div></div></div>
+    #|        <div class="controls"><h2>Choose a constraint</h2><button class="primary" data-action="wide" type="button">Set 16:9</button><button data-action="square" type="button">Set 1:1 square</button><button data-action="programmatic" type="button">Programmatic 900 x 500</button><button data-action="clear" type="button">Clear ratio</button><p id="status" role="status" aria-live="polite">Ready. Interactive resizing is freeform.</p></div>
+    #|      </section>
+    #|    </main>
+    #|    <script>
+    #|      const ratio = document.querySelector("#ratio");
+    #|      const status = document.querySelector("#status");
+    #|      const invoke = (action) => window.__MoonBit__.core.invokeOp("ext:windowAspectRatio/set", { action });
+    #|      async function run(action) { status.textContent = "Updating native window..."; try { const reply = await invoke(action); ratio.textContent = reply.ratio === 0 ? "freeform" : (Math.abs(reply.ratio - 1) < 0.001 ? "1:1" : "16:9"); status.textContent = `${reply.message} / ${reply.width} x ${reply.height}`; } catch (error) { status.textContent = `request failed: ${String(error)}`; } }
+    #|      document.querySelectorAll("[data-action]").forEach((button) => button.addEventListener("click", () => void run(button.dataset.action)));
+    #|    </script>
+    #|  </body>
+    #|</html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Aspect Ratio", html(), width=900, height=620, debug=true)
+  .identifier("dev.proton.window-aspect-ratio")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      ratio_state.val = 0.0
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/67_window_aspect_ratio/moon.pkg
+++ b/examples/67_window_aspect_ratio/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/67_window_aspect_ratio/pkg.generated.mbti
+++ b/examples/67_window_aspect_ratio/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/67_window_aspect_ratio"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type AspectReply derive(ToJson, @json.FromJson)
+pub fn AspectReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AspectReply::to_json(Self) -> Json
+
+type AspectRequest derive(ToJson, @json.FromJson)
+pub fn AspectRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AspectRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -114,6 +114,8 @@ moon -C examples run 01_run --target native
   a numeric slider, presets, and native frame checks.
 - `66_window_skip_taskbar`: manual Electron-style taskbar visibility review
   with Windows taskbar tab removal and macOS/Linux no-op checks.
+- `67_window_aspect_ratio`: manual Electron-style interactive resize ratio
+  review with 16:9, 1:1, clear, and programmatic resize checks.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -98,6 +98,9 @@ successful no-op behavior.
 frame and renderer, with values clamped to `0.0..1.0`.
 `WindowHandle::set_skip_taskbar` controls the Windows taskbar tab while
 preserving Electron's no-op behavior on macOS and Linux.
+`WindowHandle::set_aspect_ratio` constrains interactive resizing and accepts
+`0.0` to clear the constraint; programmatic `set_size` calls remain
+unconstrained, matching Electron.
 
 ## Logging
 

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -160,6 +160,11 @@ fn RuntimeSession::window_handle(
         window.set_maximum_size(width, height)
       })
     },
+    set_window_aspect_ratio: aspect_ratio => {
+      self.control_window(id, native_id, "set aspect ratio", window => {
+        window.set_aspect_ratio(aspect_ratio)
+      })
+    },
     set_window_movable: movable => {
       self.control_window(id, native_id, "set movable", window => {
         window.set_movable(movable)
@@ -1166,6 +1171,18 @@ pub fn WindowHandle::set_maximum_size(
   height : Int,
 ) -> Unit raise WindowSessionError {
   (self.set_window_maximum_size)(width, height)
+}
+
+///|
+/// Sets the live native window aspect ratio used while the user resizes it.
+/// Pass `0.0` to clear the constraint. Programmatic `set_size` calls are not
+/// constrained by the ratio, matching Electron's `setAspectRatio` behavior.
+/// Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_aspect_ratio(
+  self : WindowHandle,
+  aspect_ratio : Double,
+) -> Unit raise WindowSessionError {
+  (self.set_window_aspect_ratio)(aspect_ratio)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -430,6 +430,7 @@ pub struct WindowHandle {
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_aspect_ratio : (Double) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -66,6 +66,7 @@ fn test_window_handle(
   movable_calls? : Array[Bool],
   opacity_calls? : Array[Double],
   skip_taskbar_calls? : Array[Bool],
+  aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
   window_state? : WindowState,
@@ -119,6 +120,12 @@ fn test_window_handle(
     set_window_skip_taskbar: skip => {
       match skip_taskbar_calls {
         Some(calls) => calls.push(skip)
+        None => ()
+      }
+    },
+    set_window_aspect_ratio: aspect_ratio => {
+      match aspect_ratio_calls {
+        Some(calls) => calls.push(aspect_ratio)
         None => ()
       }
     },
@@ -2022,6 +2029,15 @@ test "window taskbar visibility routes live flags through the handle" {
   window.set_skip_taskbar(true)
   window.set_skip_taskbar(false)
   debug_inspect(calls, content="[true, false]")
+}
+
+///|
+test "window aspect ratio routes live values through the handle" {
+  let calls : Array[Double] = []
+  let window = test_window_handle("main", 17L, aspect_ratio_calls=calls)
+  window.set_aspect_ratio(16.0 / 9.0)
+  window.set_aspect_ratio(0.0)
+  debug_inspect(calls, content="[1.7777777777777777, 0]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -461,6 +461,12 @@ pub extern "C" fn proton_window_set_maximum_size_ffi(
 ) -> Int = "proton_window_set_maximum_size"
 
 ///|
+pub extern "C" fn proton_window_set_aspect_ratio_ffi(
+  window : WindowHandle,
+  aspect_ratio : Double,
+) -> Int = "proton_window_set_aspect_ratio"
+
+///|
 pub extern "C" fn proton_window_set_movable_ffi(
   window : WindowHandle,
   movable : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -160,6 +160,8 @@ int32_t proton_window_set_minimum_size(proton_window_handle_t window,
                                        int32_t width, int32_t height);
 int32_t proton_window_set_maximum_size(proton_window_handle_t window,
                                        int32_t width, int32_t height);
+int32_t proton_window_set_aspect_ratio(proton_window_handle_t window,
+                                       double aspect_ratio);
 int32_t proton_window_set_movable(proton_window_handle_t window,
                                   int32_t movable);
 int32_t proton_window_set_opacity(proton_window_handle_t window,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -206,6 +206,8 @@ pub fn proton_window_restore_ffi(WindowHandle) -> Int
 
 pub fn proton_window_set_always_on_top_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_aspect_ratio_ffi(WindowHandle, Double) -> Int
+
 pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -97,6 +97,7 @@ struct proton_engine_window {
   int min_height;
   int max_width;
   int max_height;
+  double aspect_ratio;
   int headless;
   int headless_hidden;
   int osr_popup_visible;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -67,6 +67,11 @@ static void proton_engine_apply_size_constraints(
     geometry.max_height = window->max_height;
     hints = (GdkWindowHints)(hints | GDK_HINT_MAX_SIZE);
   }
+  if (window->aspect_ratio > 0.0) {
+    geometry.min_aspect = window->aspect_ratio;
+    geometry.max_aspect = window->aspect_ratio;
+    hints = (GdkWindowHints)(hints | GDK_HINT_ASPECT);
+  }
   gtk_window_set_geometry_hints(GTK_WINDOW(window->window), NULL,
                                 hints == 0 ? NULL : &geometry, hints);
 }
@@ -853,6 +858,29 @@ int32_t proton_engine_window_set_maximum_size(
   }
   window->max_width = width;
   window->max_height = height;
+  proton_engine_apply_size_constraints(window);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_aspect_ratio(
+    proton_engine_window_t *window, double aspect_ratio, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(aspect_ratio) || aspect_ratio < 0.0) {
+    proton_engine_set_message(error, error_len,
+                              "aspect ratio must be non-negative");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window aspect ratio is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->aspect_ratio = aspect_ratio;
   proton_engine_apply_size_constraints(window);
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -160,6 +160,7 @@ struct proton_engine_window {
   int min_height;
   int max_width;
   int max_height;
+  double aspect_ratio;
   int zoom_percent;
   NSInteger attention_request_id;
   int headless;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1210,6 +1210,33 @@ int32_t proton_engine_window_set_maximum_size(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_aspect_ratio(
+    proton_engine_window_t *window, double aspect_ratio, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(aspect_ratio) || aspect_ratio < 0.0) {
+    proton_engine_set_message(error, error_len,
+                              "aspect ratio must be non-negative");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window aspect ratio is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->aspect_ratio = aspect_ratio;
+  if (aspect_ratio > 0.0) {
+    [window->window setContentAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
+  } else {
+    [window->window setResizeIncrements:NSMakeSize(1.0, 1.0)];
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
                                          int32_t movable, char *error,
                                          size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -83,6 +83,7 @@ struct proton_engine_window {
   int min_height;
   int max_width;
   int max_height;
+  double aspect_ratio;
   int titlebar_overlay;
   int fullscreen;
   int always_on_top;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -193,6 +193,61 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
                                        PROTON_WAIT_PLATFORM);
     }
     return 0;
+  case WM_SIZING:
+    if (window != NULL && window->aspect_ratio > 0.0 &&
+        window->resizable && lparam != 0) {
+      RECT *rect = (RECT *)lparam;
+      const int edge = (int)wparam;
+      RECT current_window;
+      RECT current_client;
+      int frame_width = 0;
+      int frame_height = 0;
+      if (GetWindowRect(hwnd, &current_window) &&
+          GetClientRect(hwnd, &current_client)) {
+        frame_width = (current_window.right - current_window.left) -
+                      (current_client.right - current_client.left);
+        frame_height = (current_window.bottom - current_window.top) -
+                       (current_client.bottom - current_client.top);
+      }
+      int client_width = (rect->right - rect->left) - frame_width;
+      int client_height = (rect->bottom - rect->top) - frame_height;
+      if (client_width > 0 && client_height > 0) {
+        if (edge == WMSZ_LEFT || edge == WMSZ_RIGHT) {
+          client_height = (int)lround((double)client_width /
+                                      window->aspect_ratio);
+        } else if (edge == WMSZ_TOP || edge == WMSZ_BOTTOM) {
+          client_width = (int)lround((double)client_height *
+                                     window->aspect_ratio);
+        } else {
+          int height_from_width = (int)lround((double)client_width /
+                                              window->aspect_ratio);
+          int width_from_height = (int)lround((double)client_height *
+                                              window->aspect_ratio);
+          if (abs(height_from_width - client_height) <=
+              abs(width_from_height - client_width)) {
+            client_height = height_from_width;
+          } else {
+            client_width = width_from_height;
+          }
+        }
+        const int outer_width = client_width + frame_width;
+        const int outer_height = client_height + frame_height;
+        if (edge == WMSZ_LEFT || edge == WMSZ_TOPLEFT ||
+            edge == WMSZ_BOTTOMLEFT) {
+          rect->left = rect->right - outer_width;
+        } else {
+          rect->right = rect->left + outer_width;
+        }
+        if (edge == WMSZ_TOP || edge == WMSZ_TOPLEFT ||
+            edge == WMSZ_TOPRIGHT) {
+          rect->top = rect->bottom - outer_height;
+        } else {
+          rect->bottom = rect->top + outer_height;
+        }
+      }
+      return TRUE;
+    }
+    break;
   case WM_MOVING:
     if (window != NULL && !window->movable) {
       // Electron blocks manual frame movement by restoring the current rect.
@@ -623,6 +678,28 @@ int32_t proton_engine_window_set_maximum_size(
   }
   window->max_width = width;
   window->max_height = height;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_aspect_ratio(
+    proton_engine_window_t *window, double aspect_ratio, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (isnan(aspect_ratio) || aspect_ratio < 0.0) {
+    proton_engine_set_message(error, error_len,
+                              "aspect ratio must be non-negative");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(
+        error, error_len,
+        "window aspect ratio is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->aspect_ratio = aspect_ratio;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1001,6 +1001,31 @@ int32_t proton_window_set_maximum_size(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_aspect_ratio(proton_window_handle_t window,
+                                       double aspect_ratio) {
+  if (isnan(aspect_ratio) || aspect_ratio < 0.0) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "aspect_ratio must be non-negative");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window aspect ratio requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_aspect_ratio(
+      slot->engine_window, aspect_ratio, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_movable(proton_window_handle_t window,
                                   int32_t movable) {
   if (movable != 0 && movable != 1) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -215,6 +215,9 @@ int32_t proton_engine_window_set_minimum_size(
 int32_t proton_engine_window_set_maximum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len);
+int32_t proton_engine_window_set_aspect_ratio(
+    proton_engine_window_t *window, double aspect_ratio, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_movable(proton_engine_window_t *window,
                                          int32_t movable, char *error,
                                          size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1409,6 +1409,20 @@ pub fn Window::set_maximum_size(
 }
 
 ///|
+/// Sets the live native window aspect ratio. Pass `0.0` to clear the ratio.
+pub fn Window::set_aspect_ratio(
+  self : Window,
+  aspect_ratio : Double,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_aspect_ratio_ffi(
+      self.live_handle(),
+      aspect_ratio,
+    ),
+  )
+}
+
+///|
 /// Sets whether the user can move the live native window.
 pub fn Window::set_movable(
   self : Window,

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -599,6 +599,7 @@ pub struct WindowHandle {
   set_window_resizable : (Bool) -> Unit raise WindowSessionError
   set_window_minimum_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_maximum_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_aspect_ratio : (Double) -> Unit raise WindowSessionError
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
@@ -626,6 +627,7 @@ pub fn WindowHandle::minimize(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add `WindowHandle::set_aspect_ratio(Double)` with Electron-compatible clear semantics (`0.0`)
- constrain interactive native resizing on macOS, Windows, and Linux
- keep programmatic `set_size` unconstrained, matching Electron
- add manually reviewable `examples/67_window_aspect_ratio`

## Platform behavior

- macOS uses the native content aspect-ratio constraint.
- Windows adjusts `WM_SIZING` rectangles for all resize directions.
- Linux updates GTK aspect geometry hints.
- Headless runtimes report unsupported.

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100` (571 passed)
- `moon -C examples check 67_window_aspect_ratio --target native --diagnostic-limit 100`
- `moon -C examples build 67_window_aspect_ratio --target native --diagnostic-limit 100`
- `moon check --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 100`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- macOS runtime smoke: 16:9, 1:1, programmatic `900 x 500`, and clear actions

## Manual review

See `examples/67_window_aspect_ratio/README.md`.
