### PR TITLE
docs: refresh application guide and generated interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,49 +15,53 @@ Install the CLI and create a project:
 
 ```sh
 moon install moonbit-community/proton_cli
-proton_cli new my-app --template minimal --yes
+proton_cli new my-app --yes
 cd my-app
-```
-
-Choose `minimal` for a single-module app with inline HTML, or `isomorphic` for
-the three-module Rabbita and Warren Todo example. Without `--template`, `new`
-uses `isomorphic` by default.
-
-Fetch the MoonBit dependencies and set up the native runtime:
-
-```sh
 moon update
 proton_cli cef setup
-```
-
-Start development:
-
-```sh
 proton_cli dev
 ```
 
-The minimal project runs directly from `app/main.mbt` without a separate
-frontend toolchain.
+The default `isomorphic` template contains a shared command contract, a Rabbita
+frontend, and a Proton backend. Use `--template minimal` for a single MoonBit
+module with inline HTML:
 
-`cef setup` installs the exact CEF SDK and runtime required by this Proton
-release into the user-wide immutable store at `~/.proton/store`. It also
-installs the release's CEF subprocess helper once under
-`~/.proton/helpers/<platform>/<version>`. Every project using the same Proton
-release resolves these installations directly; projects contain no runtime or
-helper copy and no runtime-selection file. Proton's native sources are compiled
-into the application by Moon, while only CEF remains an external runtime. Set
-`PROTON_RUNTIME_STORE` to an absolute path to relocate the CEF store.
+```sh
+proton_cli new my-app --template minimal --yes
+```
 
-`proton_cli`, `proton`, `proton_package`, and `proton_cefsetup` are released in
-lockstep. The CLI resolves the runtime and helper installed by setup; it does
-not inspect a project's Moon workspace or dependency source directories.
-`proton_cli cef requirements` prints the active requirement as JSON.
+`cef setup` installs the CEF runtime and subprocess helper required by the
+current Proton release. Installations are immutable and shared by all projects
+under `~/.proton/store` and `~/.proton/helpers`. Set `PROTON_RUNTIME_STORE` to
+an absolute path to relocate the runtime store.
+
+All published Proton modules use one lockstep version. The CLI, framework,
+extensions, packager, code generator, and CEF setup tool must come from the same
+release.
 
 ## Application entry
 
-Both templates define application runtime behavior with the MoonBit `App`
-builder. The `isomorphic` template also registers typed commands in
-`backend/app/main.mbt`:
+Applications are defined with the `App` builder. A small application can use
+inline HTML:
+
+```moonbit
+async fn main {
+  @proton.html(
+    "Hello Proton",
+    "<h1>Hello from MoonBit</h1>",
+    width=900,
+    height=700,
+    debug=true,
+  )
+  .load_config()
+  .run_or_abort()
+}
+```
+
+Proton also supports URL, file, and packaged asset entries through
+`@proton.url`, `@proton.file`, and `@proton.asset`.
+
+An isomorphic backend registers commands defined by the shared contract:
 
 ```moonbit
 async fn main {
@@ -70,37 +74,17 @@ async fn main {
 }
 ```
 
-Commands are declared once in the `shared/` contract package and wired into
-the runtime with `.commands(...)`; the frontend invokes them through the
-typed Rabbita client and can subscribe to events pushed by the backend.
+The frontend invokes these commands through `proton_client` or the typed
+Rabbita integration. It can also subscribe to events emitted by the backend.
 
-For a small application, inline HTML can be opened directly:
+## Capabilities
 
-```moonbit
-async fn main {
-  @proton.html(
-    "Hello Proton",
-    "<h1>Hello from MoonBit</h1>",
-    width=900,
-    height=700,
-    debug=true,
-  ).load_config().run_or_abort()
-}
-```
+Extensions expose typed capabilities. Adding a capability installs its backend
+handlers and grants access to selected renderer targets. Omitting a capability
+is valid; an unavailable operation is rejected by the bridge without preventing
+the application from starting.
 
-The root package also supports URL, file, and packaged asset entries through
-`@proton.url`, `@proton.file`, and `@proton.asset`.
-
-## Renderer capabilities
-
-Commands registered with `.commands(...)` are available to the primary
-window's configured entry by default. Use `targets` when another window or
-Proton's bundled origin also needs them.
-
-Extensions expose typed capabilities. Adding a capability both installs its
-backend handlers and grants it to the selected renderer, so registration and
-authority cannot drift apart. Filesystem access additionally declares path
-ranges and exact commands:
+Filesystem access must declare both allowed roots and commands:
 
 ```moonbit
 @proton.html("Files", html)
@@ -115,297 +99,47 @@ ranges and exact commands:
 )
 ```
 
-The default target is `@proton.RendererTarget::entry()` for the primary
-window. Multi-window applications pass `targets=[...]` with
-`RendererTarget::entry(window=...)` or `RendererTarget::bundled(window=...)`.
-Omitting a capability is valid; attempts to invoke an unavailable operation are
-rejected by the bridge rather than preventing the application from starting.
+The default target is the primary window entry. Multi-window applications can
+grant a capability to explicit `RendererTarget::entry` or
+`RendererTarget::bundled` targets. Relative filesystem roots and requests are
+anchored to `@proton.resource_dir()`.
 
-The renderer cannot select or widen these roots. Proton matches the trusted
-frame origin in native code, rechecks the grant during MoonBit dispatch, and
-the filesystem extension validates the canonical target before each operation.
-Relative filesystem roots and request paths are anchored to
-`@proton.resource_dir()`: the project root supplied by `proton_cli dev`, the
-packaged resources directory, or the startup working directory for direct runs.
+## Application windows
 
-On macOS and Windows, web content can extend beneath the native titlebar while
-retaining the system window controls:
+Additional windows are declared with `add_window` before startup, then created
+through `WindowManager::open`. `WindowHandle` provides lifecycle and native
+window operations including:
 
-```moonbit
-@proton.html("My App", html)
-.titlebar_style(@proton.TitlebarStyle::Overlay)
-```
+- show, hide, focus, close, minimize, maximize, restore, and fullscreen
+- title, size, position, centering, always-on-top, and zoom
+- resizable, movable, minimizable, maximizable, opacity, and aspect ratio
+- minimum and maximum size constraints
+- taskbar visibility, progress, attention, and content capture protection
 
-`titlebar_style` accepts `"default"` and `"overlay"`. Overlay rendering is
-implemented and shipped for macOS and Windows. Linux keeps the default
-titlebar. On Windows, Proton consumes CEF's native draggable-region updates.
-Set `-webkit-app-region: no-drag` on interactive descendants, then assign
-`element.style.webkitAppRegion = "drag"` to the draggable container after it
-exists in the DOM. The post-DOM assignment is required by the currently shipped
-CEF build to emit its initial region update; later changes are reported directly
-by CEF. These are CEF-provided regions, not an Electron compatibility shim.
-Until the page reports its first region update, Proton keeps a small DPI-aware
-leading drag fallback. Pages must also reserve the native caption-button area.
-Overlay windows request DWM's dark caption appearance so the native controls
-blend with dark application chrome.
-Typed window configs send `titlebar_style` only when the source-built backend
-reports the `titlebar_overlay` feature. Unsupported platforms retain their
-default titlebar behavior.
-See `examples/48_titlebar_overlay` for a cross-platform overlay layout example.
+Window creation, state changes, and close interception are integrated with the
+managed async runtime. By default the application quits after its final window
+closes. Use `LastWindowClosedPolicy::KeepRunning` for tray or background
+applications.
 
-The primary entry constructors accept `resizable=false` for a fixed window.
-Secondary windows can select `WindowSizeHint::Unconstrained`, `Fixed`, `Min`,
-or `Max`; minimum and maximum hints constrain resizing relative to the
-configured width and height. A running `WindowHandle` can also update those
-constraints with `set_minimum_size` and `set_maximum_size`; pass `(0, 0)` to
-clear a constraint. See `examples/62_window_size_limits` for a manual review.
-`WindowHandle::center` places a live window in the work area of its current
-monitor while preserving its size. See `examples/63_window_center` for a
-manual review.
-`WindowHandle::set_movable` controls manual title-bar movement without blocking
-programmatic `set_position` or `center` calls. It is enforced on macOS and
-Windows and follows Electron's no-op behavior on Linux. See
-`examples/64_window_movable` for a manual review.
-`WindowHandle::set_opacity` changes the whole native window and clamps values to
-the Electron-compatible `0.0..1.0` range. See `examples/65_window_opacity` for
-a manual review.
-`WindowHandle::set_skip_taskbar` removes or restores the Windows taskbar tab;
-macOS and Linux follow Electron's no-op behavior. See
-`examples/66_window_skip_taskbar` for a manual review.
-`WindowHandle::set_aspect_ratio` constrains interactive resizing while leaving
-programmatic `set_size` calls unconstrained, matching Electron's API. Pass
-`0.0` to clear the ratio. See `examples/67_window_aspect_ratio` for a manual
-review.
+Application windows can host independent web contents views with explicit
+bounds, visibility, z-order, navigation, DevTools, and lifecycle events. See
+`examples/45_bridge_multi_window` and `examples/52_web_contents_view`.
 
-The typed facade can own additional windows without replacing Proton's bridge
-pump:
+Native application menus are available on macOS and Linux. Native context
+menus are available on macOS, Windows, and Linux. Application menu bars are not
+yet implemented on Windows.
 
-```moonbit
-@proton.html("Main", main_html)
-.add_window(
-  "details",
-  "Details",
-  @proton.AppEntry::Html(details_html),
-  width=640,
-  height=480,
-  open_on_start=false,
-)
-.app_lifecycle(
-  on_start=async fn(context) {
-    let details = context.windows().open("details")
-    details.set_position(80, 80)
-    details.set_zoom_percent(110)
-  },
-  on_shutdown=fn(_) {  },
-)
-```
+Titlebar overlay uses `TitlebarStyle::Overlay` and is implemented on macOS and
+Windows. Interactive controls inside a draggable region must use
+`-webkit-app-region: no-drag`. See `examples/48_titlebar_overlay`.
 
-Runtime-created windows must be declared before startup so packaging inputs,
-origins, and renderer capabilities remain explicit. `open_on_start=false` declares a
-template without creating it; `WindowManager::open` creates a fresh concrete
-instance when the application needs it. `WindowHandle` supports show, hide,
-focus, close, title, size, position, minimize, maximize, restore, fullscreen,
-always-on-top, zoom, and a `WindowState` snapshot containing the current
-monitor, work area, scale factor, focus, and theme. `WindowHandle::center`
-centers a live window within that monitor's work area without changing its
-size.
+The runnable examples cover the full window API, including context menus,
+progress, attention, resizing, content protection, and minimize/maximize
+controls. See [examples/Readme.md](examples/Readme.md).
 
-Window state and close requests are delivered by the managed runtime session:
+## Project configuration
 
-```moonbit
-@proton.html("Main", main_html)
-.on_window_event(async fn(window, event) noraise {
-  match event {
-    StateChanged(state) => println(window.id() + ": " + state.theme)
-  }
-})
-.on_window_close_request(async fn(_window) noraise {
-  @proton.WindowCloseDecision::Allow
-})
-```
-
-Close handlers run asynchronously without blocking the native UI thread.
-`WindowHandle::close` follows the same cancellable request path; session
-cleanup uses the owning destroy lifecycle. The process remains active until
-every concrete window has closed. See `examples/45_bridge_multi_window`.
-
-A window can also host additional web contents views, following the Electron
-`WebContentsView` model: each view is an independent browser layered above the
-window's main page with explicit top-left bounds, visibility, and z-order.
-Views are added and removed imperatively through the window handle; per-view
-navigation uses `ViewHandle::load_url`, and `App::on_view_event` reports
-navigations, loading state, titles, and load failures. Engine support is
-reported through the `web_contents_view` runtime feature.
-
-The declarative path attaches a view to the primary window at startup:
-
-```moonbit
-@proton
-.html("App", sidebar, width=1120, height=720)
-.with_view(
-  "browser",
-  @proton.view("https://example.com/", width=832, height=720, x=288),
-)
-.load_config()
-.run_or_abort()
-```
-
-Imperative control uses the window handle:
-
-```moonbit
-let panel = window.add_view(
-  "panel",
-  @proton.view("https://example.com/", width=320, height=240, x=16, y=16),
-)
-panel.set_bounds(x=16, y=16, width=480, height=320)
-panel.set_z_order(1)
-panel.load_url("https://moonbitlang.com/")
-window.remove_view("panel")
-```
-
-See `examples/52_web_contents_view`.
-
-Enable operating-system single-instance routing by calling `.single_instance()`.
-The stable application identity comes from `.load_config()` or `.identifier(...)`.
-
-When another process starts, Proton forwards its protocol URLs and document
-paths to the primary process before creating CEF, then exits. The primary
-process restores and focuses its application window before delivering the typed
-activation:
-
-```moonbit
-@proton.asset("My App", "frontend/dist/index.html")
-.load_config()
-.single_instance()
-.last_window_closed_policy(@proton.LastWindowClosedPolicy::KeepRunning)
-.on_launch_input(async fn(context, input) noraise {
-  match input {
-    OpenUrls(urls) => ...
-    OpenFiles(paths) => ...
-    Reopen =>
-      if context.windows().find("main") is None {
-        ignore(context.windows().open("main")) catch {
-          _ => ()
-        }
-      }
-  }
-})
-```
-
-By default, closing the last window quits the application. Select
-`KeepRunning` for applications that should remain available in the Dock or
-system tray after their windows close. Call `context.quit()` from an
-application-lifetime callback to request an orderly shutdown.
-
-The instance coordinator is implemented on macOS, Windows, and Linux. Packaged
-macOS applications register `package.url_schemes` and `package.document_types`
-through `Info.plist`. Windows portable ZIPs and the current Linux build do not
-install operating-system associations; their `proton-package.json` metadata is
-intended for a future installer/package target. Direct launches and associations
-installed by another package manager still use the same forwarding path.
-
-Use `app.data_dir()` to resolve the stable native data directory for the
-application's configured identifier. The method does not create the directory.
-
-## Logging
-
-Applications log through `tonyfettes/xlog@0.4.1` directly. Use `app.*`
-categories for application records; Proton reserves `proton.*` for runtime
-diagnostics:
-
-```moonbit
-@xlog.info(category="app.sync") <? {
-  "message": "synchronization started",
-  "account": account_id,
-}
-```
-
-Packaged applications write `Warn` and above to the platform application log
-directory derived from their package metadata. Direct launches and
-`proton_cli dev` write to stderr; `proton_cli dev` also selects `Info`.
-`MOON_XLOG` controls xlog level and category filters, while
-`PROTON_LOG_OUTPUT` selects the initial Proton handler as `file` or `stderr`.
-File output requires packaged application metadata. Applications may replace
-the global xlog handler or configuration afterwards. CEF's temporary
-diagnostic log remains separate under `PROTON_CEF_LOG`.
-
-## Application locale
-
-Proton resolves one immutable locale snapshot before creating the native
-runtime. By default it uses the operating system's preferred language order
-and appends `en-US` as a fallback. Applications can select an explicit primary
-locale while retaining that system preference list:
-
-```moonbit
-let locale = @proton.Locale::parse("zh-CN") catch {
-  error => abort(error.message())
-}
-@proton.html("My App", html)
-.load_config()
-.locale(locale)
-.run_or_abort()
-```
-
-`ApplicationContext`, `WindowContext`, and `CommandContext` expose `locale()`
-and `preferred_languages()`. CEF receives the same values for
-`navigator.language`, `navigator.languages`, and HTTP language negotiation.
-Standard native menu roles use Proton's built-in framework labels for `en-US`
-and `zh-CN`; explicit menu labels are preserved exactly.
-
-Proton does not provide application translation catalogs, message formatting,
-or runtime language switching. The application remains responsible for its
-page content, dialogs, notifications, and custom menu labels. See
-`examples/56_i18n`.
-
-## Native menus
-
-`App::menu` accepts a complete logical `MenuBar`. Use `Menu::role` and
-`MenuItem::role` for platform-standard behavior; omitted labels and default
-items are resolved from the immutable application locale. Use `Menu` and
-`MenuItem::command` for application-defined labels and commands:
-
-```moonbit
-@proton.MenuBar(menus=[
-  @proton.Menu::role(@proton.MenuRole::Edit),
-  @proton.Menu::role(@proton.MenuRole::Window),
-  @proton.Menu("Tools", items=[
-    @proton.MenuItem::command("tools.refresh", "Refresh", key="r"),
-  ]),
-])
-```
-
-On macOS, Proton inserts an Application menu when absent and places the
-`MenuRole::Application` menu first as required by AppKit. Linux renders only
-menus supplied by the application. Native application menus are not yet
-implemented on Windows, so applications must not call `App::menu` there.
-Custom labels remain the application's localization responsibility.
-
-## Headless automation
-
-Code-driven applications can run with CEF off-screen rendering and no native
-top-level window:
-
-```moonbit
-@proton.html("Automation", html)
-.load_config()
-.headless()
-.run_or_abort()
-```
-
-Set `PROTON_HEADLESS=1` to force the same mode in automated runs without
-changing application code. Headless mode is independent of remote debugging,
-so CDP can be enabled separately for end-to-end tests. Native menus, dialogs,
-and titlebar overlay are unavailable in this mode. Linux still requires an
-X11 display; use Xvfb in display-less CI jobs.
-
-Development and explicit debug mode use an ephemeral remote-debugging port by
-default, and CEF prints the selected WebSocket endpoint to stderr. Set
-`PROTON_REMOTE_DEBUGGING_PORT` to `0` to request the same behavior explicitly,
-or to a value from `1024` through `65535` when a fixed port is required.
-
-## Frontend projects
-
-Generated projects describe their toolchain in `proton.project.json`:
+`proton.project.json` configures CLI orchestration and packaging:
 
 ```json
 {
@@ -417,219 +151,128 @@ Generated projects describe their toolchain in `proton.project.json`:
   "frontend": {
     "path": "frontend",
     "dev_url": "http://127.0.0.1:4300",
-    "before_dev": "moonx --target native moonbit-community/warren@0.2.7 dev --direct --port 4300",
-    "before_build": "moonx --target native moonbit-community/warren@0.2.7 build",
+    "before_dev": "npm run dev -- --port 4300",
+    "before_build": "npm run build",
     "dist": "dist"
-  }
-}
-```
-
-`identifier` is the required application identity shared by the runtime and
-packaging tools. Calling `.load_config()` loads it from this file during development
-and from the sanitized `proton-package.json` inside a packaged application.
-Projects without `proton.project.json` must set the same identity directly with
-`.identifier("com.example.my-app")`; the two sources cannot be combined. If
-such an application is packaged through the lower-level packaging API, Proton
-also verifies at startup that its explicit identity matches the packaged
-metadata.
-
-`backend` selects the MoonBit package that runs the Proton runtime. The
-application entry is declared in MoonBit with `@proton.html`, `url`, `file`, or
-`asset`. `backend.path` is the exact working directory passed to Moon; Proton
-does not search parent directories for `moon.work`, `moon.mod`, or another
-project configuration. Project file paths must be relative and use `/`
-separators. The
-`frontend` block drives development and build orchestration: `path` is the
-frontend working directory, `before_dev`/`before_build` run there, `dev_url`
-is the development server to wait for, and `dist` is the build output to
-validate (resolved relative to `path`).
-
-`proton_cli dev` runs `frontend.before_dev`, waits for `frontend.dev_url`, and
-launches the app in development mode. `proton_cli build` runs
-`frontend.before_build`, validates `frontend.dist`, and builds the MoonBit app
-for the native target. Vite, Next, and similar tools fit the same shape: point
-`path`, `before_dev`, `before_build`, `dev_url`, and `dist` at the equivalent
-npm scripts.
-
-## Build
-
-```sh
-moon check --target native --diagnostic-limit 80
-proton_cli build
-proton_cli build -- --release
-```
-
-Arguments after `--` are passed to `moon build`; Proton always selects the
-native target.
-
-## E2E tests
-
-The native bridge E2E suite is implemented in MoonBit and owns its application
-processes, CDP connections, frontend servers, and cleanup:
-
-```sh
-moon -C cefsetup run . --target native
-moon -C e2e test -p moonbit-community/proton/e2e/test \
-  --target native --no-parallelize --diagnostic-limit 200
-```
-
-Each E2E scenario installs its release CEF helper from the local Proton source
-with `moon install --path` into the scenario's temporary directory.
-
-For an application that is already running with CDP enabled, use the typed
-driver instead:
-
-```sh
-MBT_PROTON_E2E_SCENARIO=41_app_commands \
-MBT_CDP_TARGET=9222 moon -C e2e run test --target native
-```
-
-## Package
-
-`moonbit-community/proton_package` is the generic host-native packager. It does
-not discover Proton projects or know about CEF. `proton_cli package` builds the
-application, resolves the runtime and helper installed by `cef setup`, assembles
-the complete Proton/CEF layout, and calls `proton_package` to create the native
-artifacts. This assembly is an implementation detail of the CLI package
-workflow.
-
-Developers packaging an already-built application that does not need Proton's
-CEF layout can use `proton_package` directly:
-
-```sh
-moon install moonbit-community/proton_package
-proton_package \
-  --executable ./build/my-app \
-  --product-name "My App" \
-  --identifier com.example.my-app \
-  --version 1.0.0 \
-  --format app \
-  --output dist
-```
-
-The same implementation is available as the
-`moonbit-community/proton_package/lib` package. `--config` accepts a reusable
-JSON specification; paths in that file are resolved relative to the file.
-
-### Proton projects
-
-The top-level `identifier` is the application's canonical identity. The
-`package` block contains the remaining static metadata and payload inputs:
-
-```json
-{
-  "identifier": "com.example.my-app",
+  },
   "package": {
     "product_name": "My App",
     "version": "1.0.0",
     "formats": ["app", "zip"],
-    "resources": ["helpers/worker"],
-    "sign": {
-      "binaries": ["helpers/worker"]
-    },
-    "url_schemes": ["my-app"],
-    "document_types": [
-      {
-        "name": "Text document",
-        "extensions": ["txt", "md"],
-        "role": "Editor"
-      }
-    ],
     "output": "dist"
   }
 }
 ```
 
-`package.resources` copies project files into the package. `package.sign.binaries`
-does not copy anything; it names resource files that `proton_cli` must sign.
-Both arrays use paths relative to the directory containing `proton.project.json`. For
-the example above, the signing target is
-`My App.app/Contents/Resources/helpers/worker` on macOS and
-`My App/Resources/helpers/worker` in a Windows portable package. Use the platform's actual
-filename, such as `helpers/worker.exe`, for a Windows executable. Globs are
-allowed for `package.resources` only; every `package.sign.binaries` entry names
-one file.
+`identifier` is the stable application identity used by the runtime and
+packaging tools. `.load_config()` reads it from the project file during
+development and from packaged metadata after installation. Applications that
+do not use `proton.project.json` must call
+`.identifier("com.example.my-app")` instead.
 
-Backend code can locate these files through `@proton.resource_dir()`. It
-returns the absolute project directory supplied by `proton_cli dev`, the
-packaged resource directory at runtime, or the startup working directory for a
-direct run. Joining the same relative path,
-such as `helpers/worker`, therefore addresses the same resource before and
-after packaging.
+`backend.path` is the exact working directory passed to Moon and
+`backend.package` selects the executable package. Proton does not scan parent
+directories for `moon.work`, `moon.mod`, or another project configuration.
+Project paths must be relative and use `/` separators.
 
-Inspect the resolved package plan before creating artifacts:
+The frontend command is entirely project-defined; Proton does not embed Warren,
+Vite, or another frontend server. `proton_cli dev` runs `before_dev`, waits for
+`dev_url`, and then starts the native application. It rejects an already
+occupied development endpoint before starting the configured command. Use
+`--no-frontend` when the frontend is managed separately.
 
-```sh
-proton_cli package --dry-run
-proton_cli package
-proton_cli package --release
-```
+The Proton bridge exists only inside the CEF renderer. Opening the development
+URL in a regular browser can preview the page, but native commands and events
+are unavailable there.
 
-The package command performs an incremental debug executable build by default.
-Pass `--release` to use MoonBit's release build mode. Package output is written
-to `dist` by default.
-Icons, resources, output formats, signing, notarization, custom URL schemes, and
-macOS document types are configured through `proton.project.json` and package command
-options.
-
-The `dmg` format is available on macOS. It creates a compressed disk image
-containing the app and an `/Applications` shortcut for drag-to-install:
+## Build and diagnose
 
 ```sh
-proton_cli package --release --format app --format dmg
-```
-
-With `--notarize`, Proton submits the DMG when that format is enabled, then
-staples and validates both the DMG and the app before creating any requested
-ZIP archive. Without a `dmg` format, the existing app notarization flow is
-used. Windows supports the `app` and `zip` formats.
-
-### Open an unsigned app on macOS
-
-Apps packaged without `--sign` are ad-hoc signed. When such an app reaches
-another Mac through a download (including ZIP archives produced by the
-`zip` target), Gatekeeper quarantines it and macOS may launch it from a
-randomized App Translocation path. After confirming the app comes from a
-trusted source, remove the quarantine attribute from the top-level bundle:
-
-```sh
-xattr -d com.apple.quarantine "My App.app"
-```
-
-Do not use `xattr -cr`: recent macOS protects `com.apple.provenance`, which
-makes recursive removal fail with `Operation not permitted` without clearing
-the quarantine. Deleting the attribute from the top-level `.app` (or moving
-the app once in Finder) is sufficient. Apps signed and notarized with
-`--sign --notarize` skip this step entirely.
-
-When emitting updater metadata, provide a monotonically increasing release
-revision as well as the reproducible publication time. The revision is embedded
-in the signed app and emitted into the signed manifest fragment:
-
-```sh
-proton_cli package --release --format zip \
-  --updater-base-url https://example.com/releases \
-  --updater-published-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --updater-revision 42
-```
-
-## Diagnose a project
-
-```sh
+proton_cli build
+proton_cli build -- --release
 proton_cli doctor
 ```
 
-Doctor checks the project configuration, MoonBit toolchain, active platform,
-and required Proton runtime and helper installations without changing the
-project. Outside a Proton project, it reports environment information and skips
-project-specific checks.
+`build` runs `frontend.before_build`, validates `frontend.dist`, and builds the
+configured MoonBit package for the native target. Arguments after `--` are
+passed to `moon build`.
 
-Run `proton_cli cef setup` again when the required runtime or helper is missing
-or invalid.
-Use `PROTON_CEF_LOG=default` temporarily when browser-runtime logs are needed.
+`doctor` checks project configuration, the MoonBit toolchain, and the required
+CEF runtime and helper without changing the project.
 
-See [examples/Readme.md](examples/Readme.md) for runnable examples. Repository
-contributors and release maintainers should follow [AGENTS.md](AGENTS.md).
+## Packaging
+
+Create native artifacts with:
+
+```sh
+proton_cli package --dry-run
+proton_cli package --release
+```
+
+Supported host-native formats are:
+
+- macOS: `app`, `zip`, and `dmg`
+- Windows: `app`, `zip`, and `nsis`
+- Linux: `appimage`
+
+Use repeated `--format` options or `package.formats` in
+`proton.project.json`. Output is written to `dist` by default.
+
+`package.resources` copies sidecar files into the application resources
+directory. Backend code resolves the same files before and after packaging with
+`@proton.resource_dir()`. `package.sign.binaries` names copied executables that
+must be included in platform signing.
+
+On macOS, `--sign` signs the application and `--notarize` submits, staples, and
+validates distributable artifacts. URL schemes and document types are written
+to the macOS application metadata. Current Windows and Linux packages do not
+install operating-system URL or document associations.
+
+`moonbit-community/proton_package` is also available as a generic packager for
+already-built executables. It does not discover Proton projects, build source,
+or assemble CEF. See [package/README.md](package/README.md).
+
+## Runtime options
+
+Enable operating-system single-instance routing with `.single_instance()`.
+Later launches forward protocol URLs, document paths, and reopen activation to
+the primary process.
+
+Headless mode uses CEF off-screen rendering without native top-level windows:
+
+```moonbit
+@proton.html("Automation", html)
+.load_config()
+.headless()
+.run_or_abort()
+```
+
+`PROTON_HEADLESS=1` forces the same mode for automation. Native dialogs, menus,
+titlebars, and other native window operations are unavailable in headless mode.
+Linux still requires an X11 display, such as Xvfb in CI.
+
+Development and explicit debug mode use an ephemeral remote-debugging port by
+default. Set `PROTON_REMOTE_DEBUGGING_PORT` to a fixed port from `1024` through
+`65535` only when an external tool requires one.
+
+## Logging
+
+Applications use `tonyfettes/xlog` directly. Proton reserves `proton.*` log
+categories; applications should use their own categories such as `app.*`.
+Direct runs and `proton_cli dev` write to stderr. Packaged applications default
+to platform log files. `MOON_XLOG` controls xlog filtering and
+`PROTON_LOG_OUTPUT` selects `stderr` or `file`.
+
+CEF diagnostics are disabled by default. Use `PROTON_CEF_LOG` only while
+investigating browser-runtime failures.
+
+## Documentation
+
+- [Examples](examples/Readme.md)
+- [Proton facade](proton/README.md)
+- [Extensions](extensions/README.md)
+- [Generic packager](package/README.md)
+- [Maintainer guide](AGENTS.md)
 
 ## License
 

--- a/examples/69_window_controls/pkg.generated.mbti
+++ b/examples/69_window_controls/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/69_window_controls"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type Request derive(ToJson, @json.FromJson)
+pub fn Request::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Request::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -219,6 +219,8 @@ pub fn proton_window_set_content_protection_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_maximizable_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_maximum_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_minimizable_ffi(WindowHandle, Int) -> Int

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -575,6 +575,7 @@ pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -607,6 +607,7 @@ pub struct WindowHandle {
   set_window_skip_taskbar : (Bool) -> Unit raise WindowSessionError
   set_window_content_protection : (Bool) -> Unit raise WindowSessionError
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
+  set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -634,6 +635,7 @@ pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionEr
 pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary

- commit the generated MoonBit interfaces omitted by the recently merged window maximizable API and add the interface file for example 69
- rewrite the root README around the current application developer workflow
- correct package formats, titlebar API terminology, window capabilities, and platform association limits
- remove duplicated maintainer E2E instructions, CEF implementation details, and lengthy platform troubleshooting from the root guide

## Why

The current root README had drifted behind the implementation and had grown into a mix of application documentation, platform internals, and maintainer procedures. This change keeps it focused on installation, application structure, capabilities, project configuration, build/package workflows, and runtime options. Detailed examples and maintenance procedures remain in their dedicated documents.

The generated interface files are included separately because `moon info` showed that the merged maximizable API was not fully reflected in committed `.mbti` outputs.

## Validation

- `moon fmt`
- `moon info`
- `moon -C config test --target native --diagnostic-limit 80` (587 passed)
- `node scripts/verify_generated.mjs`
- README relative-link and JSON-block validation
- `moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`