### PR TITLE
feat(window): add content capture protection

### DIFF
--- a/examples/68_window_content_protection/README.md
+++ b/examples/68_window_content_protection/README.md
@@ -1,0 +1,15 @@
+# Window Content Protection
+
+This manual example exercises Electron's `WindowHandle::set_content_protection`.
+
+Run:
+
+```sh
+moon -C examples run 68_window_content_protection --target native
+```
+
+Enable protection, then use a screen recording or capture tool to verify the
+window is excluded or blacked out. Disable it and confirm normal capture works.
+On macOS, newer ScreenCaptureKit clients may still capture protected windows;
+this follows Electron's documented platform limitation. Linux treats the API
+as a successful no-op. Headless runtimes report unsupported.

--- a/examples/68_window_content_protection/main.mbt
+++ b/examples/68_window_content_protection/main.mbt
@@ -1,0 +1,114 @@
+///|
+struct ProtectionRequest {
+  enabled : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend ProtectionRequest with ToJson::{to_json}
+
+///|
+pub extend ProtectionRequest with FromJson::{from_json}
+
+///|
+struct ProtectionReply {
+  enabled : Bool
+  width : Int
+  height : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend ProtectionReply with ToJson::{to_json}
+
+///|
+pub extend ProtectionReply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-content-protection",
+  js_namespace="windowContentProtection",
+)
+
+///|
+let command : @proton_contract.Command[ProtectionRequest, ProtectionReply] = contract.command(
+  "set",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let protection_state : Ref[Bool] = { val: false, }
+
+///|
+fn set_protection(request : ProtectionRequest) -> ProtectionReply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        window.set_content_protection(request.enabled)
+        protection_state.val = request.enabled
+        let state = window.state()
+        ProtectionReply::{
+          enabled: request.enabled,
+          width: state.width,
+          height: state.height,
+          message: if request.enabled {
+            "Capture protection enabled"
+          } else {
+            "Capture protection disabled"
+          },
+        }
+      } catch {
+        error =>
+          ProtectionReply::{
+            enabled: protection_state.val,
+            width: 0,
+            height: 0,
+            message: error.to_string(),
+          }
+      }
+    None =>
+      ProtectionReply::{
+        enabled: protection_state.val,
+        width: 0,
+        height: 0,
+        message: "window is not ready",
+      }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(command, (_context, request) => set_protection(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Content Protection</title>
+    #|<style>body{margin:0;background:#eef2f1;color:#172522;font:16px system-ui,sans-serif}main{max-width:760px;margin:0 auto;padding:42px 24px}header{border-bottom:1px solid #70827c;padding-bottom:22px}h1{margin:0;font-size:40px;letter-spacing:0}.eyebrow{color:#1d7463;font:700 11px ui-monospace,monospace;text-transform:uppercase}.summary{color:#52645f;line-height:1.5}.panel{margin-top:24px;border:1px solid #70827c;background:#f9fbfa;padding:24px}.shield{min-height:180px;display:grid;place-items:center;border:3px solid #172522;background:repeating-linear-gradient(135deg,#d8e8e3 0,#d8e8e3 14px,#c9ddd6 14px,#c9ddd6 28px);text-align:center}.shield strong{display:block;font-size:24px}.shield span{display:block;margin-top:8px;color:#1d7463;font:700 11px ui-monospace,monospace;text-transform:uppercase}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #1d7463;background:#dcebe6;color:#172522;font-weight:700;cursor:pointer}button.primary{background:#1d7463;color:white}#status{min-height:42px;margin-top:20px;color:#52645f;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 68</p><h1>Window content protection</h1><p class="summary">Toggle the native capture-protection flag and inspect the result with a screen capture tool.</p></header><section class="panel"><div class="shield"><div><span id="label">Capture allowed</span><strong id="state">Unprotected</strong></div></div><button class="primary" data-enabled="true">Enable protection</button><button data-enabled="false">Disable protection</button><p id="status" role="status" aria-live="polite">Ready.</p></section></main><script>const state=document.querySelector('#state'),label=document.querySelector('#label'),status=document.querySelector('#status');const invoke=(enabled)=>window.__MoonBit__.core.invokeOp('ext:windowContentProtection/set',{enabled});async function run(enabled){status.textContent='Updating native window...';try{const reply=await invoke(enabled);state.textContent=reply.enabled?'Protected':'Unprotected';label.textContent=reply.enabled?'Capture blocked':'Capture allowed';status.textContent=`${reply.message} / ${reply.width} x ${reply.height}`}catch(error){status.textContent=`request failed: ${String(error)}`}}document.querySelectorAll('[data-enabled]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.enabled==='true')))</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html(
+    "Window Content Protection",
+    html(),
+    width=820,
+    height=560,
+    debug=true,
+  )
+  .identifier("dev.proton.window-content-protection")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/68_window_content_protection/moon.pkg
+++ b/examples/68_window_content_protection/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/68_window_content_protection/pkg.generated.mbti
+++ b/examples/68_window_content_protection/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/68_window_content_protection"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type ProtectionReply derive(ToJson, @json.FromJson)
+pub fn ProtectionReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ProtectionReply::to_json(Self) -> Json
+
+type ProtectionRequest derive(ToJson, @json.FromJson)
+pub fn ProtectionRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ProtectionRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -116,6 +116,7 @@ moon -C examples run 01_run --target native
   with Windows taskbar tab removal and macOS/Linux no-op checks.
 - `67_window_aspect_ratio`: manual Electron-style interactive resize ratio
   review with 16:9, 1:1, clear, and programmatic resize checks.
+- `68_window_content_protection`: manual Electron-style screen-capture protection review.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -180,6 +180,11 @@ fn RuntimeSession::window_handle(
         window.set_skip_taskbar(skip)
       })
     },
+    set_window_content_protection: enabled => {
+      self.control_window(id, native_id, "set content protection", window => {
+        window.set_content_protection(enabled)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1223,6 +1228,21 @@ pub fn WindowHandle::set_skip_taskbar(
   skip : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_skip_taskbar)(skip)
+}
+
+///|
+/// Sets whether other applications should be prevented from capturing this
+/// live native window.
+///
+/// macOS applies `NSWindowSharingNone`, although ScreenCaptureKit-based apps
+/// on recent macOS releases may still capture the window. Windows uses display
+/// affinity to exclude the window from capture. Linux follows Electron and
+/// treats this as a no-op. Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_content_protection(
+  self : WindowHandle,
+  enabled : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_content_protection)(enabled)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -434,6 +434,7 @@ pub struct WindowHandle {
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
+  set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -66,6 +66,7 @@ fn test_window_handle(
   movable_calls? : Array[Bool],
   opacity_calls? : Array[Double],
   skip_taskbar_calls? : Array[Bool],
+  content_protection_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -120,6 +121,12 @@ fn test_window_handle(
     set_window_skip_taskbar: skip => {
       match skip_taskbar_calls {
         Some(calls) => calls.push(skip)
+        None => ()
+      }
+    },
+    set_window_content_protection: enabled => {
+      match content_protection_calls {
+        Some(calls) => calls.push(enabled)
         None => ()
       }
     },
@@ -2028,6 +2035,15 @@ test "window taskbar visibility routes live flags through the handle" {
   let window = test_window_handle("main", 17L, skip_taskbar_calls=calls)
   window.set_skip_taskbar(true)
   window.set_skip_taskbar(false)
+  debug_inspect(calls, content="[true, false]")
+}
+
+///|
+test "window content protection routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, content_protection_calls=calls)
+  window.set_content_protection(true)
+  window.set_content_protection(false)
   debug_inspect(calls, content="[true, false]")
 }
 

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -488,6 +488,12 @@ pub extern "C" fn proton_window_set_skip_taskbar_ffi(
 ) -> Int = "proton_window_set_skip_taskbar"
 
 ///|
+pub extern "C" fn proton_window_set_content_protection_ffi(
+  window : WindowHandle,
+  enabled : Int,
+) -> Int = "proton_window_set_content_protection"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -170,6 +170,8 @@ int32_t proton_window_set_opacity(proton_window_handle_t window,
                                   double opacity);
 int32_t proton_window_set_skip_taskbar(proton_window_handle_t window,
                                        int32_t skip);
+int32_t proton_window_set_content_protection(proton_window_handle_t window,
+                                             int32_t enabled);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -212,6 +212,8 @@ pub fn proton_window_set_aspect_ratio_ffi(WindowHandle, Double) -> Int
 
 pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_content_protection_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -950,6 +950,26 @@ int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_content_protection(
+    proton_engine_window_t *window, int32_t enabled, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (enabled != 0 && enabled != 1) {
+    proton_engine_set_message(error, error_len, "enabled must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "content protection is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron exposes this API on macOS and Windows only; Linux is a success no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1302,6 +1302,26 @@ int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_content_protection(
+    proton_engine_window_t *window, int32_t enabled, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (enabled != 0 && enabled != 1) {
+    proton_engine_set_message(error, error_len, "enabled must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "content protection is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->window.sharingType = enabled ? NSWindowSharingNone : NSWindowSharingReadWrite;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -44,6 +44,10 @@
 #include <shobjidl.h>
 #include <windowsx.h>
 
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -794,6 +798,31 @@ int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
   if (FAILED(hr)) {
     proton_engine_set_message(error, error_len,
                               "failed to update taskbar visibility");
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_content_protection(
+    proton_engine_window_t *window, int32_t enabled, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (enabled != 0 && enabled != 1) {
+    proton_engine_set_message(error, error_len, "enabled must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "content protection is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  const DWORD affinity = enabled ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
+  if (!SetWindowDisplayAffinity(window->hwnd, affinity)) {
+    proton_engine_set_message(error, error_len,
+                              "failed to update window display affinity");
     return PROTON_ERR_PLATFORM;
   }
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1106,6 +1106,31 @@ int32_t proton_window_set_skip_taskbar(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_content_protection(proton_window_handle_t window,
+                                             int32_t enabled) {
+  if (enabled != 0 && enabled != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "enabled must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "content protection requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_content_protection(
+      slot->engine_window, enabled, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -230,6 +230,9 @@ int32_t proton_engine_window_set_opacity(proton_engine_window_t *window,
 int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
                                               int32_t skip, char *error,
                                               size_t error_len);
+int32_t proton_engine_window_set_content_protection(
+    proton_engine_window_t *window, int32_t enabled, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1483,6 +1483,25 @@ pub fn Window::set_skip_taskbar(
 }
 
 ///|
+/// Sets whether other applications should be prevented from capturing the
+/// live native window.
+pub fn Window::set_content_protection(
+  self : Window,
+  enabled : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_content_protection_ffi(
+      self.live_handle(),
+      if enabled {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -567,7 +567,9 @@ pub fn Window::respond_browser_request(Self, Int64, String, path? : String) -> U
 pub fn Window::respond_close_request(Self, Int64, Bool) -> Unit raise NativeError
 pub fn Window::restore(Self) -> Unit raise NativeError
 pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -603,6 +603,7 @@ pub struct WindowHandle {
   set_window_movable : (Bool) -> Unit raise WindowSessionError
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
+  set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -628,6 +629,7 @@ pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_content_protection` through the typed native FFI
- use `NSWindowSharingNone` on macOS and `SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)` on Windows
- keep Linux aligned with Electron as a successful no-op
- add `68_window_content_protection` for manual capture review

## Platform impact

- macOS: native window sharing protection; recent ScreenCaptureKit clients may still capture due to the documented macOS limitation
- Windows: protected windows are excluded from capture on Windows 10 2004+, with older supported versions following display-affinity behavior
- Linux: successful no-op because Electron exposes this capability on macOS and Windows only
- headless: unsupported because no native window exists

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100`
- `moon -C examples check 68_window_content_protection --target native --diagnostic-limit 100`
- `moon -C examples build 68_window_content_protection --target native --diagnostic-limit 100`
- `moon info`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`