### PR TITLE
refactor(native): remove obsolete atomic initializer macro

### DIFF
--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
@@ -80,10 +80,10 @@ static char g_proton_engine_locale[PROTON_ENGINE_MAX_PATH_BYTES];
 static int32_t g_proton_remote_debugging_port =
     PROTON_REMOTE_DEBUGGING_DISABLED;
 static proton_engine_window_t *g_windows = NULL;
-static atomic_llong g_scheduled_pump_delay_ms = ATOMIC_VAR_INIT(-1);
-static atomic_uint g_wait_source_ready_mask = ATOMIC_VAR_INIT(PROTON_WAIT_NONE);
+static atomic_llong g_scheduled_pump_delay_ms = -1;
+static atomic_uint g_wait_source_ready_mask = PROTON_WAIT_NONE;
 /* Set only while this process is inside cef_do_message_loop_work. */
-static atomic_bool g_message_pump_active = ATOMIC_VAR_INIT(false);
+static atomic_bool g_message_pump_active = false;
 static proton_engine_runtime_t *g_active_runtime = NULL;
 
 /* The host loop's wake pipe. Process-wide rather than per-runtime: the

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_runtime.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_runtime.m
@@ -86,13 +86,13 @@ void proton_engine_window_unlock(void) {
   pthread_mutex_unlock(&g_proton_engine_window_lock);
 }
 static uint64_t g_next_view_native_id = 1;
-static atomic_bool g_external_message_pump_enabled = ATOMIC_VAR_INIT(false);
+static atomic_bool g_external_message_pump_enabled = false;
 // Main-thread only, so a plain bool: set by proton_engine_host_loop_begin and
 // cleared by proton_engine_host_loop_end, both of which refuse other threads.
 static bool g_host_loop_active = false;
-static atomic_llong g_scheduled_pump_deadline_ms = ATOMIC_VAR_INIT(-1);
-static atomic_bool g_message_pump_active = ATOMIC_VAR_INIT(false);
-static atomic_uint g_wait_source_ready_mask = ATOMIC_VAR_INIT(PROTON_WAIT_NONE);
+static atomic_llong g_scheduled_pump_deadline_ms = -1;
+static atomic_bool g_message_pump_active = false;
+static atomic_uint g_wait_source_ready_mask = PROTON_WAIT_NONE;
 static CFRunLoopRef g_wait_run_loop = NULL;
 static CFRunLoopSourceRef g_wait_source = NULL;
 


### PR DESCRIPTION
## Summary

- replace the seven remaining `ATOMIC_VAR_INIT` uses with direct atomic initializers
- keep runtime initialization through `atomic_init` unchanged
- align the native runtime sources with C23, where `ATOMIC_VAR_INIT` was removed

## Validation

- `moon fmt`
- `moon info`
- `moon -C proton test internal/native --target native --diagnostic-limit 80` (29 passed)