### PR TITLE
chore(release): prepare 0.2.3

### DIFF
--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cdp"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.mbt.md"
 

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cefsetup"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/async@0.21.0",
@@ -17,8 +17,10 @@ keywords = [ "proton", "cef", "setup" ]
 
 description = "Install the CEF runtime and subprocess helper required by Proton."
 
+preferred_target = "wasm"
+
+supported_targets = "native+wasm"
+
 options(
   warn_list: "",
-  preferred_target: "wasm",
-  supported_targets: "native+wasm",
 )

--- a/cefsetup/store/requirements.generated.mbt
+++ b/cefsetup/store/requirements.generated.mbt
@@ -3,7 +3,7 @@
 
 ///|
 pub fn release_version() -> String {
-  "0.2.2"
+  "0.2.3"
 }
 
 ///|

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let cli_current_version : String = "0.2.2"
+let cli_current_version : String = "0.2.3"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton_cli"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_config@0.2.2",
-  "moonbit-community/proton_package@0.2.2",
-  "moonbit-community/proton_cefsetup@0.2.2",
-  "moonbit-community/proton_rsa@0.2.2",
-  "moonbit-community/proton_updater@0.2.2",
+  "moonbit-community/proton_config@0.2.3",
+  "moonbit-community/proton_package@0.2.3",
+  "moonbit-community/proton_cefsetup@0.2.3",
+  "moonbit-community/proton_rsa@0.2.3",
+  "moonbit-community/proton_updater@0.2.3",
   "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.13",
   "moonbitlang/async@0.21.0",
@@ -23,8 +23,10 @@ keywords = [ "proton", "cli", "desktop" ]
 
 description = "Developer CLI for Proton desktop applications."
 
+preferred_target = "wasm"
+
+supported_targets = "native+wasm"
+
 options(
   warn_list: "",
-  preferred_target: "wasm",
-  supported_targets: "native+wasm",
 )

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -1,20 +1,20 @@
 ///|
-let default_proton_version = "0.2.2"
+let default_proton_version = "0.2.3"
 
 ///|
-let default_proton_codegen_version = "0.2.2"
+let default_proton_codegen_version = "0.2.3"
 
 ///|
-let default_proton_cli_version = "0.2.2"
+let default_proton_cli_version = "0.2.3"
 
 ///|
-let default_proton_contract_version = "0.2.2"
+let default_proton_contract_version = "0.2.3"
 
 ///|
-let default_proton_client_version = "0.2.2"
+let default_proton_client_version = "0.2.3"
 
 ///|
-let default_proton_rabbita_version = "0.2.2"
+let default_proton_rabbita_version = "0.2.3"
 
 ///|
 let default_rabbita_version = "0.14.1"

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_client"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton_contract@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -17,7 +17,6 @@ keywords = [ "proton", "client", "ipc" ]
 
 description = "Typed asynchronous frontend client for Proton applications."
 
-options(
-  preferred_target: "js",
-  supported_targets: "js",
-)
+preferred_target = "js"
+
+supported_targets = "js"

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_codegen"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/async@0.21.0",
@@ -19,8 +19,10 @@ keywords = [ "proton", "codegen", "command", "wasm" ]
 
 description = "WASM code generator for typed Proton command registrars."
 
+preferred_target = "wasm"
+
+supported_targets = "native+wasm"
+
 options(
   warn_list: "",
-  preferred_target: "wasm",
-  supported_targets: "native+wasm",
 )

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_config"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/x@0.5.1",
@@ -12,8 +12,10 @@ license = "Apache-2.0"
 
 description = "Typed CLI project configuration and JSON decoding for Proton."
 
+preferred_target = "wasm"
+
+supported_targets = "native+wasm"
+
 options(
   warn_list: "",
-  preferred_target: "wasm",
-  supported_targets: "native+wasm",
 )

--- a/contract/moon.mod
+++ b/contract/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_contract"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.mbt.md"
 

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -1,15 +1,15 @@
 name = "moonbit-community/proton/e2e"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
-  "moonbit-community/proton_cdp@0.2.2",
-  "moonbit-community/proton@0.2.2",
-  "moonbit-community/proton_cefsetup@0.2.2",
-  "moonbit-community/proton_updater@0.2.2",
-  "moonbit-community/proton/examples@0.2.2",
+  "moonbit-community/proton_cdp@0.2.3",
+  "moonbit-community/proton@0.2.3",
+  "moonbit-community/proton_cefsetup@0.2.3",
+  "moonbit-community/proton_updater@0.2.3",
+  "moonbit-community/proton/examples@0.2.3",
 }
 
 readme = "README.md"
@@ -24,8 +24,10 @@ description = "CDP-based native bridge end-to-end tests for Proton examples."
 
 source = ""
 
+preferred_target = "native"
+
+supported_targets = "+native"
+
 options(
   warn_list: "",
-  preferred_target: "native",
-  supported_targets: "+native",
 )

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton/examples"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_ext@0.2.2",
-  "moonbit-community/proton_contract@0.2.2",
-  "moonbit-community/proton@0.2.2",
+  "moonbit-community/proton_ext@0.2.3",
+  "moonbit-community/proton_contract@0.2.3",
+  "moonbit-community/proton@0.2.3",
 }
 
 readme = "README.md"
@@ -34,8 +34,10 @@ rule(
 
 source = ""
 
+preferred_target = "native"
+
+supported_targets = "+native"
+
 options(
   warn_list: "",
-  preferred_target: "native",
-  supported_targets: "+native",
 )

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -1,23 +1,23 @@
 name = "moonbit-community/proton_ext"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton_clipboard@0.2.2",
-  "moonbit-community/proton_tray@0.2.2",
-  "moonbit-community/proton_global_hotkey@0.2.2",
-  "moonbit-community/proton@0.2.2",
-  "moonbit-community/proton_contract@0.2.2",
-  "moonbit-community/proton_microphone@0.2.2",
-  "moonbit-community/proton_auto_launch@0.2.2",
-  "moonbit-community/proton_keepawake@0.2.2",
-  "moonbit-community/proton_power_monitor@0.2.2",
-  "moonbit-community/proton_screen_monitor@0.2.2",
-  "moonbit-community/proton_process@0.2.2",
-  "moonbit-community/proton_shell@0.2.2",
+  "moonbit-community/proton_clipboard@0.2.3",
+  "moonbit-community/proton_tray@0.2.3",
+  "moonbit-community/proton_global_hotkey@0.2.3",
+  "moonbit-community/proton@0.2.3",
+  "moonbit-community/proton_contract@0.2.3",
+  "moonbit-community/proton_microphone@0.2.3",
+  "moonbit-community/proton_auto_launch@0.2.3",
+  "moonbit-community/proton_keepawake@0.2.3",
+  "moonbit-community/proton_power_monitor@0.2.3",
+  "moonbit-community/proton_screen_monitor@0.2.3",
+  "moonbit-community/proton_process@0.2.3",
+  "moonbit-community/proton_shell@0.2.3",
 }
 
 readme = "README.md"
@@ -32,8 +32,10 @@ description = "Extensions for proton examples and applications."
 
 source = "."
 
+preferred_target = "native"
+
+supported_targets = "+native"
+
 options(
   warn_list: "",
-  preferred_target: "native",
-  supported_targets: "+native",
 )

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/async@0.21.0",
@@ -17,8 +17,10 @@ keywords = [ "desktop", "package", "app", "dmg", "nsis", "appimage" ]
 
 description = "Host-native desktop application packaging library and CLI."
 
+preferred_target = "wasm"
+
+supported_targets = "native+wasm"
+
 options(
   warn_list: "",
-  preferred_target: "wasm",
-  supported_targets: "native+wasm",
 )

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -1,16 +1,16 @@
 name = "moonbit-community/proton"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
-  "moonbit-community/proton_config@0.2.2",
-  "moonbit-community/proton_contract@0.2.2",
-  "moonbit-community/proton_updater@0.2.2",
-  "moonbit-community/proton_rsa@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
+  "moonbit-community/proton_config@0.2.3",
+  "moonbit-community/proton_contract@0.2.3",
+  "moonbit-community/proton_updater@0.2.3",
+  "moonbit-community/proton_rsa@0.2.3",
   "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.5.1",
-  "moonbitlang/lexer@0.3.13",
+  "moonbitlang/lexer@0.3.14",
   "tonyfettes/xlog@0.4.1",
 }
 
@@ -24,9 +24,11 @@ keywords = [ "proton", "gui", "web", "desktop-app" ]
 
 description = "MoonBit bindings for the Proton native desktop runtime."
 
+preferred_target = "native"
+
+supported_targets = "+native"
+
 options(
   "--moonbit-unstable-prebuild": "build.mjs",
   warn_list: "",
-  preferred_target: "native",
-  supported_targets: "+native",
 )

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_rabbita"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_client@0.2.2",
-  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton_client@0.2.3",
+  "moonbit-community/proton_contract@0.2.3",
   "moonbit-community/rabbita@0.14.1",
 }
 
@@ -18,7 +18,6 @@ keywords = [ "proton", "rabbita", "ipc" ]
 
 description = "Rabbita commands and subscriptions for typed Proton contracts."
 
-options(
-  preferred_target: "js",
-  supported_targets: "js",
-)
+preferred_target = "js"
+
+supported_targets = "js"

--- a/rsa/moon.mod
+++ b/rsa/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_rsa"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.mbt.md"
 

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_auto_launch"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.md"
 
@@ -25,8 +25,6 @@ warnings = ""
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "+native"
 
-options(
-  supported_targets: "+native",
-)
+source = "."

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_clipboard"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.mbt.md"
 
@@ -16,8 +16,6 @@ warnings = ""
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "+native"
 
-options(
-  supported_targets: "+native",
-)
+source = "."

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_ffi"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_global_hotkey"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -26,8 +26,6 @@ description = "Cross-platform native global hotkey helpers for MoonBit."
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "+native"
 
-options(
-  supported_targets: "+native",
-)
+source = "."

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_keepawake"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -25,8 +25,6 @@ description = "Native keep-awake guards for MoonBit on Windows, Linux, and macOS
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "native"
 
-options(
-  supported_targets: "native",
-)
+source = "."

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_microphone"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"

--- a/sys/power_monitor/moon.mod
+++ b/sys/power_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_power_monitor"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -25,8 +25,6 @@ description = "Native power and idle state queries for MoonBit on Windows, Linux
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "native"
 
-options(
-  supported_targets: "native",
-)
+source = "."

--- a/sys/process/moon.mod
+++ b/sys/process/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_process"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -26,8 +26,6 @@ description = "Native child process spawning for MoonBit on Windows, Linux, and 
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "native"
 
-options(
-  supported_targets: "native",
-)
+source = "."

--- a/sys/screen_monitor/moon.mod
+++ b/sys/screen_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_screen_monitor"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -26,8 +26,6 @@ description = "Native screen and display queries plus hot-plug events for MoonBi
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "native"
 
-options(
-  supported_targets: "native",
-)
+source = "."

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_shell"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"
@@ -16,8 +16,6 @@ description = "Native shell helpers for MoonBit."
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "+native"
 
-options(
-  supported_targets: "+native",
-)
+source = "."

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_tray"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
-  "moonbit-community/proton_ffi@0.2.2",
+  "moonbit-community/proton_ffi@0.2.3",
 }
 
 readme = "README.mbt.md"
@@ -18,8 +18,6 @@ description = "Cross-platform native tray helpers for MoonBit."
 
 preferred_target = "native"
 
-source = "."
+supported_targets = "+native"
 
-options(
-  supported_targets: "+native",
-)
+source = "."

--- a/updater/moon.mod
+++ b/updater/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_updater"
 
-version = "0.2.2"
+version = "0.2.3"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
## Summary

- migrate `preferred_target` and `supported_targets` to the current top-level `moon.mod` syntax
- bump all 26 workspace modules and internal dependencies to `0.2.3`
- synchronize CLI scaffold versions and generated CEF release metadata

## Validation

- `moon fmt`
- `moon info`
- `moon check --target native --diagnostic-limit 80`
- `moon check --target wasm --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`