### PR TITLE
build: stop overriding the native compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,6 @@ jobs:
         timeout-minutes: 25
         env:
           PROTON_BRIDGE_E2E_TIMEOUT_MS: 60000
-          MOON_CC: clang
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             xvfb-run -a moon -C e2e run test --target native \

--- a/cli/build_cmd/build.mbt
+++ b/cli/build_cmd/build.mbt
@@ -272,32 +272,6 @@ async fn project_build_invocation(
 }
 
 ///|
-fn native_moon_process_env_for(
-  windows : Bool,
-  configured_cc : String?,
-) -> Map[String, String] {
-  let env : Map[String, String] = Map([])
-  if !windows {
-    // Selecting a host compiler makes Moon build its C runtime from source
-    // instead of linking libmoonbitrun.o, whose process-wide allocator symbols
-    // would otherwise interpose on CEF and libc allocations.
-    env["MOON_CC"] = match configured_cc {
-      Some(value) if value.trim() != "" => value
-      // Proton's shared native-stub package contains Objective-C sources even
-      // on Linux, so its portable host-compiler default must be Clang.
-      _ => "clang"
-    }
-  }
-  env
-}
-
-///|
-/// Returns the environment required for a Proton native Moon command.
-pub fn native_moon_process_env() -> Map[String, String] {
-  native_moon_process_env_for(@path.sep == '\\', @env.get_env_var("MOON_CC"))
-}
-
-///|
 fn build_options_from_matches(
   matches : @argparse.Matches,
 ) -> RawBuildOptions raise BuildUsageError {
@@ -516,12 +490,7 @@ async fn run_moon_build(
     app_package, moon_args, moon_target_dir,
   )
   @output.info("Building Proton app: moon " + args.join(" "))
-  let code = @process.run(
-    "moon",
-    args,
-    cwd=root,
-    extra_env=native_moon_process_env(),
-  ) catch {
+  let code = @process.run("moon", args, cwd=root) catch {
     err =>
       raise BuildProcessError::Start(
         command="MoonBit build",
@@ -616,12 +585,7 @@ async fn run_moon_build_only(
 ) -> String {
   let args = moon_build_only_args(app_package, release)
   @output.info("Building Proton executable: moon " + args.join(" "))
-  let (code, stdout) = @process.collect_stdout(
-    "moon",
-    args,
-    cwd=root,
-    extra_env=native_moon_process_env(),
-  ) catch {
+  let (code, stdout) = @process.collect_stdout("moon", args, cwd=root) catch {
     error =>
       raise BuildProcessError::Start(
         command="MoonBit executable build",

--- a/cli/build_cmd/build_wbtest.mbt
+++ b/cli/build_cmd/build_wbtest.mbt
@@ -133,17 +133,6 @@ test "moon build-only output rejects missing or ambiguous artifacts" {
 }
 
 ///|
-test "native Moon commands select a source-built runtime on Unix" {
-  @debug.assert_eq(native_moon_process_env_for(false, None), {
-    "MOON_CC": "clang",
-  })
-  @debug.assert_eq(native_moon_process_env_for(false, Some("clang")), {
-    "MOON_CC": "clang",
-  })
-  @debug.assert_eq(native_moon_process_env_for(true, None), Map([]))
-}
-
-///|
 test "frontend release requires dist" {
   let config = @proton_config.ProjectConfig(
     ".",

--- a/cli/build_cmd/pkg.generated.mbti
+++ b/cli/build_cmd/pkg.generated.mbti
@@ -12,8 +12,6 @@ pub async fn build_executable(String, String, String, Bool) -> String
 
 pub fn command() -> @argparse.Command
 
-pub fn native_moon_process_env() -> Map[String, String]
-
 pub async fn run(String, @argparse.Matches) -> Unit
 
 // Errors

--- a/cli/dev/dev.mbt
+++ b/cli/dev/dev.mbt
@@ -910,11 +910,7 @@ async fn run_app(
     }
   }
   @output.info("Starting Proton app: moon " + moon_args.join(" "))
-  let moon_env = @build.native_moon_process_env()
-  for key, value in env {
-    moon_env[key] = value
-  }
-  let code = @process.run("moon", moon_args, cwd=root, extra_env=moon_env) catch {
+  let code = @process.run("moon", moon_args, cwd=root, extra_env=env) catch {
     err => raise Start(role="MoonBit app", detail=@debug.render(Repr(err)))
   }
   code

--- a/cli/dev/moon.pkg
+++ b/cli/dev/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbit-community/proton_config",
-  "moonbit-community/proton_cli/build_cmd" @build,
   "moonbit-community/proton_cli/fsutil",
   "moonbit-community/proton_cli/output",
   "moonbit-community/proton_cefsetup/store" @cef_store,

--- a/e2e/test/orchestration.mbt
+++ b/e2e/test/orchestration.mbt
@@ -109,13 +109,6 @@ async fn app_process_env(
   result[app_child_scenario_env] = scenario
   result[path_key] = prepend_env_path(bin_dir, current_path)
   if @path.sep != '\\' {
-    // Selecting a host compiler makes Moon compile its runtime sources instead
-    // of linking libmoonbitrun.o. This keeps Moon's allocator symbols from
-    // interposing on CEF and libc allocations in the same Unix process.
-    result["MOON_CC"] = match @env.get_env_var("MOON_CC") {
-      Some(value) if value.trim() != "" => value
-      _ => "clang"
-    }
     result["LD_LIBRARY_PATH"] = prepend_env_path(
       lib_dir,
       prepend_env_path(


### PR DESCRIPTION
## Summary

- stop forcing `MOON_CC=clang` in Proton CLI builds and dev runs
- let self-hosted E2E exercise the same default native toolchain path as user applications
- remove the obsolete compiler-environment helper and its test

## Rationale

The workaround avoided an older `libmoonbitrun.o` allocator interposition bug where `malloc_usable_size` was not redirected consistently. Current MoonBit toolchains include the matching allocator symbol, so keeping the override makes CI validate a different build path from ordinary MoonBit users.

## Validation

- `moon fmt`
- `moon info`
- `moon -C cli test -p moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/dev --target native --no-parallelize --diagnostic-limit 80`
- `PROTON_BRIDGE_E2E_TIMEOUT_MS=60000 moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`