### PR TITLE
feat(window): add minimizable control

### DIFF
--- a/examples/69_window_minimizable/README.md
+++ b/examples/69_window_minimizable/README.md
@@ -1,0 +1,12 @@
+# Window Minimizable
+
+Manual review for Electron-style `WindowHandle::set_minimizable`.
+
+```sh
+moon -C examples run 69_window_minimizable --target native
+```
+
+Toggle the controls, then inspect the native title bar and try the operating
+system's minimize shortcut or menu. macOS and Windows update the native
+minimize control; Linux follows Electron as a successful no-op. Headless
+runtimes report unsupported.

--- a/examples/69_window_minimizable/main.mbt
+++ b/examples/69_window_minimizable/main.mbt
@@ -1,0 +1,90 @@
+///|
+struct Request {
+  minimizable : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend Request with ToJson::{to_json}
+
+///|
+pub extend Request with FromJson::{from_json}
+
+///|
+struct Reply {
+  minimizable : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Reply with ToJson::{to_json}
+
+///|
+pub extend Reply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-minimizable",
+  js_namespace="windowMinimizable",
+)
+
+///|
+let command : @proton_contract.Command[Request, Reply] = contract.command("set")
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let state : Ref[Bool] = { val: true, }
+
+///|
+fn set_minimizable(request : Request) -> Reply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        window.set_minimizable(request.minimizable)
+        state.val = request.minimizable
+        Reply::{
+          minimizable: request.minimizable,
+          message: if request.minimizable {
+            "Minimize control enabled"
+          } else {
+            "Minimize control disabled"
+          },
+        }
+      } catch {
+        error => Reply::{ minimizable: state.val, message: error.to_string(), }
+      }
+    None => Reply::{ minimizable: state.val, message: "window is not ready", }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(command, (_context, request) => set_minimizable(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Minimizable</title>
+    #|<style>:root{font-family:system-ui,sans-serif;color:#1b2528;background:#edf2f1}body{margin:0}main{max-width:760px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #718084;padding-bottom:20px}.eyebrow{color:#23766b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px;letter-spacing:0}.summary{color:#526166;line-height:1.5}.panel{margin-top:22px;border:1px solid #718084;background:#fafcfb;padding:24px}.chrome{border:2px solid #1b2528;background:#dce7e4}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #718084;background:#c5d4d0}.bar span{width:38px;height:38px;display:grid;place-items:center;border-left:1px solid #718084;font-weight:700}.bar span.off{color:#9aa5a3;background:#e7eeec}.screen{min-height:170px;display:grid;place-items:center;color:#23766b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #23766b;background:#d7e9e4;color:#1b2528;font-weight:700;cursor:pointer}button.primary{background:#23766b;color:white}#status{min-height:40px;color:#526166;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window minimizable</h1><p class="summary">Toggle whether the native window can be manually minimized by the user.</p></header><section class="panel"><div class="chrome"><div class="bar"><span>−</span><span class="off" id="minimize">−</span><span>×</span></div><div class="screen">Use the native title bar to review the control</div></div><button class="primary" data-value="true">Enable minimize</button><button data-value="false">Disable minimize</button><p id="status" role="status" aria-live="polite">Ready. The native minimize control is enabled.</p></section></main><script>const button=document.querySelector('#minimize'),status=document.querySelector('#status');const invoke=(minimizable)=>window.__MoonBit__.core.invokeOp('ext:windowMinimizable/set',{minimizable});async function run(value){status.textContent='Updating native window...';try{const reply=await invoke(value);button.classList.toggle('off',!reply.minimizable);status.textContent=reply.message}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-value]').forEach(b=>b.addEventListener('click',()=>void run(b.dataset.value==='true')))</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Minimizable", html(), width=820, height=560, debug=true)
+  .identifier("dev.proton.window-minimizable")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/69_window_minimizable/moon.pkg
+++ b/examples/69_window_minimizable/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/69_window_minimizable/pkg.generated.mbti
+++ b/examples/69_window_minimizable/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/69_window_minimizable"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type Request derive(ToJson, @json.FromJson)
+pub fn Request::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Request::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -117,6 +117,7 @@ moon -C examples run 01_run --target native
 - `67_window_aspect_ratio`: manual Electron-style interactive resize ratio
   review with 16:9, 1:1, clear, and programmatic resize checks.
 - `68_window_content_protection`: manual Electron-style screen-capture protection review.
+- `69_window_minimizable`: manual Electron-style native minimize-control review.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -186,6 +186,11 @@ fn RuntimeSession::window_handle(
         window.set_content_protection(enabled)
       })
     },
+    set_window_minimizable: minimizable => {
+      self.control_window(id, native_id, "set minimizable", window => {
+        window.set_minimizable(minimizable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1254,6 +1259,18 @@ pub fn WindowHandle::set_content_protection(
   enabled : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_content_protection)(enabled)
+}
+
+///|
+/// Sets whether the user can manually minimize this live native window.
+/// macOS and Windows update the native minimize control; Linux follows
+/// Electron and treats this as a successful no-op. Headless runtimes raise
+/// `WindowSessionError`.
+pub fn WindowHandle::set_minimizable(
+  self : WindowHandle,
+  minimizable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_minimizable)(minimizable)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -453,6 +453,7 @@ pub struct WindowHandle {
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
+  set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -67,6 +67,7 @@ fn test_window_handle(
   opacity_calls? : Array[Double],
   skip_taskbar_calls? : Array[Bool],
   content_protection_calls? : Array[Bool],
+  minimizable_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -127,6 +128,12 @@ fn test_window_handle(
     set_window_content_protection: enabled => {
       match content_protection_calls {
         Some(calls) => calls.push(enabled)
+        None => ()
+      }
+    },
+    set_window_minimizable: minimizable => {
+      match minimizable_calls {
+        Some(calls) => calls.push(minimizable)
         None => ()
       }
     },
@@ -2219,6 +2226,15 @@ test "window content protection routes live flags through the handle" {
   window.set_content_protection(true)
   window.set_content_protection(false)
   debug_inspect(calls, content="[true, false]")
+}
+
+///|
+test "window minimizable routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, minimizable_calls=calls)
+  window.set_minimizable(false)
+  window.set_minimizable(true)
+  debug_inspect(calls, content="[false, true]")
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -497,6 +497,12 @@ pub extern "C" fn proton_window_set_content_protection_ffi(
 ) -> Int = "proton_window_set_content_protection"
 
 ///|
+pub extern "C" fn proton_window_set_minimizable_ffi(
+  window : WindowHandle,
+  minimizable : Int,
+) -> Int = "proton_window_set_minimizable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -173,6 +173,8 @@ int32_t proton_window_set_skip_taskbar(proton_window_handle_t window,
                                        int32_t skip);
 int32_t proton_window_set_content_protection(proton_window_handle_t window,
                                              int32_t enabled);
+int32_t proton_window_set_minimizable(proton_window_handle_t window,
+                                      int32_t minimizable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -221,6 +221,8 @@ pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int
 
+pub fn proton_window_set_minimizable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_minimum_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_movable_ffi(WindowHandle, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -970,6 +970,26 @@ int32_t proton_engine_window_set_content_protection(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_minimizable(
+    proton_engine_window_t *window, int32_t minimizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (minimizable != 0 && minimizable != 1) {
+    proton_engine_set_message(error, error_len, "minimizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window minimizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron exposes this setter on macOS and Windows; Linux is a success no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1322,6 +1322,32 @@ int32_t proton_engine_window_set_content_protection(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_minimizable(
+    proton_engine_window_t *window, int32_t minimizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (minimizable != 0 && minimizable != 1) {
+    proton_engine_set_message(error, error_len, "minimizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window minimizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  NSWindowStyleMask style = window->window.styleMask;
+  if (minimizable) {
+    style |= NSWindowStyleMaskMiniaturizable;
+  } else {
+    style &= ~NSWindowStyleMaskMiniaturizable;
+  }
+  window->window.styleMask = style;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -79,6 +79,7 @@ struct proton_engine_window {
   int size_hint;
   int resizable;
   int movable;
+  int minimizable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -479,6 +479,7 @@ int32_t proton_engine_window_create(
   window->size_hint = config.size_hint;
   window->resizable = config.size_hint != 1;
   window->movable = 1;
+  window->minimizable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -825,6 +826,47 @@ int32_t proton_engine_window_set_content_protection(
                               "failed to update window display affinity");
     return PROTON_ERR_PLATFORM;
   }
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_minimizable(
+    proton_engine_window_t *window, int32_t minimizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (minimizable != 0 && minimizable != 1) {
+    proton_engine_set_message(error, error_len, "minimizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window minimizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  DWORD style = window->fullscreen
+                    ? window->windowed_style
+                    : (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);
+  if (minimizable) {
+    style |= WS_MINIMIZEBOX;
+  } else {
+    style &= ~WS_MINIMIZEBOX;
+  }
+  if (window->fullscreen) {
+    window->windowed_style = style;
+  } else {
+    SetLastError(0);
+    if (SetWindowLongW(window->hwnd, GWL_STYLE, (LONG)style) == 0 &&
+        GetLastError() != 0) {
+      proton_engine_set_message(error, error_len, "failed to update window style");
+      return PROTON_ERR_PLATFORM;
+    }
+    SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                     SWP_FRAMECHANGED);
+  }
+  window->minimizable = minimizable;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1135,6 +1135,31 @@ int32_t proton_window_set_content_protection(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_minimizable(proton_window_handle_t window,
+                                      int32_t minimizable) {
+  if (minimizable != 0 && minimizable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "minimizable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window minimizability requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_minimizable(
+      slot->engine_window, minimizable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -233,6 +233,9 @@ int32_t proton_engine_window_set_skip_taskbar(proton_engine_window_t *window,
 int32_t proton_engine_window_set_content_protection(
     proton_engine_window_t *window, int32_t enabled, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_minimizable(
+    proton_engine_window_t *window, int32_t minimizable, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1509,6 +1509,24 @@ pub fn Window::set_content_protection(
 }
 
 ///|
+/// Sets whether the user can manually minimize the live native window.
+pub fn Window::set_minimizable(
+  self : Window,
+  minimizable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_minimizable_ffi(
+      self.live_handle(),
+      if minimizable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -576,6 +576,7 @@ pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
+pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_movable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_opacity(Self, Double) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -606,6 +606,7 @@ pub struct WindowHandle {
   set_window_opacity : (Double) -> Unit raise WindowSessionError
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
+  set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -634,6 +635,7 @@ pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionE
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_movable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_opacity(Self, Double) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_minimizable`
- update native minimize controls on macOS and Windows
- keep Linux aligned with Electron as a successful no-op
- add `69_window_minimizable` for manual native title-bar review

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100`
- `moon -C examples check 69_window_minimizable --target native --diagnostic-limit 100`
- `moon -C examples build 69_window_minimizable --target native --diagnostic-limit 100`
- `moon info`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS example startup smoke