### PR TITLE
fix(window): correct platform-specific window state handling

### DIFF
--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -251,6 +251,15 @@ static void proton_engine_window_state_notify(GObject *object,
   }
 }
 
+static void proton_engine_window_active_notify(GObject *object,
+                                               GParamSpec *parameter,
+                                               gpointer user_data) {
+  if (gtk_window_is_active(GTK_WINDOW(object))) {
+    gtk_window_set_urgency_hint(GTK_WINDOW(object), FALSE);
+  }
+  proton_engine_window_state_notify(object, parameter, user_data);
+}
+
 static void proton_engine_window_screen_changed(GtkWidget *widget,
                                                 GdkScreen *previous,
                                                 gpointer user_data) {
@@ -569,7 +578,7 @@ int32_t proton_engine_window_create(
     g_signal_connect(window->window, "configure-event",
                      G_CALLBACK(proton_engine_window_configure), window);
     g_signal_connect(window->window, "notify::is-active",
-                     G_CALLBACK(proton_engine_window_state_notify), window);
+                     G_CALLBACK(proton_engine_window_active_notify), window);
     g_signal_connect(window->window, "notify::scale-factor",
                      G_CALLBACK(proton_engine_window_state_notify), window);
     g_signal_connect(window->window, "screen-changed",
@@ -953,7 +962,9 @@ int32_t proton_engine_window_flash_frame(
         "window attention is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  gtk_window_set_urgency_hint(GTK_WINDOW(window->window), flash != 0);
+  gboolean urgent =
+      flash != 0 && !gtk_window_is_active(GTK_WINDOW(window->window));
+  gtk_window_set_urgency_hint(GTK_WINDOW(window->window), urgent);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -40,13 +40,13 @@ static void proton_engine_apply_size_constraints(
     return;
   }
   [window->window
-      setContentMinSize:window->min_width > 0
-                        ? NSMakeSize(window->min_width, window->min_height)
-                        : NSZeroSize];
+      setMinSize:window->min_width > 0
+                     ? NSMakeSize(window->min_width, window->min_height)
+                     : NSZeroSize];
   [window->window
-      setContentMaxSize:window->max_width > 0
-                        ? NSMakeSize(window->max_width, window->max_height)
-                        : NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX)];
+      setMaxSize:window->max_width > 0
+                     ? NSMakeSize(window->max_width, window->max_height)
+                     : NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX)];
 }
 
 static void proton_engine_dock_progress_clear(void) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -985,6 +985,18 @@ int32_t proton_engine_window_apply(
     window->always_on_top = action->value != 0;
     break;
   case PROTON_ENGINE_WINDOW_SET_RESIZABLE: {
+    if (action->value == 0 && window->resizable) {
+      RECT frame;
+      if (window->fullscreen) {
+        frame = window->windowed_placement.rcNormalPosition;
+      } else if (!GetWindowRect(window->hwnd, &frame)) {
+        proton_engine_set_message(error, error_len,
+                                  "failed to read current window frame");
+        return PROTON_ERR_PLATFORM;
+      }
+      window->width = frame.right - frame.left;
+      window->height = frame.bottom - frame.top;
+    }
     DWORD style = window->fullscreen
                       ? window->windowed_style
                       : (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);


### PR DESCRIPTION
## Summary

- apply macOS min/max constraints to the outer window frame so the public dimensions match the actual frame
- preserve the current Windows outer-frame size when disabling resize, including while fullscreen
- clear Linux urgency when a window becomes active and avoid setting urgency on an already-active window

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- manually verified macOS frame constraints with example 62: 480x360 minimum, 1100x760 maximum, and unconstrained 300x300 after clearing limits