### PR TITLE
feat(window): implement Windows native application menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ Application windows can host independent web contents views with explicit
 bounds, visibility, z-order, navigation, DevTools, and lifecycle events. See
 `examples/45_bridge_multi_window` and `examples/52_web_contents_view`.
 
-Native application menus are available on macOS and Linux. Native context
-menus are available on macOS, Windows, and Linux. Application menu bars are not
-yet implemented on Windows.
+Native application menus and native context menus are available on macOS,
+Windows, and Linux.
 
 Titlebar overlay uses `TitlebarStyle::Overlay` and is implemented on macOS and
 Windows. Interactive controls inside a draggable region must use

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -58,6 +58,7 @@ struct proton_engine_runtime {
   char wakeup_path[256];
   char dialog_ok_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
+  proton_menu_bar_t *menu_definition;
 };
 
 struct proton_engine_window {
@@ -115,6 +116,10 @@ struct proton_engine_window {
   int closed;
   struct proton_engine_view *views;
   int finalize_queued;
+  HMENU app_menu;
+  proton_menu_bar_t *app_menu_definition;
+  void *app_menu_bindings;
+  size_t app_menu_binding_count;
   struct proton_engine_window *next;
 };
 
@@ -127,6 +132,12 @@ int proton_engine_browser_id(cef_browser_t *browser);
 void proton_engine_browser_release(cef_browser_t *browser);
 proton_engine_view_t *proton_engine_find_view_by_browser_id(int browser_id);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
+void proton_win_menu_dispatch_command(proton_engine_window_t *window,
+                                      UINT command_id);
+int32_t proton_win_menu_apply_to_window(
+    proton_engine_window_t *window, const proton_menu_bar_t *menu_bar,
+    char *error, size_t error_len);
+void proton_win_menu_cleanup_window(proton_engine_window_t *window);
 
 cef_life_span_handler_t *CEF_CALLBACK
 proton_engine_client_get_life_span_handler(cef_client_t *self);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_menu.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_menu.c
@@ -23,15 +23,147 @@ typedef struct {
   UINT next_id;
 } proton_win_menu_builder_t;
 
-// TODO: Implement application menu rendering and command events on Windows.
+static int32_t proton_win_menu_wide_text(
+    const char *value, wchar_t **out_text, char *error, size_t error_len);
+static int32_t proton_win_menu_append_definition(
+    HMENU menu, const proton_menu_t *definition,
+    proton_win_menu_builder_t *builder, char *error, size_t error_len);
+
+void proton_win_menu_cleanup_window(proton_engine_window_t *window) {
+  if (window == NULL) return;
+  if (window->app_menu != NULL) {
+    if (window->hwnd != NULL) {
+      SetMenu(window->hwnd, NULL);
+      DrawMenuBar(window->hwnd);
+    }
+    DestroyMenu(window->app_menu);
+  }
+  free(window->app_menu_bindings);
+  proton_menu_bar_destroy(window->app_menu_definition);
+  window->app_menu = NULL;
+  window->app_menu_definition = NULL;
+  window->app_menu_bindings = NULL;
+  window->app_menu_binding_count = 0;
+}
+
+int32_t proton_win_menu_apply_to_window(
+    proton_engine_window_t *window, const proton_menu_bar_t *menu_bar,
+    char *error, size_t error_len) {
+  if (window == NULL || window->hwnd == NULL || menu_bar == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "window and menu definition are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (menu_bar->menu_count == 0) {
+    proton_win_menu_cleanup_window(window);
+    return PROTON_OK;
+  }
+  proton_menu_bar_t *definition = proton_menu_bar_clone(menu_bar);
+  if (definition == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "failed to copy application menu");
+    return PROTON_ERR_ENGINE;
+  }
+  HMENU menu = CreateMenu();
+  if (menu == NULL) {
+    proton_menu_bar_destroy(definition);
+    proton_engine_set_message(error, error_len,
+                              "failed to create application menu");
+    return PROTON_ERR_PLATFORM;
+  }
+  proton_win_menu_builder_t builder = {.next_id = 1};
+  for (size_t index = 0; index < definition->menu_count; index++) {
+    const proton_menu_t *top_level = &definition->menus[index];
+    if (top_level->label == NULL || top_level->label[0] == '\0') {
+      proton_menu_bar_destroy(definition);
+      DestroyMenu(menu);
+      free(builder.bindings);
+      proton_engine_set_message(error, error_len,
+                                "application menu label is required");
+      return PROTON_ERR_INVALID_ARGUMENT;
+    }
+    wchar_t *label = NULL;
+    int32_t status = proton_win_menu_wide_text(
+        top_level->label, &label, error, error_len);
+    HMENU submenu = NULL;
+    if (status == PROTON_OK) {
+      submenu = CreatePopupMenu();
+      if (submenu == NULL) {
+        free(label);
+        DestroyMenu(menu);
+        free(builder.bindings);
+        proton_menu_bar_destroy(definition);
+        proton_engine_set_message(error, error_len,
+                                  "failed to create application submenu");
+        return PROTON_ERR_PLATFORM;
+      }
+      status = proton_win_menu_append_definition(
+          submenu, top_level, &builder, error, error_len);
+    }
+    if (status == PROTON_OK &&
+        !AppendMenuW(menu, MF_STRING | MF_POPUP, (UINT_PTR)submenu, label)) {
+      proton_engine_set_message(error, error_len,
+                                "failed to append application menu");
+      status = PROTON_ERR_PLATFORM;
+    }
+    free(label);
+    if (status != PROTON_OK) {
+      if (submenu != NULL) DestroyMenu(submenu);
+      proton_menu_bar_destroy(definition);
+      DestroyMenu(menu);
+      free(builder.bindings);
+      return status;
+    }
+  }
+  if (!SetMenu(window->hwnd, menu)) {
+    proton_menu_bar_destroy(definition);
+    DestroyMenu(menu);
+    free(builder.bindings);
+    proton_engine_set_message(error, error_len,
+                              "failed to install application menu");
+    return PROTON_ERR_PLATFORM;
+  }
+  HMENU old_menu = window->app_menu;
+  proton_menu_bar_t *old_definition = window->app_menu_definition;
+  void *old_bindings = window->app_menu_bindings;
+  window->app_menu = menu;
+  window->app_menu_definition = definition;
+  window->app_menu_bindings = builder.bindings;
+  window->app_menu_binding_count = builder.binding_count;
+  if (old_menu != NULL) DestroyMenu(old_menu);
+  proton_menu_bar_destroy(old_definition);
+  free(old_bindings);
+  DrawMenuBar(window->hwnd);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_runtime_set_menu(
     proton_engine_runtime_t *runtime, const proton_menu_bar_t *menu_bar,
     char *error, size_t error_len) {
-  (void)runtime;
-  (void)menu_bar;
-  proton_engine_set_message(error, error_len,
-                            "native app menus are not implemented on Windows");
-  return PROTON_ERR_UNSUPPORTED;
+  if (runtime == NULL || menu_bar == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "runtime and menu definition are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  proton_menu_bar_t *definition = proton_menu_bar_clone(menu_bar);
+  if (definition == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "failed to copy runtime menu definition");
+    return PROTON_ERR_ENGINE;
+  }
+  for (proton_engine_window_t *window = proton_engine_windows_head();
+       window != NULL; window = window->next) {
+    if (window->runtime != runtime || window->hwnd == NULL) continue;
+    int32_t status = proton_win_menu_apply_to_window(
+        window, definition, error, error_len);
+    if (status != PROTON_OK) {
+      proton_menu_bar_destroy(definition);
+      return status;
+    }
+  }
+  proton_menu_bar_destroy(runtime->menu_definition);
+  runtime->menu_definition = definition;
+  return PROTON_OK;
 }
 
 static int32_t proton_win_menu_append_binding(
@@ -292,6 +424,18 @@ static void proton_win_menu_dispatch(
     }
     return;
   }
+}
+
+void proton_win_menu_dispatch_command(proton_engine_window_t *window,
+                                      UINT command_id) {
+  if (window == NULL || window->app_menu_bindings == NULL) return;
+  proton_win_menu_builder_t builder = {
+      .bindings = (proton_win_menu_binding_t *)window->app_menu_bindings,
+      .binding_count = window->app_menu_binding_count,
+      .binding_capacity = window->app_menu_binding_count,
+      .next_id = 0,
+  };
+  proton_win_menu_dispatch(window, &builder, command_id);
 }
 
 int32_t proton_engine_window_popup_menu(

--- a/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
@@ -612,6 +612,7 @@ static void proton_engine_dispose_runtime_state(
     g_proton_engine_active_runtime = NULL;
   }
   g_proton_cef_runtime_active = 0;
+  proton_menu_bar_destroy(runtime->menu_definition);
   free(runtime);
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -336,8 +336,16 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
       return 0;
     }
     break;
+  case WM_COMMAND:
+    if (window != NULL && HIWORD(wparam) == 0 &&
+        window->app_menu_bindings != NULL) {
+      proton_win_menu_dispatch_command(window, LOWORD(wparam));
+      return 0;
+    }
+    break;
   case WM_DESTROY:
     if (window != NULL) {
+      proton_win_menu_cleanup_window(window);
       if (window->window_icon != NULL) {
         DestroyIcon(window->window_icon);
         window->window_icon = NULL;
@@ -572,6 +580,20 @@ int32_t proton_engine_window_create(
                        SWP_FRAMECHANGED);
     }
     ShowWindow(window->hwnd, SW_SHOW);
+    if (runtime->menu_definition != NULL) {
+      int32_t menu_status = proton_win_menu_apply_to_window(
+          window, runtime->menu_definition, error, error_len);
+      if (menu_status != PROTON_OK) {
+        DestroyWindow(window->hwnd);
+        window->hwnd = NULL;
+        ((cef_base_ref_counted_t *)window->client)
+            ->release((cef_base_ref_counted_t *)window->client);
+        proton_browser_session_destroy(window->browser_session);
+        free(window->bridge_config_json);
+        free(window);
+        return menu_status;
+      }
+    }
   }
 
   int32_t status =


### PR DESCRIPTION
## Summary
- implement native Windows application menu bars with `HMENU`
- support commands, roles, separators, and nested submenus
- apply runtime menus to existing windows and newly created windows
- retain menu definitions per window so command bindings remain valid
- allow `set_menu(None)` to clear the installed menu

## Platform impact
- Windows: adds the previously missing native application menu implementation
- macOS/Linux: no behavior change

## Validation
- `moon -C proton test internal/native --target native --diagnostic-limit 80` (29 passed)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- GitHub Actions: macOS, Windows, Linux, and format checks passed
