### PR TITLE
feat(window): complete core window controls

### DIFF
--- a/examples/69_window_controls/README.md
+++ b/examples/69_window_controls/README.md
@@ -1,13 +1,20 @@
 # Window Controls
 
-Manual review for Electron-style `WindowHandle::set_minimizable` and
-`WindowHandle::set_maximizable`.
+Manual review for Electron-style `WindowHandle::set_minimizable`,
+`WindowHandle::set_maximizable`, and `WindowHandle::set_closable`.
 
 ```sh
 moon -C examples run 69_window_controls --target native
 ```
 
-Toggle each combination and inspect the native title bar. Confirm that
-disabling minimize or maximize affects only that button, while ordinary edge
-resizing remains independent. macOS and Windows update native controls; Linux
-follows Electron as a successful no-op. Headless runtimes report unsupported.
+1. Toggle each capability and inspect the native title bar.
+2. Disable close and confirm the native close button and user close shortcut do
+   not close the window.
+3. Confirm disabling minimize, maximize, or close affects only that capability,
+   while ordinary edge resizing remains available.
+4. With close still disabled, use **Programmatic close** as the final check and
+   confirm the application can still close its own window.
+
+macOS and Windows update native controls. Linux follows Electron and treats
+these capability setters as successful no-ops. Headless runtimes report
+unsupported.

--- a/examples/69_window_controls/README.md
+++ b/examples/69_window_controls/README.md
@@ -1,7 +1,8 @@
 # Window Controls
 
 Manual review for Electron-style `WindowHandle::set_minimizable`,
-`WindowHandle::set_maximizable`, and `WindowHandle::set_closable`.
+`WindowHandle::set_maximizable`, `WindowHandle::set_closable`, and
+`WindowHandle::set_focusable`.
 
 ```sh
 moon -C examples run 69_window_controls --target native
@@ -14,6 +15,8 @@ moon -C examples run 69_window_controls --target native
    while ordinary edge resizing remains available.
 4. With close still disabled, use **Programmatic close** as the final check and
    confirm the application can still close its own window.
+5. Disable focus and click the window; on macOS and Windows it should not
+   become the active window. Re-enable focus before the final close check.
 
 macOS and Windows update native controls. Linux follows Electron and treats
 these capability setters as successful no-ops. Headless runtimes report

--- a/examples/69_window_controls/README.md
+++ b/examples/69_window_controls/README.md
@@ -3,6 +3,7 @@
 Manual review for Electron-style `WindowHandle::set_minimizable`,
 `WindowHandle::set_maximizable`, `WindowHandle::set_closable`, and
 `WindowHandle::set_focusable`.
+`WindowHandle::set_fullscreenable`.
 
 ```sh
 moon -C examples run 69_window_controls --target native
@@ -17,6 +18,8 @@ moon -C examples run 69_window_controls --target native
    confirm the application can still close its own window.
 5. Disable focus and click the window; on macOS and Windows it should not
    become the active window. Re-enable focus before the final close check.
+6. Disable fullscreenable and confirm entering fullscreen is blocked; exiting
+   an already-fullscreen window remains possible.
 
 macOS and Windows update native controls. Linux follows Electron and treats
 these capability setters as successful no-ops. Headless runtimes report

--- a/examples/69_window_controls/README.md
+++ b/examples/69_window_controls/README.md
@@ -4,6 +4,7 @@ Manual review for Electron-style `WindowHandle::set_minimizable`,
 `WindowHandle::set_maximizable`, `WindowHandle::set_closable`, and
 `WindowHandle::set_focusable`.
 `WindowHandle::set_fullscreenable`.
+`WindowHandle::set_has_shadow`.
 
 ```sh
 moon -C examples run 69_window_controls --target native
@@ -20,6 +21,8 @@ moon -C examples run 69_window_controls --target native
    become the active window. Re-enable focus before the final close check.
 6. Disable fullscreenable and confirm entering fullscreen is blocked; exiting
    an already-fullscreen window remains possible.
+7. On macOS, disable shadow and inspect the window edge against the desktop,
+   then re-enable it. Windows and Linux currently accept this as a no-op.
 
 macOS and Windows update native controls. Linux follows Electron and treats
 these capability setters as successful no-ops. Headless runtimes report

--- a/examples/69_window_controls/main.mbt
+++ b/examples/69_window_controls/main.mbt
@@ -4,6 +4,7 @@ struct Request {
   maximizable : Bool
   closable : Bool
   focusable : Bool
+  fullscreenable : Bool
 } derive(ToJson, FromJson)
 
 ///|
@@ -18,6 +19,7 @@ struct Reply {
   maximizable : Bool
   closable : Bool
   focusable : Bool
+  fullscreenable : Bool
   message : String
 } derive(ToJson, FromJson)
 
@@ -57,6 +59,9 @@ let closable_state : Ref[Bool] = { val: true, }
 let focusable_state : Ref[Bool] = { val: true, }
 
 ///|
+let fullscreenable_state : Ref[Bool] = { val: true, }
+
+///|
 fn set_controls(request : Request) -> Reply {
   match window_slot.val {
     Some(window) =>
@@ -69,11 +74,14 @@ fn set_controls(request : Request) -> Reply {
         closable_state.val = request.closable
         window.set_focusable(request.focusable)
         focusable_state.val = request.focusable
+        window.set_fullscreenable(request.fullscreenable)
+        fullscreenable_state.val = request.fullscreenable
         Reply::{
           minimizable: request.minimizable,
           maximizable: request.maximizable,
           closable: request.closable,
           focusable: request.focusable,
+          fullscreenable: request.fullscreenable,
           message: "Native window controls updated",
         }
       } catch {
@@ -83,6 +91,7 @@ fn set_controls(request : Request) -> Reply {
             maximizable: maximizable_state.val,
             closable: closable_state.val,
             focusable: focusable_state.val,
+            fullscreenable: fullscreenable_state.val,
             message: error.to_string(),
           }
       }
@@ -92,6 +101,7 @@ fn set_controls(request : Request) -> Reply {
         maximizable: maximizable_state.val,
         closable: closable_state.val,
         focusable: focusable_state.val,
+        fullscreenable: fullscreenable_state.val,
         message: "window is not ready",
       }
   }
@@ -113,7 +123,7 @@ fn html() -> String {
   (
     #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Controls</title>
     #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
-    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle native minimize, maximize, close, and focus behavior. Programmatic close remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true" data-focus="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false" data-focus="true">Disable close</button><button data-min="true" data-max="true" data-close="true" data-focus="false">Disable focus</button><button data-min="false" data-max="false" data-close="false" data-focus="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable,focusable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable,focusable});async function run(a,b,c,d){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c,d);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.focusable?' Focusable.':' Not focusable.')}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true',button.dataset.focus==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle native minimize, maximize, close, focus, and fullscreen behavior. Programmatic close remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true" data-full="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true" data-focus="true" data-full="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false" data-focus="true" data-full="true">Disable close</button><button data-min="true" data-max="true" data-close="true" data-focus="false" data-full="true">Disable focus</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="false">Disable fullscreen</button><button data-min="false" data-max="false" data-close="false" data-focus="false" data-full="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable,focusable,fullscreenable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable,focusable,fullscreenable});async function run(a,b,c,d,e){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c,d,e);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.focusable?' Focusable.':' Not focusable.')+(reply.fullscreenable?' Fullscreenable.':' Fullscreen disabled.')}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true',button.dataset.focus==='true',button.dataset.full==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
   )
 }
 

--- a/examples/69_window_controls/main.mbt
+++ b/examples/69_window_controls/main.mbt
@@ -3,6 +3,7 @@ struct Request {
   minimizable : Bool
   maximizable : Bool
   closable : Bool
+  focusable : Bool
 } derive(ToJson, FromJson)
 
 ///|
@@ -16,6 +17,7 @@ struct Reply {
   minimizable : Bool
   maximizable : Bool
   closable : Bool
+  focusable : Bool
   message : String
 } derive(ToJson, FromJson)
 
@@ -52,6 +54,9 @@ let maximizable_state : Ref[Bool] = { val: true, }
 let closable_state : Ref[Bool] = { val: true, }
 
 ///|
+let focusable_state : Ref[Bool] = { val: true, }
+
+///|
 fn set_controls(request : Request) -> Reply {
   match window_slot.val {
     Some(window) =>
@@ -62,10 +67,13 @@ fn set_controls(request : Request) -> Reply {
         maximizable_state.val = request.maximizable
         window.set_closable(request.closable)
         closable_state.val = request.closable
+        window.set_focusable(request.focusable)
+        focusable_state.val = request.focusable
         Reply::{
           minimizable: request.minimizable,
           maximizable: request.maximizable,
           closable: request.closable,
+          focusable: request.focusable,
           message: "Native window controls updated",
         }
       } catch {
@@ -74,6 +82,7 @@ fn set_controls(request : Request) -> Reply {
             minimizable: minimizable_state.val,
             maximizable: maximizable_state.val,
             closable: closable_state.val,
+            focusable: focusable_state.val,
             message: error.to_string(),
           }
       }
@@ -82,6 +91,7 @@ fn set_controls(request : Request) -> Reply {
         minimizable: minimizable_state.val,
         maximizable: maximizable_state.val,
         closable: closable_state.val,
+        focusable: focusable_state.val,
         message: "window is not ready",
       }
   }
@@ -103,7 +113,7 @@ fn html() -> String {
   (
     #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Controls</title>
     #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
-    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle whether the native window can be manually minimized, maximized, or closed. Resizing and programmatic close remain independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true">Enable all</button><button data-min="false" data-max="true" data-close="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false">Disable close</button><button data-min="false" data-max="false" data-close="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable});async function run(a,b,c){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle native minimize, maximize, close, and focus behavior. Programmatic close remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true" data-focus="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false" data-focus="true">Disable close</button><button data-min="true" data-max="true" data-close="true" data-focus="false">Disable focus</button><button data-min="false" data-max="false" data-close="false" data-focus="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable,focusable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable,focusable});async function run(a,b,c,d){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c,d);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.focusable?' Focusable.':' Not focusable.')}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true',button.dataset.focus==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
   )
 }
 

--- a/examples/69_window_controls/main.mbt
+++ b/examples/69_window_controls/main.mbt
@@ -5,6 +5,7 @@ struct Request {
   closable : Bool
   focusable : Bool
   fullscreenable : Bool
+  has_shadow : Bool
 } derive(ToJson, FromJson)
 
 ///|
@@ -20,6 +21,7 @@ struct Reply {
   closable : Bool
   focusable : Bool
   fullscreenable : Bool
+  has_shadow : Bool
   message : String
 } derive(ToJson, FromJson)
 
@@ -62,6 +64,9 @@ let focusable_state : Ref[Bool] = { val: true, }
 let fullscreenable_state : Ref[Bool] = { val: true, }
 
 ///|
+let has_shadow_state : Ref[Bool] = { val: true, }
+
+///|
 fn set_controls(request : Request) -> Reply {
   match window_slot.val {
     Some(window) =>
@@ -76,12 +81,15 @@ fn set_controls(request : Request) -> Reply {
         focusable_state.val = request.focusable
         window.set_fullscreenable(request.fullscreenable)
         fullscreenable_state.val = request.fullscreenable
+        window.set_has_shadow(request.has_shadow)
+        has_shadow_state.val = request.has_shadow
         Reply::{
           minimizable: request.minimizable,
           maximizable: request.maximizable,
           closable: request.closable,
           focusable: request.focusable,
           fullscreenable: request.fullscreenable,
+          has_shadow: request.has_shadow,
           message: "Native window controls updated",
         }
       } catch {
@@ -92,6 +100,7 @@ fn set_controls(request : Request) -> Reply {
             closable: closable_state.val,
             focusable: focusable_state.val,
             fullscreenable: fullscreenable_state.val,
+            has_shadow: has_shadow_state.val,
             message: error.to_string(),
           }
       }
@@ -102,6 +111,7 @@ fn set_controls(request : Request) -> Reply {
         closable: closable_state.val,
         focusable: focusable_state.val,
         fullscreenable: fullscreenable_state.val,
+        has_shadow: has_shadow_state.val,
         message: "window is not ready",
       }
   }
@@ -123,7 +133,7 @@ fn html() -> String {
   (
     #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Controls</title>
     #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
-    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle native minimize, maximize, close, focus, and fullscreen behavior. Programmatic close remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true" data-full="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true" data-focus="true" data-full="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false" data-focus="true" data-full="true">Disable close</button><button data-min="true" data-max="true" data-close="true" data-focus="false" data-full="true">Disable focus</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="false">Disable fullscreen</button><button data-min="false" data-max="false" data-close="false" data-focus="false" data-full="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable,focusable,fullscreenable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable,focusable,fullscreenable});async function run(a,b,c,d,e){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c,d,e);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.focusable?' Focusable.':' Not focusable.')+(reply.fullscreenable?' Fullscreenable.':' Fullscreen disabled.')}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true',button.dataset.focus==='true',button.dataset.full==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle native minimize, maximize, close, focus, fullscreen, and shadow behavior. Programmatic close remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true" data-focus="true" data-full="true" data-shadow="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false" data-focus="true" data-full="true" data-shadow="true">Disable close</button><button data-min="true" data-max="true" data-close="true" data-focus="false" data-full="true" data-shadow="true">Disable focus</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="false" data-shadow="true">Disable fullscreen</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="false">Disable shadow</button><button data-min="false" data-max="false" data-close="false" data-focus="false" data-full="false" data-shadow="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable,focusable,fullscreenable,has_shadow)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable,focusable,fullscreenable,has_shadow});async function run(a,b,c,d,e,f){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c,d,e,f);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.focusable?' Focusable.':' Not focusable.')+(reply.fullscreenable?' Fullscreenable.':' Fullscreen disabled.')+(reply.has_shadow?' Shadow enabled.':' Shadow disabled.')}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true',button.dataset.focus==='true',button.dataset.full==='true',button.dataset.shadow==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
   )
 }
 

--- a/examples/69_window_controls/main.mbt
+++ b/examples/69_window_controls/main.mbt
@@ -2,6 +2,7 @@
 struct Request {
   minimizable : Bool
   maximizable : Bool
+  closable : Bool
 } derive(ToJson, FromJson)
 
 ///|
@@ -14,6 +15,7 @@ pub extend Request with FromJson::{from_json}
 struct Reply {
   minimizable : Bool
   maximizable : Bool
+  closable : Bool
   message : String
 } derive(ToJson, FromJson)
 
@@ -33,6 +35,11 @@ let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
 let command : @proton_contract.Command[Request, Reply] = contract.command("set")
 
 ///|
+let close_command : @proton_contract.Command[Unit, Unit] = contract.command(
+  "close",
+)
+
+///|
 let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
 
 ///|
@@ -40,6 +47,9 @@ let minimizable_state : Ref[Bool] = { val: true, }
 
 ///|
 let maximizable_state : Ref[Bool] = { val: true, }
+
+///|
+let closable_state : Ref[Bool] = { val: true, }
 
 ///|
 fn set_controls(request : Request) -> Reply {
@@ -50,9 +60,12 @@ fn set_controls(request : Request) -> Reply {
         minimizable_state.val = request.minimizable
         window.set_maximizable(request.maximizable)
         maximizable_state.val = request.maximizable
+        window.set_closable(request.closable)
+        closable_state.val = request.closable
         Reply::{
           minimizable: request.minimizable,
           maximizable: request.maximizable,
+          closable: request.closable,
           message: "Native window controls updated",
         }
       } catch {
@@ -60,6 +73,7 @@ fn set_controls(request : Request) -> Reply {
           Reply::{
             minimizable: minimizable_state.val,
             maximizable: maximizable_state.val,
+            closable: closable_state.val,
             message: error.to_string(),
           }
       }
@@ -67,6 +81,7 @@ fn set_controls(request : Request) -> Reply {
       Reply::{
         minimizable: minimizable_state.val,
         maximizable: maximizable_state.val,
+        closable: closable_state.val,
         message: "window is not ready",
       }
   }
@@ -75,6 +90,12 @@ fn set_controls(request : Request) -> Reply {
 ///|
 fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
   registrar.bind(command, (_context, request) => set_controls(request))
+  registrar.bind(close_command, (_context, _request) => {
+    match window_slot.val {
+      Some(window) => window.close()
+      None => ()
+    }
+  })
 }
 
 ///|
@@ -82,7 +103,7 @@ fn html() -> String {
   (
     #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Controls</title>
     #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
-    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle whether the native window can be manually minimized or maximized. Resizing remains independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span>×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true">Enable both</button><button data-min="false" data-max="true">Disable minimize</button><button data-min="true" data-max="false">Disable maximize</button><button data-min="false" data-max="false">Disable both</button><p id="status" role="status" aria-live="polite">Ready. Both native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),status=document.querySelector('#status');const invoke=(minimizable,maximizable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable});async function run(a,b){status.textContent='Updating native window...';try{const reply=await invoke(a,b);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);status.textContent=reply.message}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true')))</script></body></html>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Toggle whether the native window can be manually minimized, maximized, or closed. Resizing and programmatic close remain independent.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true">Enable all</button><button data-min="false" data-max="true" data-close="true">Disable minimize</button><button data-min="true" data-max="false" data-close="true">Disable maximize</button><button data-min="true" data-max="true" data-close="false">Disable close</button><button data-min="false" data-max="false" data-close="false">Disable all</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(minimizable,maximizable,closable)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',{minimizable,maximizable,closable});async function run(a,b,c){status.textContent='Updating native window...';try{const reply=await invoke(a,b,c);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message}catch(error){status.textContent='request failed: '+String(error)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button.dataset.min==='true',button.dataset.max==='true',button.dataset.close==='true')));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
   )
 }
 

--- a/examples/69_window_controls/pkg.generated.mbti
+++ b/examples/69_window_controls/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/69_window_controls"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type Request derive(ToJson, @json.FromJson)
+pub fn Request::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Request::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -117,7 +117,7 @@ moon -C examples run 01_run --target native
 - `67_window_aspect_ratio`: manual Electron-style interactive resize ratio
   review with 16:9, 1:1, clear, and programmatic resize checks.
 - `68_window_content_protection`: manual Electron-style screen-capture protection review.
-- `69_window_controls`: combined manual Electron-style minimize/maximize control review.
+- `69_window_controls`: combined manual Electron-style minimize, maximize, and close control review.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -196,6 +196,11 @@ fn RuntimeSession::window_handle(
         window.set_maximizable(maximizable)
       })
     },
+    set_window_closable: closable => {
+      self.control_window(id, native_id, "set closable", window => {
+        window.set_closable(closable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1288,6 +1293,19 @@ pub fn WindowHandle::set_maximizable(
   maximizable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_maximizable)(maximizable)
+}
+
+///|
+/// Sets whether the user can manually close this live native window.
+///
+/// macOS and Windows update the native close control; programmatic `close`
+/// calls remain available. Linux follows Electron and treats this as a
+/// successful no-op. Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_closable(
+  self : WindowHandle,
+  closable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_closable)(closable)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -211,6 +211,11 @@ fn RuntimeSession::window_handle(
         window.set_fullscreenable(fullscreenable)
       })
     },
+    set_window_has_shadow: has_shadow => {
+      self.control_window(id, native_id, "set window shadow", window => {
+        window.set_has_shadow(has_shadow)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1342,6 +1347,19 @@ pub fn WindowHandle::set_fullscreenable(
   fullscreenable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_fullscreenable)(fullscreenable)
+}
+
+///|
+/// Sets whether this live native window draws a frame shadow.
+///
+/// macOS applies this directly to the native window. Linux and Windows accept
+/// the setting as a successful no-op when the platform frame owns the shadow.
+/// Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_has_shadow(
+  self : WindowHandle,
+  has_shadow : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_has_shadow)(has_shadow)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -201,6 +201,11 @@ fn RuntimeSession::window_handle(
         window.set_closable(closable)
       })
     },
+    set_window_focusable: focusable => {
+      self.control_window(id, native_id, "set focusable", window => {
+        window.set_focusable(focusable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1306,6 +1311,20 @@ pub fn WindowHandle::set_closable(
   closable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_closable)(closable)
+}
+
+///|
+/// Sets whether this live native window can receive focus.
+///
+/// macOS and Windows update the native window behavior. On macOS, disabling
+/// focus does not remove focus from a window that is already focused, matching
+/// Electron. Linux follows Electron and treats this as a successful no-op.
+/// Headless runtimes raise `WindowSessionError`.
+pub fn WindowHandle::set_focusable(
+  self : WindowHandle,
+  focusable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_focusable)(focusable)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -206,6 +206,11 @@ fn RuntimeSession::window_handle(
         window.set_focusable(focusable)
       })
     },
+    set_window_fullscreenable: fullscreenable => {
+      self.control_window(id, native_id, "set fullscreenable", window => {
+        window.set_fullscreenable(fullscreenable)
+      })
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1325,6 +1330,18 @@ pub fn WindowHandle::set_focusable(
   focusable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_focusable)(focusable)
+}
+
+///|
+/// Sets whether this live native window can enter fullscreen mode.
+///
+/// When disabled, attempts to enter fullscreen are ignored. An already
+/// fullscreen window can still exit fullscreen.
+pub fn WindowHandle::set_fullscreenable(
+  self : WindowHandle,
+  fullscreenable : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_fullscreenable)(fullscreenable)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -457,6 +457,7 @@ pub struct WindowHandle {
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
+  set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -455,6 +455,7 @@ pub struct WindowHandle {
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
+  set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -458,6 +458,7 @@ pub struct WindowHandle {
   set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
+  set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -456,6 +456,7 @@ pub struct WindowHandle {
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
+  set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -69,6 +69,7 @@ fn test_window_handle(
   content_protection_calls? : Array[Bool],
   minimizable_calls? : Array[Bool],
   maximizable_calls? : Array[Bool],
+  closable_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -141,6 +142,12 @@ fn test_window_handle(
     set_window_maximizable: maximizable => {
       match maximizable_calls {
         Some(calls) => calls.push(maximizable)
+        None => ()
+      }
+    },
+    set_window_closable: closable => {
+      match closable_calls {
+        Some(calls) => calls.push(closable)
         None => ()
       }
     },
@@ -2250,6 +2257,15 @@ test "window maximizable routes live flags through the handle" {
   let window = test_window_handle("main", 17L, maximizable_calls=calls)
   window.set_maximizable(false)
   window.set_maximizable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window closable routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, closable_calls=calls)
+  window.set_closable(false)
+  window.set_closable(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -72,6 +72,7 @@ fn test_window_handle(
   closable_calls? : Array[Bool],
   focusable_calls? : Array[Bool],
   fullscreenable_calls? : Array[Bool],
+  has_shadow_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -162,6 +163,12 @@ fn test_window_handle(
     set_window_fullscreenable: fullscreenable => {
       match fullscreenable_calls {
         Some(calls) => calls.push(fullscreenable)
+        None => ()
+      }
+    },
+    set_window_has_shadow: has_shadow => {
+      match has_shadow_calls {
+        Some(calls) => calls.push(has_shadow)
         None => ()
       }
     },
@@ -2298,6 +2305,15 @@ test "window fullscreenable routes live flags through the handle" {
   let window = test_window_handle("main", 17L, fullscreenable_calls=calls)
   window.set_fullscreenable(false)
   window.set_fullscreenable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window shadow routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, has_shadow_calls=calls)
+  window.set_has_shadow(false)
+  window.set_has_shadow(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -70,6 +70,7 @@ fn test_window_handle(
   minimizable_calls? : Array[Bool],
   maximizable_calls? : Array[Bool],
   closable_calls? : Array[Bool],
+  focusable_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -148,6 +149,12 @@ fn test_window_handle(
     set_window_closable: closable => {
       match closable_calls {
         Some(calls) => calls.push(closable)
+        None => ()
+      }
+    },
+    set_window_focusable: focusable => {
+      match focusable_calls {
+        Some(calls) => calls.push(focusable)
         None => ()
       }
     },
@@ -2266,6 +2273,15 @@ test "window closable routes live flags through the handle" {
   let window = test_window_handle("main", 17L, closable_calls=calls)
   window.set_closable(false)
   window.set_closable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window focusable routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, focusable_calls=calls)
+  window.set_focusable(false)
+  window.set_focusable(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -71,6 +71,7 @@ fn test_window_handle(
   maximizable_calls? : Array[Bool],
   closable_calls? : Array[Bool],
   focusable_calls? : Array[Bool],
+  fullscreenable_calls? : Array[Bool],
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
@@ -155,6 +156,12 @@ fn test_window_handle(
     set_window_focusable: focusable => {
       match focusable_calls {
         Some(calls) => calls.push(focusable)
+        None => ()
+      }
+    },
+    set_window_fullscreenable: fullscreenable => {
+      match fullscreenable_calls {
+        Some(calls) => calls.push(fullscreenable)
         None => ()
       }
     },
@@ -2282,6 +2289,15 @@ test "window focusable routes live flags through the handle" {
   let window = test_window_handle("main", 17L, focusable_calls=calls)
   window.set_focusable(false)
   window.set_focusable(true)
+  debug_inspect(calls, content="[false, true]")
+}
+
+///|
+test "window fullscreenable routes live flags through the handle" {
+  let calls : Array[Bool] = []
+  let window = test_window_handle("main", 17L, fullscreenable_calls=calls)
+  window.set_fullscreenable(false)
+  window.set_fullscreenable(true)
   debug_inspect(calls, content="[false, true]")
 }
 

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -527,6 +527,12 @@ pub extern "C" fn proton_window_set_fullscreenable_ffi(
 ) -> Int = "proton_window_set_fullscreenable"
 
 ///|
+pub extern "C" fn proton_window_set_has_shadow_ffi(
+  window : WindowHandle,
+  has_shadow : Int,
+) -> Int = "proton_window_set_has_shadow"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -509,6 +509,12 @@ pub extern "C" fn proton_window_set_maximizable_ffi(
 ) -> Int = "proton_window_set_maximizable"
 
 ///|
+pub extern "C" fn proton_window_set_closable_ffi(
+  window : WindowHandle,
+  closable : Int,
+) -> Int = "proton_window_set_closable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -521,6 +521,12 @@ pub extern "C" fn proton_window_set_focusable_ffi(
 ) -> Int = "proton_window_set_focusable"
 
 ///|
+pub extern "C" fn proton_window_set_fullscreenable_ffi(
+  window : WindowHandle,
+  fullscreenable : Int,
+) -> Int = "proton_window_set_fullscreenable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -515,6 +515,12 @@ pub extern "C" fn proton_window_set_closable_ffi(
 ) -> Int = "proton_window_set_closable"
 
 ///|
+pub extern "C" fn proton_window_set_focusable_ffi(
+  window : WindowHandle,
+  focusable : Int,
+) -> Int = "proton_window_set_focusable"
+
+///|
 pub extern "C" fn proton_window_set_zoom_percent_ffi(
   window : WindowHandle,
   zoom_percent : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -181,6 +181,8 @@ int32_t proton_window_set_closable(proton_window_handle_t window,
                                    int32_t closable);
 int32_t proton_window_set_focusable(proton_window_handle_t window,
                                     int32_t focusable);
+int32_t proton_window_set_fullscreenable(proton_window_handle_t window,
+                                         int32_t fullscreenable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -179,6 +179,8 @@ int32_t proton_window_set_maximizable(proton_window_handle_t window,
                                       int32_t maximizable);
 int32_t proton_window_set_closable(proton_window_handle_t window,
                                    int32_t closable);
+int32_t proton_window_set_focusable(proton_window_handle_t window,
+                                    int32_t focusable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -177,6 +177,8 @@ int32_t proton_window_set_minimizable(proton_window_handle_t window,
                                       int32_t minimizable);
 int32_t proton_window_set_maximizable(proton_window_handle_t window,
                                       int32_t maximizable);
+int32_t proton_window_set_closable(proton_window_handle_t window,
+                                   int32_t closable);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -183,6 +183,8 @@ int32_t proton_window_set_focusable(proton_window_handle_t window,
                                     int32_t focusable);
 int32_t proton_window_set_fullscreenable(proton_window_handle_t window,
                                          int32_t fullscreenable);
+int32_t proton_window_set_has_shadow(proton_window_handle_t window,
+                                     int32_t has_shadow);
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                                   int32_t zoom_percent);
 /* Matches Electron's progress value semantics: negative clears the indicator,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -223,6 +223,8 @@ pub fn proton_window_set_focusable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_fullscreenable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_maximizable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -225,6 +225,8 @@ pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreenable_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_has_shadow_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_maximizable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -213,11 +213,15 @@ pub fn proton_window_set_always_on_top_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_aspect_ratio_ffi(WindowHandle, Double) -> Int
 
+pub fn proton_window_set_closable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_content_protection_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
+
+pub fn proton_window_set_maximizable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int
 

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -219,6 +219,8 @@ pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_content_protection_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_focusable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_maximizable_ffi(WindowHandle, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -105,6 +105,7 @@ struct proton_engine_window {
   int size_hint;
   int titlebar_overlay;
   int always_on_top;
+  int fullscreenable;
   int zoom_percent;
   int close_interception_enabled;
   int close_interception_bypass;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1010,6 +1010,26 @@ int32_t proton_engine_window_set_maximizable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_closable(
+    proton_engine_window_t *window, int32_t closable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (closable != 0 && closable != 1) {
+    proton_engine_set_message(error, error_len, "closable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window closability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron exposes this setter on macOS and Windows; Linux is a success no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -455,6 +455,7 @@ int32_t proton_engine_window_create(
            sizeof(window->titlebar_close_label), "%s",
            config.titlebar_close_label);
   window->zoom_percent = 100;
+  window->fullscreenable = 1;
   window->bridge_config_json =
       config.bridge_config_json != NULL
           ? proton_engine_strdup(config.bridge_config_json)
@@ -1050,6 +1051,27 @@ int32_t proton_engine_window_set_focusable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_fullscreenable(
+    proton_engine_window_t *window, int32_t fullscreenable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (fullscreenable != 0 && fullscreenable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "fullscreenable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window fullscreenability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->fullscreenable = fullscreenable;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {
@@ -1134,9 +1156,9 @@ int32_t proton_engine_window_apply(
     gtk_window_deiconify(GTK_WINDOW(window->window));
     break;
   case PROTON_ENGINE_WINDOW_SET_FULLSCREEN:
-    if (action->value != 0) {
+    if (action->value != 0 && window->fullscreenable) {
       gtk_window_fullscreen(GTK_WINDOW(window->window));
-    } else {
+    } else if (action->value == 0) {
       gtk_window_unfullscreen(GTK_WINDOW(window->window));
     }
     break;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1072,6 +1072,25 @@ int32_t proton_engine_window_set_fullscreenable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_has_shadow(
+    proton_engine_window_t *window, int32_t has_shadow, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (has_shadow != 0 && has_shadow != 1) {
+    proton_engine_set_message(error, error_len, "has_shadow must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window shadow is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1030,6 +1030,26 @@ int32_t proton_engine_window_set_closable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_focusable(
+    proton_engine_window_t *window, int32_t focusable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (focusable != 0 && focusable != 1) {
+    proton_engine_set_message(error, error_len, "focusable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window focusability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  // Electron exposes this setter on macOS and Windows; Linux is a success no-op.
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -137,6 +137,8 @@ struct proton_engine_window {
   int close_interception_enabled;
   int close_interception_bypass;
   int close_request_pending;
+  int closable;
+  int programmatic_close_pending;
   uint64_t close_request_id;
   proton_browser_session_t *browser_session;
   proton_engine_client_t *client;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -167,6 +167,7 @@ struct proton_engine_window {
   NSInteger attention_request_id;
   int headless;
   int maximizable;
+  int fullscreenable;
   int headless_hidden;
   int headless_focused;
   int osr_popup_visible;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1688,6 +1688,26 @@ int32_t proton_engine_window_set_fullscreenable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_has_shadow(
+    proton_engine_window_t *window, int32_t has_shadow, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (has_shadow != 0 && has_shadow != 1) {
+    proton_engine_set_message(error, error_len, "has_shadow must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window shadow is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->window.hasShadow = has_shadow != 0;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_get_state(
     proton_engine_window_t *window,
     proton_engine_window_state_t *out_state,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -470,6 +470,18 @@ static void proton_engine_window_apply_closable_style(
   window->window.styleMask = style;
 }
 
+static void proton_engine_window_update_zoom_button(
+    proton_engine_window_t *window) {
+  if (window == NULL || window->window == nil) return;
+  NSButton *button = [window->window standardWindowButton:NSWindowZoomButton];
+  if (button != nil) {
+    const BOOL resizable =
+        (window->window.styleMask & NSWindowStyleMaskResizable) != 0;
+    button.enabled = resizable &&
+                     (window->maximizable || window->fullscreenable);
+  }
+}
+
 @interface ProtonWindow : NSWindow {
   BOOL proton_focusable;
 }
@@ -788,6 +800,7 @@ int32_t proton_engine_window_create(
   window->zoom_percent = 100;
   window->maximizable = 1;
   window->closable = 1;
+  window->fullscreenable = 1;
   window->headless = runtime->headless;
   window->bridge_config_json =
       config.bridge_config_json != NULL
@@ -1416,11 +1429,8 @@ int32_t proton_engine_window_set_maximizable(
                               "window maximizability is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  NSButton *zoom_button = [window->window standardWindowButton:NSWindowZoomButton];
-  if (zoom_button != nil) {
-    zoom_button.enabled = maximizable != 0;
-  }
   window->maximizable = maximizable;
+  proton_engine_window_update_zoom_button(window);
   return PROTON_OK;
 }
 
@@ -1607,6 +1617,7 @@ int32_t proton_engine_window_apply(
     }
     break;
   case PROTON_ENGINE_WINDOW_SET_FULLSCREEN: {
+    if (!window->fullscreenable && action->value != 0) break;
     const BOOL fullscreen =
         (window->window.styleMask & NSWindowStyleMaskFullScreen) != 0;
     if (fullscreen != (action->value != 0)) {
@@ -1634,10 +1645,7 @@ int32_t proton_engine_window_apply(
       style &= ~NSWindowStyleMaskResizable;
     }
     window->window.styleMask = style;
-    NSButton *zoom_button = [window->window standardWindowButton:NSWindowZoomButton];
-    if (zoom_button != nil) {
-      zoom_button.enabled = window->maximizable;
-    }
+    proton_engine_window_update_zoom_button(window);
     break;
   }
   default:
@@ -1646,6 +1654,37 @@ int32_t proton_engine_window_apply(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_fullscreenable(
+    proton_engine_window_t *window, int32_t fullscreenable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (fullscreenable != 0 && fullscreenable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "fullscreenable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window fullscreenability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->fullscreenable = fullscreenable;
+  NSWindowCollectionBehavior behavior = window->window.collectionBehavior;
+  if (fullscreenable) {
+    behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+    behavior &= ~NSWindowCollectionBehaviorFullScreenAuxiliary;
+  } else {
+    behavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
+    behavior |= NSWindowCollectionBehaviorFullScreenAuxiliary;
+  }
+  window->window.collectionBehavior = behavior;
+  proton_engine_window_update_zoom_button(window);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -470,6 +470,40 @@ static void proton_engine_window_apply_closable_style(
   window->window.styleMask = style;
 }
 
+@interface ProtonWindow : NSWindow {
+  BOOL proton_focusable;
+}
+- (void)setProtonFocusable:(BOOL)focusable;
+@end
+
+@implementation ProtonWindow
+- (instancetype)initWithContentRect:(NSRect)contentRect
+                          styleMask:(NSWindowStyleMask)style
+                            backing:(NSBackingStoreType)backingStoreType
+                              defer:(BOOL)flag {
+  self = [super initWithContentRect:contentRect
+                         styleMask:style
+                           backing:backingStoreType
+                             defer:flag];
+  if (self != nil) {
+    proton_focusable = YES;
+  }
+  return self;
+}
+
+- (BOOL)canBecomeKeyWindow {
+  return proton_focusable;
+}
+
+- (BOOL)canBecomeMainWindow {
+  return proton_focusable;
+}
+
+- (void)setProtonFocusable:(BOOL)focusable {
+  proton_focusable = focusable;
+}
+@end
+
 @interface ProtonWindowDelegate : NSObject <NSWindowDelegate> {
 @public
   proton_engine_window_t *window;
@@ -792,7 +826,7 @@ int32_t proton_engine_window_create(
       style |= NSWindowStyleMaskFullSizeContentView;
     }
     NSString *title = [NSString stringWithUTF8String:config.title];
-    window->window = [[NSWindow alloc] initWithContentRect:rect
+    window->window = [[ProtonWindow alloc] initWithContentRect:rect
                                                  styleMask:style
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
@@ -1408,6 +1442,26 @@ int32_t proton_engine_window_set_closable(
   }
   window->closable = closable;
   proton_engine_window_apply_closable_style(window);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_focusable(
+    proton_engine_window_t *window, int32_t focusable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (focusable != 0 && focusable != 1) {
+    proton_engine_set_message(error, error_len, "focusable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window focusability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  [(ProtonWindow *)window->window setProtonFocusable:focusable != 0];
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -456,6 +456,20 @@ static void proton_engine_window_commit_appkit_close(
   [native_window autorelease];
 }
 
+static void proton_engine_window_apply_closable_style(
+    proton_engine_window_t *window) {
+  if (window == NULL || window->window == nil) {
+    return;
+  }
+  NSWindowStyleMask style = window->window.styleMask;
+  if (window->closable || window->programmatic_close_pending) {
+    style |= NSWindowStyleMaskClosable;
+  } else {
+    style &= ~NSWindowStyleMaskClosable;
+  }
+  window->window.styleMask = style;
+}
+
 @interface ProtonWindowDelegate : NSObject <NSWindowDelegate> {
 @public
   proton_engine_window_t *window;
@@ -739,6 +753,7 @@ int32_t proton_engine_window_create(
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->zoom_percent = 100;
   window->maximizable = 1;
+  window->closable = 1;
   window->headless = runtime->headless;
   window->bridge_config_json =
       config.bridge_config_json != NULL
@@ -1022,6 +1037,8 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
   }
   window->close_interception_bypass = 0;
   if (!window->headless) {
+    window->programmatic_close_pending = 1;
+    proton_engine_window_apply_closable_style(window);
     [window->window performClose:nil];
     return PROTON_OK;
   }
@@ -1373,6 +1390,27 @@ int32_t proton_engine_window_set_maximizable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_closable(
+    proton_engine_window_t *window, int32_t closable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (closable != 0 && closable != 1) {
+    proton_engine_set_message(error, error_len, "closable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window closability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->closable = closable;
+  proton_engine_window_apply_closable_style(window);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {
@@ -1632,6 +1670,8 @@ int32_t proton_engine_window_set_close_interception(
   window->close_interception_enabled = enabled != 0;
   if (!window->close_interception_enabled) {
     window->close_request_pending = 0;
+    window->programmatic_close_pending = 0;
+    proton_engine_window_apply_closable_style(window);
   }
   return PROTON_OK;
 }
@@ -1672,6 +1712,9 @@ int32_t proton_engine_window_respond_close_request(
       return proton_engine_window_close(window, error, error_len);
     }
     [window->window performClose:nil];
+  } else if (!allow) {
+    window->programmatic_close_pending = 0;
+    proton_engine_window_apply_closable_style(window);
   }
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -83,6 +83,7 @@ struct proton_engine_window {
   int maximizable;
   int closable;
   int focusable;
+  int fullscreenable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -82,6 +82,7 @@ struct proton_engine_window {
   int minimizable;
   int maximizable;
   int closable;
+  int focusable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -81,6 +81,7 @@ struct proton_engine_window {
   int movable;
   int minimizable;
   int maximizable;
+  int closable;
   int min_width;
   int min_height;
   int max_width;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -286,6 +286,12 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
       return 0;
     }
     break;
+  case WM_SYSCOMMAND:
+    if (window != NULL && (wparam & 0xfff0) == SC_CLOSE &&
+        !window->closable) {
+      return 0;
+    }
+    break;
   case WM_CLOSE:
     if (window != NULL) {
       if (window->close_interception_enabled &&
@@ -481,6 +487,7 @@ int32_t proton_engine_window_create(
   window->movable = 1;
   window->minimizable = 1;
   window->maximizable = 1;
+  window->closable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -909,6 +916,36 @@ int32_t proton_engine_window_set_maximizable(
                      SWP_FRAMECHANGED);
   }
   window->maximizable = maximizable;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_closable(
+    proton_engine_window_t *window, int32_t closable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (closable != 0 && closable != 1) {
+    proton_engine_set_message(error, error_len, "closable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window closability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  HMENU system_menu = GetSystemMenu(window->hwnd, FALSE);
+  if (system_menu == NULL ||
+      EnableMenuItem(system_menu, SC_CLOSE,
+                     MF_BYCOMMAND | (closable ? MF_ENABLED : MF_GRAYED)) ==
+          (UINT)-1) {
+    proton_engine_set_message(error, error_len,
+                              "failed to update window close control");
+    return PROTON_ERR_PLATFORM;
+  }
+  DrawMenuBar(window->hwnd);
+  window->closable = closable;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -494,6 +494,7 @@ int32_t proton_engine_window_create(
   window->maximizable = 1;
   window->closable = 1;
   window->focusable = 1;
+  window->fullscreenable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -1204,6 +1205,7 @@ int32_t proton_engine_window_apply(
     ShowWindow(window->hwnd, SW_RESTORE);
     break;
   case PROTON_ENGINE_WINDOW_SET_FULLSCREEN:
+    if (!window->fullscreenable && action->value != 0) break;
     if (action->value != 0 && !window->fullscreen) {
       window->windowed_style =
           (DWORD)GetWindowLongW(window->hwnd, GWL_STYLE);
@@ -1283,6 +1285,27 @@ int32_t proton_engine_window_apply(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_signal_wait_source(window->runtime, PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_fullscreenable(
+    proton_engine_window_t *window, int32_t fullscreenable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (fullscreenable != 0 && fullscreenable != 1) {
+    proton_engine_set_message(error, error_len,
+                              "fullscreenable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window fullscreenability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->fullscreenable = fullscreenable;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -98,6 +98,11 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
       return 0;
     }
     break;
+  case WM_MOUSEACTIVATE:
+    if (window != NULL && !window->focusable) {
+      return MA_NOACTIVATE;
+    }
+    break;
   case WM_NCHITTEST:
     if (window != NULL && window->titlebar_overlay) {
       return proton_engine_overlay_hit_test(hwnd, lparam);
@@ -488,6 +493,7 @@ int32_t proton_engine_window_create(
   window->minimizable = 1;
   window->maximizable = 1;
   window->closable = 1;
+  window->focusable = 1;
   window->min_width = config.size_hint == 2 ? config.width : 0;
   window->min_height = config.size_hint == 2 ? config.height : 0;
   window->max_width = config.size_hint == 3 ? config.width : 0;
@@ -946,6 +952,36 @@ int32_t proton_engine_window_set_closable(
   }
   DrawMenuBar(window->hwnd);
   window->closable = closable;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_focusable(
+    proton_engine_window_t *window, int32_t focusable, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (focusable != 0 && focusable != 1) {
+    proton_engine_set_message(error, error_len, "focusable must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window focusability is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  LONG_PTR style = GetWindowLongPtrW(window->hwnd, GWL_EXSTYLE);
+  LONG_PTR updated = focusable ? (style & ~WS_EX_NOACTIVATE)
+                               : (style | WS_EX_NOACTIVATE);
+  SetLastError(0);
+  if (SetWindowLongPtrW(window->hwnd, GWL_EXSTYLE, updated) == 0 &&
+      GetLastError() != 0) {
+    proton_engine_set_message(error, error_len,
+                              "failed to update window focusability");
+    return PROTON_ERR_PLATFORM;
+  }
+  window->focusable = focusable;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1309,6 +1309,25 @@ int32_t proton_engine_window_set_fullscreenable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_has_shadow(
+    proton_engine_window_t *window, int32_t has_shadow, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (has_shadow != 0 && has_shadow != 1) {
+    proton_engine_set_message(error, error_len, "has_shadow must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window shadow is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  return PROTON_OK;
+}
+
 static int proton_engine_windows_theme(void) {
   DWORD light = 1;
   DWORD size = sizeof(light);

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1185,6 +1185,31 @@ int32_t proton_window_set_maximizable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_closable(proton_window_handle_t window,
+                                   int32_t closable) {
+  if (closable != 0 && closable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "closable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window closability requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_closable(
+      slot->engine_window, closable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1210,6 +1210,31 @@ int32_t proton_window_set_closable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_focusable(proton_window_handle_t window,
+                                    int32_t focusable) {
+  if (focusable != 0 && focusable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "focusable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window focusability requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_focusable(
+      slot->engine_window, focusable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1256,6 +1256,27 @@ int32_t proton_window_set_fullscreenable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_has_shadow(proton_window_handle_t window,
+                                     int32_t has_shadow) {
+  if (has_shadow != 0 && has_shadow != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "has_shadow must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window shadow requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_has_shadow(
+      slot->engine_window, has_shadow, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1235,6 +1235,27 @@ int32_t proton_window_set_focusable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_fullscreenable(proton_window_handle_t window,
+                                         int32_t fullscreenable) {
+  if (fullscreenable != 0 && fullscreenable != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "fullscreenable must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window fullscreenability requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_fullscreenable(
+      slot->engine_window, fullscreenable, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_zoom_percent(proton_window_handle_t window,
                                        int32_t zoom_percent) {
   if (zoom_percent < 25 || zoom_percent > 500) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -248,6 +248,9 @@ int32_t proton_engine_window_set_focusable(
 int32_t proton_engine_window_set_fullscreenable(
     proton_engine_window_t *window, int32_t fullscreenable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_has_shadow(
+    proton_engine_window_t *window, int32_t has_shadow, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -239,6 +239,9 @@ int32_t proton_engine_window_set_minimizable(
 int32_t proton_engine_window_set_maximizable(
     proton_engine_window_t *window, int32_t maximizable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_closable(
+    proton_engine_window_t *window, int32_t closable, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -245,6 +245,9 @@ int32_t proton_engine_window_set_closable(
 int32_t proton_engine_window_set_focusable(
     proton_engine_window_t *window, int32_t focusable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_fullscreenable(
+    proton_engine_window_t *window, int32_t fullscreenable, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -242,6 +242,9 @@ int32_t proton_engine_window_set_maximizable(
 int32_t proton_engine_window_set_closable(
     proton_engine_window_t *window, int32_t closable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_focusable(
+    proton_engine_window_t *window, int32_t focusable, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1598,6 +1598,23 @@ pub fn Window::set_fullscreenable(
 }
 
 ///|
+pub fn Window::set_has_shadow(
+  self : Window,
+  has_shadow : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_has_shadow_ffi(
+      self.live_handle(),
+      if has_shadow {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1545,6 +1545,24 @@ pub fn Window::set_maximizable(
 }
 
 ///|
+/// Sets whether the user can manually close the live native window.
+pub fn Window::set_closable(
+  self : Window,
+  closable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_closable_ffi(
+      self.live_handle(),
+      if closable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1581,6 +1581,23 @@ pub fn Window::set_focusable(
 }
 
 ///|
+pub fn Window::set_fullscreenable(
+  self : Window,
+  fullscreenable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_fullscreenable_ffi(
+      self.live_handle(),
+      if fullscreenable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1563,6 +1563,24 @@ pub fn Window::set_closable(
 }
 
 ///|
+/// Sets whether the live native window can receive focus.
+pub fn Window::set_focusable(
+  self : Window,
+  focusable : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_focusable_ffi(
+      self.live_handle(),
+      if focusable {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_zoom_percent(
   self : Window,
   zoom_percent : Int,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -577,6 +577,7 @@ pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_focusable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_fullscreenable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -572,9 +572,11 @@ pub fn Window::respond_close_request(Self, Int64, Bool) -> Unit raise NativeErro
 pub fn Window::restore(Self) -> Unit raise NativeError
 pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
+pub fn Window::set_closable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -575,6 +575,7 @@ pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
 pub fn Window::set_closable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_focusable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -578,6 +578,7 @@ pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_focusable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreenable(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_has_shadow(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -609,6 +609,7 @@ pub struct WindowHandle {
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
+  set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -636,6 +637,7 @@ pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionEr
 pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_closable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_focusable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -611,6 +611,7 @@ pub struct WindowHandle {
   set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
+  set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -641,6 +642,7 @@ pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSess
 pub fn WindowHandle::set_focusable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreenable(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_has_shadow(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -610,6 +610,7 @@ pub struct WindowHandle {
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
+  set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -639,6 +640,7 @@ pub fn WindowHandle::set_closable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_focusable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_fullscreenable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -607,6 +607,8 @@ pub struct WindowHandle {
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
+  set_window_maximizable : (Bool) -> Unit raise WindowSessionError
+  set_window_closable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -632,8 +634,10 @@ pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_closable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

Complete the core Electron-style native window controls in one aggregate PR:

- `WindowHandle::set_closable`
- `WindowHandle::set_focusable`
- `WindowHandle::set_fullscreenable`
- `WindowHandle::set_has_shadow`
- preserve existing resizable, movable, opacity, taskbar, content protection,
  minimizable, and maximizable controls
- expand `examples/69_window_controls` for manual review

Each feature is a separate Conventional Commit for incremental review.

## Platform impact

- macOS: native close/focus/fullscreen/shadow behavior
- Windows: native close/focus behavior; fullscreenability gates fullscreen entry
- Linux: Electron-compatible successful no-ops where the platform frame owns the behavior
- headless: unsupported for native window controls

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 100`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`
- macOS runtime smoke for native controls and programmatic close
