### PR TITLE
feat(window): add inactive visibility controls

### DIFF
--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -105,6 +105,11 @@ fn RuntimeSession::window_handle(
     show_window: () => {
       self.control_window(id, native_id, "show", window => window.show())
     },
+    show_window_inactive: () => {
+      self.control_window(id, native_id, "show inactive", window => {
+        window.show_inactive()
+      })
+    },
     hide_window: () => {
       self.control_window(id, native_id, "hide", window => window.hide())
     },
@@ -1183,6 +1188,28 @@ pub fn WindowHandle::id(self : WindowHandle) -> String {
 ///|
 pub fn WindowHandle::show(self : WindowHandle) -> Unit raise WindowSessionError {
   (self.show_window)()
+}
+
+///|
+/// Shows the window without activating it.
+pub fn WindowHandle::show_inactive(
+  self : WindowHandle,
+) -> Unit raise WindowSessionError {
+  (self.show_window_inactive)()
+}
+
+///|
+pub fn WindowHandle::is_visible(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().visible
+}
+
+///|
+pub fn WindowHandle::is_focused(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().focused
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -434,6 +434,7 @@ pub struct WindowHandle {
   id : String
   native_id : Int64
   show_window : () -> Unit raise WindowSessionError
+  show_window_inactive : () -> Unit raise WindowSessionError
   hide_window : () -> Unit raise WindowSessionError
   close_window : () -> Unit raise WindowSessionError
   focus_window : () -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -97,6 +97,7 @@ fn test_window_handle(
     id,
     native_id,
     show_window: fn() {  },
+    show_window_inactive: fn() {  },
     hide_window: fn() {  },
     close_window: fn() {  },
     focus_window: fn() {  },

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -396,6 +396,9 @@ pub extern "C" fn proton_window_destroy_ffi(window : WindowHandle) -> Int = "pro
 pub extern "C" fn proton_window_show_ffi(window : WindowHandle) -> Int = "proton_window_show"
 
 ///|
+pub extern "C" fn proton_window_show_inactive_ffi(window : WindowHandle) -> Int = "proton_window_show_inactive"
+
+///|
 pub extern "C" fn proton_window_hide_ffi(window : WindowHandle) -> Int = "proton_window_hide"
 
 ///|

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -141,6 +141,7 @@ int32_t proton_notification_cleanup(void);
 
 int32_t proton_window_destroy(proton_window_handle_t window);
 int32_t proton_window_show(proton_window_handle_t window);
+int32_t proton_window_show_inactive(proton_window_handle_t window);
 int32_t proton_window_hide(proton_window_handle_t window);
 int32_t proton_window_close(proton_window_handle_t window);
 int32_t proton_window_focus(proton_window_handle_t window);

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -697,6 +697,17 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_show_inactive(proton_engine_window_t *window,
+                                           char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) return proton_engine_window_show(window, error, error_len);
+  gtk_widget_show_all(window->window);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_hide(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -1047,6 +1047,17 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_show_inactive(proton_engine_window_t *window,
+                                           char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) return proton_engine_window_show(window, error, error_len);
+  [window->window orderFront:nil];
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_hide(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -664,6 +664,17 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_show_inactive(proton_engine_window_t *window,
+                                           char *error, size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) return proton_engine_window_show(window, error, error_len);
+  ShowWindow(window->hwnd, SW_SHOWNOACTIVATE);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_minimum_size(
     proton_engine_window_t *window, int32_t width, int32_t height,
     char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -727,6 +727,21 @@ int32_t proton_window_show(proton_window_handle_t window) {
   return PROTON_OK;
 }
 
+int32_t proton_window_show_inactive(proton_window_handle_t window) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window != NULL) {
+    char engine_error[512] = {0};
+    status = proton_engine_window_show_inactive(
+        slot->engine_window, engine_error, sizeof(engine_error));
+    if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  }
+  slot->visible = true;
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_hide(proton_window_handle_t window) {
   proton_window_slot_t *slot = NULL;
   int32_t status = proton_get_window(window, &slot);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -190,6 +190,8 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
 int32_t proton_engine_window_show(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len);
+int32_t proton_engine_window_show_inactive(proton_engine_window_t *window,
+                                           char *error, size_t error_len);
 int32_t proton_engine_window_hide(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1232,6 +1232,11 @@ pub fn Window::show(self : Window) -> Unit raise NativeError {
 }
 
 ///|
+pub fn Window::show_inactive(self : Window) -> Unit raise NativeError {
+  check_status(@native_ffi.proton_window_show_inactive_ffi(self.live_handle()))
+}
+
+///|
 /// Borrows this owning window handle for APIs that must not destroy it.
 pub fn Window::as_ref(self : Window) -> WindowRef {
   WindowRef::unsafe_from_handle(


### PR DESCRIPTION
## Summary
- add `WindowHandle::show_inactive()` to show a window without activating it
- add `WindowHandle::is_visible()` and `WindowHandle::is_focused()` state queries
- preserve existing stale-window and native error handling

## Platform implementation
- macOS: `orderFront:` without making the window key or activating the app
- Windows: `ShowWindow(..., SW_SHOWNOACTIVATE)`
- Linux: `gtk_widget_show_all` without `gtk_window_present`

## Validation
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80` (597 passed)
- `moon fmt --check`
- `git diff --check`
- Windows e2e rerun is in progress after an unrelated scenario process access violation
