### PR TITLE
feat(window): add Electron-style bounds helpers

### DIFF
--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1259,6 +1259,30 @@ pub fn WindowHandle::content_size(
 }
 
 ///|
+/// Returns `(x, y, width, height)` in logical screen pixels, matching
+/// Electron's `getBounds` coordinate order.
+pub fn WindowHandle::bounds(
+  self : WindowHandle,
+) -> (Int, Int, Int, Int) raise WindowSessionError {
+  let state = (self.read_window_state)()
+  (state.x, state.y, state.width, state.height)
+}
+
+///|
+/// Sets `(x, y, width, height)` in logical screen pixels, matching Electron's
+/// `setBounds` coordinate order.
+pub fn WindowHandle::set_bounds(
+  self : WindowHandle,
+  x~ : Int,
+  y~ : Int,
+  width~ : Int,
+  height~ : Int,
+) -> Unit raise WindowSessionError {
+  self.set_position(x, y)
+  self.set_size(width, height)
+}
+
+///|
 pub fn WindowHandle::minimize(
   self : WindowHandle,
 ) -> Unit raise WindowSessionError {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -59,6 +59,7 @@ fn test_window_handle(
   id : String,
   native_id : Int64,
   position_calls? : Array[(Int, Int)],
+  size_calls? : Array[(Int, Int)],
   popup_calls? : Array[String],
   progress_calls? : Array[Double],
   flash_calls? : Array[Bool],
@@ -103,7 +104,12 @@ fn test_window_handle(
     set_window_title: fn(_title) {  },
     set_window_icon: fn(_path) {  },
     set_window_parent: fn(_parent, _modal) {  },
-    set_window_size: fn(_width, _height) {  },
+    set_window_size: (width, height) => {
+      match size_calls {
+        Some(calls) => calls.push((width, height))
+        None => ()
+      }
+    },
     set_window_button_visibility: fn(_visible) {  },
     set_window_content_size: (width, height) => {
       match content_size_calls {
@@ -2466,6 +2472,41 @@ test "window center uses the current monitor work area and frame size" {
   })
   window.center()
   debug_inspect(position_calls, content="[(560, 240)]")
+}
+
+///|
+test "window bounds read and write use Electron coordinate order" {
+  let position_calls : Array[(Int, Int)] = []
+  let size_calls : Array[(Int, Int)] = []
+  let window = test_window_handle("main", 17L, position_calls~, size_calls~, window_state=WindowState::{
+    x: 120,
+    y: 80,
+    width: 800,
+    height: 600,
+    monitor: WindowMonitor::{
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+      work_x: 0,
+      work_y: 0,
+      work_width: 1920,
+      work_height: 1080,
+      scale_factor_percent: 100,
+    },
+    zoom_percent: 100,
+    visible: true,
+    focused: true,
+    minimized: false,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: "system",
+  })
+  assert_eq(window.bounds(), (120, 80, 800, 600))
+  window.set_bounds(x=40, y=50, width=640, height=480)
+  debug_inspect(position_calls, content="[(40, 50)]")
+  debug_inspect(size_calls, content="[(640, 480)]")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add `WindowHandle::bounds()` returning `(x, y, width, height)` in logical screen pixels
- add `WindowHandle::set_bounds(x~, y~, width~, height~)` using Electron-compatible coordinate order
- compose the existing cross-platform state, position, and size operations without adding another native ABI path
- add facade routing tests for reading and writing bounds

## Platform impact
- macOS, Windows, and Linux reuse their existing window state and geometry implementations

## Validation
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80` (597 passed)
- `moon fmt --check`
- `git diff --check`
- Windows e2e rerun is in progress after a transient CDP disconnect
