### PR TITLE
feat(browser): expose main browser zoom controls

### DIFF
--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -587,6 +587,24 @@ fn RuntimeSession::browser_handle(
         window.browser_command(command, download_id?)
       })
     },
+    set_browser_zoom_percent: zoom_percent => {
+      self.control_window(id, native_id, "set browser zoom", window => {
+        window.set_zoom_percent(zoom_percent)
+      })
+    },
+    read_browser_zoom_percent: () => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.state().zoom_percent catch {
+        error =>
+          raise window_operation_failed(
+            "read browser zoom in window " + id,
+            error,
+          )
+      }
+    },
   }
 }
 
@@ -1593,6 +1611,14 @@ pub fn WindowHandle::set_zoom_percent(
 }
 
 ///|
+/// Returns the main browser zoom percentage.
+pub fn WindowHandle::zoom_percent(
+  self : WindowHandle,
+) -> Int raise WindowSessionError {
+  (self.read_window_state)().zoom_percent
+}
+
+///|
 /// Sets the platform progress indicator using Electron-compatible values.
 ///
 /// Pass a negative value to clear the indicator, a value from `0.0` through
@@ -1846,6 +1872,23 @@ pub fn BrowserHandle::forward(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
   (self.send_browser_command)("forward", None)
+}
+
+///|
+/// Sets the main browser zoom from 25% through 500%.
+pub fn BrowserHandle::set_zoom_percent(
+  self : BrowserHandle,
+  zoom_percent : Int,
+) -> Unit raise WindowSessionError {
+  (self.set_browser_zoom_percent)(zoom_percent)
+}
+
+///|
+/// Returns the main browser zoom percentage.
+pub fn BrowserHandle::zoom_percent(
+  self : BrowserHandle,
+) -> Int raise WindowSessionError {
+  (self.read_browser_zoom_percent)()
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -401,6 +401,8 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
+  read_browser_zoom_percent : () -> Int raise WindowSessionError
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -92,6 +92,8 @@ fn test_window_handle(
     load_browser_html: fn(_html, _base_url) {  },
     eval_browser_script: fn(_script) {  },
     send_browser_command: fn(_command, _download_id) {  },
+    set_browser_zoom_percent: fn(_zoom_percent) {  },
+    read_browser_zoom_percent: fn() { 100 },
   }
   WindowHandle::{
     id,


### PR DESCRIPTION
## Summary
- add `BrowserHandle::set_zoom_percent()` for the main browser
- add `BrowserHandle::zoom_percent()` and `WindowHandle::zoom_percent()` reads
- reuse the existing native window/main-browser zoom implementation
- preserve the existing 25% through 500% validation range

## Scope
- this PR covers `WindowHandle` and the main `BrowserHandle`
- independent `ViewHandle` zoom is intentionally not included and requires separate native view state

## Validation
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80` (597 passed)
- `moon fmt --check`
- `git diff --check`
- GitHub Actions: macOS, Windows, Linux, and format checks passed
