### PR TITLE
feat(browser): expose navigation history state

### DIFF
--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -381,6 +381,18 @@ fn RuntimeSession::view_handle(
         view => view.browser_command(command, download_id?),
       )
     },
+    read_view_navigation_state: () => {
+      let running = self.resolve_view(
+        window_id, window_native_id, id, native_id,
+      )
+      running.view.navigation_state() catch {
+        error =>
+          raise window_operation_failed(
+            "read navigation state of view " + id + " in window " + window_id,
+            error,
+          )
+      }
+    },
     read_view_state: () => {
       let running = self.resolve_view(
         window_id, window_native_id, id, native_id,
@@ -586,6 +598,19 @@ fn RuntimeSession::browser_handle(
       self.control_window(id, native_id, command + " in", window => {
         window.browser_command(command, download_id?)
       })
+    },
+    read_browser_navigation_state: () => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.navigation_state() catch {
+        error =>
+          raise window_operation_failed(
+            "read browser navigation state in window " + id,
+            error,
+          )
+      }
     },
   }
 }
@@ -1757,6 +1782,22 @@ pub fn ViewHandle::forward(self : ViewHandle) -> Unit raise WindowSessionError {
 }
 
 ///|
+/// Returns whether the view can navigate to a previous history entry.
+pub fn ViewHandle::can_go_back(
+  self : ViewHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_view_navigation_state)().0
+}
+
+///|
+/// Returns whether the view can navigate to a later history entry.
+pub fn ViewHandle::can_go_forward(
+  self : ViewHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_view_navigation_state)().1
+}
+
+///|
 pub fn ViewHandle::reload(
   self : ViewHandle,
   ignore_cache? : Bool = false,
@@ -1846,6 +1887,22 @@ pub fn BrowserHandle::forward(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
   (self.send_browser_command)("forward", None)
+}
+
+///|
+/// Returns whether the main browser can navigate to a previous history entry.
+pub fn BrowserHandle::can_go_back(
+  self : BrowserHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_browser_navigation_state)().0
+}
+
+///|
+/// Returns whether the main browser can navigate to a later history entry.
+pub fn BrowserHandle::can_go_forward(
+  self : BrowserHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_browser_navigation_state)().1
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -401,6 +401,7 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  read_browser_navigation_state : () -> (Bool, Bool) raise WindowSessionError
 }
 
 ///|
@@ -421,6 +422,7 @@ pub struct ViewHandle {
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
+  read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
 }

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -92,6 +92,7 @@ fn test_window_handle(
     load_browser_html: fn(_html, _base_url) {  },
     eval_browser_script: fn(_script) {  },
     send_browser_command: fn(_command, _download_id) {  },
+    read_browser_navigation_state: fn() { (true, false) },
   }
   WindowHandle::{
     id,
@@ -2204,6 +2205,7 @@ fn test_view_handle(
     load_view_html: fn(_html, _base_url) {  },
     eval_view_script: fn(_script) {  },
     send_view_command: fn(_command, _download_id) {  },
+    read_view_navigation_state: fn() { (true, false) },
     read_view_state: fn() {
       { x: 1, y: 2, width: 300, height: 200, visible: true, z_order: 1, }
     },
@@ -2220,6 +2222,8 @@ test "view handle routes operations through its closures" {
   view.set_visible(false)
   view.set_z_order(2)
   view.load_url("https://example.com/")
+  assert_true(view.can_go_back())
+  assert_false(view.can_go_forward())
   let state = view.state()
   inspect(state.width, content="300")
   inspect(state.z_order, content="1")

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -625,6 +625,14 @@ pub extern "C" fn proton_window_browser_command_json_ffi(
 ) -> Int = "proton_window_browser_command_json"
 
 ///|
+#borrow(out_can_go_back, out_can_go_forward)
+pub extern "C" fn proton_window_get_navigation_state_ffi(
+  window : WindowHandle,
+  out_can_go_back : Ref[Int],
+  out_can_go_forward : Ref[Int],
+) -> Int = "proton_window_get_navigation_state"
+
+///|
 #borrow(response_json)
 pub extern "C" fn proton_window_respond_browser_request_json_ffi(
   window : WindowHandle,
@@ -828,6 +836,14 @@ pub extern "C" fn proton_view_browser_command_json_ffi(
   view : ViewHandle,
   command_json : Bytes,
 ) -> Int = "proton_view_browser_command_json"
+
+///|
+#borrow(out_can_go_back, out_can_go_forward)
+pub extern "C" fn proton_view_get_navigation_state_ffi(
+  view : ViewHandle,
+  out_can_go_back : Ref[Int],
+  out_can_go_forward : Ref[Int],
+) -> Int = "proton_view_get_navigation_state"
 
 ///|
 #borrow(out_fields, out_screen_count)

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -232,6 +232,9 @@ int32_t proton_window_eval(proton_window_handle_t window,
                                       const char *script);
 int32_t proton_window_browser_command_json(
     proton_window_handle_t window, const char *command_json);
+int32_t proton_window_get_navigation_state(
+    proton_window_handle_t window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward);
 int32_t proton_window_respond_browser_request_json(
     proton_window_handle_t window, const char *response_json);
 int32_t proton_window_emit_bridge_event_json(
@@ -389,6 +392,9 @@ int32_t proton_view_load_url(proton_view_handle_t view,
 int32_t proton_view_eval(proton_view_handle_t view, const char *script);
 int32_t proton_view_browser_command_json(
     proton_view_handle_t view, const char *command_json);
+int32_t proton_view_get_navigation_state(
+    proton_view_handle_t view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward);
 /* Writes the six integer fields of the current view state into out_fields. */
 int32_t proton_view_get_state(proton_view_handle_t view,
                               int32_t *out_fields,

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -807,3 +807,17 @@ int32_t proton_browser_session_command_json(
   }
   return PROTON_OK;
 }
+
+int32_t proton_browser_navigation_state(
+    cef_browser_t *browser, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (browser == NULL || out_can_go_back == NULL ||
+      out_can_go_forward == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser and navigation outputs are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  *out_can_go_back = browser->can_go_back(browser) ? 1 : 0;
+  *out_can_go_forward = browser->can_go_forward(browser) ? 1 : 0;
+  return PROTON_OK;
+}

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -45,6 +45,9 @@ int32_t proton_browser_session_respond_json(
 int32_t proton_browser_session_command_json(
     proton_browser_session_t *session, cef_browser_t *browser,
     const char *command_json, char *error, size_t error_len);
+int32_t proton_browser_navigation_state(
+    cef_browser_t *browser, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len);
 
 int proton_browser_session_before_browse(
     proton_browser_session_t *session, cef_frame_t *frame,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -581,4 +581,15 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_navigation_state(
+    proton_engine_view_t *view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1605,6 +1605,17 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_navigation_state(
+    proton_engine_window_t *window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 int32_t proton_engine_window_respond_browser_request_json(
     proton_engine_window_t *window, const char *response_json,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -746,4 +746,15 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_navigation_state(
+    proton_engine_view_t *view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -2170,6 +2170,17 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_navigation_state(
+    proton_engine_window_t *window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 int32_t proton_engine_window_respond_browser_request_json(
     proton_engine_window_t *window, const char *response_json,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -590,5 +590,16 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_navigation_state(
+    proton_engine_view_t *view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1790,6 +1790,17 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_navigation_state(
+    proton_engine_window_t *window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_navigation_state(
+      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
 int32_t proton_engine_window_respond_browser_request_json(
     proton_engine_window_t *window, const char *response_json,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1796,6 +1796,25 @@ int32_t proton_window_browser_command_json(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_get_navigation_state(
+    proton_window_handle_t window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "navigation state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_get_navigation_state(
+      slot->engine_window, out_can_go_back, out_can_go_forward, engine_error,
+      sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_respond_browser_request_json(
     proton_window_handle_t window, const char *response_json) {
   proton_window_slot_t *slot = NULL;
@@ -2567,6 +2586,25 @@ int32_t proton_view_browser_command_json(proton_view_handle_t view,
   if (status != PROTON_OK) {
     return proton_set_engine_status(status, engine_error);
   }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_get_navigation_state(
+    proton_view_handle_t view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_view == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "navigation state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_view_get_navigation_state(
+      slot->engine_view, out_can_go_back, out_can_go_forward, engine_error,
+      sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
   g_last_error[0] = '\0';
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -317,6 +317,9 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
 int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len);
+int32_t proton_engine_window_get_navigation_state(
+    proton_engine_window_t *window, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len);
 int32_t proton_engine_window_respond_browser_request_json(
     proton_engine_window_t *window, const char *response_json,
     char *error, size_t error_len);
@@ -419,6 +422,9 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 const char *command_json,
                                                 char *error,
                                                 size_t error_len);
+int32_t proton_engine_view_get_navigation_state(
+    proton_engine_view_t *view, int32_t *out_can_go_back,
+    int32_t *out_can_go_forward, char *error, size_t error_len);
 /* Session cookie and cache management. The engine implementation reaches the
    CEF cookie manager through the window's browser host request context. Cookie
    get completion is published to the runtime event queue; set, delete, flush,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1854,6 +1854,23 @@ pub fn Window::state(self : Window) -> WindowState raise NativeError {
 }
 
 ///|
+/// Returns whether the main browser has backward and forward history.
+pub fn Window::navigation_state(
+  self : Window,
+) -> (Bool, Bool) raise NativeError {
+  let can_go_back : Ref[Int] = { val: 0, }
+  let can_go_forward : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_get_navigation_state_ffi(
+      self.live_handle(),
+      can_go_back,
+      can_go_forward,
+    ),
+  )
+  (can_go_back.val != 0, can_go_forward.val != 0)
+}
+
+///|
 pub fn Window::set_close_interception(
   self : Window,
   enabled : Bool,
@@ -2658,6 +2675,21 @@ pub fn View::state(self : View) -> ViewState raise NativeError {
     visible: fields[4] != 0,
     z_order: fields[5],
   }
+}
+
+///|
+/// Returns whether this view has backward and forward history.
+pub fn View::navigation_state(self : View) -> (Bool, Bool) raise NativeError {
+  let can_go_back : Ref[Int] = { val: 0, }
+  let can_go_forward : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_view_get_navigation_state_ffi(
+      self.live_handle(),
+      can_go_back,
+      can_go_forward,
+    ),
+  )
+  (can_go_back.val != 0, can_go_forward.val != 0)
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add `can_go_back()` and `can_go_forward()` to `BrowserHandle` and `ViewHandle`
- add a synchronous native navigation-state query shared by main browsers and web contents views
- preserve stale-handle and native error handling through the facade

## Platform impact
- macOS, Windows, and Linux use the same CEF `can_go_back` / `can_go_forward` state

## Validation
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80` (597 passed)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon fmt --check`
- GitHub Actions: macOS, Windows, Linux, and format checks passed
