### PR TITLE
feat(window): add maximizable control

### DIFF
--- a/examples/70_window_maximizable/README.md
+++ b/examples/70_window_maximizable/README.md
@@ -1,0 +1,13 @@
+# Window Maximizable
+
+Manual review for Electron-style `WindowHandle::set_maximizable`.
+
+```sh
+moon -C examples run 70_window_maximizable --target native
+```
+
+Disable maximize, then inspect the native title bar and try the operating
+system's maximize action. Confirm ordinary edge resizing still works. Enable
+maximize and confirm the native action returns. macOS and Windows update the
+native maximize/zoom control; Linux follows Electron as a successful no-op.
+Headless runtimes report unsupported.

--- a/examples/70_window_maximizable/main.mbt
+++ b/examples/70_window_maximizable/main.mbt
@@ -1,0 +1,91 @@
+///|
+struct Request {
+  maximizable : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend Request with ToJson::{to_json}
+
+///|
+pub extend Request with FromJson::{from_json}
+
+///|
+struct Reply {
+  maximizable : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Reply with ToJson::{to_json}
+
+///|
+pub extend Reply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/window-maximizable",
+  js_namespace="windowMaximizable",
+)
+
+///|
+let command : @proton_contract.Command[Request, Reply] = contract.command("set")
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let state : Ref[Bool] = { val: true, }
+
+///|
+fn set_maximizable(request : Request) -> Reply {
+  match window_slot.val {
+    Some(window) =>
+      try {
+        window.set_maximizable(request.maximizable)
+        state.val = request.maximizable
+        Reply::{
+          maximizable: request.maximizable,
+          message: if request.maximizable {
+            "Maximize control enabled"
+          } else {
+            "Maximize control disabled"
+          },
+        }
+      } catch {
+        error => Reply::{ maximizable: state.val, message: error.to_string(), }
+      }
+    None => Reply::{ maximizable: state.val, message: "window is not ready", }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(command, (_context, request) => set_maximizable(request))
+}
+
+///|
+fn html() -> String {
+  (
+    #|<!doctype html>
+    #|<html lang="en">
+    #|<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Maximizable</title>
+    #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px;letter-spacing:0}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 70</p><h1>Window maximizable</h1><p class="summary">Toggle whether the native window can be manually maximized while preserving normal resizing.</p></header><section class="panel"><div class="window"><div class="bar"><span>−</span><span id="maximize">□</span><span>×</span></div><div class="screen">Review the real native maximize control</div></div><button class="primary" data-value="true">Enable maximize</button><button data-value="false">Disable maximize</button><p id="status" role="status" aria-live="polite">Ready. The native maximize control is enabled.</p></section></main><script>const icon=document.querySelector('#maximize'),status=document.querySelector('#status');const invoke=(maximizable)=>window.__MoonBit__.core.invokeOp('ext:windowMaximizable/set',{maximizable});async function run(value){status.textContent='Updating native window...';try{const reply=await invoke(value);icon.classList.toggle('off',!reply.maximizable);status.textContent=reply.message}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-value]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.value==='true')))</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Window Maximizable", html(), width=820, height=560, debug=true)
+  .identifier("dev.proton.window-maximizable")
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      window
+    },
+    on_close=fn(_window) { window_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/70_window_maximizable/moon.pkg
+++ b/examples/70_window_maximizable/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -118,6 +118,7 @@ moon -C examples run 01_run --target native
   review with 16:9, 1:1, clear, and programmatic resize checks.
 - `68_window_content_protection`: manual Electron-style screen-capture protection review.
 - `69_window_minimizable`: manual Electron-style native minimize-control review.
+- `70_window_maximizable`: manual Electron-style native maximize-control review.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -191,6 +191,11 @@ fn RuntimeSession::window_handle(
         window.set_minimizable(minimizable)
       })
     },
+    set_window_maximizable: maximizable => {
+      self.control_window(id, native_id, "set maximizable", window => {
+        window.set_maximizable(maximizable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1271,6 +1276,18 @@ pub fn WindowHandle::set_minimizable(
   minimizable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_minimizable)(minimizable)
+}
+
+///|
+/// Sets whether the user can manually maximize this live native window.
+/// macOS and Windows update the native maximize/zoom control; Linux follows
+/// Electron and treats this as a successful no-op. Headless runtimes raise
+/// `WindowSessionError`.
+pub fn WindowHandle::set_maximizable(
+  self : WindowHandle,
+  maximizable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_maximizable)(maximizable)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -454,6 +454,7 @@ pub struct WindowHandle {
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
+  set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -68,6 +68,7 @@ fn test_window_handle(
   skip_taskbar_calls? : Array[Bool],
   content_protection_calls? : Array[Bool],
   minimizable_calls? : Array[Bool],
+  maximizable_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -134,6 +135,12 @@ fn test_window_handle(
     set_window_minimizable: minimizable => {
       match minimizable_calls {
         Some(calls) => calls.push(minimizable)
+        None => ()
+      }
+    },
+    set_window_maximizable: maximizable => {
+      match maximizable_calls {
+        Some(calls) => calls.push(maximizable)
         None => ()
       }
     },
@@ -2234,6 +2241,15 @@ test "window minimizable routes live flags through the handle" {
   let window = test_window_handle("main", 17L, minimizable_calls=calls)
   window.set_minimizable(false)
   window.set_minimizable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window maximizable routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, maximizable_calls=calls)
+  window.set_maximizable(false)
+  window.set_maximizable(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -503,6 +503,12 @@ pub extern "C" fn proton_window_set_minimizable_ffi(
 ) -> Int = "proton_window_set_minimizable"
 
 ///|
+pub extern "C" fn proton_window_set_maximizable_ffi(
+  window : WindowHandle,
+  maximizable : Int,
+) -> Int = "proton_window_set_maximizable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -175,6 +175,8 @@ int32_t proton_window_set_content_protection(proton_window_handle_t window,
                                              int32_t enabled);
 int32_t proton_window_set_minimizable(proton_window_handle_t window,
                                       int32_t minimizable);
+int32_t proton_window_set_maximizable(proton_window_handle_t window,
+                                      int32_t maximizable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -990,6 +990,26 @@ int32_t proton_engine_window_set_minimizable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_maximizable(
+    proton_engine_window_t *window, int32_t maximizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (maximizable != 0 && maximizable != 1) {
+    proton_engine_set_message(error, error_len, "maximizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window maximizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron exposes this setter on macOS and Windows; Linux is a success no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -164,6 +164,7 @@ struct proton_engine_window {
   int zoom_percent;
   NSInteger attention_request_id;
   int headless;
+  int maximizable;
   int headless_hidden;
   int headless_focused;
   int osr_popup_visible;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -738,6 +738,7 @@ int32_t proton_engine_window_create(
   window->max_width = config.size_hint == 3 ? config.width : 0;
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->zoom_percent = 100;
+  window->maximizable = 1;
   window->headless = runtime->headless;
   window->bridge_config_json =
       config.bridge_config_json != NULL
@@ -1318,7 +1319,7 @@ int32_t proton_engine_window_set_content_protection(
                               "content protection is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  window->window.sharingType = enabled ? NSWindowSharingNone : NSWindowSharingReadWrite;
+  window->window.sharingType = enabled ? NSWindowSharingNone : NSWindowSharingReadOnly;
   return PROTON_OK;
 }
 
@@ -1345,6 +1346,30 @@ int32_t proton_engine_window_set_minimizable(
     style &= ~NSWindowStyleMaskMiniaturizable;
   }
   window->window.styleMask = style;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_maximizable(
+    proton_engine_window_t *window, int32_t maximizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (maximizable != 0 && maximizable != 1) {
+    proton_engine_set_message(error, error_len, "maximizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window maximizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  NSButton *zoom_button = [window->window standardWindowButton:NSWindowZoomButton];
+  if (zoom_button != nil) {
+    zoom_button.enabled = maximizable != 0;
+  }
+  window->maximizable = maximizable;
   return PROTON_OK;
 }
 
@@ -1517,6 +1542,10 @@ int32_t proton_engine_window_apply(
       style &= ~NSWindowStyleMaskResizable;
     }
     window->window.styleMask = style;
+    NSButton *zoom_button = [window->window standardWindowButton:NSWindowZoomButton];
+    if (zoom_button != nil) {
+      zoom_button.enabled = window->maximizable;
+    }
     break;
   }
   default:

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -80,6 +80,7 @@ struct proton_engine_window {
   int resizable;
   int movable;
   int minimizable;
+  int maximizable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -480,6 +480,7 @@ int32_t proton_engine_window_create(
   window->resizable = config.size_hint != 1;
   window->movable = 1;
   window->minimizable = 1;
+  window->maximizable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -870,6 +871,47 @@ int32_t proton_engine_window_set_minimizable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_maximizable(
+    proton_engine_window_t *window, int32_t maximizable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (maximizable != 0 && maximizable != 1) {
+    proton_engine_set_message(error, error_len, "maximizable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window maximizability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  DWORD style = window->fullscreen
+                    ? window->windowed_style
+                    : (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);
+  if (maximizable) {
+    style |= WS_MAXIMIZEBOX;
+  } else {
+    style &= ~WS_MAXIMIZEBOX;
+  }
+  if (window->fullscreen) {
+    window->windowed_style = style;
+  } else {
+    SetLastError(0);
+    if (SetWindowLongW(window->hwnd, GWL_STYLE, (LONG)style) == 0 &&
+        GetLastError() != 0) {
+      proton_engine_set_message(error, error_len, "failed to update window style");
+      return PROTON_ERR_PLATFORM;
+    }
+    SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                     SWP_FRAMECHANGED);
+  }
+  window->maximizable = maximizable;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_hide(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len) {
@@ -1137,7 +1179,10 @@ int32_t proton_engine_window_apply(
                       ? window->windowed_style
                       : (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);
     if (action->value != 0) {
-      style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
+      style |= WS_THICKFRAME;
+      if (window->maximizable) {
+        style |= WS_MAXIMIZEBOX;
+      }
     } else {
       style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
     }

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1160,6 +1160,31 @@ int32_t proton_window_set_minimizable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_maximizable(proton_window_handle_t window,
+                                      int32_t maximizable) {
+  if (maximizable != 0 && maximizable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "maximizable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window maximizability requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_maximizable(
+      slot->engine_window, maximizable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -236,6 +236,9 @@ int32_t proton_engine_window_set_content_protection(
 int32_t proton_engine_window_set_minimizable(
     proton_engine_window_t *window, int32_t minimizable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_maximizable(
+    proton_engine_window_t *window, int32_t maximizable, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1527,6 +1527,24 @@ pub fn Window::set_minimizable(
 }
 
 ///|
+/// Sets whether the user can manually maximize the live native window.
+pub fn Window::set_maximizable(
+  self : Window,
+  maximizable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_maximizable_ffi(
+      self.live_handle(),
+      if maximizable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,


### PR DESCRIPTION
## Summary

- add Electron-style `WindowHandle::set_maximizable`
- update native maximize/zoom controls on macOS and Windows
- preserve independent resize and maximize state
- keep Linux aligned with Electron as a successful no-op
- add `70_window_maximizable` for manual native title-bar review

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100`
- `moon -C examples check 70_window_maximizable --target native --diagnostic-limit 100`
- `moon -C examples build 70_window_maximizable --target native --diagnostic-limit 100`
- `moon info`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS native build smoke