### PR TITLE
feat(window): add Electron-style platform controls

### DIFF
--- a/examples/69_window_controls/README.md
+++ b/examples/69_window_controls/README.md
@@ -7,6 +7,8 @@ Manual review for Electron-style `WindowHandle::set_minimizable`,
 `WindowHandle::set_has_shadow`, `set_ignore_mouse_events`,
 `set_background_color`, `set_kiosk`, `set_visible_on_all_workspaces`, and
 `set_enabled`.
+Also covers `set_content_size`, `content_size`, `set_menu`, `set_icon`,
+`set_parent`, and `set_window_button_visibility`.
 
 ```sh
 moon -C examples run 69_window_controls --target native
@@ -34,3 +36,6 @@ unsupported.
 all-workspace visibility, and disable the window. Re-enable with **Enable all**.
 9. Enter kiosk and confirm it exits automatically after five seconds; use
 **Exit kiosk** as the immediate programmatic exit check.
+10. Review content-size changes, runtime menu replacement/clearing, native icon
+    loading from a local path, parent/modal relationship, and macOS traffic-light
+    visibility. Parent and modal controls include explicit clear/reset actions.

--- a/examples/69_window_controls/main.mbt
+++ b/examples/69_window_controls/main.mbt
@@ -56,7 +56,41 @@ let close_command : @proton_contract.Command[Unit, Unit] = contract.command(
 )
 
 ///|
+struct AdvancedRequest {
+  action : String
+  path : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend AdvancedRequest with ToJson::{to_json}
+
+///|
+pub extend AdvancedRequest with FromJson::{from_json}
+
+///|
+struct AdvancedReply {
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend AdvancedReply with ToJson::{to_json}
+
+///|
+pub extend AdvancedReply with FromJson::{from_json}
+
+///|
+let advanced_command : @proton_contract.Command[AdvancedRequest, AdvancedReply] = contract.command(
+  "advanced",
+)
+
+///|
 let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let child_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let window_manager_slot : Ref[@proton.WindowManager?] = { val: None, }
 
 ///|
 let minimizable_state : Ref[Bool] = { val: true, }
@@ -176,6 +210,65 @@ fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
       None => ()
     }
   })
+  registrar.bind(advanced_command, (_context, request) => {
+    let main = window_slot.val.unwrap()
+    let message = match request.action {
+      "content" => {
+        main.set_content_size(720, 420)
+        let (width, height) = main.content_size()
+        "Content area: \{width} x \{height}"
+      }
+      "menu" => {
+        main.set_menu(
+          Some(
+            @proton.MenuBar(menus=[
+              @proton.Menu("Review", items=[
+                @proton.MenuItem::command("review-ready", "Review ready"),
+                @proton.MenuItem::separator(),
+                @proton.MenuItem::role(@proton.MenuItemRole::Close),
+              ]),
+            ]),
+          ),
+        )
+        "Runtime menu installed"
+      }
+      "clear-menu" => {
+        main.set_menu(None)
+        "Runtime menu cleared"
+      }
+      "hide-buttons" => {
+        main.set_window_button_visibility(false)
+        "Native window buttons hidden"
+      }
+      "show-buttons" => {
+        main.set_window_button_visibility(true)
+        "Native window buttons shown"
+      }
+      "icon" => {
+        main.set_icon(request.path)
+        "Window icon loaded from \{request.path}"
+      }
+      "parent" | "modal" => {
+        let child = match child_slot.val {
+          Some(child) => child
+          None => window_manager_slot.val.unwrap().open("review-child")
+        }
+        child_slot.val = Some(child)
+        child.set_parent(Some(main), modal=request.action == "modal")
+        child.show()
+        "Child relationship set: \{request.action}"
+      }
+      "clear-parent" => {
+        match child_slot.val {
+          Some(child) => child.set_parent(None)
+          None => ()
+        }
+        "Child relationship cleared"
+      }
+      _ => "Unknown advanced action"
+    }
+    AdvancedReply::{ message, }
+  })
 }
 
 ///|
@@ -183,7 +276,7 @@ fn html() -> String {
   (
     #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Window Controls</title>
     #|<style>:root{font-family:system-ui,sans-serif;color:#20262b;background:#eef0f3}body{margin:0}main{max-width:780px;margin:auto;padding:42px 24px}header{border-bottom:1px solid #727b85;padding-bottom:20px}.eyebrow{color:#3f659b;font:700 11px ui-monospace,monospace;text-transform:uppercase}h1{margin:0;font-size:42px}.summary{color:#59636c;line-height:1.5}.panel{margin-top:22px;border:1px solid #727b85;background:#fafbfc;padding:24px}.window{border:2px solid #20262b;background:#dce3eb}.bar{height:38px;display:flex;justify-content:flex-end;align-items:center;border-bottom:1px solid #727b85;background:#c8d2dd}.bar span{width:40px;height:38px;display:grid;place-items:center;border-left:1px solid #727b85;font-weight:700}.bar span.off{color:#9da5ad;background:#e8ebef}.screen{min-height:170px;display:grid;place-items:center;color:#3f659b;font:700 13px ui-monospace,monospace}button{margin:18px 10px 0 0;padding:12px 16px;border:1px solid #3f659b;background:#dbe5f2;color:#20262b;font-weight:700;cursor:pointer}button.primary{background:#3f659b;color:white}#status{min-height:40px;color:#59636c;font:12px ui-monospace,monospace;line-height:1.5}</style></head>
-    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Review native frame capabilities and interaction controls. Kiosk includes a timed exit path.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Disable minimize</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="true" data-color="#203040" data-kiosk="false" data-workspaces="true" data-enabled="false">Interaction test (auto-restore 5s)</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="true" data-workspaces="false" data-enabled="true">Enter kiosk (auto-exit 5s)</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Exit kiosk</button><button id="programmatic-close">Programmatic close</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(v)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',v);async function run(button){status.textContent='Updating native window...';const v={minimizable:button.dataset.min==='true',maximizable:button.dataset.max==='true',closable:button.dataset.close==='true',focusable:button.dataset.focus==='true',fullscreenable:button.dataset.full==='true',has_shadow:button.dataset.shadow==='true',ignore_mouse_events:button.dataset.ignore==='true',background_color:button.dataset.color,kiosk:button.dataset.kiosk==='true',visible_on_all_workspaces:button.dataset.workspaces==='true',enabled:button.dataset.enabled==='true'};try{const reply=await invoke(v);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.enabled?' Enabled.':' Disabled.')+(reply.kiosk?' Kiosk active.':'')}catch(error){status.textContent='request failed: '+String(error)}if(v.kiosk||!v.enabled||v.ignore_mouse_events){setTimeout(()=>{const exit=document.querySelector('[data-kiosk="false"]');void run(exit)},5000)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button)));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
+    #|<body><main><header><p class="eyebrow">Native frame / manual test 69</p><h1>Window controls</h1><p class="summary">Review native frame capabilities and interaction controls. Kiosk includes a timed exit path.</p></header><section class="panel"><div class="window"><div class="bar"><span id="minimize">−</span><span id="maximize">□</span><span id="close">×</span></div><div class="screen">Review the real native title-bar controls</div></div><button class="primary" data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Enable all</button><button data-min="false" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Disable minimize</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="true" data-color="#203040" data-kiosk="false" data-workspaces="true" data-enabled="false">Interaction test (auto-restore 5s)</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="true" data-workspaces="false" data-enabled="true">Enter kiosk (auto-exit 5s)</button><button data-min="true" data-max="true" data-close="true" data-focus="true" data-full="true" data-shadow="true" data-ignore="false" data-color="#dce3eb" data-kiosk="false" data-workspaces="false" data-enabled="true">Exit kiosk</button><button id="programmatic-close">Programmatic close</button><hr><button data-advanced="content">Set content 720×420</button><button data-advanced="menu">Install menu</button><button data-advanced="clear-menu">Clear menu</button><button data-advanced="hide-buttons">Hide window buttons</button><button data-advanced="show-buttons">Show window buttons</button><button data-advanced="parent">Open child</button><button data-advanced="modal">Open modal child</button><button data-advanced="clear-parent">Clear child parent</button><input id="icon-path" placeholder="Absolute .ico/.png path"><button data-advanced="icon">Set icon</button><p id="status" role="status" aria-live="polite">Ready. All native controls are enabled.</p></section></main><script>const min=document.querySelector('#minimize'),max=document.querySelector('#maximize'),close=document.querySelector('#close'),status=document.querySelector('#status');const invoke=(v)=>window.__MoonBit__.core.invokeOp('ext:windowControls/set',v);const advanced=(action)=>window.__MoonBit__.core.invokeOp('ext:windowControls/advanced',{action,path:document.querySelector('#icon-path').value});async function run(button){status.textContent='Updating native window...';const v={minimizable:button.dataset.min==='true',maximizable:button.dataset.max==='true',closable:button.dataset.close==='true',focusable:button.dataset.focus==='true',fullscreenable:button.dataset.full==='true',has_shadow:button.dataset.shadow==='true',ignore_mouse_events:button.dataset.ignore==='true',background_color:button.dataset.color,kiosk:button.dataset.kiosk==='true',visible_on_all_workspaces:button.dataset.workspaces==='true',enabled:button.dataset.enabled==='true'};try{const reply=await invoke(v);min.classList.toggle('off',!reply.minimizable);max.classList.toggle('off',!reply.maximizable);close.classList.toggle('off',!reply.closable);status.textContent=reply.message+(reply.enabled?' Enabled.':' Disabled.')+(reply.kiosk?' Kiosk active.':'')}catch(error){status.textContent='request failed: '+String(error)}if(v.kiosk||!v.enabled||v.ignore_mouse_events){setTimeout(()=>{const exit=document.querySelector('[data-kiosk="false"]');void run(exit)},5000)}}document.querySelectorAll('[data-min]').forEach(button=>button.addEventListener('click',()=>void run(button)));document.querySelectorAll('[data-advanced]').forEach(button=>button.addEventListener('click',async()=>{try{status.textContent=(await advanced(button.dataset.advanced)).message}catch(error){status.textContent=String(error)}}));document.querySelector('#programmatic-close').addEventListener('click',()=>void window.__MoonBit__.core.invokeOp('ext:windowControls/close',null))</script></body></html>
   )
 }
 
@@ -191,14 +284,35 @@ fn html() -> String {
 async fn main {
   @proton.html("Window Controls", html(), width=820, height=560, debug=true)
   .identifier("dev.proton.window-controls")
+  .add_window(
+    "review-child",
+    "Window Controls Child",
+    @proton.AppEntry::Html(
+      "<html><body style='font:16px system-ui;padding:32px'><h2>Child window</h2><p>Use the parent controls to test owner and modal relationships.</p></body></html>",
+    ),
+    width=420,
+    height=260,
+    open_on_start=false,
+  )
   .commands(register_commands)
   .window_lifecycle(
     on_ready=context => {
       let window = context.handle()
-      window_slot.val = Some(window)
+      window_manager_slot.val = Some(context.windows())
+      if context.id() == "main" {
+        window_slot.val = Some(window)
+      } else if context.id() == "review-child" {
+        child_slot.val = Some(window)
+      }
       window
     },
-    on_close=fn(_window) { window_slot.val = None },
+    on_close=fn(window) {
+      if window.id() == "main" {
+        window_slot.val = None
+      } else if window.id() == "review-child" {
+        child_slot.val = None
+      }
+    },
   )
   .run_or_abort()
 }

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -119,7 +119,8 @@ moon -C examples run 01_run --target native
 - `68_window_content_protection`: manual Electron-style screen-capture protection review.
 - `69_window_controls`: combined manual Electron-style minimize, maximize, and close control review.
   Includes focus/fullscreen/shadow plus mouse ignoring, background color,
-  kiosk, workspace visibility, and enabled-state controls.
+  kiosk, workspace visibility, enabled-state, content-size, menu, icon,
+  parent/modal, and native button-visibility controls.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/README.md
+++ b/proton/README.md
@@ -101,6 +101,12 @@ preserving Electron's no-op behavior on macOS and Linux.
 `WindowHandle::set_aspect_ratio` constrains interactive resizing and accepts
 `0.0` to clear the constraint; programmatic `set_size` calls remain
 unconstrained, matching Electron.
+`WindowHandle::set_content_size` adjusts the renderer area while accounting for
+the native frame. `content_size` reads that area back in logical pixels.
+`set_menu` replaces or clears the runtime menu, `set_icon` loads a native icon
+from a file path, and `set_parent` establishes a native owner/transient or modal
+relationship. `set_window_button_visibility` controls standard title-bar buttons
+on macOS and is a successful no-op on other platforms.
 
 ## Logging
 

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -122,6 +122,10 @@ fn RuntimeSession::window_handle(
         window.set_icon(path)
       })
     },
+    set_window_parent: (parent, modal) => {
+      let parent_native_id = parent.map(parent => parent.native_id)
+      self.set_window_parent(id, native_id, parent_native_id, modal)
+    },
     set_window_size: (width, height) => {
       self.control_window(id, native_id, "set size", window => {
         window.set_size(width, height)
@@ -755,6 +759,39 @@ fn RuntimeSession::read_window_content_size(
 }
 
 ///|
+fn RuntimeSession::set_window_parent(
+  self : RuntimeSession,
+  id : String,
+  native_id : Int64,
+  parent_native_id : Int64?,
+  modal : Bool,
+) -> Unit raise WindowSessionError {
+  let running = match self.find_active_window(id) {
+    Some(running) if running.window.id() == native_id => running
+    _ => raise StaleWindow(id~)
+  }
+  let parent = match parent_native_id {
+    Some(parent_id) => {
+      let mut found : RunningWindow? = None
+      for candidate in self.windows {
+        if candidate.is_active() && candidate.window.id() == parent_id {
+          found = Some(candidate)
+          break
+        }
+      }
+      match found {
+        Some(parent) => Some(parent.window.as_ref())
+        None => raise StaleWindow(id="parent")
+      }
+    }
+    None => None
+  }
+  running.window.set_parent(parent, modal) catch {
+    error => raise window_operation_failed("set parent of window " + id, error)
+  }
+}
+
+///|
 fn RuntimeSession::find_definition(
   self : RuntimeSession,
   id : String,
@@ -1182,6 +1219,16 @@ pub fn WindowHandle::set_icon(
   path : String,
 ) -> Unit raise WindowSessionError {
   (self.set_window_icon)(path)
+}
+
+///|
+/// Establishes or clears this window's native parent relationship.
+pub fn WindowHandle::set_parent(
+  self : WindowHandle,
+  parent : WindowHandle?,
+  modal? : Bool = false,
+) -> Unit raise WindowSessionError {
+  (self.set_window_parent)(parent, modal)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -247,6 +247,17 @@ fn RuntimeSession::window_handle(
         window.set_enabled(enabled)
       })
     },
+    set_window_menu: menu => {
+      try {
+        match menu {
+          Some(menu) => self.runtime.set_menu(menu.to_native())
+          None => self.runtime.set_menu(@native.MenuBar(menus=[]))
+        }
+      } catch {
+        error =>
+          raise window_operation_failed("set menu in window " + id, error)
+      }
+    },
     set_window_zoom_percent: zoom_percent => {
       self.control_window(id, native_id, "set zoom", window => {
         window.set_zoom_percent(zoom_percent)
@@ -1484,6 +1495,16 @@ pub fn WindowHandle::set_enabled(
   enabled : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_enabled)(enabled)
+}
+
+///|
+/// Replaces the native menu for the application runtime containing this window.
+/// Passing `None` clears the menu.
+pub fn WindowHandle::set_menu(
+  self : WindowHandle,
+  menu : MenuBar?,
+) -> Unit raise WindowSessionError {
+  (self.set_window_menu)(menu)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -212,6 +212,11 @@ fn RuntimeSession::window_handle(
         window.set_closable(closable)
       })
     },
+    set_window_button_visibility: visible => {
+      self.control_window(id, native_id, "set window button visibility", window => {
+        window.set_button_visibility(visible)
+      })
+    },
     set_window_focusable: focusable => {
       self.control_window(id, native_id, "set focusable", window => {
         window.set_focusable(focusable)
@@ -1409,6 +1414,17 @@ pub fn WindowHandle::set_closable(
   closable : Bool,
 ) -> Unit raise WindowSessionError {
   (self.set_window_closable)(closable)
+}
+
+///|
+/// Sets visibility of the standard close, minimize, and maximize buttons.
+/// On macOS this updates the native traffic-light controls. Other platforms
+/// apply the equivalent live capability controls where available.
+pub fn WindowHandle::set_window_button_visibility(
+  self : WindowHandle,
+  visible : Bool,
+) -> Unit raise WindowSessionError {
+  (self.set_window_button_visibility)(visible)
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -122,6 +122,12 @@ fn RuntimeSession::window_handle(
         window.set_size(width, height)
       })
     },
+    set_window_content_size: (width, height) => {
+      self.control_window(id, native_id, "set content size", window => {
+        window.set_content_size(width, height)
+      })
+    },
+    read_window_content_size: () => self.read_window_content_size(id, native_id),
     minimize_window: () => {
       self.control_window(id, native_id, "minimize", window => window.minimize())
     },
@@ -712,6 +718,22 @@ fn RuntimeSession::read_window_state(
 }
 
 ///|
+fn RuntimeSession::read_window_content_size(
+  self : RuntimeSession,
+  id : String,
+  native_id : Int64,
+) -> (Int, Int) raise WindowSessionError {
+  let running = match self.find_active_window(id) {
+    Some(running) if running.window.id() == native_id => running
+    _ => raise StaleWindow(id~)
+  }
+  running.window.content_size() catch {
+    error =>
+      raise window_operation_failed("read content size of window " + id, error)
+  }
+}
+
+///|
 fn RuntimeSession::find_definition(
   self : RuntimeSession,
   id : String,
@@ -1139,6 +1161,24 @@ pub fn WindowHandle::set_size(
   height : Int,
 ) -> Unit raise WindowSessionError {
   (self.set_window_size)(width, height)
+}
+
+///|
+/// Sets the renderer content area in logical pixels.
+pub fn WindowHandle::set_content_size(
+  self : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Unit raise WindowSessionError {
+  (self.set_window_content_size)(width, height)
+}
+
+///|
+/// Returns the renderer content area in logical pixels.
+pub fn WindowHandle::content_size(
+  self : WindowHandle,
+) -> (Int, Int) raise WindowSessionError {
+  (self.read_window_content_size)()
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -117,6 +117,11 @@ fn RuntimeSession::window_handle(
         window.set_title(title)
       })
     },
+    set_window_icon: path => {
+      self.control_window(id, native_id, "set icon", window => {
+        window.set_icon(path)
+      })
+    },
     set_window_size: (width, height) => {
       self.control_window(id, native_id, "set size", window => {
         window.set_size(width, height)
@@ -1168,6 +1173,15 @@ pub fn WindowHandle::set_title(
   title : String,
 ) -> Unit raise WindowSessionError {
   (self.set_window_title)(title)
+}
+
+///|
+/// Sets the native window icon from an image file path.
+pub fn WindowHandle::set_icon(
+  self : WindowHandle,
+  path : String,
+) -> Unit raise WindowSessionError {
+  (self.set_window_icon)(path)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -439,6 +439,8 @@ pub struct WindowHandle {
   focus_window : () -> Unit raise WindowSessionError
   set_window_title : (String) -> Unit raise WindowSessionError
   set_window_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_content_size : (Int, Int) -> Unit raise WindowSessionError
+  read_window_content_size : () -> (Int, Int) raise WindowSessionError
   minimize_window : () -> Unit raise WindowSessionError
   maximize_window : () -> Unit raise WindowSessionError
   restore_window : () -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -466,6 +466,7 @@ pub struct WindowHandle {
   set_window_background_color : (String) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
+  set_window_menu : (MenuBar?) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -459,6 +459,7 @@ pub struct WindowHandle {
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
+  set_window_button_visibility : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -438,6 +438,7 @@ pub struct WindowHandle {
   close_window : () -> Unit raise WindowSessionError
   focus_window : () -> Unit raise WindowSessionError
   set_window_title : (String) -> Unit raise WindowSessionError
+  set_window_icon : (String) -> Unit raise WindowSessionError
   set_window_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_content_size : (Int, Int) -> Unit raise WindowSessionError
   read_window_content_size : () -> (Int, Int) raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -439,6 +439,7 @@ pub struct WindowHandle {
   focus_window : () -> Unit raise WindowSessionError
   set_window_title : (String) -> Unit raise WindowSessionError
   set_window_icon : (String) -> Unit raise WindowSessionError
+  set_window_parent : (WindowHandle?, Bool) -> Unit raise WindowSessionError
   set_window_size : (Int, Int) -> Unit raise WindowSessionError
   set_window_content_size : (Int, Int) -> Unit raise WindowSessionError
   read_window_content_size : () -> (Int, Int) raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -101,6 +101,7 @@ fn test_window_handle(
     close_window: fn() {  },
     focus_window: fn() {  },
     set_window_title: fn(_title) {  },
+    set_window_icon: fn(_path) {  },
     set_window_size: fn(_width, _height) {  },
     set_window_button_visibility: fn(_visible) {  },
     set_window_content_size: (width, height) => {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -102,6 +102,7 @@ fn test_window_handle(
     focus_window: fn() {  },
     set_window_title: fn(_title) {  },
     set_window_icon: fn(_path) {  },
+    set_window_parent: fn(_parent, _modal) {  },
     set_window_size: fn(_width, _height) {  },
     set_window_button_visibility: fn(_visible) {  },
     set_window_content_size: (width, height) => {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -102,6 +102,7 @@ fn test_window_handle(
     focus_window: fn() {  },
     set_window_title: fn(_title) {  },
     set_window_size: fn(_width, _height) {  },
+    set_window_button_visibility: fn(_visible) {  },
     set_window_content_size: (width, height) => {
       match content_size_calls {
         Some(calls) => calls.push((width, height))

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -81,6 +81,8 @@ fn test_window_handle(
   aspect_ratio_calls? : Array[Double],
   minimum_size_calls? : Array[(Int, Int)],
   maximum_size_calls? : Array[(Int, Int)],
+  content_size_calls? : Array[(Int, Int)],
+  content_size? : (Int, Int),
   window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
@@ -100,6 +102,13 @@ fn test_window_handle(
     focus_window: fn() {  },
     set_window_title: fn(_title) {  },
     set_window_size: fn(_width, _height) {  },
+    set_window_content_size: (width, height) => {
+      match content_size_calls {
+        Some(calls) => calls.push((width, height))
+        None => ()
+      }
+    },
+    read_window_content_size: fn() { content_size.unwrap_or((320, 240)) },
     minimize_window: fn() {  },
     maximize_window: fn() {  },
     restore_window: fn() {  },
@@ -2232,6 +2241,20 @@ test "window context menu routes through the public window handle" {
   let menu = Menu("Context", items=[MenuItem::separator()])
   menu.popup(window, 123, 456)
   debug_inspect(calls, content="[\"popup:Context@123,456\"]")
+}
+
+///|
+test "window content size routes logical dimensions through the handle" {
+  let calls : Array[(Int, Int)] = []
+  let window = test_window_handle(
+    "main",
+    17L,
+    content_size_calls=calls,
+    content_size=(640, 360),
+  )
+  window.set_content_size(800, 450)
+  inspect(window.content_size(), content="(640, 360)")
+  inspect(calls, content="[(800, 450)]")
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -109,6 +109,7 @@ fn test_window_handle(
       }
     },
     read_window_content_size: fn() { content_size.unwrap_or((320, 240)) },
+    set_window_menu: fn(_menu) {  },
     minimize_window: fn() {  },
     maximize_window: fn() {  },
     restore_window: fn() {  },

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -419,6 +419,13 @@ pub extern "C" fn proton_window_set_icon_ffi(
 ) -> Int = "proton_window_set_icon"
 
 ///|
+pub extern "C" fn proton_window_set_parent_ffi(
+  window : WindowHandle,
+  parent : WindowHandle,
+  modal : Int,
+) -> Int = "proton_window_set_parent"
+
+///|
 pub extern "C" fn proton_window_set_size_ffi(
   window : WindowHandle,
   width : Int,

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -412,6 +412,13 @@ pub extern "C" fn proton_window_set_title_ffi(
 ) -> Int = "proton_window_set_title"
 
 ///|
+#borrow(path)
+pub extern "C" fn proton_window_set_icon_ffi(
+  window : WindowHandle,
+  path : Bytes,
+) -> Int = "proton_window_set_icon"
+
+///|
 pub extern "C" fn proton_window_set_size_ffi(
   window : WindowHandle,
   width : Int,

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -419,6 +419,21 @@ pub extern "C" fn proton_window_set_size_ffi(
 ) -> Int = "proton_window_set_size"
 
 ///|
+pub extern "C" fn proton_window_set_content_size_ffi(
+  window : WindowHandle,
+  width : Int,
+  height : Int,
+) -> Int = "proton_window_set_content_size"
+
+///|
+#borrow(out_width, out_height)
+pub extern "C" fn proton_window_get_content_size_ffi(
+  window : WindowHandle,
+  out_width : Ref[Int],
+  out_height : Ref[Int],
+) -> Int = "proton_window_get_content_size"
+
+///|
 pub extern "C" fn proton_window_minimize_ffi(window : WindowHandle) -> Int = "proton_window_minimize"
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -536,6 +536,12 @@ pub extern "C" fn proton_window_set_closable_ffi(
 ) -> Int = "proton_window_set_closable"
 
 ///|
+pub extern "C" fn proton_window_set_button_visibility_ffi(
+  window : WindowHandle,
+  visible : Int,
+) -> Int = "proton_window_set_button_visibility"
+
+///|
 pub extern "C" fn proton_window_set_focusable_ffi(
   window : WindowHandle,
   focusable : Int,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -148,6 +148,9 @@ int32_t proton_window_set_title(proton_window_handle_t window,
                                            const char *title);
 int32_t proton_window_set_icon(proton_window_handle_t window,
                                const char *path);
+int32_t proton_window_set_parent(proton_window_handle_t window,
+                                 proton_window_handle_t parent,
+                                 int32_t modal);
 int32_t proton_window_set_size(proton_window_handle_t window,
                                           int32_t width, int32_t height);
 int32_t proton_window_set_content_size(proton_window_handle_t window,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -186,6 +186,8 @@ int32_t proton_window_set_maximizable(proton_window_handle_t window,
                                       int32_t maximizable);
 int32_t proton_window_set_closable(proton_window_handle_t window,
                                    int32_t closable);
+int32_t proton_window_set_button_visibility(proton_window_handle_t window,
+                                            int32_t visible);
 int32_t proton_window_set_focusable(proton_window_handle_t window,
                                     int32_t focusable);
 int32_t proton_window_set_fullscreenable(proton_window_handle_t window,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -146,6 +146,8 @@ int32_t proton_window_close(proton_window_handle_t window);
 int32_t proton_window_focus(proton_window_handle_t window);
 int32_t proton_window_set_title(proton_window_handle_t window,
                                            const char *title);
+int32_t proton_window_set_icon(proton_window_handle_t window,
+                               const char *path);
 int32_t proton_window_set_size(proton_window_handle_t window,
                                           int32_t width, int32_t height);
 int32_t proton_window_set_content_size(proton_window_handle_t window,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -148,6 +148,11 @@ int32_t proton_window_set_title(proton_window_handle_t window,
                                            const char *title);
 int32_t proton_window_set_size(proton_window_handle_t window,
                                           int32_t width, int32_t height);
+int32_t proton_window_set_content_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height);
+int32_t proton_window_get_content_size(proton_window_handle_t window,
+                                       int32_t *out_width,
+                                       int32_t *out_height);
 int32_t proton_window_minimize(proton_window_handle_t window);
 int32_t proton_window_maximize(proton_window_handle_t window);
 int32_t proton_window_restore(proton_window_handle_t window);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -193,6 +193,8 @@ pub fn proton_window_flash_frame_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_focus_ffi(WindowHandle) -> Int
 
+pub fn proton_window_get_content_size_ffi(WindowHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
+
 pub fn proton_window_get_state_ffi(WindowHandle, FixedArray[Int], Int) -> Int
 
 pub fn proton_window_hide_ffi(WindowHandle) -> Int
@@ -215,11 +217,15 @@ pub fn proton_window_set_aspect_ratio_ffi(WindowHandle, Double) -> Int
 
 pub fn proton_window_set_background_color_ffi(WindowHandle, Bytes) -> Int
 
+pub fn proton_window_set_button_visibility_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_closable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_close_interception_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_content_protection_ffi(WindowHandle, Int) -> Int
+
+pub fn proton_window_set_content_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_enabled_ffi(WindowHandle, Int) -> Int
 
@@ -230,6 +236,8 @@ pub fn proton_window_set_fullscreen_ffi(WindowHandle, Int) -> Int
 pub fn proton_window_set_fullscreenable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_has_shadow_ffi(WindowHandle, Int) -> Int
+
+pub fn proton_window_set_icon_ffi(WindowHandle, Bytes) -> Int
 
 pub fn proton_window_set_ignore_mouse_events_ffi(WindowHandle, Int, Int) -> Int
 
@@ -246,6 +254,8 @@ pub fn proton_window_set_minimum_size_ffi(WindowHandle, Int, Int) -> Int
 pub fn proton_window_set_movable_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_set_opacity_ffi(WindowHandle, Double) -> Int
+
+pub fn proton_window_set_parent_ffi(WindowHandle, WindowHandle, Int) -> Int
 
 pub fn proton_window_set_position_ffi(WindowHandle, Int, Int) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -825,6 +825,32 @@ int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_parent(proton_engine_window_t *window,
+                                        proton_engine_window_t *parent,
+                                        int32_t modal, char *error,
+                                        size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (modal != 0 && modal != 1) {
+    proton_engine_set_message(error, error_len, "modal must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window parenting is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  GtkWindow *parent_window = parent != NULL && parent->window != NULL
+                                 ? GTK_WINDOW(parent->window)
+                                 : NULL;
+  gtk_window_set_transient_for(GTK_WINDOW(window->window), parent_window);
+  gtk_window_set_modal(GTK_WINDOW(window->window),
+                       parent_window != NULL && modal != 0);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -799,6 +799,32 @@ int32_t proton_engine_window_set_title(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
+                                      const char *path, char *error,
+                                      size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (path == NULL || path[0] == '\0') {
+    proton_engine_set_message(error, error_len, "icon path is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window icon is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  GError *load_error = NULL;
+  gtk_window_set_icon_from_file(GTK_WINDOW(window->window), path, &load_error);
+  if (load_error != NULL) {
+    proton_engine_set_message(error, error_len, load_error->message);
+    g_error_free(load_error);
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1089,6 +1089,25 @@ int32_t proton_engine_window_set_closable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_button_visibility(
+    proton_engine_window_t *window, int32_t visible, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (visible != 0 && visible != 1) {
+    proton_engine_set_message(error, error_len, "visible must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window buttons are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_focusable(
     proton_engine_window_t *window, int32_t focusable, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -823,6 +823,54 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_content_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (width <= 0 || height <= 0) {
+    proton_engine_set_message(error, error_len, "width and height must be positive");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    window->width = width;
+    window->height = height;
+    proton_engine_sync_browser_bounds(window);
+    return PROTON_OK;
+  }
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(window->browser_host, &allocation);
+  int outer_width = 0;
+  int outer_height = 0;
+  gtk_window_get_size(GTK_WINDOW(window->window), &outer_width, &outer_height);
+  int target_outer_width = outer_width + width - allocation.width;
+  int target_outer_height = outer_height + height - allocation.height;
+  gtk_window_resize(GTK_WINDOW(window->window), target_outer_width,
+                    target_outer_height);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_get_content_size(
+    proton_engine_window_t *window, int32_t *out_width, int32_t *out_height,
+    char *error, size_t error_len) {
+  if (window == NULL || out_width == NULL || out_height == NULL) {
+    proton_engine_set_message(error, error_len, "window and outputs are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    *out_width = window->width;
+    *out_height = window->height;
+    return PROTON_OK;
+  }
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(window->browser_host, &allocation);
+  *out_width = allocation.width > 0 ? allocation.width : window->width;
+  *out_height = allocation.height > 0 ? allocation.height : window->height;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_minimum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1233,6 +1233,56 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_content_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (width <= 0 || height <= 0) {
+    proton_engine_set_message(error, error_len,
+                              "width and height must be positive");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    window->width = width;
+    window->height = height;
+    if (window->browser != NULL) {
+      cef_browser_host_t *host = window->browser->get_host(window->browser);
+      if (host != NULL) {
+        host->was_resized(host);
+        host->base.release((cef_base_ref_counted_t *)host);
+      }
+    }
+    return PROTON_OK;
+  }
+  [window->window setContentSize:NSMakeSize(width, height)];
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_get_content_size(
+    proton_engine_window_t *window, int32_t *out_width, int32_t *out_height,
+    char *error, size_t error_len) {
+  if (window == NULL || out_width == NULL || out_height == NULL) {
+    proton_engine_set_message(error, error_len, "window and outputs are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    *out_width = window->width;
+    *out_height = window->height;
+    return PROTON_OK;
+  }
+  if (window->window == nil) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  NSRect bounds = window->window.contentView.bounds;
+  *out_width = (int32_t)llround(bounds.size.width);
+  *out_height = (int32_t)llround(bounds.size.height);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_minimum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1226,6 +1226,41 @@ int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_parent(proton_engine_window_t *window,
+                                        proton_engine_window_t *parent,
+                                        int32_t modal, char *error,
+                                        size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (modal != 0 && modal != 1) {
+    proton_engine_set_message(error, error_len, "modal must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window parenting is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  NSWindow *native = window->window;
+  NSWindow *sheet_parent = native.sheetParent;
+  if (sheet_parent != nil) [sheet_parent endSheet:native];
+  NSWindow *child_parent = native.parentWindow;
+  if (child_parent != nil) [child_parent removeChildWindow:native];
+  if (parent == NULL) return PROTON_OK;
+  if (parent->window == nil) {
+    proton_engine_set_message(error, error_len, "parent window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (modal) {
+    [parent->window beginSheet:native completionHandler:nil];
+  } else {
+    [parent->window addChildWindow:native ordered:NSWindowAbove];
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1199,6 +1199,33 @@ int32_t proton_engine_window_set_title(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
+                                      const char *path, char *error,
+                                      size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (path == NULL || path[0] == '\0') {
+    proton_engine_set_message(error, error_len, "icon path is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window icon is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  NSString *value = [NSString stringWithUTF8String:path];
+  NSImage *image = [[NSImage alloc] initWithContentsOfFile:value];
+  if (image == nil) {
+    proton_engine_set_message(error, error_len, "failed to load window icon");
+    return PROTON_ERR_PLATFORM;
+  }
+  [window->window setMiniwindowImage:image];
+  [image release];
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1513,6 +1513,31 @@ int32_t proton_engine_window_set_closable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_button_visibility(
+    proton_engine_window_t *window, int32_t visible, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (visible != 0 && visible != 1) {
+    proton_engine_set_message(error, error_len, "visible must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window buttons are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  const NSWindowButton buttons[] = {
+      NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton};
+  for (size_t index = 0; index < sizeof(buttons) / sizeof(buttons[0]); index++) {
+    NSButton *button = [window->window standardWindowButton:buttons[index]];
+    if (button != nil) button.hidden = visible == 0;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_focusable(
     proton_engine_window_t *window, int32_t focusable, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -89,6 +89,7 @@ struct proton_engine_window {
   int enabled;
   HWND parent_hwnd;
   int modal_parent;
+  HICON window_icon;
   HBRUSH background_brush;
   int min_width;
   int min_height;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -87,6 +87,8 @@ struct proton_engine_window {
   int ignore_mouse_events;
   int ignore_mouse_forward;
   int enabled;
+  HWND parent_hwnd;
+  int modal_parent;
   HBRUSH background_brush;
   int min_width;
   int min_height;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1104,6 +1104,39 @@ int32_t proton_engine_window_set_title(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
+                                      const char *path, char *error,
+                                      size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (path == NULL || path[0] == '\0') {
+    proton_engine_set_message(error, error_len, "icon path is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window icon is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  wchar_t wide_path[PROTON_ENGINE_MAX_PATH_BYTES];
+  if (proton_engine_utf8_to_wide(path, wide_path,
+                                 (int)(sizeof(wide_path) / sizeof(wide_path[0]))) <= 0) {
+    proton_engine_set_message(error, error_len, "icon path is not valid UTF-8");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  HICON icon = (HICON)LoadImageW(NULL, wide_path, IMAGE_ICON, 0, 0,
+                                 LR_LOADFROMFILE | LR_DEFAULTSIZE);
+  if (icon == NULL) {
+    proton_engine_set_message(error, error_len, "failed to load window icon");
+    return PROTON_ERR_PLATFORM;
+  }
+  SendMessageW(window->hwnd, WM_SETICON, ICON_SMALL, (LPARAM)icon);
+  SendMessageW(window->hwnd, WM_SETICON, ICON_BIG, (LPARAM)icon);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1137,6 +1137,43 @@ int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_parent(proton_engine_window_t *window,
+                                        proton_engine_window_t *parent,
+                                        int32_t modal, char *error,
+                                        size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (modal != 0 && modal != 1) {
+    proton_engine_set_message(error, error_len, "modal must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window parenting is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (window->modal_parent && window->parent_hwnd != NULL &&
+      IsWindow(window->parent_hwnd)) {
+    EnableWindow(window->parent_hwnd, TRUE);
+  }
+  HWND parent_hwnd = parent != NULL ? parent->hwnd : NULL;
+  SetLastError(0);
+  if (SetWindowLongPtrW(window->hwnd, GWLP_HWNDPARENT,
+                        (LONG_PTR)parent_hwnd) == 0 &&
+      GetLastError() != 0) {
+    proton_engine_set_message(error, error_len, "failed to set window owner");
+    window->parent_hwnd = NULL;
+    window->modal_parent = 0;
+    return PROTON_ERR_PLATFORM;
+  }
+  window->parent_hwnd = parent_hwnd;
+  window->modal_parent = modal != 0 && parent_hwnd != NULL;
+  if (window->modal_parent) EnableWindow(parent_hwnd, FALSE);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -338,6 +338,14 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
     break;
   case WM_DESTROY:
     if (window != NULL) {
+      if (window->window_icon != NULL) {
+        DestroyIcon(window->window_icon);
+        window->window_icon = NULL;
+      }
+      if (window->modal_parent && window->parent_hwnd != NULL &&
+          IsWindow(window->parent_hwnd)) {
+        EnableWindow(window->parent_hwnd, TRUE);
+      }
       window->closed = 1;
       window->hwnd = NULL;
     }
@@ -1132,6 +1140,8 @@ int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
     proton_engine_set_message(error, error_len, "failed to load window icon");
     return PROTON_ERR_PLATFORM;
   }
+  if (window->window_icon != NULL) DestroyIcon(window->window_icon);
+  window->window_icon = icon;
   SendMessageW(window->hwnd, WM_SETICON, ICON_SMALL, (LPARAM)icon);
   SendMessageW(window->hwnd, WM_SETICON, ICON_BIG, (LPARAM)icon);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1110,6 +1110,57 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_content_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (width <= 0 || height <= 0) {
+    proton_engine_set_message(error, error_len, "width and height must be positive");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    window->width = width;
+    window->height = height;
+    proton_engine_resize_browser(window, width, height);
+    return PROTON_OK;
+  }
+  RECT desired = {0, 0, width, height};
+  DWORD style = (DWORD)GetWindowLongPtrW(window->hwnd, GWL_STYLE);
+  DWORD ex_style = (DWORD)GetWindowLongPtrW(window->hwnd, GWL_EXSTYLE);
+  if (!AdjustWindowRectEx(&desired, style, FALSE, ex_style)) {
+    proton_engine_set_message(error, error_len, "failed to calculate window frame");
+    return PROTON_ERR_PLATFORM;
+  }
+  return proton_engine_window_set_size(window, desired.right - desired.left,
+                                       desired.bottom - desired.top, error,
+                                       error_len);
+}
+
+int32_t proton_engine_window_get_content_size(
+    proton_engine_window_t *window, int32_t *out_width, int32_t *out_height,
+    char *error, size_t error_len) {
+  if (window == NULL || out_width == NULL || out_height == NULL) {
+    proton_engine_set_message(error, error_len, "window and outputs are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    *out_width = window->width;
+    *out_height = window->height;
+    return PROTON_OK;
+  }
+  RECT rect;
+  if (!GetClientRect(window->hwnd, &rect)) {
+    proton_engine_set_message(error, error_len, "failed to read client area");
+    return PROTON_ERR_PLATFORM;
+  }
+  *out_width = rect.right - rect.left;
+  *out_height = rect.bottom - rect.top;
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_progress_bar(
     proton_engine_window_t *window, double progress, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -959,6 +959,25 @@ int32_t proton_engine_window_set_closable(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_button_visibility(
+    proton_engine_window_t *window, int32_t visible, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (visible != 0 && visible != 1) {
+    proton_engine_set_message(error, error_len, "visible must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window buttons are not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_focusable(
     proton_engine_window_t *window, int32_t focusable, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1267,6 +1267,27 @@ int32_t proton_window_set_closable(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_button_visibility(proton_window_handle_t window,
+                                            int32_t visible) {
+  if (visible != 0 && visible != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "visible must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window button visibility requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_button_visibility(
+      slot->engine_window, visible, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_focusable(proton_window_handle_t window,
                                     int32_t focusable) {
   if (focusable != 0 && focusable != 1) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -850,6 +850,50 @@ int32_t proton_window_set_size(proton_window_handle_t window, int32_t width,
   return PROTON_OK;
 }
 
+int32_t proton_window_set_content_size(proton_window_handle_t window,
+                                       int32_t width, int32_t height) {
+  if (width <= 0 || height <= 0) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "width and height must be positive");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "content size requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_content_size(
+      slot->engine_window, width, height, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_get_content_size(proton_window_handle_t window,
+                                       int32_t *out_width,
+                                       int32_t *out_height) {
+  if (out_width == NULL || out_height == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "output dimensions are required");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "content size requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_get_content_size(
+      slot->engine_window, out_width, out_height, engine_error,
+      sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 static int32_t
 proton_window_apply_action(proton_window_handle_t window,
                            const proton_engine_window_action_t *action) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -824,6 +824,26 @@ int32_t proton_window_set_title(proton_window_handle_t window, const char *title
   return PROTON_OK;
 }
 
+int32_t proton_window_set_icon(proton_window_handle_t window, const char *path) {
+  if (path == NULL || path[0] == '\0') {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "icon path is required");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window icon requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_icon(slot->engine_window, path,
+                                         engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_size(proton_window_handle_t window, int32_t width,
                                int32_t height) {
   proton_window_slot_t *slot = NULL;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -844,6 +844,46 @@ int32_t proton_window_set_icon(proton_window_handle_t window, const char *path) 
   return PROTON_OK;
 }
 
+int32_t proton_window_set_parent(proton_window_handle_t window,
+                                 proton_window_handle_t parent,
+                                 int32_t modal) {
+  if (modal != 0 && modal != 1) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "modal must be 0 or 1");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  proton_window_slot_t *parent_slot = NULL;
+  if (parent != PROTON_INVALID_HANDLE) {
+    status = proton_get_window(parent, &parent_slot);
+    if (status != PROTON_OK) return status;
+    if (parent_slot == slot) {
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "window cannot parent itself");
+    }
+    if (parent_slot->runtime != slot->runtime) {
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "parent window belongs to another runtime");
+    }
+  } else if (modal != 0) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "modal window requires a parent");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window parenting requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_parent(
+      slot->engine_window,
+      parent_slot != NULL ? parent_slot->engine_window : NULL, modal,
+      engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_set_size(proton_window_handle_t window, int32_t width,
                                int32_t height) {
   proton_window_slot_t *slot = NULL;

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -208,6 +208,10 @@ int32_t proton_engine_window_set_title(proton_engine_window_t *window,
                                        const char *title,
                                        char *error,
                                        size_t error_len);
+int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
+                                      const char *path,
+                                      char *error,
+                                      size_t error_len);
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -213,6 +213,12 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t height,
                                       char *error,
                                       size_t error_len);
+int32_t proton_engine_window_set_content_size(
+    proton_engine_window_t *window, int32_t width, int32_t height,
+    char *error, size_t error_len);
+int32_t proton_engine_window_get_content_size(
+    proton_engine_window_t *window, int32_t *out_width, int32_t *out_height,
+    char *error, size_t error_len);
 int32_t proton_engine_window_set_minimum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -212,6 +212,10 @@ int32_t proton_engine_window_set_icon(proton_engine_window_t *window,
                                       const char *path,
                                       char *error,
                                       size_t error_len);
+int32_t proton_engine_window_set_parent(proton_engine_window_t *window,
+                                        proton_engine_window_t *parent,
+                                        int32_t modal, char *error,
+                                        size_t error_len);
 int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                                       int32_t width,
                                       int32_t height,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -249,6 +249,9 @@ int32_t proton_engine_window_set_maximizable(
 int32_t proton_engine_window_set_closable(
     proton_engine_window_t *window, int32_t closable, char *error,
     size_t error_len);
+int32_t proton_engine_window_set_button_visibility(
+    proton_engine_window_t *window, int32_t visible, char *error,
+    size_t error_len);
 int32_t proton_engine_window_set_focusable(
     proton_engine_window_t *window, int32_t focusable, char *error,
     size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1611,6 +1611,24 @@ pub fn Window::set_closable(
 }
 
 ///|
+/// Sets visibility of the standard native window buttons.
+pub fn Window::set_button_visibility(
+  self : Window,
+  visible : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_button_visibility_ffi(
+      self.live_handle(),
+      if visible {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 /// Sets whether the live native window can receive focus.
 pub fn Window::set_focusable(
   self : Window,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1304,6 +1304,40 @@ pub fn Window::set_size(
 }
 
 ///|
+/// Sets the live renderer content area in logical pixels.
+pub fn Window::set_content_size(
+  self : Window,
+  width : Int,
+  height : Int,
+) -> Unit raise NativeError {
+  if width <= 0 || height <= 0 {
+    raise invalid_argument("width and height must be positive")
+  }
+  check_status(
+    @native_ffi.proton_window_set_content_size_ffi(
+      self.live_handle(),
+      width,
+      height,
+    ),
+  )
+}
+
+///|
+/// Returns the live renderer content area in logical pixels.
+pub fn Window::content_size(self : Window) -> (Int, Int) raise NativeError {
+  let width : Ref[Int] = { val: 0, }
+  let height : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_get_content_size_ffi(
+      self.live_handle(),
+      width,
+      height,
+    ),
+  )
+  (width.val, height.val)
+}
+
+///|
 pub fn Window::minimize(self : Window) -> Unit raise NativeError {
   check_status(@native_ffi.proton_window_minimize_ffi(self.live_handle()))
 }

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1290,6 +1290,20 @@ pub fn Window::set_title(
 }
 
 ///|
+/// Sets the native window icon from an image file path.
+pub fn Window::set_icon(self : Window, path : String) -> Unit raise NativeError {
+  if path.length() == 0 {
+    raise invalid_argument("icon path must not be empty")
+  }
+  check_status(
+    @native_ffi.proton_window_set_icon_ffi(
+      self.live_handle(),
+      @ffi.to_cstr(path),
+    ),
+  )
+}
+
+///|
 pub fn Window::set_size(
   self : Window,
   width : Int,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1304,6 +1304,30 @@ pub fn Window::set_icon(self : Window, path : String) -> Unit raise NativeError 
 }
 
 ///|
+/// Establishes or clears this window's native parent relationship.
+pub fn Window::set_parent(
+  self : Window,
+  parent : WindowRef?,
+  modal : Bool,
+) -> Unit raise NativeError {
+  let parent_handle = match parent {
+    Some(parent) => parent.handle
+    None => @native_ffi.window_null()
+  }
+  check_status(
+    @native_ffi.proton_window_set_parent_ffi(
+      self.live_handle(),
+      parent_handle,
+      if modal {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::set_size(
   self : Window,
   width : Int,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -552,6 +552,7 @@ pub fn Window::bridge_lifecycle_state(Self) -> BridgeLifecycleState raise Native
 pub fn Window::browser_command(Self, String, download_id? : Int) -> Unit raise NativeError
 pub fn Window::clear_cache(Self) -> Unit raise NativeError
 pub fn Window::close(Self) -> Unit raise NativeError
+pub fn Window::content_size(Self) -> (Int, Int) raise NativeError
 pub fn Window::cookie_begin_get(Self, String?, Bool) -> Int64 raise NativeError
 pub fn Window::cookie_delete(Self, String?, String?) -> Unit raise NativeError
 pub fn Window::cookie_flush(Self) -> Unit raise NativeError
@@ -573,14 +574,17 @@ pub fn Window::restore(Self) -> Unit raise NativeError
 pub fn Window::set_always_on_top(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_aspect_ratio(Self, Double) -> Unit raise NativeError
 pub fn Window::set_background_color(Self, String) -> Unit raise NativeError
+pub fn Window::set_button_visibility(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_closable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_close_interception(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_content_protection(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_content_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_enabled(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_focusable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreen(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_fullscreenable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_has_shadow(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_icon(Self, String) -> Unit raise NativeError
 pub fn Window::set_ignore_mouse_events(Self, Bool, Bool) -> Unit raise NativeError
 pub fn Window::set_kiosk(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_maximizable(Self, Bool) -> Unit raise NativeError
@@ -589,6 +593,7 @@ pub fn Window::set_minimizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_minimum_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_movable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_opacity(Self, Double) -> Unit raise NativeError
+pub fn Window::set_parent(Self, WindowRef?, Bool) -> Unit raise NativeError
 pub fn Window::set_position(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -591,7 +591,11 @@ pub struct WindowHandle {
   close_window : () -> Unit raise WindowSessionError
   focus_window : () -> Unit raise WindowSessionError
   set_window_title : (String) -> Unit raise WindowSessionError
+  set_window_icon : (String) -> Unit raise WindowSessionError
+  set_window_parent : (WindowHandle?, Bool) -> Unit raise WindowSessionError
   set_window_size : (Int, Int) -> Unit raise WindowSessionError
+  set_window_content_size : (Int, Int) -> Unit raise WindowSessionError
+  read_window_content_size : () -> (Int, Int) raise WindowSessionError
   minimize_window : () -> Unit raise WindowSessionError
   maximize_window : () -> Unit raise WindowSessionError
   restore_window : () -> Unit raise WindowSessionError
@@ -610,6 +614,7 @@ pub struct WindowHandle {
   set_window_minimizable : (Bool) -> Unit raise WindowSessionError
   set_window_maximizable : (Bool) -> Unit raise WindowSessionError
   set_window_closable : (Bool) -> Unit raise WindowSessionError
+  set_window_button_visibility : (Bool) -> Unit raise WindowSessionError
   set_window_focusable : (Bool) -> Unit raise WindowSessionError
   set_window_fullscreenable : (Bool) -> Unit raise WindowSessionError
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
@@ -617,6 +622,7 @@ pub struct WindowHandle {
   set_window_background_color : (String) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
+  set_window_menu : (MenuBar?) -> Unit raise WindowSessionError
   set_window_zoom_percent : (Int) -> Unit raise WindowSessionError
   set_window_progress_bar : (Double) -> Unit raise WindowSessionError
   flash_window_frame : (Bool) -> Unit raise WindowSessionError
@@ -632,6 +638,7 @@ pub fn WindowHandle::add_view(Self, String, ViewConfig) -> ViewHandle raise Wind
 pub fn WindowHandle::browser(Self) -> BrowserHandle
 pub fn WindowHandle::center(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::close(Self) -> Unit raise WindowSessionError
+pub fn WindowHandle::content_size(Self) -> (Int, Int) raise WindowSessionError
 pub fn WindowHandle::flash_frame(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::focus(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::hide(Self) -> Unit raise WindowSessionError
@@ -645,19 +652,23 @@ pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionE
 pub fn WindowHandle::set_background_color(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_closable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_content_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_enabled(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_focusable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreen(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_fullscreenable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_has_shadow(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_icon(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_ignore_mouse_events(Self, Bool, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_kiosk(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_maximum_size(Self, Int, Int) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_menu(Self, MenuBar?) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_minimum_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_movable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_opacity(Self, Double) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_parent(Self, Self?, modal? : Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_position(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError
@@ -665,6 +676,7 @@ pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_skip_taskbar(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_visible_on_all_workspaces(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_window_button_visibility(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::show(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::state(Self) -> WindowState raise WindowSessionError


### PR DESCRIPTION
## Summary
- add live content-size setters/readback with native frame conversion
- add runtime menu replacement/clearing through WindowHandle
- add parent/child and modal window relationships
- add runtime native icon loading
- add macOS standard window button visibility control
- expand example 69 for manual review and document the APIs

## Validation
- `moon -C proton test --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Platform notes
- Content size, icon, and parent/modal APIs have native macOS, Windows, and Linux implementations.
- Window button visibility is implemented on macOS and is a successful no-op on Windows/Linux, matching the Electron platform-specific surface.
- Runtime menu uses the existing native menu route; Windows native application menu support remains an existing unsupported backend and is surfaced by the API.
