### PR TITLE
fix(runtime): harden window and bridge lifecycles

### DIFF
--- a/contract/contract.mbt
+++ b/contract/contract.mbt
@@ -98,6 +98,7 @@ pub(all) suberror ContractDefinitionError {
   EmptyExtensionNamespace
   EmptyExtensionMember(extension_namespace~ : String)
   DuplicateEventRoute(route~ : String)
+  ExpectedExtensionEvent(route~ : String)
 } derive(Debug, Eq)
 
 ///|
@@ -332,6 +333,8 @@ pub fn ContractDefinitionError::message(
       "extension contract member must not be empty: " + extension_namespace
     DuplicateEventRoute(route~) =>
       "event route is declared more than once: " + route
+    ExpectedExtensionEvent(route~) =>
+      "event route does not belong to an extension: " + route
   }
 }
 

--- a/contract/contract_wbtest.mbt
+++ b/contract/contract_wbtest.mbt
@@ -75,3 +75,11 @@ test "extension identity validation rejects empty fields" {
     _ => abort("expected EmptyExtensionNamespace")
   }
 }
+
+///|
+test "expected extension event error reports its route" {
+  assert_eq(
+    ContractDefinitionError::ExpectedExtensionEvent(route="app:changed").message(),
+    "event route does not belong to an extension: app:changed",
+  )
+}

--- a/contract/pkg.generated.mbti
+++ b/contract/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub(all) suberror ContractDefinitionError {
   EmptyExtensionNamespace
   EmptyExtensionMember(extension_namespace~ : String)
   DuplicateEventRoute(route~ : String)
+  ExpectedExtensionEvent(route~ : String)
 } derive(Eq, @debug.Debug)
 pub fn ContractDefinitionError::equal(Self, Self) -> Bool
 pub fn ContractDefinitionError::message(Self) -> String

--- a/e2e/test/orchestration.mbt
+++ b/e2e/test/orchestration.mbt
@@ -468,25 +468,14 @@ async fn close_browser(target : String, timeout : Int) -> Unit {
 
 ///|
 async fn close_connected_browser(browser : @client.CdpClient) -> Unit {
-  let close_response = browser.send_command("Browser.close")
-  match close_response.error {
-    Some(error) =>
-      fail(
-        "Browser.close failed: " + error.code.to_string() + " " + error.message,
-      )
-    None => ()
+  let page_targets = browser
+    .get_targets()
+    .filter(info => info.target_type == "page")
+  guard page_targets.length() > 0 else {
+    fail("CDP browser has no live page target to close")
   }
-  // CEF's Alloy runtime acknowledges Browser.close but does not route the
-  // Chrome-specific close request to CefBrowserHost::CloseBrowser.  Keep the
-  // protocol request in the probe, then close every live page target through
-  // the browser connection so that the native lifecycle is exercised and all
-  // windows are covered.
-  @async.sleep(cdp_start_poll_timeout_ms)
-  let targets = browser.get_targets() catch { _ => return }
-  for info in targets {
-    if info.target_type == "page" {
-      close_page_target(browser, info.target_id)
-    }
+  for info in page_targets {
+    close_page_target(browser, info.target_id)
   }
 }
 

--- a/e2e/test/web_contents_view_scenario.mbt
+++ b/e2e/test/web_contents_view_scenario.mbt
@@ -223,4 +223,7 @@ fn assert_web_contents_view_events(path : String) -> Unit raise {
     events.contains("view_loading_changed loading=false") else {
     fail("view events missed loading state changes: " + events)
   }
+  guard events.contains("view_closed") else {
+    fail("view events missed the closed view lifecycle: " + events)
+  }
 }

--- a/examples/52_web_contents_view/main.mbt
+++ b/examples/52_web_contents_view/main.mbt
@@ -229,6 +229,7 @@ async fn main {
           error=Some("load failed: " + error_text),
         )
       LoadingChanged(..) => ()
+      Closed => panel_slot.val = None
     }
   })
   .window_lifecycle(

--- a/examples/e2e_fixtures/web_contents_view.mbt
+++ b/examples/e2e_fixtures/web_contents_view.mbt
@@ -85,5 +85,6 @@ fn web_contents_view_event_line(event : @proton.ViewEvent) -> String {
       error_code.to_string() +
       " error_text=" +
       error_text
+    Closed => "view_closed"
   }
 }

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -85,8 +85,8 @@ and bridge ABI. The v1 API exposes `support`, `show`, `hide`, `setIcon`,
 
 Tray menus are flat. Supported item kinds are `normal`, `separator`, and
 `checkbox`; nested submenus remain outside the Proton v1 surface. Native tray
-events are pumped by the extension and forwarded as extension events named
-`click`, `rightClick`, `doubleClick`, and `menuItemClick`.
+callbacks enqueue events and wake Proton's host loop, which forwards extension
+events named `click`, `rightClick`, `doubleClick`, and `menuItemClick`.
 
 Windows is the baseline for tray-icon click, right-click, and double-click
 events. Menu item clicks are the portable event path across Windows, Linux, and

--- a/extensions/global_hotkey/contract/contract.mbt
+++ b/extensions/global_hotkey/contract/contract.mbt
@@ -103,12 +103,6 @@ pub let list : @proton_contract.Command[
 ] = extension.command("list")
 
 ///|
-pub let drain_triggered : @proton_contract.Command[
-  @proton_contract.EmptyRequest,
-  GlobalHotkeyListReply,
-] = extension.command("drainTriggered")
-
-///|
 pub let activity : @proton_contract.Event[GlobalHotkeyActivity] = extension.event(
   "activity",
 )

--- a/extensions/global_hotkey/contract/pkg.generated.mbti
+++ b/extensions/global_hotkey/contract/pkg.generated.mbti
@@ -10,8 +10,6 @@ import {
 // Values
 pub let activity : @proton_contract.Event[GlobalHotkeyActivity]
 
-pub let drain_triggered : @proton_contract.Command[@proton_contract.EmptyRequest, GlobalHotkeyListReply]
-
 pub let extension : @proton_contract.ExtensionContract
 
 pub let list : @proton_contract.Command[@proton_contract.EmptyRequest, GlobalHotkeyListReply]

--- a/extensions/global_hotkey/extension.g.mbt
+++ b/extensions/global_hotkey/extension.g.mbt
@@ -7,7 +7,6 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
     register_command.contract_route(),
     unregister_command.contract_route(),
     list_command.contract_route(),
-    drain_triggered_command.contract_route(),
   ]
 }
 
@@ -26,9 +25,5 @@ pub fn register_commands(
   registrar.bind(
     list_command,
     (_context, request) => list(request),
-  )
-  registrar.bind(
-    drain_triggered_command,
-    (context, request) => drain_triggered(context, request),
   )
 }

--- a/extensions/global_hotkey/extension.mbt
+++ b/extensions/global_hotkey/extension.mbt
@@ -8,9 +8,6 @@ let unregister_command = @global_hotkey_contract.unregister
 let list_command = @global_hotkey_contract.list
 
 ///|
-let drain_triggered_command = @global_hotkey_contract.drain_triggered
-
-///|
 async fn emit_command_activity(
   context : @proton.CommandContext,
   operation : String,
@@ -73,39 +70,36 @@ fn list(
 }
 
 ///|
-/// Drains triggered global hotkeys from a generated app-command extension.
-#proton.command(contract=drain_triggered_command)
-async fn drain_triggered(
-  context : @proton.CommandContext,
-  _request : @proton_contract.EmptyRequest,
-) -> @global_hotkey_contract.GlobalHotkeyListReply {
-  let reply = drain_triggered_hotkeys(app_command_manager_handle())
-  for accelerator in reply.accelerators {
-    context.emit(@global_hotkey_contract.triggered, @global_hotkey_contract.GlobalHotkeyTriggered::{
-      accelerator,
-    })
+fn drain_events() -> Array[@proton_extension.Event] raise {
+  let events : Array[@proton_extension.Event] = []
+  match app_command_manager.val {
+    Some(manager) =>
+      for accelerator in manager.drain_triggered() {
+        events.push(
+          @proton_extension.event(@global_hotkey_contract.triggered, @global_hotkey_contract.GlobalHotkeyTriggered::{
+            accelerator,
+          }),
+        )
+      }
+    None => ()
   }
-  reply
+  events
 }
 
 ///|
-fn extension() -> @proton_extension.Extension {
-  @proton_extension.typed(
-    @global_hotkey_contract.extension,
-    generated_extension_command_routes(),
-    fn(registrar) raise { register_commands(registrar) },
-    scripts=[
-      @proton_extension.poller_script(
-        js_namespace="globalHotkey",
-        drain_method="drainTriggered",
-        poller_field="__protonTriggerPoller",
-      ),
-    ],
-  )
-}
+let extension_definition : @proton_extension.Extension = @proton_extension.typed(
+  @global_hotkey_contract.extension,
+  generated_extension_command_routes(),
+  fn(registrar) raise { register_commands(registrar) },
+  event_source=@proton_extension.event_source(
+    wakeup => install_event_wakeup(wakeup),
+    () => cleanup_manager(),
+    () => drain_events(),
+  ),
+)
 
 ///|
 /// Grants global-hotkey commands to renderer targets selected by `App::capability`.
 pub fn capability() -> @proton_extension.RendererCapability {
-  @proton_extension.capability(extension())
+  @proton_extension.capability(extension_definition)
 }

--- a/extensions/global_hotkey/extension_wbtest.mbt
+++ b/extensions/global_hotkey/extension_wbtest.mbt
@@ -1,5 +1,10 @@
 ///|
 test "global hotkey metadata constants match generated app command extension" {
-  assert_eq(extension().id(), "moonbit-community/proton-global-hotkey")
-  assert_eq(extension().command_spec().js_namespace(), "globalHotkey")
+  assert_eq(extension_definition.id(), "moonbit-community/proton-global-hotkey")
+  let capability = capability()
+  let spec = capability.command_spec()
+  assert_eq(spec.js_namespace(), "globalHotkey")
+  assert_false(spec.op_names().contains("ext:globalHotkey/drainTriggered"))
+  assert_eq(spec.scripts(), [])
+  assert_true(capability.event_source() is Some(_))
 }

--- a/extensions/global_hotkey/global_hotkey.mbt
+++ b/extensions/global_hotkey/global_hotkey.mbt
@@ -4,6 +4,9 @@ let app_command_manager : Ref[@sys_global_hotkey.GlobalHotkeyManager?] = Ref(
 )
 
 ///|
+let app_command_event_wakeup : Ref[@proton_extension.EventWakeup?] = Ref(None)
+
+///|
 /// Verifies that global hotkeys are available on the current platform.
 fn ensure_supported() -> Unit raise GlobalHotkeyError {
   match @sys_global_hotkey.ensure_supported() {
@@ -17,9 +20,34 @@ fn ensure_supported() -> Unit raise GlobalHotkeyError {
 fn init_manager() -> @sys_global_hotkey.GlobalHotkeyManager raise GlobalHotkeyError {
   ensure_supported()
   match @sys_global_hotkey.create() {
-    Ok(handle) => handle
+    Ok(handle) => {
+      match app_command_event_wakeup.val {
+        Some(wakeup) => handle.set_event_wakeup(wakeup)
+        None => ()
+      }
+      handle
+    }
     Err(error) => raise ManagerInitializationFailed(detail=error)
   }
+}
+
+///|
+fn install_event_wakeup(wakeup : @proton_extension.EventWakeup) -> Unit {
+  app_command_event_wakeup.val = Some(wakeup)
+  match app_command_manager.val {
+    Some(manager) => manager.set_event_wakeup(wakeup)
+    None => ()
+  }
+}
+
+///|
+fn cleanup_manager() -> Unit {
+  match app_command_manager.val {
+    Some(manager) => manager.destroy()
+    None => ()
+  }
+  app_command_manager.val = None
+  app_command_event_wakeup.val = None
 }
 
 ///|
@@ -72,11 +100,4 @@ fn list_hotkeys(
   manager : @sys_global_hotkey.GlobalHotkeyManager,
 ) -> @global_hotkey_contract.GlobalHotkeyListReply {
   list_or_empty(manager, fn(handle) { handle.list() })
-}
-
-///|
-fn drain_triggered_hotkeys(
-  manager : @sys_global_hotkey.GlobalHotkeyManager,
-) -> @global_hotkey_contract.GlobalHotkeyListReply {
-  list_or_empty(manager, fn(handle) { handle.drain_triggered() })
 }

--- a/extensions/power_monitor/contract/contract.mbt
+++ b/extensions/power_monitor/contract/contract.mbt
@@ -69,23 +69,6 @@ pub extend PowerMonitorEventPayload with ToJson::{to_json}
 pub extend PowerMonitorEventPayload with FromJson::{from_json}
 
 ///|
-pub(all) struct PowerMonitorEventReply {
-  count : Int
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
-pub extend PowerMonitorEventReply with Eq::{not_equal, equal}
-
-///|
-pub extend PowerMonitorEventReply with Debug::{to_repr}
-
-///|
-pub extend PowerMonitorEventReply with ToJson::{to_json}
-
-///|
-pub extend PowerMonitorEventReply with FromJson::{from_json}
-
-///|
 pub let get_idle_time : @proton_contract.Command[
   @proton_contract.EmptyRequest,
   IdleTimeReply,
@@ -96,12 +79,6 @@ pub let get_power_source : @proton_contract.Command[
   @proton_contract.EmptyRequest,
   PowerSourceReply,
 ] = extension.command("getPowerSource")
-
-///|
-pub let drain_events : @proton_contract.Command[
-  @proton_contract.EmptyRequest,
-  PowerMonitorEventReply,
-] = extension.command("drainEvents")
 
 ///|
 pub let activity : @proton_contract.Event[PowerMonitorActivity] = extension.event(

--- a/extensions/power_monitor/contract/pkg.generated.mbti
+++ b/extensions/power_monitor/contract/pkg.generated.mbti
@@ -10,8 +10,6 @@ import {
 // Values
 pub let activity : @proton_contract.Event[PowerMonitorActivity]
 
-pub let drain_events : @proton_contract.Command[@proton_contract.EmptyRequest, PowerMonitorEventReply]
-
 pub let extension : @proton_contract.ExtensionContract
 
 pub let get_idle_time : @proton_contract.Command[@proton_contract.EmptyRequest, IdleTimeReply]
@@ -58,15 +56,6 @@ pub fn PowerMonitorEventPayload::from_json(Json, @json.JsonPath) -> Self raise @
 pub fn PowerMonitorEventPayload::not_equal(Self, Self) -> Bool
 pub fn PowerMonitorEventPayload::to_json(Self) -> Json
 pub fn PowerMonitorEventPayload::to_repr(Self) -> @debug.Repr
-
-pub(all) struct PowerMonitorEventReply {
-  count : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn PowerMonitorEventReply::equal(Self, Self) -> Bool
-pub fn PowerMonitorEventReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn PowerMonitorEventReply::not_equal(Self, Self) -> Bool
-pub fn PowerMonitorEventReply::to_json(Self) -> Json
-pub fn PowerMonitorEventReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PowerSourceReply {
   source : String

--- a/extensions/power_monitor/extension.g.mbt
+++ b/extensions/power_monitor/extension.g.mbt
@@ -6,7 +6,6 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
   [
     get_idle_time_command.contract_route(),
     get_power_source_command.contract_route(),
-    drain_events_command.contract_route(),
   ]
 }
 
@@ -21,9 +20,5 @@ pub fn register_commands(
   registrar.bind(
     get_power_source_command,
     (context, request) => get_power_source(context, request),
-  )
-  registrar.bind(
-    drain_events_command,
-    (context, request) => drain_events(context, request),
   )
 }

--- a/extensions/power_monitor/extension.mbt
+++ b/extensions/power_monitor/extension.mbt
@@ -5,10 +5,10 @@ let get_idle_time_command = @power_monitor_contract.get_idle_time
 let get_power_source_command = @power_monitor_contract.get_power_source
 
 ///|
-let drain_events_command = @power_monitor_contract.drain_events
+let active_monitor : Ref[@sys_power_monitor.PowerMonitor?] = Ref(None)
 
 ///|
-let active_monitor : Ref[@sys_power_monitor.PowerMonitor?] = Ref(None)
+let event_wakeup : Ref[@proton_extension.EventWakeup?] = Ref(None)
 
 ///|
 fn ensure_monitor() -> @sys_power_monitor.PowerMonitor raise PowerMonitorError {
@@ -17,6 +17,10 @@ fn ensure_monitor() -> @sys_power_monitor.PowerMonitor raise PowerMonitorError {
     None => {
       let monitor = @sys_power_monitor.PowerMonitor() catch {
         error => raise BackendUnavailable(detail=error.to_string())
+      }
+      match event_wakeup.val {
+        Some(wakeup) => monitor.set_event_wakeup(wakeup)
+        None => ()
       }
       // Best-effort: enable the event watch backend. A platform that cannot
       // watch only loses events; polling queries stay fully usable.
@@ -74,34 +78,39 @@ async fn get_power_source(
 }
 
 ///|
-async fn emit_power_monitor_event(
-  context : @proton.CommandContext,
+fn power_monitor_event(
   event : @sys_power_monitor.PowerMonitorEvent,
-) -> Unit {
+) -> @proton_extension.Event raise {
   let payload = @power_monitor_contract.PowerMonitorEventPayload::{ }
   match event {
-    Suspend => context.emit(@power_monitor_contract.suspend, payload)
-    Resume => context.emit(@power_monitor_contract.resume_event, payload)
-    OnAC => context.emit(@power_monitor_contract.on_ac, payload)
-    OnBattery => context.emit(@power_monitor_contract.on_battery, payload)
-    LockScreen => context.emit(@power_monitor_contract.lock_screen, payload)
-    UnlockScreen => context.emit(@power_monitor_contract.unlock_screen, payload)
+    Suspend => @proton_extension.event(@power_monitor_contract.suspend, payload)
+    Resume =>
+      @proton_extension.event(@power_monitor_contract.resume_event, payload)
+    OnAC => @proton_extension.event(@power_monitor_contract.on_ac, payload)
+    OnBattery =>
+      @proton_extension.event(@power_monitor_contract.on_battery, payload)
+    LockScreen =>
+      @proton_extension.event(@power_monitor_contract.lock_screen, payload)
+    UnlockScreen =>
+      @proton_extension.event(@power_monitor_contract.unlock_screen, payload)
   }
 }
 
 ///|
-/// Drains native power-monitor events into JavaScript extension events.
-#proton.command(contract=drain_events_command)
-async fn drain_events(
-  context : @proton.CommandContext,
-  _request : @proton_contract.EmptyRequest,
-) -> @power_monitor_contract.PowerMonitorEventReply {
-  let monitor = ensure_monitor()
-  let events = monitor.drain_events()
-  for event in events {
-    emit_power_monitor_event(context, event)
+fn start_event_source(wakeup : @proton_extension.EventWakeup) -> Unit {
+  event_wakeup.val = Some(wakeup)
+  match active_monitor.val {
+    Some(monitor) => monitor.set_event_wakeup(wakeup)
+    None => ignore(ensure_monitor()) catch { _ => () }
   }
-  @power_monitor_contract.PowerMonitorEventReply::{ count: events.length(), }
+}
+
+///|
+fn drain_events() -> Array[@proton_extension.Event] raise {
+  match active_monitor.val {
+    Some(monitor) => monitor.drain_events().map(power_monitor_event)
+    None => []
+  }
 }
 
 ///|
@@ -113,27 +122,23 @@ fn cleanup_power_monitor() -> Unit {
     }
     None => ()
   }
+  event_wakeup.val = None
 }
 
 ///|
-fn extension() -> @proton_extension.Extension {
-  @proton_extension.typed(
-    @power_monitor_contract.extension,
-    generated_extension_command_routes(),
-    fn(registrar) raise { register_commands(registrar) },
-    scripts=[
-      @proton_extension.poller_script(
-        js_namespace="powerMonitor",
-        drain_method="drainEvents",
-        poller_field="__protonEventPoller",
-      ),
-    ],
-    on_destroy=fn() { cleanup_power_monitor() },
-  )
-}
+let extension_definition : @proton_extension.Extension = @proton_extension.typed(
+  @power_monitor_contract.extension,
+  generated_extension_command_routes(),
+  fn(registrar) raise { register_commands(registrar) },
+  event_source=@proton_extension.event_source(
+    wakeup => start_event_source(wakeup),
+    () => cleanup_power_monitor(),
+    () => drain_events(),
+  ),
+)
 
 ///|
 /// Grants power-monitor commands to renderer targets selected by `App::capability`.
 pub fn capability() -> @proton_extension.RendererCapability {
-  @proton_extension.capability(extension())
+  @proton_extension.capability(extension_definition)
 }

--- a/extensions/power_monitor/extension_wbtest.mbt
+++ b/extensions/power_monitor/extension_wbtest.mbt
@@ -1,5 +1,10 @@
 ///|
 test "power monitor extension identity matches the generated app command extension" {
-  assert_eq(extension().id(), "moonbit-community/proton-power-monitor")
-  assert_eq(extension().command_spec().js_namespace(), "powerMonitor")
+  let capability = capability()
+  assert_eq(capability.id(), "moonbit-community/proton-power-monitor")
+  let spec = capability.command_spec()
+  assert_eq(spec.js_namespace(), "powerMonitor")
+  assert_false(spec.op_names().contains("ext:powerMonitor/drainEvents"))
+  assert_eq(spec.scripts(), [])
+  assert_true(capability.event_source() is Some(_))
 }

--- a/extensions/screen_monitor/contract/contract.mbt
+++ b/extensions/screen_monitor/contract/contract.mbt
@@ -137,25 +137,6 @@ pub extend NearestPointRequest with ToJson::{to_json}
 pub extend NearestPointRequest with FromJson::{from_json}
 
 ///|
-/// Reply for `drainEvents`: the number of topology events that were drained and
-/// forwarded to this renderer.
-pub(all) struct ScreenEventReply {
-  count : Int
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
-pub extend ScreenEventReply with Eq::{not_equal, equal}
-
-///|
-pub extend ScreenEventReply with Debug::{to_repr}
-
-///|
-pub extend ScreenEventReply with ToJson::{to_json}
-
-///|
-pub extend ScreenEventReply with FromJson::{from_json}
-
-///|
 /// Telemetry for screen query commands, so renderers can observe which screen
 /// APIs were exercised. Follows the activity-event convention shared by the
 /// other `proton_ext` command extensions.
@@ -198,12 +179,6 @@ pub let get_cursor_point : @proton_contract.Command[
   @proton_contract.EmptyRequest,
   CursorPointReply,
 ] = extension.command("getCursorScreenPoint")
-
-///|
-pub let drain_events : @proton_contract.Command[
-  @proton_contract.EmptyRequest,
-  ScreenEventReply,
-] = extension.command("drainEvents")
 
 ///|
 /// Payload for display topology change events. Mirrors the `newDisplay`

--- a/extensions/screen_monitor/contract/pkg.generated.mbti
+++ b/extensions/screen_monitor/contract/pkg.generated.mbti
@@ -16,8 +16,6 @@ pub let display_metrics_changed : @proton_contract.Event[DisplayJSON]
 
 pub let display_removed : @proton_contract.Event[DisplayJSON]
 
-pub let drain_events : @proton_contract.Command[@proton_contract.EmptyRequest, ScreenEventReply]
-
 pub let extension : @proton_contract.ExtensionContract
 
 pub let get_all_displays : @proton_contract.Command[@proton_contract.EmptyRequest, DisplaysReply]
@@ -102,15 +100,6 @@ pub fn PointJSON::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecode
 pub fn PointJSON::not_equal(Self, Self) -> Bool
 pub fn PointJSON::to_json(Self) -> Json
 pub fn PointJSON::to_repr(Self) -> @debug.Repr
-
-pub(all) struct ScreenEventReply {
-  count : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn ScreenEventReply::equal(Self, Self) -> Bool
-pub fn ScreenEventReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn ScreenEventReply::not_equal(Self, Self) -> Bool
-pub fn ScreenEventReply::to_json(Self) -> Json
-pub fn ScreenEventReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScreenMonitorActivity {
   operation : String

--- a/extensions/screen_monitor/extension.g.mbt
+++ b/extensions/screen_monitor/extension.g.mbt
@@ -8,7 +8,6 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
     get_primary_display_command.contract_route(),
     get_display_nearest_point_command.contract_route(),
     get_cursor_point_command.contract_route(),
-    drain_events_command.contract_route(),
   ]
 }
 
@@ -31,9 +30,5 @@ pub fn register_commands(
   registrar.bind(
     get_cursor_point_command,
     (context, request) => get_cursor_point(context, request),
-  )
-  registrar.bind(
-    drain_events_command,
-    (context, request) => drain_events(context, request),
   )
 }

--- a/extensions/screen_monitor/extension.mbt
+++ b/extensions/screen_monitor/extension.mbt
@@ -11,10 +11,10 @@ let get_display_nearest_point_command = @screen_monitor_contract.get_display_nea
 let get_cursor_point_command = @screen_monitor_contract.get_cursor_point
 
 ///|
-let drain_events_command = @screen_monitor_contract.drain_events
+let active_monitor : Ref[@sys_screen_monitor.ScreenMonitor?] = Ref(None)
 
 ///|
-let active_monitor : Ref[@sys_screen_monitor.ScreenMonitor?] = Ref(None)
+let event_wakeup : Ref[@proton_extension.EventWakeup?] = Ref(None)
 
 ///|
 fn ensure_monitor() -> @sys_screen_monitor.ScreenMonitor raise ScreenMonitorError {
@@ -23,6 +23,10 @@ fn ensure_monitor() -> @sys_screen_monitor.ScreenMonitor raise ScreenMonitorErro
     None => {
       let monitor = @sys_screen_monitor.ScreenMonitor() catch {
         error => raise BackendUnavailable(detail=error.to_string())
+      }
+      match event_wakeup.val {
+        Some(wakeup) => monitor.set_event_wakeup(wakeup)
+        None => ()
       }
       // Best-effort: enable the event watch backend. A platform that cannot
       // watch only loses topology events; polling queries stay fully usable.
@@ -149,41 +153,42 @@ async fn get_cursor_point(
 }
 
 ///|
-async fn emit_screen_event(
-  context : @proton.CommandContext,
+fn screen_event(
   event : @sys_screen_monitor.ScreenMonitorEvent,
   payload : @screen_monitor_contract.DisplayJSON,
-) -> Unit {
+) -> @proton_extension.Event raise {
   match event {
     DisplayAdded =>
-      context.emit(@screen_monitor_contract.display_added, payload)
+      @proton_extension.event(@screen_monitor_contract.display_added, payload)
     DisplayRemoved =>
-      context.emit(@screen_monitor_contract.display_removed, payload)
+      @proton_extension.event(@screen_monitor_contract.display_removed, payload)
     DisplayMetricsChanged =>
-      context.emit(@screen_monitor_contract.display_metrics_changed, payload)
+      @proton_extension.event(
+        @screen_monitor_contract.display_metrics_changed, payload,
+      )
   }
 }
 
 ///|
-/// Drains native display topology events and forwards each as a JavaScript
-/// extension event carrying the current primary display snapshot.
-#proton.command(contract=drain_events_command)
-async fn drain_events(
-  context : @proton.CommandContext,
-  _request : @proton_contract.EmptyRequest,
-) -> @screen_monitor_contract.ScreenEventReply {
-  let monitor = ensure_monitor()
-  let events = monitor.drain_events()
+fn start_event_source(wakeup : @proton_extension.EventWakeup) -> Unit {
+  event_wakeup.val = Some(wakeup)
+  match active_monitor.val {
+    Some(monitor) => monitor.set_event_wakeup(wakeup)
+    None => ignore(ensure_monitor()) catch { _ => () }
+  }
+}
+
+///|
+fn drain_events() -> Array[@proton_extension.Event] raise {
+  guard active_monitor.val is Some(monitor) else { return [] }
+  let native_events = monitor.drain_events()
   let payload = Some(display_to_contract(monitor.primary_display())) catch {
     _ => None
   }
-  for event in events {
-    match payload {
-      Some(payload) => emit_screen_event(context, event, payload)
-      None => ()
-    }
+  match payload {
+    Some(payload) => native_events.map(event => screen_event(event, payload))
+    None => []
   }
-  @screen_monitor_contract.ScreenEventReply::{ count: events.length(), }
 }
 
 ///|
@@ -195,28 +200,24 @@ fn cleanup_screen_monitor() -> Unit {
     }
     None => ()
   }
+  event_wakeup.val = None
 }
 
 ///|
-fn extension() -> @proton_extension.Extension {
-  @proton_extension.typed(
-    @screen_monitor_contract.extension,
-    generated_extension_command_routes(),
-    fn(registrar) raise { register_commands(registrar) },
-    scripts=[
-      @proton_extension.poller_script(
-        js_namespace="screen",
-        drain_method="drainEvents",
-        poller_field="__protonEventPoller",
-      ),
-    ],
-    on_destroy=fn() { cleanup_screen_monitor() },
-  )
-}
+let extension_definition : @proton_extension.Extension = @proton_extension.typed(
+  @screen_monitor_contract.extension,
+  generated_extension_command_routes(),
+  fn(registrar) raise { register_commands(registrar) },
+  event_source=@proton_extension.event_source(
+    wakeup => start_event_source(wakeup),
+    () => cleanup_screen_monitor(),
+    () => drain_events(),
+  ),
+)
 
 ///|
 /// Grants screen-monitor commands to renderer targets selected by
 /// `App::capability`.
 pub fn capability() -> @proton_extension.RendererCapability {
-  @proton_extension.capability(extension())
+  @proton_extension.capability(extension_definition)
 }

--- a/extensions/screen_monitor/extension_wbtest.mbt
+++ b/extensions/screen_monitor/extension_wbtest.mbt
@@ -1,5 +1,10 @@
 ///|
 test "screen monitor extension identity matches the generated app command extension" {
-  assert_eq(capability().id(), "moonbit-community/proton-screen-monitor")
-  assert_eq(capability().command_spec().js_namespace(), "screen")
+  let capability = capability()
+  assert_eq(capability.id(), "moonbit-community/proton-screen-monitor")
+  let spec = capability.command_spec()
+  assert_eq(spec.js_namespace(), "screen")
+  assert_false(spec.op_names().contains("ext:screen/drainEvents"))
+  assert_eq(spec.scripts(), [])
+  assert_true(capability.event_source() is Some(_))
 }

--- a/extensions/tray/contract/contract.mbt
+++ b/extensions/tray/contract/contract.mbt
@@ -124,23 +124,6 @@ pub extend TrayReply with ToJson::{to_json}
 pub extend TrayReply with FromJson::{from_json}
 
 ///|
-pub(all) struct TrayEventReply {
-  count : Int
-} derive(ToJson, FromJson, Debug, Eq)
-
-///|
-pub extend TrayEventReply with Eq::{not_equal, equal}
-
-///|
-pub extend TrayEventReply with Debug::{to_repr}
-
-///|
-pub extend TrayEventReply with ToJson::{to_json}
-
-///|
-pub extend TrayEventReply with FromJson::{from_json}
-
-///|
 pub(all) struct TrayActivity {
   operation : String
   visible : Bool
@@ -260,12 +243,6 @@ pub let set_tooltip : @proton_contract.Command[SetTooltipRequest, TrayReply] = e
 pub let set_menu : @proton_contract.Command[SetMenuRequest, TrayReply] = extension.command(
   "setMenu",
 )
-
-///|
-pub let drain_events : @proton_contract.Command[
-  @proton_contract.EmptyRequest,
-  TrayEventReply,
-] = extension.command("drainEvents")
 
 ///|
 pub let destroy : @proton_contract.Command[

--- a/extensions/tray/contract/pkg.generated.mbti
+++ b/extensions/tray/contract/pkg.generated.mbti
@@ -16,8 +16,6 @@ pub let destroy : @proton_contract.Command[@proton_contract.EmptyRequest, TrayRe
 
 pub let double_click : @proton_contract.Event[TrayDoubleClick]
 
-pub let drain_events : @proton_contract.Command[@proton_contract.EmptyRequest, TrayEventReply]
-
 pub let extension : @proton_contract.ExtensionContract
 
 pub let hide : @proton_contract.Command[@proton_contract.EmptyRequest, TrayReply]
@@ -106,15 +104,6 @@ pub fn TrayDoubleClick::from_json(Json, @json.JsonPath) -> Self raise @json.Json
 pub fn TrayDoubleClick::not_equal(Self, Self) -> Bool
 pub fn TrayDoubleClick::to_json(Self) -> Json
 pub fn TrayDoubleClick::to_repr(Self) -> @debug.Repr
-
-pub(all) struct TrayEventReply {
-  count : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn TrayEventReply::equal(Self, Self) -> Bool
-pub fn TrayEventReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn TrayEventReply::not_equal(Self, Self) -> Bool
-pub fn TrayEventReply::to_json(Self) -> Json
-pub fn TrayEventReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TrayMenu {
   items : Array[TrayMenuItem]

--- a/extensions/tray/error.mbt
+++ b/extensions/tray/error.mbt
@@ -11,7 +11,6 @@ suberror TrayError {
   ShowFailed(detail~ : String)
   HideFailed(detail~ : String)
   SetTooltipFailed(detail~ : String)
-  PumpFailed(detail~ : String)
 } derive(Debug, Eq)
 
 ///|
@@ -36,7 +35,6 @@ fn TrayError::message(self : TrayError) -> String {
     ShowFailed(detail~) => "failed to show tray: " + detail
     HideFailed(detail~) => "failed to hide tray: " + detail
     SetTooltipFailed(detail~) => "failed to set tray tooltip: " + detail
-    PumpFailed(detail~) => "failed to pump tray events: " + detail
   }
 }
 

--- a/extensions/tray/extension.g.mbt
+++ b/extensions/tray/extension.g.mbt
@@ -10,7 +10,6 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
     set_icon_command.contract_route(),
     set_tooltip_command.contract_route(),
     set_menu_command.contract_route(),
-    drain_events_command.contract_route(),
     destroy_command.contract_route(),
   ]
 }
@@ -42,10 +41,6 @@ pub fn register_commands(
   registrar.bind(
     set_menu_command,
     (context, request) => set_menu(context, request),
-  )
-  registrar.bind(
-    drain_events_command,
-    (context, request) => drain_events(context, request),
   )
   registrar.bind(
     destroy_command,

--- a/extensions/tray/extension.mbt
+++ b/extensions/tray/extension.mbt
@@ -23,9 +23,6 @@ let set_tooltip_command = @tray_contract.set_tooltip
 let set_menu_command = @tray_contract.set_menu
 
 ///|
-let drain_events_command = @tray_contract.drain_events
-
-///|
 let destroy_command = @tray_contract.destroy
 
 ///|
@@ -33,6 +30,9 @@ let app_command_tray_handle : Ref[@sys_tray.Tray?] = Ref(None)
 
 ///|
 let app_command_tray_visible : Ref[Bool] = Ref(false)
+
+///|
+let app_command_event_wakeup : Ref[@proton_extension.EventWakeup?] = Ref(None)
 
 ///|
 fn platform_label(platform : @sys_tray.Platform) -> String {
@@ -70,6 +70,10 @@ fn tray_handle() -> @sys_tray.Tray raise TrayError {
     None =>
       match @sys_tray.create(identifier="moonbit-community.proton.tray") {
         Ok(handle) => {
+          match app_command_event_wakeup.val {
+            Some(wakeup) => handle.set_event_wakeup(wakeup)
+            None => ()
+          }
           app_command_tray_handle.val = Some(handle)
           handle
         }
@@ -183,28 +187,44 @@ async fn emit_command_activity(
 }
 
 ///|
-async fn emit_native_tray_event(
-  context : @proton.CommandContext,
+fn native_tray_event(
   event : @sys_tray.TrayEvent,
-) -> Unit {
+) -> @proton_extension.Event raise {
   match event {
     Click =>
-      context.emit(@tray_contract.click, @tray_contract.TrayClick::{
+      @proton_extension.event(@tray_contract.click, @tray_contract.TrayClick::{
         visible: app_command_tray_visible.val,
       })
     RightClick =>
-      context.emit(@tray_contract.right_click, @tray_contract.TrayRightClick::{
+      @proton_extension.event(@tray_contract.right_click, @tray_contract.TrayRightClick::{
         visible: app_command_tray_visible.val,
       })
     DoubleClick =>
-      context.emit(@tray_contract.double_click, @tray_contract.TrayDoubleClick::{
+      @proton_extension.event(@tray_contract.double_click, @tray_contract.TrayDoubleClick::{
         visible: app_command_tray_visible.val,
       })
     MenuItemClick(item_id) =>
-      context.emit(@tray_contract.menu_item_click, @tray_contract.TrayMenuItemClick::{
+      @proton_extension.event(@tray_contract.menu_item_click, @tray_contract.TrayMenuItemClick::{
         item_id,
         visible: app_command_tray_visible.val,
       })
+  }
+}
+
+///|
+fn install_event_wakeup(wakeup : @proton_extension.EventWakeup) -> Unit {
+  app_command_event_wakeup.val = Some(wakeup)
+  match app_command_tray_handle.val {
+    Some(handle) => handle.set_event_wakeup(wakeup)
+    None => ()
+  }
+}
+
+///|
+fn drain_native_events() -> Array[@proton_extension.Event] raise {
+  match app_command_tray_handle.val {
+    None => []
+    Some(handle) => handle.drain_events().map(native_tray_event)
   }
 }
 
@@ -221,6 +241,7 @@ fn destroy_tray(tray_handle : @sys_tray.Tray?) -> Unit {
 ///|
 fn cleanup_tray() -> Unit {
   destroy_tray(app_command_tray_handle.val)
+  app_command_event_wakeup.val = None
 }
 
 ///|
@@ -337,29 +358,6 @@ async fn set_menu(
 }
 
 ///|
-/// Drains native tray events into JavaScript extension events.
-#proton.command(contract=drain_events_command)
-async fn drain_events(
-  context : @proton.CommandContext,
-  _request : @proton_contract.EmptyRequest,
-) -> @tray_contract.TrayEventReply {
-  match app_command_tray_handle.val {
-    None => @tray_contract.TrayEventReply::{ count: 0, }
-    Some(handle) => {
-      match handle.pump(blocking=false) {
-        Ok(_) => ()
-        Err(error) => raise PumpFailed(detail=error)
-      }
-      let events = handle.drain_events()
-      for event in events {
-        emit_native_tray_event(context, event)
-      }
-      @tray_contract.TrayEventReply::{ count: events.length(), }
-    }
-  }
-}
-
-///|
 /// Destroys the native tray icon.
 #proton.command(contract=destroy_command)
 async fn destroy(
@@ -372,24 +370,19 @@ async fn destroy(
 }
 
 ///|
-fn extension() -> @proton_extension.Extension {
-  @proton_extension.typed(
-    @tray_contract.extension,
-    generated_extension_command_routes(),
-    fn(registrar) raise { register_commands(registrar) },
-    scripts=[
-      @proton_extension.poller_script(
-        js_namespace="tray",
-        drain_method="drainEvents",
-        poller_field="__protonEventPoller",
-      ),
-    ],
-    on_destroy=fn() { cleanup_tray() },
-  )
-}
+let extension_definition : @proton_extension.Extension = @proton_extension.typed(
+  @tray_contract.extension,
+  generated_extension_command_routes(),
+  fn(registrar) raise { register_commands(registrar) },
+  event_source=@proton_extension.event_source(
+    wakeup => install_event_wakeup(wakeup),
+    () => cleanup_tray(),
+    () => drain_native_events(),
+  ),
+)
 
 ///|
 /// Grants tray commands to renderer targets selected by `App::capability`.
 pub fn capability() -> @proton_extension.RendererCapability {
-  @proton_extension.capability(extension())
+  @proton_extension.capability(extension_definition)
 }

--- a/extensions/tray/extension_wbtest.mbt
+++ b/extensions/tray/extension_wbtest.mbt
@@ -16,6 +16,15 @@ test "tray support reports the v1 platform contract" {
 }
 
 ///|
+test "tray events use the native event source instead of a renderer poller" {
+  let capability = capability()
+  let spec = capability.command_spec()
+  assert_false(spec.op_names().contains("ext:tray/drainEvents"))
+  assert_eq(spec.scripts(), [])
+  assert_true(capability.event_source() is Some(_))
+}
+
+///|
 test "tray menu payload maps v1 items" {
   let items = menu_items_to_native([
     {

--- a/proton/extension/extension.mbt
+++ b/proton/extension/extension.mbt
@@ -1,12 +1,49 @@
 ///|
 struct Extension {
+  definition_id : UInt64
   contract : @proton_contract.ExtensionContract
   command_routes : Array[@proton_contract.ContractRoute]
   register : (@proton_command.CommandRegistrar) -> Unit raise
   scripts : Array[String]
   dependencies : Array[String]
   resolve_permission : (Json, String) -> Json raise @proton_command.PermissionScopeValidationError
+  event_source : EventSource?
   on_destroy : () -> Unit raise
+}
+
+///|
+/// One event produced by an extension-owned native event source.
+pub struct Event {
+  extension_id : String
+  extension_namespace : String
+  name : String
+  payload : Json
+}
+
+///|
+/// A native event source integrated with Proton's host event loop.
+///
+/// `start` installs an opaque native wakeup before the source begins producing
+/// events. Native callbacks enqueue their payload and invoke that wakeup;
+/// Proton later calls `drain` on the runtime owner thread. `stop` must be
+/// idempotent and wait until the source can no longer invoke the wakeup.
+pub struct EventSource {
+  start : (EventWakeup) -> Unit raise
+  stop : () -> Unit
+  drain : () -> Array[Event] raise
+}
+
+///|
+/// The opaque native callback supplied to an extension event source.
+pub type EventWakeup = @ffi.EventWakeup
+
+///|
+let next_extension_definition_id : Ref[UInt64] = Ref(0UL)
+
+///|
+fn allocate_extension_definition_id() -> UInt64 {
+  next_extension_definition_id.val += 1UL
+  next_extension_definition_id.val
 }
 
 ///|
@@ -51,16 +88,51 @@ pub fn typed(
     }
     scope
   },
+  event_source? : EventSource,
   on_destroy? : () -> Unit raise = fn() {  },
 ) -> Extension {
   Extension::{
+    definition_id: allocate_extension_definition_id(),
     contract,
     command_routes: command_routes.map(route => route),
     register,
     scripts: scripts.map(script => script),
     dependencies: dependencies.map(dependency => dependency),
     resolve_permission,
+    event_source,
     on_destroy,
+  }
+}
+
+///|
+/// Defines a wake-driven event source with explicit teardown.
+pub fn event_source(
+  start : (EventWakeup) -> Unit raise,
+  stop : () -> Unit,
+  drain : () -> Array[Event] raise,
+) -> EventSource {
+  EventSource::{ start, stop, drain, }
+}
+
+///|
+/// Encodes a typed extension event for delivery to renderer subscribers.
+pub fn[Payload : ToJson] event(
+  descriptor : @proton_contract.Event[Payload],
+  payload : Payload,
+) -> Event raise @proton_contract.ContractDefinitionError {
+  descriptor.validate()
+  let route = descriptor.contract_route()
+  guard route.extension_id() is Some(extension_id) &&
+    route.extension_namespace() is Some(extension_namespace) else {
+    raise @proton_contract.ContractDefinitionError::ExpectedExtensionEvent(
+      route=route.operation_name(),
+    )
+  }
+  Event::{
+    extension_id,
+    extension_namespace,
+    name: descriptor.name(),
+    payload: ToJson::to_json(payload),
   }
 }
 
@@ -95,6 +167,65 @@ pub fn RendererCapability::command_spec(
 #doc(hidden)
 pub fn RendererCapability::scope(self : RendererCapability) -> Json {
   clone_capability_json(self.scope)
+}
+
+///|
+#doc(hidden)
+pub fn RendererCapability::event_source(
+  self : RendererCapability,
+) -> EventSource? {
+  self.extension.event_source
+}
+
+///|
+#doc(hidden)
+pub fn RendererCapability::definition_id(self : RendererCapability) -> UInt64 {
+  self.extension.definition_id
+}
+
+///|
+#doc(hidden)
+pub fn EventSource::start(
+  self : EventSource,
+  wakeup : EventWakeup,
+) -> Unit raise {
+  (self.start)(wakeup)
+}
+
+///|
+#doc(hidden)
+pub fn EventSource::stop(self : EventSource) -> Unit {
+  (self.stop)()
+}
+
+///|
+#doc(hidden)
+pub fn EventSource::drain(self : EventSource) -> Array[Event] raise {
+  (self.drain)()
+}
+
+///|
+#doc(hidden)
+pub fn Event::extension_id(self : Event) -> String {
+  self.extension_id
+}
+
+///|
+#doc(hidden)
+pub fn Event::extension_namespace(self : Event) -> String {
+  self.extension_namespace
+}
+
+///|
+#doc(hidden)
+pub fn Event::name(self : Event) -> String {
+  self.name
+}
+
+///|
+#doc(hidden)
+pub fn Event::payload(self : Event) -> Json {
+  clone_capability_json(self.payload)
 }
 
 ///|
@@ -136,54 +267,4 @@ fn clone_capability_json(value : Json) -> Json {
     }
     _ => value
   }
-}
-
-///|
-/// Builds the standard JavaScript event-poller script for an extension namespace.
-///
-/// Extensions that pump native events through a `drain*` command install this
-/// script so the renderer polls the host on a fixed interval. The script is
-/// idempotent: it exits early if the namespace or its drain method is missing,
-/// or if a poller is already registered.
-pub fn poller_script(
-  js_namespace~ : String,
-  drain_method~ : String,
-  poller_field~ : String,
-) -> String {
-  let ns = js_namespace
-  "(() => {\n" +
-  "  const root = window.__MoonBit__;\n" +
-  "  const " +
-  ns +
-  " = root && root." +
-  ns +
-  ";\n" +
-  "  if (!" +
-  ns +
-  " || typeof " +
-  ns +
-  "." +
-  drain_method +
-  " !== \"function\") {\n" +
-  "    return;\n" +
-  "  }\n" +
-  "  if (" +
-  ns +
-  "." +
-  poller_field +
-  ") {\n" +
-  "    return;\n" +
-  "  }\n" +
-  "  " +
-  ns +
-  "." +
-  poller_field +
-  " = window.setInterval(() => {\n" +
-  "    " +
-  ns +
-  "." +
-  drain_method +
-  "({}).catch(() => {});\n" +
-  "  }, 100);\n" +
-  "})();"
 }

--- a/proton/extension/extension_wbtest.mbt
+++ b/proton/extension/extension_wbtest.mbt
@@ -54,3 +54,33 @@ test "typed extension adaptation reports foreign routes" {
     _ => fail("expected typed extension adaptation failure")
   }
 }
+
+///|
+test "typed extension events preserve their contract identity" {
+  let contract = @proton_contract.extension(
+    id="example/events",
+    js_namespace="events",
+  )
+  let changed : @proton_contract.Event[String] = contract.event("changed")
+  let emitted = event(changed, "ready")
+  assert_eq(emitted.extension_id(), "example/events")
+  assert_eq(emitted.extension_namespace(), "events")
+  assert_eq(emitted.name(), "changed")
+  debug_inspect(emitted.payload(), content="String(\"ready\")")
+}
+
+///|
+test "extension event encoding rejects application routes" {
+  let changed : @proton_contract.Event[String] = @proton_contract.event(
+    "application-changed",
+  )
+  try {
+    ignore(event(changed, "ready"))
+    fail("expected application event rejection")
+  } catch {
+    @proton_contract.ContractDefinitionError::ExpectedExtensionEvent(
+      route="app:application-changed"
+    ) => ()
+    _ => fail("expected ExpectedExtensionEvent")
+  }
+}

--- a/proton/extension/moon.pkg
+++ b/proton/extension/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/json",
   "moonbit-community/proton/command" @proton_command,
+  "moonbit-community/proton_ffi" @ffi,
   "moonbit-community/proton_contract",
 }
 

--- a/proton/extension/pkg.generated.mbti
+++ b/proton/extension/pkg.generated.mbti
@@ -4,15 +4,18 @@ package "moonbit-community/proton/extension"
 import {
   "moonbit-community/proton/command",
   "moonbit-community/proton_contract",
+  "moonbit-community/proton_ffi",
   "moonbitlang/core/debug",
 }
 
 // Values
 pub fn capability(Extension, scope? : Json) -> RendererCapability
 
-pub fn poller_script(js_namespace~ : String, drain_method~ : String, poller_field~ : String) -> String
+pub fn[Payload : ToJson] event(@proton_contract.Event[Payload], Payload) -> Event raise @proton_contract.ContractDefinitionError
 
-pub fn typed(@proton_contract.ExtensionContract, Array[@proton_contract.ContractRoute], (@command.CommandRegistrar) -> Unit raise, scripts? : Array[String], dependencies? : Array[String], resolve_permission? : (Json, String) -> Json raise @command.PermissionScopeValidationError, on_destroy? : () -> Unit raise) -> Extension
+pub fn event_source((@proton_ffi.EventWakeup) -> Unit raise, () -> Unit, () -> Array[Event] raise) -> EventSource
+
+pub fn typed(@proton_contract.ExtensionContract, Array[@proton_contract.ContractRoute], (@command.CommandRegistrar) -> Unit raise, scripts? : Array[String], dependencies? : Array[String], resolve_permission? : (Json, String) -> Json raise @command.PermissionScopeValidationError, event_source? : EventSource, on_destroy? : () -> Unit raise) -> Extension
 
 // Errors
 pub(all) suberror ExtensionAdapterError {
@@ -24,6 +27,19 @@ pub fn ExtensionAdapterError::to_repr(Self) -> @debug.Repr
 pub fn ExtensionAdapterError::to_string(Self) -> String
 
 // Types and methods
+pub struct Event {
+  extension_id : String
+  extension_namespace : String
+  name : String
+  payload : Json
+}
+
+pub struct EventSource {
+  start : (@proton_ffi.EventWakeup) -> Unit raise
+  stop : () -> Unit
+  drain : () -> Array[Event] raise
+}
+
 type Extension
 pub fn Extension::command_spec(Self) -> @command.AppCommandExtensionSpec raise ExtensionAdapterError
 pub fn Extension::id(Self) -> String
@@ -34,5 +50,6 @@ pub struct RendererCapability {
 }
 
 // Type aliases
+pub using @proton_ffi {type EventWakeup}
 
 // Traits

--- a/proton/facade_bridge.mbt
+++ b/proton/facade_bridge.mbt
@@ -1,7 +1,7 @@
 ///|
 fn build_command_host(
   command_capabilities : Array[AppCommandCapability],
-  extension_capabilities : Array[ExtensionCapabilityBinding],
+  command_extensions : CommandExtensionCatalog,
 ) -> CommandHostBuild raise AppRunError {
   let host = @core.AppCommandHost(
     expose_error_details=proton_dev_mode_enabled(),
@@ -11,6 +11,7 @@ fn build_command_host(
     },
   )
   let destroy_hooks : Array[CommandExtensionDestroyHook] = []
+  let event_sources : Array[CommandExtensionEventSource] = []
   let app_capabilities : Array[RegisteredAppCommandCapability] = []
   let mut has_commands = false
   let registrar = @proton_command.CommandRegistrar(host)
@@ -37,20 +38,14 @@ fn build_command_host(
       targets: capability.targets.copy(),
     })
   }
-  let command_extensions = command_extension_specs(extension_capabilities) catch {
-    error => {
-      ignore(close_command_host_runtime(host, destroy_hooks))
-      raise ConfigurationError(error)
-    }
-  }
-  let ordered_ids = command_extension_order(command_extensions) catch {
+  let ordered_ids = command_extension_order(command_extensions.specs) catch {
     error => {
       ignore(close_command_host_runtime(host, destroy_hooks))
       raise ConfigurationError(error)
     }
   }
   for id in ordered_ids {
-    let spec = command_extensions[id]
+    let spec = command_extensions.specs[id]
     destroy_hooks.push(CommandExtensionDestroyHook::{
       extension_id: id,
       callback: fn() raise { spec.destroy() },
@@ -70,12 +65,27 @@ fn build_command_host(
         }
       }
     }
+    match command_extensions.event_sources.get(id) {
+      Some(source) =>
+        event_sources.push(CommandExtensionEventSource::{
+          extension_id: id,
+          extension_namespace: spec.js_namespace(),
+          source,
+          started: false,
+        })
+      None => ()
+    }
     has_commands = true
   }
   if has_commands {
     host.seal_registrations()
     CommandHostBuild::{
-      runtime: Some(CommandHostRuntime::{ host, destroy_hooks, closed: false, }),
+      runtime: Some(CommandHostRuntime::{
+        host,
+        destroy_hooks,
+        event_sources,
+        closed: false,
+      }),
       app_capabilities,
     }
   } else {
@@ -85,10 +95,12 @@ fn build_command_host(
 }
 
 ///|
-fn command_extension_specs(
+fn command_extension_catalog(
   capabilities : Array[ExtensionCapabilityBinding],
-) -> Map[String, @proton_command.AppCommandExtensionSpec] raise AppConfigurationError {
+) -> CommandExtensionCatalog raise AppConfigurationError {
   let specs : Map[String, @proton_command.AppCommandExtensionSpec] = Map([])
+  let event_sources : Map[String, @proton_extension.EventSource] = Map([])
+  let event_source_definition_ids : Map[String, UInt64] = Map([])
   for capability in capabilities {
     let id = capability.spec.id()
     match specs.get(id) {
@@ -98,11 +110,54 @@ fn command_extension_specs(
             detail="extension " + id + " has conflicting definitions",
           )
         }
+        match (capability.event_source, event_source_definition_ids.get(id)) {
+          (Some(_), Some(definition_id)) => {
+            guard definition_id == capability.definition_id else {
+              raise InvalidRendererCapability(
+                detail="extension " + id + " has conflicting event sources",
+              )
+            }
+          }
+          (None, None) => ()
+          (_, _) =>
+            raise InvalidRendererCapability(
+              detail="extension " + id + " has conflicting event sources",
+            )
+        }
       }
-      None => specs[id] = capability.spec
+      None => {
+        specs[id] = capability.spec
+        match capability.event_source {
+          Some(source) => {
+            event_sources[id] = source
+            event_source_definition_ids[id] = capability.definition_id
+          }
+          None => ()
+        }
+      }
     }
   }
-  specs
+  CommandExtensionCatalog::{ specs, event_sources, }
+}
+
+///|
+fn stop_command_extension_event_sources(
+  event_sources : Array[CommandExtensionEventSource],
+) -> Unit {
+  let source_count = event_sources.length()
+  for index in 0..<source_count {
+    let event_source = event_sources[source_count - index - 1]
+    event_source.stop()
+  }
+}
+
+///|
+fn CommandExtensionEventSource::stop(
+  self : CommandExtensionEventSource,
+) -> Unit {
+  guard self.started else { return }
+  self.source.stop()
+  self.started = false
 }
 
 ///|

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -623,7 +623,9 @@ pub fn App::capability(
     match command_spec {
       Some(spec) =>
         self.extension_capabilities.push(ExtensionCapabilityBinding::{
+          definition_id: capability.definition_id(),
           spec,
+          event_source: capability.event_source(),
           scope: capability.scope(),
           targets: renderer_capability_targets(targets),
         })

--- a/proton/facade_error.mbt
+++ b/proton/facade_error.mbt
@@ -91,6 +91,11 @@ pub fn CommandExtensionLifecycleError::message(
       "failed to register application commands: " + detail
     RegistrationFailed(extension_id~, detail~) =>
       "failed to register command extension " + extension_id + ": " + detail
+    EventSourceStartFailed(extension_id~, detail~) =>
+      "failed to start command extension event source " +
+      extension_id +
+      ": " +
+      detail
     DestroyFailed(extension_id~, detail~) =>
       "failed to destroy command extension " + extension_id + ": " + detail
   }

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -261,13 +261,11 @@ async fn run_manifest(
         },
       )
     }
-    let ops = match command_host {
-      Some(host) => host.host.registered_ops()
-      None => []
-    }
-    let bridge_enabled = ops.length() > 0 ||
-      forward_menu_events ||
-      window_lifecycle_hooks.length() > 0
+    let bridge_enabled = requires_renderer_bridge(
+      command_host,
+      forward_menu_events,
+      window_lifecycle_hooks.length() > 0,
+    )
     if bridge_enabled && !@native.bridge_permission_grants_supported() {
       raise UnsupportedNativeFeature(feature="bridge_permission_grants")
     }
@@ -352,7 +350,6 @@ async fn run_manifest(
         )
         session.drive_until_complete(application_start)
         active_update_channel.val = update_channel
-        session.start_extension_event_sources()
         for definition in definitions {
           if definition.plan.open_on_start &&
             session.find_active_window(definition.plan.id) is None {
@@ -369,6 +366,9 @@ async fn run_manifest(
               "window_count": windows.length(),
             }
         }
+        // A source may enqueue synchronously from start(). Initial windows must
+        // be able to receive those events before native production begins.
+        session.start_extension_event_sources()
         for running in windows {
           if !running.is_closed() {
             session.activate_window(running)
@@ -433,6 +433,15 @@ async fn run_manifest(
     Some(error) => raise error
     None => ()
   }
+}
+
+///|
+fn requires_renderer_bridge(
+  command_host : CommandHostRuntime?,
+  forward_menu_events : Bool,
+  has_window_lifecycle_hooks : Bool,
+) -> Bool {
+  command_host is Some(_) || forward_menu_events || has_window_lifecycle_hooks
 }
 
 ///|

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -228,16 +228,17 @@ async fn run_manifest(
     ) catch {
       error => raise ConfigurationError(error)
     }
-    let command_extensions = command_extension_specs(extension_capabilities) catch {
+    let extension_catalog = command_extension_catalog(extension_capabilities) catch {
       error => raise ConfigurationError(error)
     }
+    let command_extensions = extension_catalog.specs
     let resolved_extension_capabilities = resolve_extension_capabilities(
       extension_capabilities, permission_base_path,
     ) catch {
       error => raise ConfigurationError(error)
     }
     let command_build = build_command_host(
-      command_capabilities, extension_capabilities,
+      command_capabilities, extension_catalog,
     )
     command_host = command_build.runtime
     let policies : Array[BridgePagePolicy] = []
@@ -351,6 +352,7 @@ async fn run_manifest(
         )
         session.drive_until_complete(application_start)
         active_update_channel.val = update_channel
+        session.start_extension_event_sources()
         for definition in definitions {
           if definition.plan.open_on_start &&
             session.find_active_window(definition.plan.id) is None {
@@ -579,6 +581,7 @@ fn CommandHostRuntime::close(
   self : CommandHostRuntime,
 ) -> Array[CommandExtensionLifecycleError] {
   guard !self.closed else { return [] }
+  stop_command_extension_event_sources(self.event_sources)
   let failures = close_command_host_runtime(self.host, self.destroy_hooks)
   self.closed = true
   failures

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -360,23 +360,27 @@ async fn run_manifest(
           session.wait_for_bridge_startup(bridge_startup_timeout_ms) catch {
             error => raise normalize_async_run_error(error)
           }
-          @xlog.info(category="proton.bridge") <?
-            {
-              "message": "renderer bridge ready",
-              "window_count": windows.length(),
-            }
-        }
-        // A source may enqueue synchronously from start(). Initial windows must
-        // be able to receive those events before native production begins.
-        session.start_extension_event_sources()
-        for running in windows {
-          if !running.is_closed() {
-            session.activate_window(running)
+          if !session.quit_requested {
+            @xlog.info(category="proton.bridge") <?
+              {
+                "message": "renderer bridge ready",
+                "window_count": windows.length(),
+              }
           }
         }
-        lifecycle.begin_running()
-        cleanup_previous_update()
-        start_update_check(update_channel, update_handlers, application_tasks)
+        if !session.quit_requested {
+          // A source may enqueue synchronously from start(). Initial windows must
+          // be able to receive those events before native production begins.
+          session.start_extension_event_sources()
+          for running in windows {
+            if !running.is_closed() {
+              session.activate_window(running)
+            }
+          }
+          lifecycle.begin_running()
+          cleanup_previous_update()
+          start_update_check(update_channel, update_handlers, application_tasks)
+        }
         session.run() catch {
           error => raise normalize_async_run_error(error)
         }

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1631,6 +1631,9 @@ fn RuntimeSession::pump_once(
   if self.drain_runtime_events() {
     did_work = true
   }
+  if self.drain_extension_events() {
+    did_work = true
+  }
   if monitor_bridge {
     self.check_bridge_failures()
   }
@@ -1653,6 +1656,126 @@ fn RuntimeSession::pump_once(
     did_work = true
   }
   did_work
+}
+
+///|
+fn RuntimeSession::start_extension_event_sources(
+  self : RuntimeSession,
+) -> Unit raise AppRunError {
+  match self.command_host {
+    None => ()
+    Some(host) =>
+      start_command_extension_event_sources(
+        host.event_sources,
+        @native.event_wakeup_callback(),
+      )
+  }
+}
+
+///|
+fn start_command_extension_event_sources(
+  event_sources : Array[CommandExtensionEventSource],
+  wakeup : @proton_extension.EventWakeup,
+) -> Unit raise AppRunError {
+  for event_source in event_sources {
+    guard !event_source.started else { continue }
+    event_source.started = true
+    event_source.source.start(wakeup) catch {
+      error => {
+        event_source.source.stop()
+        event_source.started = false
+        raise CommandExtensionLifecycleError(
+          EventSourceStartFailed(
+            extension_id=event_source.extension_id,
+            detail=@debug.render(Repr(error)),
+          ),
+        )
+      }
+    }
+  }
+}
+
+///|
+fn RuntimeSession::drain_extension_events(
+  self : RuntimeSession,
+) -> Bool raise AppRunError {
+  let mut did_work = false
+  match self.command_host {
+    None => ()
+    Some(host) =>
+      for event_source in host.event_sources {
+        guard event_source.started else { continue }
+        let events = event_source.drain()
+        if !events.is_empty() {
+          did_work = true
+        }
+        for event in events {
+          guard event.extension_id() == event_source.extension_id &&
+            event.extension_namespace() == event_source.extension_namespace else {
+            event_source.disable(
+              "event descriptor belongs to " +
+              event.extension_id() +
+              " (" +
+              event.extension_namespace() +
+              ")",
+            )
+            break
+          }
+          self.forward_extension_event_to_granted_windows(
+            event_source.extension_id,
+            event_source.extension_namespace,
+            event.name(),
+            event.payload(),
+          )
+        }
+      }
+  }
+  did_work
+}
+
+///|
+fn CommandExtensionEventSource::drain(
+  self : CommandExtensionEventSource,
+) -> Array[@proton_extension.Event] {
+  guard self.started else { return [] }
+  self.source.drain() catch {
+    error => {
+      self.disable(@debug.render(Repr(error)))
+      []
+    }
+  }
+}
+
+///|
+fn CommandExtensionEventSource::disable(
+  self : CommandExtensionEventSource,
+  detail : String,
+) -> Unit {
+  self.stop()
+  @xlog.error(category="proton.extension") <?
+    {
+      "message": "event source disabled",
+      "extension_id": self.extension_id,
+      "detail": detail,
+    }
+}
+
+///|
+fn RuntimeSession::forward_extension_event_to_granted_windows(
+  self : RuntimeSession,
+  extension_id : String,
+  extension_namespace : String,
+  name : String,
+  payload : Json,
+) -> Unit raise AppRunError {
+  for running in self.windows {
+    guard running.is_active() &&
+      running.bridge_ready &&
+      running.permissions.grants_extension(extension_id) else {
+      continue
+    }
+    forward_extension_event(running.window, extension_namespace, name, payload)
+  }
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -952,7 +952,7 @@ fn RuntimeSession::advance_window_opens(self : RuntimeSession) -> Bool {
           Some(_) => {
             did_work = true
             pending.timeout.cancel()
-            if pending.running.is_closed() {
+            if !pending.running.is_active() {
               pending.completion.fail(Cancelled)
             } else {
               pending.completion.succeed(self.window_handle(pending.running))
@@ -2092,7 +2092,7 @@ fn RuntimeSession::complete_browser_requests(
       Some(response) => {
         did_work = true
         match self.find_window_by_native_id(pending.window) {
-          Some(window) if !window.is_closed() => {
+          Some(window) if window.is_active() => {
             let path = response.path
             window.window.respond_browser_request(
               pending.request_id,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1880,8 +1880,9 @@ fn RuntimeSession::dispatch_window_event(
 fn RuntimeSession::dispatch_view_event(
   self : RuntimeSession,
   event : @native.RuntimeEvent,
-) -> Unit {
-  if self.view_event_handlers.is_empty() {
+) -> Unit raise AppRunError {
+  let closes_view = event.is_view_closed()
+  if self.view_event_handlers.is_empty() && !closes_view {
     return
   }
   let info = match event.view_event() {
@@ -1897,7 +1898,7 @@ fn RuntimeSession::dispatch_view_event(
     Some(running) => running
     None => return
   }
-  for view in running.views {
+  for index, view in running.views {
     if view.view.id() == view_native_id {
       let handle = self.view_handle(running, view)
       let view_event = match event.event_type() {
@@ -1911,7 +1912,18 @@ fn RuntimeSession::dispatch_view_event(
             error_code=info.error_code.unwrap_or(0),
             error_text=info.error_text.unwrap_or(""),
           )
+        "view_closed" => Closed
         _ => return
+      }
+      if closes_view {
+        view.view.destroy() catch {
+          error =>
+            raise native_run_error(
+              "destroy closed view " + view.id + " in window " + running.id,
+              error,
+            )
+        }
+        ignore(running.views.remove(index))
       }
       for handler in self.view_event_handlers {
         ignore(

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -365,9 +365,19 @@ fn RuntimeSession::add_window_view(
     Some(running) if running.window.id() == window_native_id => running
     _ => raise StaleWindow(id=window_id)
   }
+  let running_view = add_view_to_running_window(running, view_id, config)
+  self.view_handle(running, running_view)
+}
+
+///|
+fn add_view_to_running_window(
+  running : RunningWindow,
+  view_id : String,
+  config : @native.ViewConfig,
+) -> RunningView raise WindowSessionError {
   if view_id.is_empty() {
     raise window_operation_failed(
-      "add view to window " + window_id,
+      "add view to window " + running.id,
       @native.NativeError::InvalidArgument(message="view id must not be empty"),
     )
   }
@@ -379,7 +389,7 @@ fn RuntimeSession::add_window_view(
   let created = @native.View::View(running.window, config) catch {
     error =>
       raise window_operation_failed(
-        "add view " + view_id + " to window " + window_id,
+        "add view " + view_id + " to window " + running.id,
         error,
       )
   }
@@ -389,7 +399,7 @@ fn RuntimeSession::add_window_view(
     document: None,
   }
   running.views.push(running_view)
-  self.view_handle(running, running_view)
+  running_view
 }
 
 ///|
@@ -693,15 +703,6 @@ fn RuntimeSession::create_window(
   ) catch {
     error => raise native_run_error("create window " + plan.id, error)
   }
-  if self.window_close_handler is Some(_) {
-    created_window.set_close_interception(true) catch {
-      error =>
-        raise native_run_error(
-          "enable close interception for " + plan.id,
-          error,
-        )
-    }
-  }
   let (document, asset_root) = match definition.entry {
     RemoteEntry(_) => (None, None)
     DocumentEntry(document, asset_root) => (Some(document), asset_root)
@@ -717,19 +718,28 @@ fn RuntimeSession::create_window(
     bridge_ready: !self.monitor_bridge,
     state: WindowStarting,
   }
-  self.windows.push(running)
+  errdefer (created_window.destroy() catch {
+    error =>
+      self.lifecycle_failures.push(
+        WindowDestroy(status=error.status(), detail=error.message()),
+      )
+  })
+  if self.window_close_handler is Some(_) {
+    created_window.set_close_interception(true) catch {
+      error =>
+        raise native_run_error(
+          "enable close interception for " + plan.id,
+          error,
+        )
+    }
+  }
   load_prepared_entry(created_window, definition.entry) catch {
     error => raise EntryLoadError(error)
   }
   for view_plan in definition.views {
     let (view_id, view_config) = view_plan
     ignore(
-      self.add_window_view(
-        running.id,
-        created_window.id(),
-        view_id,
-        view_config,
-      ) catch {
+      add_view_to_running_window(running, view_id, view_config) catch {
         error =>
           raise match error {
             OperationFailed(action~, status~, detail~) =>
@@ -739,6 +749,7 @@ fn RuntimeSession::create_window(
       },
     )
   }
+  self.windows.push(running)
   @xlog.info(category="proton.window") <?
     { "message": "window created", "window": running.id }
   running

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -37,6 +37,7 @@ fn RuntimeSession::RuntimeSession(
     locale_preferences,
     definitions,
     windows,
+    has_created_window: windows.length() > 0,
     command_host,
     pending_bridge: [],
     dialog_completions,
@@ -750,6 +751,7 @@ fn RuntimeSession::create_window(
     )
   }
   self.windows.push(running)
+  self.has_created_window = true
   @xlog.info(category="proton.window") <?
     { "message": "window created", "window": running.id }
   running
@@ -1837,16 +1839,15 @@ fn RuntimeSession::dispatch_runtime_event(
 fn RuntimeSession::dispatch_window_event(
   self : RuntimeSession,
   event : @native.RuntimeEvent,
-) -> Unit {
-  runtime_session_dispatch_window_event(
-    self.windows,
-    self.pending_bridge,
-    event,
-  )
+) -> Unit raise AppRunError {
   if event.is_window_closed() {
-    self.cancel_window_close_requests(event.window_id())
-    self.cancel_browser_requests(event.window_id())
-    self.cancel_resource_requests_for_window(event.window_id())
+    let window_id = event.window_id()
+    runtime_session_cancel_window_bridge_tasks(self.pending_bridge, window_id)
+    self.cancel_window_close_requests(window_id)
+    self.cancel_browser_requests(window_id)
+    self.cancel_resource_requests_for_window(window_id)
+    self.retire_closed_window(window_id)
+    return
   }
   match (event.window_id(), event.window_state_change()) {
     (Some(window_id), Some(state)) =>
@@ -2354,21 +2355,6 @@ fn RuntimeSession::cancel_all_window_close_requests(
 }
 
 ///|
-fn runtime_session_dispatch_window_event(
-  windows : Array[RunningWindow],
-  pending_bridge : Array[BridgeDispatchTask],
-  event : @native.RuntimeEvent,
-) -> Unit {
-  if event.is_window_closed() {
-    runtime_session_mark_window_closed(windows, event.window_id())
-    runtime_session_cancel_window_bridge_tasks(
-      pending_bridge,
-      event.window_id(),
-    )
-  }
-}
-
-///|
 fn RuntimeSession::dispatch_notification_event(
   self : RuntimeSession,
   event : @native.RuntimeEvent,
@@ -2660,42 +2646,34 @@ fn RuntimeSession::find_window_by_native_id(
 }
 
 ///|
-fn runtime_session_mark_window_closed(
-  windows : Array[RunningWindow],
+fn RuntimeSession::retire_closed_window(
+  self : RuntimeSession,
   window_id : Int64?,
-) -> Unit {
-  match window_id {
-    Some(window_id) =>
-      match runtime_session_find_window_by_native_id(windows, window_id) {
-        Some(window) => {
-          window.state = WindowClosed
-          window.lifetime.close()
-          @xlog.info(category="proton.window") <?
-            { "message": "window closed", "window": window.id }
-        }
-        None => ()
-      }
-    None => ()
-  }
-}
-
-///|
-fn runtime_session_find_window_by_native_id(
-  windows : Array[RunningWindow],
-  window_id : Int64,
-) -> RunningWindow? {
-  for running in windows {
+) -> Unit raise AppRunError {
+  guard window_id is Some(window_id) else { return }
+  let mut index = -1
+  for i, running in self.windows {
     if running.window.id() == window_id {
-      return Some(running)
+      index = i
+      break
     }
   }
-  None
+  guard index >= 0 else { return }
+  let running = self.windows[index]
+  running.state = WindowClosed
+  running.lifetime.close()
+  running.window.destroy() catch {
+    error =>
+      raise native_run_error("destroy closed window " + running.id, error)
+  }
+  ignore(self.windows.remove(index))
+  @xlog.info(category="proton.window") <?
+    { "message": "window closed", "window": running.id }
 }
 
 ///|
 fn RuntimeSession::all_windows_closed(self : RuntimeSession) -> Bool {
-  self.windows.length() > 0 &&
-  self.windows.all(fn(window) { window.is_closed() })
+  self.has_created_window && self.windows.all(fn(window) { window.is_closed() })
 }
 
 ///|
@@ -2724,7 +2702,7 @@ fn RuntimeSession::advance_application_lifetime(
   if !self.quit_requested &&
     should_quit_after_last_window(
       self.last_window_closed_policy,
-      self.windows.length() > 0,
+      self.has_created_window,
       self.all_windows_closed(),
     ) {
     self.request_quit()

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1560,6 +1560,9 @@ async fn RuntimeSession::wait_for_bridge_startup(
     while true {
       let revision = self.wakeup.revision()
       let did_work = self.pump_once(monitor_bridge=false)
+      if self.quit_requested {
+        return
+      }
       match refresh_bridge_startup_states(self.windows) {
         None => return
         Some(_) =>
@@ -1577,6 +1580,9 @@ async fn RuntimeSession::wait_for_bridge_startup(
     Some(_) => ()
     None => {
       ignore(self.pump_once(monitor_bridge=false))
+      if self.quit_requested {
+        return
+      }
       match refresh_bridge_startup_states(self.windows) {
         None => return
         Some(state) =>
@@ -2510,8 +2516,9 @@ fn RuntimeSession::dispatch_menu_event(
 fn RuntimeSession::check_bridge_failures(
   self : RuntimeSession,
 ) -> Unit raise AppRunError {
+  guard !self.quit_requested else { return }
   for running in self.windows {
-    if running.is_closed() {
+    if !running.is_active() {
       continue
     }
     let failure = take_runtime_bridge_failure(running.window) catch {

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -551,9 +551,7 @@ fn RuntimeSession::close_window(
   running.window.close() catch {
     error => raise window_operation_failed("close window " + id, error)
   }
-  if self.window_close_handler is None {
-    running.state = WindowCloseRequested
-  }
+  running.state = WindowCloseRequested
 }
 
 ///|
@@ -789,7 +787,7 @@ async fn RuntimeSession::activate_window(
     ),
   )
   running.lifetime.wait_until_ready()
-  if running.is_closed() {
+  if !running.is_active() {
     return
   }
   running.window.show() catch {
@@ -2284,6 +2282,7 @@ fn RuntimeSession::start_window_close_request(
 ) -> Unit {
   guard self.window_close_handler is Some(handler) else { return }
   guard self.find_window_by_native_id(window_id) is Some(window) else { return }
+  window.state = WindowCloseRequested
   let handle = self.window_handle(window)
   let task = self.window_tasks.spawn(
     () => {
@@ -2326,9 +2325,12 @@ fn RuntimeSession::complete_window_close_requests(
             }
             if decision == Allow {
               window.state = WindowCloseRequested
-            } else if self.quit_requested {
-              self.quit_requested = false
-              self.quit_close_started = false
+            } else {
+              window.state = WindowOpen
+              if self.quit_requested {
+                self.quit_requested = false
+                self.quit_close_started = false
+              }
             }
           }
           _ => ()
@@ -2737,9 +2739,7 @@ fn RuntimeSession::advance_application_lifetime(
       running.window.close() catch {
         error => raise native_run_error("close window " + running.id, error)
       }
-      if self.window_close_handler is None {
-        running.state = WindowCloseRequested
-      }
+      running.state = WindowCloseRequested
     }
   }
   did_work

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -88,7 +88,9 @@ priv struct AppCommandCapability {
 
 ///|
 priv struct ExtensionCapabilityBinding {
+  definition_id : UInt64
   spec : @proton_command.AppCommandExtensionSpec
+  event_source : @proton_extension.EventSource?
   scope : Json
   targets : Array[RendererTarget]
 }
@@ -97,6 +99,12 @@ priv struct ExtensionCapabilityBinding {
 priv struct RegisteredAppCommandCapability {
   ops : Array[String]
   targets : Array[RendererTarget]
+}
+
+///|
+priv struct CommandExtensionCatalog {
+  specs : Map[String, @proton_command.AppCommandExtensionSpec]
+  event_sources : Map[String, @proton_extension.EventSource]
 }
 
 ///|
@@ -229,7 +237,16 @@ priv struct PreparedWindow {
 priv struct CommandHostRuntime {
   host : @core.AppCommandHost
   destroy_hooks : Array[CommandExtensionDestroyHook]
+  event_sources : Array[CommandExtensionEventSource]
   mut closed : Bool
+}
+
+///|
+priv struct CommandExtensionEventSource {
+  extension_id : String
+  extension_namespace : String
+  source : @proton_extension.EventSource
+  mut started : Bool
 }
 
 ///|
@@ -705,6 +722,7 @@ pub extend AppEntryError with Debug::{to_repr}
 pub(all) suberror CommandExtensionLifecycleError {
   ApplicationRegistrationFailed(detail~ : String)
   RegistrationFailed(extension_id~ : String, detail~ : String)
+  EventSourceStartFailed(extension_id~ : String, detail~ : String)
   DestroyFailed(extension_id~ : String, detail~ : String)
 } derive(Debug)
 

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -491,6 +491,7 @@ pub(all) enum ViewEvent {
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  Closed
 } derive(Debug, Eq)
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -290,6 +290,7 @@ priv struct RuntimeSession {
   locale_preferences : @locale.LocalePreferences
   definitions : Array[PreparedWindow]
   windows : Array[RunningWindow]
+  mut has_created_window : Bool
   command_host : CommandHostRuntime?
   pending_bridge : Array[BridgeDispatchTask]
   dialog_completions : DialogCompletionStore

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -229,8 +229,27 @@ fn test_extension_capability(
   spec : @proton_command.AppCommandExtensionSpec,
   scope? : Json = Json::empty_object(),
   targets? : Array[RendererTarget] = [RendererTarget::entry()],
+  definition_id? : UInt64 = 1UL,
+  event_source? : @proton_extension.EventSource,
 ) -> ExtensionCapabilityBinding {
-  ExtensionCapabilityBinding::{ spec, scope, targets, }
+  ExtensionCapabilityBinding::{
+    definition_id,
+    spec,
+    event_source,
+    scope,
+    targets,
+  }
+}
+
+///|
+fn test_build_command_host(
+  command_capabilities : Array[AppCommandCapability],
+  extension_capabilities : Array[ExtensionCapabilityBinding],
+) -> CommandHostBuild raise AppRunError {
+  let catalog = command_extension_catalog(extension_capabilities) catch {
+    error => raise ConfigurationError(error)
+  }
+  build_command_host(command_capabilities, catalog)
 }
 
 ///|
@@ -241,6 +260,7 @@ fn test_command_spec(
   dependencies? : Array[String] = [],
   scripts? : Array[String] = [],
   resolve_permission? : (Json, String) -> Json raise @proton_command.PermissionScopeValidationError,
+  on_destroy? : () -> Unit raise = fn() {  },
 ) -> @proton_command.AppCommandExtensionSpec {
   let contract = @proton_contract.extension(id=extension_id, js_namespace~)
   let routes = api_names.map(fn(api_name) {
@@ -256,6 +276,7 @@ fn test_command_spec(
     scripts~,
     dependencies~,
     resolve_permission?,
+    on_destroy~,
   ) catch {
     error => abort(error.message())
   }
@@ -1021,7 +1042,7 @@ test "one extension supports distinct scopes in different windows" {
   let resolved = unwrap_configuration(() => {
     resolve_extension_capabilities(capabilities, "/trusted/project")
   })
-  let build = unwrap_app_run(() => build_command_host([], capabilities))
+  let build = unwrap_app_run(() => test_build_command_host([], capabilities))
   assert_eq(registered.val, 1)
   let main_policy = unwrap_configuration(() => {
     resolve_window_permission_policy(
@@ -1059,7 +1080,7 @@ test "application commands grant the primary entry by default" {
     registrar.bind(ping, (_context, _request) => "pong")
   })
   let build = unwrap_app_run(() => {
-    build_command_host(configured.command_capabilities, [])
+    test_build_command_host(configured.command_capabilities, [])
   })
   let policy = resolve_window_permission_policy(
     "main",
@@ -1077,7 +1098,7 @@ test "omitted renderer capabilities are a valid empty policy" {
   unwrap_configuration(() => {
     validate_renderer_capability_targets(manifest, [], [])
   })
-  let build = unwrap_app_run(() => build_command_host([], []))
+  let build = unwrap_app_run(() => test_build_command_host([], []))
   assert_true(build.runtime is None)
   let policy = resolve_window_permission_policy(
     "main",
@@ -1108,7 +1129,7 @@ test "application command registrars retain separate renderer targets" {
       targets=[RendererTarget::entry(window="secondary")],
     )
   let build = unwrap_app_run(() => {
-    build_command_host(configured.command_capabilities, [])
+    test_build_command_host(configured.command_capabilities, [])
   })
   let primary_policy = resolve_window_permission_policy(
     "main",
@@ -1212,7 +1233,7 @@ test "command host close runs extension destroy hooks once" {
     error => abort(error.message())
   }
   let build = unwrap_app_run(() => {
-    build_command_host([], [test_extension_capability(spec)])
+    test_build_command_host([], [test_extension_capability(spec)])
   })
   match build.runtime {
     Some(host) => {
@@ -1222,6 +1243,129 @@ test "command host close runs extension destroy hooks once" {
       assert_eq(destroyed.val, 1)
     }
     None => fail("expected command host")
+  }
+}
+
+///|
+test "command host stops event sources before extension destroy hooks" {
+  let lifecycle : Array[String] = []
+  let spec = test_command_spec(
+    "examples/event-source-lifecycle",
+    "eventSourceLifecycle",
+    ["ping"],
+    on_destroy=fn() { lifecycle.push("destroy") },
+  )
+  let source = @proton_extension.event_source(
+    _wakeup => lifecycle.push("start"),
+    () => lifecycle.push("stop"),
+    () => [],
+  )
+  let build = unwrap_app_run(() => {
+    test_build_command_host([], [
+      test_extension_capability(spec, event_source=source),
+    ])
+  })
+  match build.runtime {
+    Some(host) => {
+      unwrap_app_run(() => {
+        start_command_extension_event_sources(
+          host.event_sources,
+          @native.event_wakeup_callback(),
+        )
+      })
+      assert_eq(lifecycle, ["start"])
+      assert_eq(close_command_host(Some(host)).length(), 0)
+      assert_eq(lifecycle, ["start", "stop", "destroy"])
+      assert_eq(close_command_host(Some(host)).length(), 0)
+      assert_eq(lifecycle, ["start", "stop", "destroy"])
+    }
+    None => fail("expected command host")
+  }
+}
+
+///|
+test "event source startup failure runs its teardown" {
+  let lifecycle : Array[String] = []
+  let source = @proton_extension.event_source(
+    _wakeup => {
+      lifecycle.push("start")
+      raise FacadeLifecycleTestError::StartFailed("event source")
+    },
+    () => lifecycle.push("stop"),
+    () => [],
+  )
+  let event_sources = [
+    CommandExtensionEventSource::{
+      extension_id: "examples/start-failure",
+      extension_namespace: "startFailure",
+      source,
+      started: false,
+    },
+  ]
+  match
+    expect_app_run_error(() => {
+      start_command_extension_event_sources(
+        event_sources,
+        @native.event_wakeup_callback(),
+      )
+    }) {
+    CommandExtensionLifecycleError(EventSourceStartFailed(..)) => ()
+    error => fail(error.message())
+  }
+  assert_eq(lifecycle, ["start", "stop"])
+  assert_false(event_sources[0].started)
+}
+
+///|
+test "duplicate extension event sources require the same definition" {
+  let spec = test_command_spec(
+    "examples/definition-identity",
+    "definitionIdentity",
+    ["ping"],
+  )
+  let source = @proton_extension.event_source(_wakeup => (), () => (), () => [])
+  match
+    expect_configuration_error(() => {
+      ignore(
+        command_extension_catalog([
+          test_extension_capability(
+            spec,
+            definition_id=1UL,
+            event_source=source,
+          ),
+          test_extension_capability(
+            spec,
+            definition_id=2UL,
+            event_source=source,
+          ),
+        ]),
+      )
+    }) {
+    InvalidRendererCapability(detail~) =>
+      assert_true(detail.contains("conflicting event sources"))
+    error => fail(error.message())
+  }
+}
+
+///|
+test "duplicate renderer capabilities may share one extension event source" {
+  let spec = test_command_spec(
+    "examples/shared-event-source",
+    "sharedEventSource",
+    ["ping"],
+  )
+  let source = @proton_extension.event_source(_wakeup => (), () => (), () => [])
+  let capabilities = [
+    test_extension_capability(spec, definition_id=7UL, event_source=source),
+    test_extension_capability(spec, definition_id=7UL, event_source=source),
+  ]
+  let catalog = unwrap_configuration(() => {
+    command_extension_catalog(capabilities)
+  })
+  assert_eq(catalog.specs.length(), 1)
+  match catalog.event_sources.get(spec.id()) {
+    Some(_) => ()
+    None => fail("expected shared event source")
   }
 }
 
@@ -1238,7 +1382,7 @@ test "command host installs typed application registrars before sealing" {
       targets: [RendererTarget::entry()],
     },
   ]
-  let build = unwrap_app_run(() => build_command_host(capabilities, []))
+  let build = unwrap_app_run(() => test_build_command_host(capabilities, []))
   assert_eq(build.app_capabilities.length(), 1)
   assert_eq(build.app_capabilities[0].ops, ["app:ping"])
   match build.runtime {
@@ -1276,7 +1420,7 @@ test "command host close drains every destroy hook after a failure" {
     error => abort(error.message())
   }
   let build = unwrap_app_run(() => {
-    build_command_host([], [
+    test_build_command_host([], [
       test_extension_capability(base_spec),
       test_extension_capability(feature_spec),
     ])
@@ -1316,7 +1460,7 @@ test "command host registration preserves cleanup failures" {
     error => abort(error.message())
   }
   let error = expect_app_run_error(() => {
-    ignore(build_command_host([], [test_extension_capability(spec)]))
+    ignore(test_build_command_host([], [test_extension_capability(spec)]))
   })
   match error {
     CleanupFailed(primary~, failures~) => {
@@ -1559,7 +1703,7 @@ test "command host registers extension dependencies before dependents" {
     dependency_id, "base", registered,
   )
   let build = unwrap_app_run(() => {
-    build_command_host([], [
+    test_build_command_host([], [
       test_extension_capability(feature_spec),
       test_extension_capability(dependency_spec),
     ])
@@ -1582,7 +1726,7 @@ test "command host rejects missing extension dependencies" {
   ])
   match
     expect_app_run_error(() => {
-      build_command_host([], [test_extension_capability(feature_spec)])
+      test_build_command_host([], [test_extension_capability(feature_spec)])
     }) {
     ConfigurationError(
       ExtensionUnavailable(extension_id=missing_id, requested_by~, state~)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -1060,6 +1060,9 @@ test "one extension supports distinct scopes in different windows" {
       resolved,
     )
   })
+  assert_true(main_policy.grants_extension(extension_id))
+  assert_true(secondary_policy.grants_extension(extension_id))
+  assert_false(main_policy.grants_extension("examples/other-extension"))
   inspect(
     main_policy.grants[0].scope.stringify(),
     content="{\"root\":\"./main\"}",
@@ -1367,6 +1370,33 @@ test "duplicate renderer capabilities may share one extension event source" {
     Some(_) => ()
     None => fail("expected shared event source")
   }
+}
+
+///|
+test "event-only extensions still create a renderer bridge host" {
+  let spec = test_command_spec("examples/event-only", "eventOnly", [])
+  let source = @proton_extension.event_source(_wakeup => (), () => (), () => [])
+  let build = unwrap_app_run(() => {
+    test_build_command_host([], [
+      test_extension_capability(spec, event_source=source),
+    ])
+  })
+  match build.runtime {
+    Some(host) => {
+      assert_eq(host.host.registered_ops(), [])
+      assert_eq(host.event_sources.length(), 1)
+      assert_true(requires_renderer_bridge(Some(host), false, false))
+      assert_eq(close_command_host(Some(host)).length(), 0)
+    }
+    None => fail("expected event-only extension to require a bridge host")
+  }
+}
+
+///|
+test "renderer bridge requirement includes every bridge-owned feature" {
+  assert_false(requires_renderer_bridge(None, false, false))
+  assert_true(requires_renderer_bridge(None, true, false))
+  assert_true(requires_renderer_bridge(None, false, true))
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -143,6 +143,9 @@ pub extern "C" fn proton_runtime_destroy_ffi(runtime : RuntimeHandle) -> Int = "
 pub extern "C" fn proton_runtime_signal_wakeup_ffi() -> Unit = "proton_runtime_signal_wakeup"
 
 ///|
+pub extern "C" fn proton_runtime_event_wakeup_callback_ffi() -> @proton_ffi.EventWakeup = "proton_runtime_event_wakeup_callback"
+
+///|
 pub extern "C" fn proton_host_loop_begin_ffi() -> Int = "proton_host_loop_begin"
 
 ///|

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -101,6 +101,7 @@ int32_t proton_runtime_complete_resource_request(
 /* Wakes a blocked host-loop poll, or makes the next one return immediately.
  * Takes no handle because the foreign waiting thread owns none. */
 void proton_runtime_signal_wakeup(void);
+void (*proton_runtime_event_wakeup_callback(void))(void);
 
 /* The main thread's event loop.
  *

--- a/proton/internal/native/ffi/moon.pkg
+++ b/proton/internal/native/ffi/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbit-community/proton/internal/native/cef_loader",
+  "moonbit-community/proton_ffi",
 }
 
 supported_targets = "native"

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbit-community/proton/internal/native/ffi"
 
 import {
+  "moonbit-community/proton_ffi",
   "moonbitlang/core/ref",
 }
 
@@ -109,6 +110,8 @@ pub fn proton_notification_show_ffi(Bytes, Bytes, Bytes, Int) -> Int
 pub fn proton_runtime_begin_message_dialog_ffi(RuntimeHandle, Bytes, Int, Bytes, Int, Int, @ref.Ref[Int64]) -> Int
 
 pub fn proton_runtime_destroy_ffi(RuntimeHandle) -> Int
+
+pub fn proton_runtime_event_wakeup_callback_ffi() -> @proton_ffi.EventWakeup
 
 pub fn proton_runtime_platform_id_ffi(FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_common/view_events.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/view_events.c
@@ -15,6 +15,7 @@ struct proton_view_events {
   proton_view_id_t view;
   proton_window_id_t window;
   int bound;
+  int closed;
 #ifdef _WIN32
   CRITICAL_SECTION lock;
 #else
@@ -94,16 +95,20 @@ int proton_view_events_ids(proton_view_events_t *events,
 }
 
 static void proton_view_events_enqueue(proton_view_events_t *events,
-                                       proton_event_t *event) {
+                                       proton_event_t *event,
+                                       int closes_view) {
   if (events == NULL || event == NULL) {
     proton_event_destroy(event);
     return;
   }
   proton_view_events_lock(events);
-  if (!events->bound) {
+  if (!events->bound || events->closed) {
     proton_view_events_unlock(events);
     proton_event_destroy(event);
     return;
+  }
+  if (closes_view) {
+    events->closed = 1;
   }
   event->view = events->view;
   event->window = events->window;
@@ -118,7 +123,7 @@ void proton_view_events_loading_changed(proton_view_events_t *events,
   if (event != NULL) {
     event->bool_a = is_loading;
   }
-  proton_view_events_enqueue(events, event);
+  proton_view_events_enqueue(events, event, 0);
 }
 
 void proton_view_events_navigated(proton_view_events_t *events,
@@ -128,7 +133,7 @@ void proton_view_events_navigated(proton_view_events_t *events,
     proton_event_destroy(event);
     event = NULL;
   }
-  proton_view_events_enqueue(events, event);
+  proton_view_events_enqueue(events, event, 0);
 }
 
 void proton_view_events_title_updated(proton_view_events_t *events,
@@ -139,7 +144,7 @@ void proton_view_events_title_updated(proton_view_events_t *events,
     proton_event_destroy(event);
     event = NULL;
   }
-  proton_view_events_enqueue(events, event);
+  proton_view_events_enqueue(events, event, 0);
 }
 
 void proton_view_events_load_failed(proton_view_events_t *events,
@@ -156,5 +161,10 @@ void proton_view_events_load_failed(proton_view_events_t *events,
   if (event != NULL) {
     event->int_a = error_code;
   }
-  proton_view_events_enqueue(events, event);
+  proton_view_events_enqueue(events, event, 0);
+}
+
+void proton_view_events_closed(proton_view_events_t *events) {
+  proton_view_events_enqueue(
+      events, proton_event_create(PROTON_EVENT_VIEW_CLOSED), 1);
 }

--- a/proton/internal/native/ffi/src/engine/cef_common/view_events.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/view_events.h
@@ -33,6 +33,7 @@ void proton_view_events_load_failed(proton_view_events_t *events,
                                     const char *url,
                                     int32_t error_code,
                                     const char *error_text);
+void proton_view_events_closed(proton_view_events_t *events);
 
 
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -468,6 +468,7 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   if (view != NULL) {
     view->browser_before_close_seen = 1;
     view->closed = 1;
+    proton_view_events_closed(view->events);
     view->xwindow = 0;
     if (view->browser != NULL) {
       proton_engine_browser_release(view->browser);

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -432,6 +432,7 @@ void proton_engine_view_on_before_close(proton_engine_view_t *view,
   }
   view->browser_before_close_seen = 1;
   proton_engine_view_mark_closed(view);
+  proton_view_events_closed(view->events);
   proton_engine_view_release_browser(view);
   if (view->browser_view != nil) {
     [view->browser_view removeFromSuperview];

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -1226,6 +1226,7 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     proton_engine_runtime_t *runtime = view->window->runtime;
     view->browser_before_close_seen = 1;
     view->closed = 1;
+    proton_view_events_closed(view->events);
     view->hwnd = NULL;
     if (view->browser != NULL) {
       proton_engine_browser_release(view->browser);

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1305,9 +1305,14 @@ int32_t proton_window_respond_close_request(proton_window_handle_t window,
                             "allow must be 0 or 1");
   }
   proton_window_slot_t *slot = NULL;
-  int32_t status = proton_get_window(window, &slot);
+  int32_t status = proton_get_window_for_destroy(window, &slot);
   if (status != PROTON_OK) {
     return status;
+  }
+  if (slot->lifecycle != PROTON_WINDOW_LIVE &&
+      slot->lifecycle != PROTON_WINDOW_CLOSE_REQUESTED) {
+    return proton_set_error(PROTON_ERR_DESTROYED,
+                            "window close request is no longer active");
   }
   if (slot->engine_window == NULL) {
     return proton_set_error(PROTON_ERR_UNSUPPORTED,
@@ -1319,6 +1324,11 @@ int32_t proton_window_respond_close_request(proton_window_handle_t window,
       sizeof(engine_error));
   if (status != PROTON_OK) {
     return proton_set_engine_status(status, engine_error);
+  }
+  if (allow) {
+    proton_window_slot_request_close(slot);
+  } else {
+    proton_window_slot_cancel_close(slot);
   }
   g_last_error[0] = '\0';
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -374,6 +374,10 @@ void proton_runtime_signal_wakeup(void) {
   proton_engine_runtime_signal_external_event(NULL);
 }
 
+void (*proton_runtime_event_wakeup_callback(void))(void) {
+  return proton_runtime_signal_wakeup;
+}
+
 int32_t proton_internal_runtime_set_menu(proton_runtime_handle_t runtime,
                                          const proton_menu_bar_t *menu_bar) {
   proton_runtime_slot_t *slot = NULL;

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -45,6 +45,7 @@ typedef enum proton_event_kind {
   PROTON_EVENT_RESOURCE_REQUEST_CANCELLED = 26,
   PROTON_EVENT_NOTIFICATION_CLICKED = 27,
   PROTON_EVENT_QUIT_REQUESTED = 28,
+  PROTON_EVENT_VIEW_CLOSED = 29,
 } proton_event_kind_t;
 
 typedef struct proton_event {

--- a/proton/internal/native/ffi/src/proton_state.c
+++ b/proton/internal/native/ffi/src/proton_state.c
@@ -237,6 +237,12 @@ void proton_window_slot_request_close(proton_window_slot_t *window) {
   }
 }
 
+void proton_window_slot_cancel_close(proton_window_slot_t *window) {
+  if (window != NULL && window->lifecycle == PROTON_WINDOW_CLOSE_REQUESTED) {
+    window->lifecycle = PROTON_WINDOW_LIVE;
+  }
+}
+
 void proton_window_slot_mark_closed(proton_window_slot_t *window) {
   if (window != NULL && window->lifecycle != PROTON_WINDOW_DESTROYING &&
       window->lifecycle != PROTON_WINDOW_DESTROYED) {

--- a/proton/internal/native/ffi/src/proton_state.h
+++ b/proton/internal/native/ffi/src/proton_state.h
@@ -128,6 +128,8 @@ PROTON_INTERNAL int32_t proton_window_slot_create(
 PROTON_INTERNAL void proton_window_slot_destroy(proton_window_slot_t *window);
 PROTON_INTERNAL void proton_window_slot_request_close(
     proton_window_slot_t *window);
+PROTON_INTERNAL void proton_window_slot_cancel_close(
+    proton_window_slot_t *window);
 PROTON_INTERNAL void proton_window_slot_mark_closed(
     proton_window_slot_t *window);
 PROTON_INTERNAL void proton_window_slot_begin_destroy(

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1577,17 +1577,25 @@ pub fn Window::respond_close_request(
   request_id : Int64,
   allow : Bool,
 ) -> Unit raise NativeError {
-  check_status(
-    @native_ffi.proton_window_respond_close_request_ffi(
-      self.live_handle(),
-      request_id,
-      if allow {
-        1
-      } else {
-        0
-      },
-    ),
+  match self.lifecycle {
+    WindowLive | WindowCloseRequested => ()
+    WindowDestroying | WindowDestroyed =>
+      raise Status(
+        status=proton_err_invalid_state,
+        message="window is closing or destroyed",
+      )
+  }
+  let status = @native_ffi.proton_window_respond_close_request_ffi(
+    self.handle,
+    request_id,
+    if allow {
+      1
+    } else {
+      0
+    },
   )
+  check_status(status)
+  self.lifecycle = if allow { WindowCloseRequested } else { WindowLive }
 }
 
 ///|

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -575,6 +575,12 @@ pub fn signal_wakeup() -> Unit {
 }
 
 ///|
+/// Returns the opaque native callback used by extension event producers.
+pub fn event_wakeup_callback() -> @ffi.EventWakeup {
+  @native_ffi.proton_runtime_event_wakeup_callback_ffi()
+}
+
+///|
 fn menu_item_kind_code(kind : MenuItemKind) -> Int {
   match kind {
     Command => 0

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1006,6 +1006,7 @@ fn decode_native_runtime_event(
         },
       )
     28 => QuitRequested
+    29 => ViewEvent(window, @native_ffi.event_int64(event, 1), Closed)
     kind =>
       raise InvalidPayload(
         context="runtime event",

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -135,6 +135,15 @@ test "quit request is an application-level runtime event" {
 }
 
 ///|
+test "view closed events preserve owning window and view ids" {
+  let event = RuntimeEvent::ViewEvent(7L, 11L, Closed)
+  assert_eq(event.event_type(), "view_closed")
+  assert_true(event.is_view_closed())
+  assert_eq(event.window_id(), Some(7L))
+  assert_eq(event.view_id(), Some(11L))
+}
+
+///|
 test "native ABI version and availability" {
   inspect(abi_version(), content="1")
 }

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbit-community/proton/internal/native"
 import {
   "moonbit-community/proton/internal/locale",
   "moonbit-community/proton/internal/native/ffi",
+  "moonbit-community/proton_ffi",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
@@ -12,6 +13,8 @@ import {
 pub fn abi_version() -> Int
 
 pub fn bridge_permission_grants_supported() -> Bool
+
+pub fn event_wakeup_callback() -> @proton_ffi.EventWakeup
 
 pub fn execute_process(config? : RuntimeConfig) -> ProcessResult raise NativeError
 

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -420,6 +420,7 @@ pub fn RuntimeEvent::event_type(Self) -> String
 pub fn RuntimeEvent::has_window(Self) -> Bool
 pub fn RuntimeEvent::is_bridge_lifecycle_changed(Self) -> Bool
 pub fn RuntimeEvent::is_quit_requested(Self) -> Bool
+pub fn RuntimeEvent::is_view_closed(Self) -> Bool
 pub fn RuntimeEvent::is_window_closed(Self) -> Bool
 pub fn RuntimeEvent::is_window_created(Self) -> Bool
 pub fn RuntimeEvent::launch_input(Self) -> RuntimeLaunchInput?

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -571,6 +571,7 @@ pub fn Window::respond_browser_request(Self, Int64, String, path? : String) -> U
 pub fn Window::respond_close_request(Self, Int64, Bool) -> Unit raise NativeError
 pub fn Window::restore(Self) -> Unit raise NativeError
 pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -195,6 +195,7 @@ enum NativeViewEvent {
   Navigated(String)
   TitleUpdated(String)
   LoadFailed(String, Int, String)
+  Closed
 } derive(Debug, Eq)
 
 ///|
@@ -664,6 +665,7 @@ pub fn RuntimeEvent::event_type(self : RuntimeEvent) -> String {
     ViewEvent(_, _, Navigated(_)) => "view_navigated"
     ViewEvent(_, _, TitleUpdated(_)) => "view_title_updated"
     ViewEvent(_, _, LoadFailed(_, _, _)) => "view_load_failed"
+    ViewEvent(_, _, Closed) => "view_closed"
     ResourceRequested(_) => "resource_requested"
     ResourceRequestCancelled(_) => "resource_request_cancelled"
     QuitRequested => "quit_requested"
@@ -784,8 +786,21 @@ pub fn RuntimeEvent::view_event(self : RuntimeEvent) -> ViewEventInfo? {
         error_code: Some(error_code),
         error_text: Some(error_text),
       })
+    ViewEvent(_, _, Closed) =>
+      Some({
+        url: None,
+        title: None,
+        is_loading: None,
+        error_code: None,
+        error_text: None,
+      })
     _ => None
   }
+}
+
+///|
+pub fn RuntimeEvent::is_view_closed(self : RuntimeEvent) -> Bool {
+  self is ViewEvent(_, _, Closed)
 }
 
 ///|

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -102,6 +102,7 @@ pub fn AppRunError::to_string(Self) -> String
 pub(all) suberror CommandExtensionLifecycleError {
   ApplicationRegistrationFailed(detail~ : String)
   RegistrationFailed(extension_id~ : String, detail~ : String)
+  EventSourceStartFailed(extension_id~ : String, detail~ : String)
   DestroyFailed(extension_id~ : String, detail~ : String)
 } derive(@debug.Debug)
 pub fn CommandExtensionLifecycleError::message(Self) -> String

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -500,6 +500,7 @@ pub(all) enum ViewEvent {
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  Closed
 } derive(Eq, @debug.Debug)
 pub fn ViewEvent::equal(Self, Self) -> Bool
 pub fn ViewEvent::not_equal(Self, Self) -> Bool

--- a/sys/ffi/src/event_wakeup.mbt
+++ b/sys/ffi/src/event_wakeup.mbt
@@ -1,0 +1,8 @@
+///|
+/// An opaque native callback that wakes an embedding host event loop.
+///
+/// MoonBit code may only pass this token back to a native event producer. It
+/// cannot invoke or wrap the callback, which keeps foreign threads out of the
+/// MoonBit runtime.
+#external
+pub type EventWakeup

--- a/sys/ffi/src/pkg.generated.mbti
+++ b/sys/ffi/src/pkg.generated.mbti
@@ -13,6 +13,8 @@ pub fn to_wstr(String) -> Bytes
 // Errors
 
 // Types and methods
+#external
+pub type EventWakeup
 
 // Type aliases
 

--- a/sys/global_hotkey/ffi.mbt
+++ b/sys/global_hotkey/ffi.mbt
@@ -41,5 +41,12 @@ extern "C" fn unregister_hotkey_ffi(state : GlobalHotkeyState, id : Int) -> Int 
 extern "C" fn take_triggered_id_ffi(state : GlobalHotkeyState) -> Int = "mb_global_hotkey_take_triggered_id"
 
 ///|
+#borrow(state)
+extern "C" fn set_event_wakeup_ffi(
+  state : GlobalHotkeyState,
+  wakeup : @ffi.EventWakeup,
+) -> Unit = "mb_global_hotkey_set_event_wakeup"
+
+///|
 /// Returns the last backend error message as UTF-8 bytes.
 extern "C" fn last_error_message_ffi() -> Bytes = "mb_global_hotkey_last_error_message"

--- a/sys/global_hotkey/global_hotkey.mbt
+++ b/sys/global_hotkey/global_hotkey.mbt
@@ -372,6 +372,19 @@ pub fn GlobalHotkeyManager::drain_triggered(
 }
 
 ///|
+/// Installs the opaque native wakeup supplied by an embedding event loop.
+#doc(hidden)
+pub fn GlobalHotkeyManager::set_event_wakeup(
+  self : GlobalHotkeyManager,
+  wakeup : @ffi.EventWakeup,
+) -> Unit {
+  match self.resolve_state() {
+    Ok(state) => set_event_wakeup_ffi(state, wakeup)
+    Err(_) => ()
+  }
+}
+
+///|
 /// Releases every native resource owned by this manager and clears its registry.
 ///
 /// Calling `destroy()` more than once is harmless. After destruction,

--- a/sys/global_hotkey/global_hotkey_native.c
+++ b/sys/global_hotkey/global_hotkey_native.c
@@ -55,10 +55,13 @@ typedef struct mb_trigger {
   struct mb_trigger *next;
 } mb_trigger_t;
 
+typedef void (*mb_global_hotkey_event_wakeup_fn)(void);
+
 typedef struct mb_global_hotkey_state {
   mb_registration_t *registrations;
   mb_trigger_t *triggered_head;
   mb_trigger_t *triggered_tail;
+  mb_global_hotkey_event_wakeup_fn event_wakeup;
   int32_t startup_status;
   char startup_error[512];
 #ifdef _WIN32
@@ -99,7 +102,7 @@ static int mb_keycode_from_name_common(
 static void mb_state_set_startup_error(
     mb_global_hotkey_state_t *state,
     const char *message);
-static void mb_push_trigger_locked(
+static mb_global_hotkey_event_wakeup_fn mb_push_trigger_locked(
     mb_global_hotkey_state_t *state,
     int32_t id);
 static void mb_set_error_message(const char *message);
@@ -472,6 +475,7 @@ static CGEventRef mb_macos_event_callback(CGEventTapProxy proxy,
     return event;
   }
 
+  mb_global_hotkey_event_wakeup_fn wakeup = NULL;
   pthread_mutex_lock(&state->lock);
   {
     uint32_t keycode = (uint32_t)mb_macos_api.CGEventGetIntegerValueField(
@@ -481,13 +485,16 @@ static CGEventRef mb_macos_event_callback(CGEventTapProxy proxy,
     mb_registration_t *cursor = state->registrations;
     while (cursor != NULL) {
       if (cursor->keycode == keycode && cursor->modifiers == modifiers) {
-        mb_push_trigger_locked(state, cursor->id);
+        wakeup = mb_push_trigger_locked(state, cursor->id);
         break;
       }
       cursor = cursor->next;
     }
   }
   pthread_mutex_unlock(&state->lock);
+  if (wakeup != NULL) {
+    wakeup();
+  }
   return event;
 }
 
@@ -1095,6 +1102,7 @@ static void *mb_linux_thread_main(void *raw_state) {
           break;
         }
         if (event.type == KeyPress) {
+          mb_global_hotkey_event_wakeup_fn wakeup = NULL;
           unsigned int clean_modifiers =
               mb_linux_clean_event_modifiers(state, event.xkey.state);
           pthread_mutex_lock(&state->lock);
@@ -1103,13 +1111,16 @@ static void *mb_linux_thread_main(void *raw_state) {
             while (cursor != NULL) {
               if (cursor->keycode == (uint32_t)event.xkey.keycode &&
                   cursor->modifiers == clean_modifiers) {
-                mb_push_trigger_locked(state, cursor->id);
+                wakeup = mb_push_trigger_locked(state, cursor->id);
                 break;
               }
               cursor = cursor->next;
             }
           }
           pthread_mutex_unlock(&state->lock);
+          if (wakeup != NULL) {
+            wakeup();
+          }
         }
       }
     }
@@ -1207,12 +1218,12 @@ static void mb_clear_runtime_state_locked(mb_global_hotkey_state_t *state) {
   state->triggered_tail = NULL;
 }
 
-static void mb_push_trigger_locked(
+static mb_global_hotkey_event_wakeup_fn mb_push_trigger_locked(
     mb_global_hotkey_state_t *state,
     int32_t id) {
   mb_trigger_t *node = (mb_trigger_t *)calloc(1, sizeof(*node));
   if (node == NULL) {
-    return;
+    return NULL;
   }
   node->id = id;
   if (state->triggered_tail == NULL) {
@@ -1222,6 +1233,7 @@ static void mb_push_trigger_locked(
     state->triggered_tail->next = node;
     state->triggered_tail = node;
   }
+  return state->event_wakeup;
 }
 
 static int32_t mb_take_triggered_id_locked(mb_global_hotkey_state_t *state) {
@@ -1508,9 +1520,13 @@ static DWORD WINAPI mb_windows_thread_main(void *raw_state) {
     }
 
     if (message.message == WM_HOTKEY) {
+      mb_global_hotkey_event_wakeup_fn wakeup;
       EnterCriticalSection(&state->lock);
-      mb_push_trigger_locked(state, (int32_t)message.wParam);
+      wakeup = mb_push_trigger_locked(state, (int32_t)message.wParam);
       LeaveCriticalSection(&state->lock);
+      if (wakeup != NULL) {
+        wakeup();
+      }
     }
   }
 
@@ -2047,6 +2063,25 @@ MOONBIT_FFI_EXPORT int32_t mb_global_hotkey_take_triggered_id(
   }
 #else
   return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT void mb_global_hotkey_set_event_wakeup(
+    mb_global_hotkey_state_t *state,
+    mb_global_hotkey_event_wakeup_fn wakeup) {
+  if (state == NULL) {
+    return;
+  }
+#ifdef _WIN32
+  EnterCriticalSection(&state->lock);
+  state->event_wakeup = wakeup;
+  LeaveCriticalSection(&state->lock);
+#elif defined(__linux__) || defined(__APPLE__)
+  pthread_mutex_lock(&state->lock);
+  state->event_wakeup = wakeup;
+  pthread_mutex_unlock(&state->lock);
+#else
+  state->event_wakeup = wakeup;
 #endif
 }
 

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -2,6 +2,10 @@ name = "moonbit-community/proton_global_hotkey"
 
 version = "0.2.2"
 
+import {
+  "moonbit-community/proton_ffi@0.2.2",
+}
+
 readme = "README.mbt.md"
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/global_hotkey"

--- a/sys/global_hotkey/moon.pkg
+++ b/sys/global_hotkey/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/encoding/utf8",
 }
 

--- a/sys/power_monitor/moon.pkg
+++ b/sys/power_monitor/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/encoding/utf8",
 }
 

--- a/sys/power_monitor/native_common.c
+++ b/sys/power_monitor/native_common.c
@@ -66,6 +66,7 @@ void power_monitor_push_event(power_monitor_state_t *state, int32_t event) {
   if (state == NULL) {
     return;
   }
+  power_monitor_event_wakeup_fn wakeup = NULL;
   power_monitor_lock_acquire(state);
   if (state->event_queue_size >= POWER_MONITOR_EVENT_QUEUE_CAPACITY) {
     /* A full queue drops the oldest entry so the latest system state is always
@@ -93,7 +94,22 @@ void power_monitor_push_event(power_monitor_state_t *state, int32_t event) {
       state->event_tail = node;
     }
     state->event_queue_size++;
+    wakeup = state->event_wakeup;
   }
+  power_monitor_lock_release(state);
+  if (wakeup != NULL) {
+    wakeup();
+  }
+}
+
+void power_monitor_set_event_wakeup(
+    power_monitor_state_t *state,
+    power_monitor_event_wakeup_fn wakeup) {
+  if (state == NULL) {
+    return;
+  }
+  power_monitor_lock_acquire(state);
+  state->event_wakeup = wakeup;
   power_monitor_lock_release(state);
 }
 
@@ -259,6 +275,12 @@ int32_t moonbit_power_monitor_take_event(void *handle, int32_t *out_event) {
     return power_monitor_STATUS_OPERATION_FAILED;
   }
   return power_monitor_take_event((power_monitor_state_t *)handle, out_event);
+}
+
+MOONBIT_FFI_EXPORT void moonbit_power_monitor_set_event_wakeup(
+    void *handle,
+    power_monitor_event_wakeup_fn wakeup) {
+  power_monitor_set_event_wakeup((power_monitor_state_t *)handle, wakeup);
 }
 
 MOONBIT_FFI_EXPORT

--- a/sys/power_monitor/native_ffi.mbt
+++ b/sys/power_monitor/native_ffi.mbt
@@ -42,6 +42,13 @@ extern "C" fn native_take_event(handle : State, out_event : Ref[Int]) -> Int = "
 
 ///|
 #borrow(handle)
+extern "C" fn native_set_event_wakeup(
+  handle : State,
+  wakeup : @ffi.EventWakeup,
+) -> Unit = "moonbit_power_monitor_set_event_wakeup"
+
+///|
+#borrow(handle)
 extern "C" fn native_destroy(handle : State) -> Unit = "moonbit_power_monitor_destroy"
 
 ///|

--- a/sys/power_monitor/native_stub.h
+++ b/sys/power_monitor/native_stub.h
@@ -34,6 +34,8 @@ typedef struct power_monitor_event_node {
   struct power_monitor_event_node *next;
 } power_monitor_event_node_t;
 
+typedef void (*power_monitor_event_wakeup_fn)(void);
+
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -57,6 +59,7 @@ typedef struct power_monitor_state {
   power_monitor_event_node_t *event_tail;
   int32_t event_queue_size;
   int32_t event_queue_overflow;
+  power_monitor_event_wakeup_fn event_wakeup;
   /* Watch backend state. `watch_started` is best-effort: a backend that is
      unavailable records the failure on `watch_error` and returns a non-OK
      status while leaving the state usable for polling queries. */
@@ -115,6 +118,9 @@ void power_monitor_lock_destroy(power_monitor_state_t *state);
 void power_monitor_push_event(power_monitor_state_t *state, int32_t event);
 int32_t power_monitor_take_event(power_monitor_state_t *state,
                                  int32_t *out_event);
+void power_monitor_set_event_wakeup(
+    power_monitor_state_t *state,
+    power_monitor_event_wakeup_fn wakeup);
 void power_monitor_release_events(power_monitor_state_t *state);
 
 #endif

--- a/sys/power_monitor/native_windows.c
+++ b/sys/power_monitor/native_windows.c
@@ -210,8 +210,9 @@ int32_t power_monitor_platform_start_watching(power_monitor_state_t *state) {
     power_monitor_set_watch_error(state, "CreateThread failed");
     return power_monitor_STATUS_OPERATION_FAILED;
   }
-  WaitForSingleObject(state->ready_event, 10000);
+  WaitForSingleObject(state->ready_event, INFINITE);
   if (!state->watch_started) {
+    WaitForSingleObject(state->watch_thread, INFINITE);
     CloseHandle(state->watch_thread);
     state->watch_thread = NULL;
     CloseHandle(state->ready_event);
@@ -227,7 +228,7 @@ int32_t power_monitor_platform_start_watching(power_monitor_state_t *state) {
 int32_t power_monitor_platform_stop_watching(power_monitor_state_t *state) {
   if (state->watch_thread != NULL) {
     PostThreadMessageW(state->watch_thread_id, WM_QUIT, 0, 0);
-    WaitForSingleObject(state->watch_thread, 10000);
+    WaitForSingleObject(state->watch_thread, INFINITE);
     CloseHandle(state->watch_thread);
     state->watch_thread = NULL;
   }

--- a/sys/power_monitor/power_monitor.mbt
+++ b/sys/power_monitor/power_monitor.mbt
@@ -141,6 +141,16 @@ pub fn PowerMonitor::drain_events(
 }
 
 ///|
+/// Installs the opaque native wakeup supplied by an embedding event loop.
+#doc(hidden)
+pub fn PowerMonitor::set_event_wakeup(
+  self : PowerMonitor,
+  wakeup : @ffi.EventWakeup,
+) -> Unit {
+  native_set_event_wakeup(self.handle, wakeup)
+}
+
+///|
 fn PowerMonitor::classify_status(
   self : PowerMonitor,
   status : Int,

--- a/sys/screen_monitor/moon.pkg
+++ b/sys/screen_monitor/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbit-community/proton_ffi" @ffi,
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
 }

--- a/sys/screen_monitor/native_common.c
+++ b/sys/screen_monitor/native_common.c
@@ -66,6 +66,7 @@ void screen_monitor_push_event(screen_monitor_state_t *state, int32_t event) {
   if (state == NULL) {
     return;
   }
+  screen_monitor_event_wakeup_fn wakeup = NULL;
   screen_monitor_lock_acquire(state);
   if (state->event_queue_size >= SCREEN_MONITOR_EVENT_QUEUE_CAPACITY) {
     /* A full queue drops the oldest entry so the latest topology state is
@@ -93,7 +94,22 @@ void screen_monitor_push_event(screen_monitor_state_t *state, int32_t event) {
       state->event_tail = node;
     }
     state->event_queue_size++;
+    wakeup = state->event_wakeup;
   }
+  screen_monitor_lock_release(state);
+  if (wakeup != NULL) {
+    wakeup();
+  }
+}
+
+void screen_monitor_set_event_wakeup(
+    screen_monitor_state_t *state,
+    screen_monitor_event_wakeup_fn wakeup) {
+  if (state == NULL) {
+    return;
+  }
+  screen_monitor_lock_acquire(state);
+  state->event_wakeup = wakeup;
   screen_monitor_lock_release(state);
 }
 
@@ -216,6 +232,12 @@ int32_t moonbit_screen_monitor_take_event(void *handle, int32_t *out_event) {
     return screen_monitor_STATUS_OPERATION_FAILED;
   }
   return screen_monitor_take_event((screen_monitor_state_t *)handle, out_event);
+}
+
+MOONBIT_FFI_EXPORT void moonbit_screen_monitor_set_event_wakeup(
+    void *handle,
+    screen_monitor_event_wakeup_fn wakeup) {
+  screen_monitor_set_event_wakeup((screen_monitor_state_t *)handle, wakeup);
 }
 
 /* --- JSON query helpers -------------------------------------------------- */

--- a/sys/screen_monitor/native_ffi.mbt
+++ b/sys/screen_monitor/native_ffi.mbt
@@ -42,6 +42,13 @@ extern "C" fn native_take_event(handle : State, out_event : Ref[Int]) -> Int = "
 
 ///|
 #borrow(handle)
+extern "C" fn native_set_event_wakeup(
+  handle : State,
+  wakeup : @ffi.EventWakeup,
+) -> Unit = "moonbit_screen_monitor_set_event_wakeup"
+
+///|
+#borrow(handle)
 extern "C" fn native_destroy(handle : State) -> Unit = "moonbit_screen_monitor_destroy"
 
 ///|

--- a/sys/screen_monitor/native_stub.h
+++ b/sys/screen_monitor/native_stub.h
@@ -48,6 +48,8 @@ typedef struct screen_monitor_event_node {
   struct screen_monitor_event_node *next;
 } screen_monitor_event_node_t;
 
+typedef void (*screen_monitor_event_wakeup_fn)(void);
+
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -68,6 +70,7 @@ typedef struct screen_monitor_state {
   screen_monitor_event_node_t *event_tail;
   int32_t event_queue_size;
   int32_t event_queue_overflow;
+  screen_monitor_event_wakeup_fn event_wakeup;
   /* Watch backend state. `watch_started` is best-effort: a backend that is
      unavailable records the failure on `watch_error` and returns a non-OK
      status while leaving query APIs fully usable. */
@@ -80,6 +83,7 @@ typedef struct screen_monitor_state {
 #if defined(_WIN32)
   CRITICAL_SECTION event_lock;
   HANDLE device_handle;
+  HANDLE ready_event;
   HANDLE watch_thread;
   DWORD watch_thread_id;
   HWND message_window;
@@ -135,6 +139,9 @@ void screen_monitor_lock_destroy(screen_monitor_state_t *state);
 void screen_monitor_push_event(screen_monitor_state_t *state, int32_t event);
 int32_t screen_monitor_take_event(screen_monitor_state_t *state,
                                   int32_t *out_event);
+void screen_monitor_set_event_wakeup(
+    screen_monitor_state_t *state,
+    screen_monitor_event_wakeup_fn wakeup);
 void screen_monitor_release_events(screen_monitor_state_t *state);
 
 #endif

--- a/sys/screen_monitor/native_windows.c
+++ b/sys/screen_monitor/native_windows.c
@@ -257,6 +257,7 @@ static DWORD WINAPI screen_monitor_watch_thread_main(LPVOID param) {
   if (RegisterClassW(&wc) == 0 && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
     screen_monitor_set_watch_error(state, "RegisterClassW failed");
     state->watch_started = 0;
+    SetEvent(state->ready_event);
     return 1;
   }
 
@@ -266,6 +267,7 @@ static DWORD WINAPI screen_monitor_watch_thread_main(LPVOID param) {
   if (hwnd == NULL) {
     screen_monitor_set_watch_error(state, "CreateWindowExW failed");
     state->watch_started = 0;
+    SetEvent(state->ready_event);
     return 1;
   }
   state->message_window = hwnd;
@@ -285,6 +287,7 @@ static DWORD WINAPI screen_monitor_watch_thread_main(LPVOID param) {
   screen_monitor_platform_enumerate(state);
 
   state->watch_started = 1;
+  SetEvent(state->ready_event);
 
   MSG msg;
   while (GetMessageW(&msg, NULL, 0, 0) > 0) {
@@ -301,12 +304,33 @@ int32_t screen_monitor_platform_start_watching(screen_monitor_state_t *state) {
     return screen_monitor_STATUS_OK;
   }
   state->watch_started = 0;
+  if (state->ready_event == NULL) {
+    state->ready_event = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (state->ready_event == NULL) {
+      screen_monitor_set_watch_error(state, "CreateEventW failed");
+      return screen_monitor_STATUS_OPERATION_FAILED;
+    }
+  }
   state->watch_thread =
       CreateThread(NULL, 0, screen_monitor_watch_thread_main, state, 0,
                    &state->watch_thread_id);
   if (state->watch_thread == NULL) {
+    CloseHandle(state->ready_event);
+    state->ready_event = NULL;
     screen_monitor_set_watch_error(state, "CreateThread failed");
     return screen_monitor_STATUS_OPERATION_FAILED;
+  }
+  WaitForSingleObject(state->ready_event, INFINITE);
+  if (!state->watch_started) {
+    WaitForSingleObject(state->watch_thread, INFINITE);
+    CloseHandle(state->watch_thread);
+    state->watch_thread = NULL;
+    CloseHandle(state->ready_event);
+    state->ready_event = NULL;
+    if (state->watch_error[0] == '\0') {
+      screen_monitor_set_watch_error(state, "watch backend failed to start");
+    }
+    return screen_monitor_STATUS_BACKEND_UNAVAILABLE;
   }
   return screen_monitor_STATUS_OK;
 }
@@ -314,9 +338,13 @@ int32_t screen_monitor_platform_start_watching(screen_monitor_state_t *state) {
 int32_t screen_monitor_platform_stop_watching(screen_monitor_state_t *state) {
   if (state->watch_thread != NULL) {
     PostThreadMessageW(state->watch_thread_id, WM_QUIT, 0, 0);
-    WaitForSingleObject(state->watch_thread, 10000);
+    WaitForSingleObject(state->watch_thread, INFINITE);
     CloseHandle(state->watch_thread);
     state->watch_thread = NULL;
+  }
+  if (state->ready_event != NULL) {
+    CloseHandle(state->ready_event);
+    state->ready_event = NULL;
   }
   if (state->device_handle != NULL) {
     UnregisterDeviceNotification(state->device_handle);

--- a/sys/screen_monitor/screen_monitor.mbt
+++ b/sys/screen_monitor/screen_monitor.mbt
@@ -308,6 +308,16 @@ pub fn ScreenMonitor::drain_events(
 }
 
 ///|
+/// Installs the opaque native wakeup supplied by an embedding event loop.
+#doc(hidden)
+pub fn ScreenMonitor::set_event_wakeup(
+  self : ScreenMonitor,
+  wakeup : @ffi.EventWakeup,
+) -> Unit {
+  native_set_event_wakeup(self.handle, wakeup)
+}
+
+///|
 fn screen_monitor_event_from_native_code(code : Int) -> ScreenMonitorEvent {
   match code {
     _ if code == native_event_added => DisplayAdded

--- a/sys/tray/native_ffi.mbt
+++ b/sys/tray/native_ffi.mbt
@@ -105,5 +105,11 @@ extern "C" fn pump_state_ffi(state : Int64, blocking : Int) -> Int = "moonbit_tr
 extern "C" fn poll_event_json_ffi(state : Int64) -> Bytes = "moonbit_tray_poll_event_json"
 
 ///|
+extern "C" fn set_event_wakeup_ffi(
+  state : Int64,
+  wakeup : @ffi.EventWakeup,
+) -> Unit = "moonbit_tray_set_event_wakeup"
+
+///|
 /// Returns the most recent state-operation error message as UTF-8 bytes.
 extern "C" fn last_state_error_ffi(state : Int64) -> Bytes = "moonbit_tray_last_error"

--- a/sys/tray/tray.mbt
+++ b/sys/tray/tray.mbt
@@ -488,6 +488,15 @@ pub fn Tray::drain_events(self : Tray) -> Array[TrayEvent] {
 }
 
 ///|
+/// Installs the opaque native wakeup supplied by an embedding event loop.
+#doc(hidden)
+pub fn Tray::set_event_wakeup(self : Tray, wakeup : @ffi.EventWakeup) -> Unit {
+  if self.native && !self.destroyed {
+    set_event_wakeup_ffi(self.handle, wakeup)
+  }
+}
+
+///|
 /// Pumps one native tray loop iteration.
 ///
 /// Call this from long-running native applications when the host platform needs

--- a/sys/tray/tray_native.c
+++ b/sys/tray/tray_native.c
@@ -38,6 +38,8 @@
 #define MOONBIT_TRAY_COMMAND_BASE 0x7000
 #endif
 
+typedef void (*moonbit_tray_event_wakeup_fn)(void);
+
 typedef struct moonbit_tray_state {
 #ifdef _WIN32
   HWND hwnd;
@@ -76,6 +78,7 @@ typedef struct moonbit_tray_state {
   char events[MOONBIT_TRAY_MAX_EVENTS][MOONBIT_TRAY_MAX_EVENT_BYTES];
   uint32_t event_head;
   uint32_t event_count;
+  moonbit_tray_event_wakeup_fn event_wakeup;
   char last_error[256];
 } moonbit_tray_state_t;
 
@@ -254,6 +257,9 @@ static int32_t moonbit_tray_enqueue_event(
       (state->event_head + state->event_count) % MOONBIT_TRAY_MAX_EVENTS;
   memcpy(state->events[index], event_json, len + 1);
   state->event_count++;
+  if (state->event_wakeup != NULL) {
+    state->event_wakeup();
+  }
   return 1;
 }
 
@@ -3078,6 +3084,15 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_poll_event_json(
   state->event_head = (state->event_head + 1) % MOONBIT_TRAY_MAX_EVENTS;
   state->event_count--;
   return result;
+}
+
+MOONBIT_FFI_EXPORT void moonbit_tray_set_event_wakeup(
+    int64_t handle,
+    moonbit_tray_event_wakeup_fn wakeup) {
+  moonbit_tray_state_t *state = moonbit_tray_from_handle(handle);
+  if (state != NULL) {
+    state->event_wakeup = wakeup;
+  }
 }
 
 MOONBIT_FFI_EXPORT moonbit_bytes_t moonbit_tray_last_error(


### PR DESCRIPTION
## Background

Several runtime ownership boundaries could diverge during startup and shutdown. A failed window startup could leave partially published ownership, closed windows and WebContentsViews remained registered longer than their native lifetime, and bridge monitoring could query handles after native close had begun. Programmatic close interception also marked a handle unavailable before its asynchronous Allow/Deny response could be delivered. These races contributed to intermittent hangs in lifecycle-heavy examples such as `46_asset_sidecar_resources`.

## Changes

- route native extension wakeups through the host event loop and start event sources only after the renderer bridge is ready
- close CDP page targets directly during E2E teardown
- make window creation transactional and promptly retire closed window/view ownership
- stop bridge startup and failure monitoring once shutdown begins
- keep intercepted close requests replyable and restore open state after Deny
- discard window activation and browser-policy completions after closing starts
- synchronize the generated native interface with current window APIs

## Validation

- `moon fmt`
- `moon info`
- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test internal/native --target native --diagnostic-limit 100` (29 passed)
- `moon -C proton test -p moonbit-community/proton --target native --diagnostic-limit 100` (104 passed)
- `moon -C examples build --target native --diagnostic-limit 100`
- `node scripts/verify_generated.mjs`
- `MOON_CC=cc moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`

The full self-hosted macOS suite passed, including multi-window, WebContentsView, bridge reload, DevTools, asset sidecar, and shutdown scenarios.