### PR TITLE
refactor(runtime): centralize asynchronous shutdown coordination

### DIFF
--- a/proton/build.mjs
+++ b/proton/build.mjs
@@ -50,46 +50,14 @@ function runtimeStoreRoot(env) {
   return path.resolve(home, ".proton", "store");
 }
 
-function runtimeInstallation(env) {
+function cefSdkRoot(env) {
   const platform = runtimePlatformId();
   const requirement = runtimeRequirements[platform];
   if (!requirement?.supported) {
     throw new Error(`The Proton CEF backend is not supported for ${platform}`);
   }
   const id = `cef-${requirement.sha256}-layout-${runtimeLayoutVersion}`;
-  return {
-    platform,
-    requirement,
-    root: path.join(runtimeStoreRoot(env), platform, id),
-  };
-}
-
-function installedCefRoot(env) {
-  const installation = runtimeInstallation(env);
-  const manifestPath = path.join(installation.root, "manifest.json");
-  if (!fs.existsSync(manifestPath)) {
-    throw new Error(
-      `The required Proton runtime is not installed: ${installation.root}\n` +
-      "Run `moonx moonbit-community/proton_cefsetup`.",
-    );
-  }
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  if (manifest.schema_version !== 1 ||
-      manifest.platform !== installation.platform ||
-      manifest.cef_archive !== installation.requirement.archive ||
-      manifest.cef_sha256 !== installation.requirement.sha256 ||
-      manifest.layout_version !== runtimeLayoutVersion ||
-      manifest.sdk !== "sdk" ||
-      manifest.runtime !== "runtime") {
-    throw new Error(
-      `Invalid Proton runtime manifest: ${manifestPath}`,
-    );
-  }
-  const cefRoot = path.join(installation.root, manifest.sdk);
-  if (!fs.existsSync(cefRoot)) {
-    throw new Error(`CEF SDK does not exist: ${cefRoot}`);
-  }
-  return cefRoot;
+  return path.join(runtimeStoreRoot(env), platform, id, "sdk");
 }
 
 function pkgConfig(args) {
@@ -170,7 +138,7 @@ export function createNativeLinkConfig(env = readPayloadEnv()) {
   if (envValue(env, "PROTON_CEF_SETUP_BOOTSTRAP") === "1") {
     return { vars: {}, link_configs: [] };
   }
-  const cefRoot = installedCefRoot(env);
+  const cefRoot = cefSdkRoot(env);
   const config = platformConfig(cefRoot, env);
   return {
     vars: {

--- a/proton/facade_dialog.mbt
+++ b/proton/facade_dialog.mbt
@@ -31,20 +31,21 @@ fn DialogCompletionStore::remove(
 }
 
 ///|
-fn DialogCompletionStore::complete(
+fn DialogCompletionStore::route_completion(
   self : DialogCompletionStore,
   completion : @native.NativeDialogCompletion?,
-) -> Unit {
-  guard completion is Some(completion) else { return }
+) -> Bool {
+  guard completion is Some(completion) else { return false }
   for pending in self.pending {
     if pending.dialog == completion.dialog {
       if pending.state is Waiting {
         pending.state = Completed(completion.result)
         pending.changed.broadcast()
       }
-      return
+      return true
     }
   }
+  true
 }
 
 ///|
@@ -65,36 +66,16 @@ async fn DialogCompletionStore::wait(
 }
 
 ///|
-fn drain_failure_dialog_events(
-  runtime : @native.Runtime,
-  completions : DialogCompletionStore,
-) -> Unit raise @native.NativeError {
-  while true {
-    match runtime.poll_event() {
-      Some(event) => completions.complete(event.dialog_completion())
-      None => return
-    }
-  }
-}
-
-///|
 async fn wait_for_failure_dialog(
-  runtime : @native.Runtime,
-  completions : DialogCompletionStore,
+  events : RuntimeEventPump,
   wakeup : RuntimeWakeup,
   dialog : Int64,
 ) -> Unit raise AppRunError {
-  let completion = completions.register(dialog)
-  defer completions.remove(dialog)
-  while completion.state is Waiting {
-    let revision = wakeup.revision()
-    drain_failure_dialog_events(runtime, completions) catch {
-      error => raise native_run_error("receive dialog completion", error)
-    }
-    if completion.state is Waiting {
-      wakeup.wait_after(revision)
-    }
-  }
+  let completion = events.dialog_completions.register(dialog)
+  defer events.dialog_completions.remove(dialog)
+  drive_wakeup_until(wakeup, () => !(completion.state is Waiting), () => {
+    events.poll_native_events()
+  })
   match completion.state {
     Completed(Ok(_)) => ()
     Completed(Err(error)) =>

--- a/proton/facade_lifecycle.mbt
+++ b/proton/facade_lifecycle.mbt
@@ -70,13 +70,14 @@ fn AppLifecycle::finish(self : AppLifecycle) -> Unit {
 }
 
 ///|
-fn app_cleanup(
+async fn app_cleanup(
   lifecycle : AppLifecycle,
   runtime : @native.Runtime,
   windows : Array[RunningWindow],
   command_host : CommandHostRuntime?,
+  wakeup : RuntimeWakeup,
   lifecycle_failures? : Array[AppCleanupError] = [],
-) -> Array[AppCleanupError] {
+) -> Array[AppCleanupError] noraise {
   lifecycle.begin_draining()
   let failures = lifecycle_failures.copy()
   for error in close_command_host(command_host) {
@@ -92,11 +93,45 @@ fn app_cleanup(
     }
   }
   let failure_count = failures.length()
-  runtime.destroy() catch {
+  let mut destroy_started = false
+  runtime.begin_destroy() catch {
     error =>
       failures.push(
         RuntimeDestroy(status=error.status(), detail=error.message()),
       )
+  }
+  if failures.length() == failure_count {
+    destroy_started = true
+  }
+  if destroy_started {
+    let mut ready = false
+    while !ready {
+      let revision = wakeup.revision()
+      ready = runtime.destroy_ready() catch {
+        error => {
+          failures.push(
+            RuntimeDestroy(status=error.status(), detail=error.message()),
+          )
+          true
+        }
+      }
+      if !ready {
+        wakeup.wait_after(revision) catch {
+          error => {
+            failures.push(RuntimeDestroy(status=-1, detail=error.message()))
+            ready = true
+          }
+        }
+      }
+    }
+  }
+  if destroy_started && failures.length() == failure_count {
+    runtime.finish_destroy() catch {
+      error =>
+        failures.push(
+          RuntimeDestroy(status=error.status(), detail=error.message()),
+        )
+    }
   }
   if failures.length() == failure_count {
     lifecycle.finish()

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -182,6 +182,8 @@ async fn run_manifest(
   ) catch {
     error => raise native_run_error("create runtime", error)
   }
+  let wakeup = RuntimeWakeup()
+  let dialog_completions = DialogCompletionStore()
   match app_instance {
     Some(instance) =>
       instance.attach_runtime(runtime) catch {
@@ -189,7 +191,7 @@ async fn run_manifest(
           let attach_error = native_run_error("attach app instance", error)
           let failure = cleanup_run_error(
             Some(attach_error),
-            app_cleanup(lifecycle, runtime, [], None),
+            app_cleanup(lifecycle, runtime, [], None, wakeup),
           )
           match failure {
             Some(cleanup_error) => raise cleanup_error
@@ -202,8 +204,6 @@ async fn run_manifest(
   let mut command_host : CommandHostRuntime? = None
   let windows : Array[RunningWindow] = []
   let lifecycle_failures : Array[AppCleanupError] = []
-  let wakeup = RuntimeWakeup()
-  let dialog_completions = DialogCompletionStore()
   try {
     if !headless {
       let platform = @native.runtime_info().platform catch {
@@ -360,7 +360,7 @@ async fn run_manifest(
           session.wait_for_bridge_startup(bridge_startup_timeout_ms) catch {
             error => raise normalize_async_run_error(error)
           }
-          if !session.quit_requested {
+          if !session.is_quitting() {
             @xlog.info(category="proton.bridge") <?
               {
                 "message": "renderer bridge ready",
@@ -368,7 +368,7 @@ async fn run_manifest(
               }
           }
         }
-        if !session.quit_requested {
+        if !session.is_quitting() {
           // A source may enqueue synchronously from start(). Initial windows must
           // be able to receive those events before native production begins.
           session.start_extension_event_sources()
@@ -414,6 +414,7 @@ async fn run_manifest(
           runtime,
           windows,
           command_host,
+          wakeup,
           lifecycle_failures~,
         ),
       )
@@ -431,6 +432,7 @@ async fn run_manifest(
         runtime,
         windows,
         command_host,
+        wakeup,
         lifecycle_failures~,
       ),
     ) {

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -184,6 +184,7 @@ async fn run_manifest(
   }
   let wakeup = RuntimeWakeup()
   let dialog_completions = DialogCompletionStore()
+  let event_pump = RuntimeEventPump(runtime, dialog_completions)
   match app_instance {
     Some(instance) =>
       instance.attach_runtime(runtime) catch {
@@ -329,7 +330,7 @@ async fn run_manifest(
     @async.with_task_group(application_tasks => {
       @async.with_task_group(window_tasks => {
         let session = RuntimeSession(
-          runtime, locale_preferences, definitions, windows, command_host, dialog_completions,
+          runtime, event_pump, locale_preferences, definitions, windows, command_host,
           wakeup, forward_menu_events, bridge_enabled, launch_input_handlers, window_event_handlers,
           application_tasks, last_window_closed_policy, window_tasks, view_event_handlers,
           window_close_handler, window_lifecycle_hooks, lifecycle_failures, bridge_startup_timeout_ms,
@@ -397,8 +398,8 @@ async fn run_manifest(
       if !headless {
         show_app_run_failure(
           runtime,
+          event_pump,
           preferred_active_window(windows).map(window => window.window),
-          dialog_completions,
           wakeup,
           primary,
           locale_preferences,
@@ -755,7 +756,7 @@ fn app_run_error_dialog_text(error : AppRunError) -> String {
 ///|
 async fn show_runtime_failure_dialog(
   runtime : @native.Runtime,
-  dialog_completions : DialogCompletionStore,
+  event_pump : RuntimeEventPump,
   wakeup : RuntimeWakeup,
   detail : String,
   preferences : @locale.LocalePreferences,
@@ -777,16 +778,15 @@ async fn show_runtime_failure_dialog(
   ) catch {
     _ => return
   }
-  wait_for_failure_dialog(runtime, dialog_completions, wakeup, dialog) catch {
+  wait_for_failure_dialog(event_pump, wakeup, dialog) catch {
     _ => return
   }
 }
 
 ///|
 async fn show_window_failure_dialog(
-  runtime : @native.Runtime,
   window : @native.WindowRef,
-  dialog_completions : DialogCompletionStore,
+  event_pump : RuntimeEventPump,
   wakeup : RuntimeWakeup,
   detail : String,
   preferences : @locale.LocalePreferences,
@@ -802,7 +802,7 @@ async fn show_window_failure_dialog(
   ) catch {
     _ => return false
   }
-  wait_for_failure_dialog(runtime, dialog_completions, wakeup, dialog) catch {
+  wait_for_failure_dialog(event_pump, wakeup, dialog) catch {
     _ => return false
   }
   true
@@ -811,8 +811,8 @@ async fn show_window_failure_dialog(
 ///|
 async fn show_app_run_failure(
   runtime : @native.Runtime,
+  event_pump : RuntimeEventPump,
   window : @native.Window?,
-  dialog_completions : DialogCompletionStore,
   wakeup : RuntimeWakeup,
   error : AppRunError,
   preferences : @locale.LocalePreferences,
@@ -823,9 +823,8 @@ async fn show_app_run_failure(
     match window {
       Some(window) =>
         if show_window_failure_dialog(
-            runtime,
             window.as_ref(),
-            dialog_completions,
+            event_pump,
             wakeup,
             message,
             preferences,
@@ -836,7 +835,7 @@ async fn show_app_run_failure(
     }
   }
   show_runtime_failure_dialog(
-    runtime, dialog_completions, wakeup, message, preferences, application_started,
+    runtime, event_pump, wakeup, message, preferences, application_started,
   )
 }
 

--- a/proton/facade_runtime_events.mbt
+++ b/proton/facade_runtime_events.mbt
@@ -1,0 +1,51 @@
+///|
+fn RuntimeEventPump::RuntimeEventPump(
+  runtime : @native.Runtime,
+  dialog_completions : DialogCompletionStore,
+) -> RuntimeEventPump {
+  RuntimeEventPump::{ runtime, dialog_completions, session_events: [], }
+}
+
+///|
+/// Pulls every currently available native event into its single MoonBit owner.
+/// Dialog completions wake their registered waiter; all other events remain
+/// queued for the runtime session.
+fn RuntimeEventPump::poll_native_events(
+  self : RuntimeEventPump,
+) -> Bool raise AppRunError {
+  let mut did_work = false
+  let mut polling = true
+  while polling {
+    let event = self.runtime.poll_event() catch {
+      error => raise native_run_error("poll event", error)
+    }
+    match event {
+      None => polling = false
+      Some(event) => {
+        did_work = true
+        if !self.dialog_completions.route_completion(event.dialog_completion()) {
+          self.session_events.push(event)
+        }
+      }
+    }
+  }
+  did_work
+}
+
+///|
+/// Dispatches queued non-dialog events without allowing another component to
+/// consume the native queue. The inbox is cleared only after the whole batch
+/// dispatches successfully.
+fn RuntimeEventPump::drain_session_events(
+  self : RuntimeEventPump,
+  dispatch : (@native.RuntimeEvent) -> Unit raise AppRunError,
+) -> Bool raise AppRunError {
+  let did_work = self.poll_native_events()
+  guard !self.session_events.is_empty() else { return did_work }
+  let queued = self.session_events.copy()
+  for event in queued {
+    dispatch(event)
+  }
+  self.session_events.clear()
+  true
+}

--- a/proton/facade_runtime_wakeup.mbt
+++ b/proton/facade_runtime_wakeup.mbt
@@ -32,3 +32,33 @@ async fn RuntimeWakeup::wait_after(
     error => raise normalize_async_run_error(error)
   }
 }
+
+///|
+/// Drives one wake-based state machine until its completion predicate holds.
+///
+/// Capturing the revision before checking state closes the notification race:
+/// work arriving between the check and suspension changes the revision, so
+/// `wait_after` returns instead of sleeping indefinitely.
+async fn drive_wakeup_until(
+  wakeup : RuntimeWakeup,
+  complete : () -> Bool raise AppRunError,
+  advance : () -> Bool raise AppRunError,
+) -> Unit raise AppRunError {
+  while true {
+    let revision = wakeup.revision()
+    if complete() {
+      return
+    }
+    let did_work = advance()
+    if complete() {
+      return
+    }
+    if did_work {
+      @async.pause() catch {
+        error => raise normalize_async_run_error(error)
+      }
+    } else {
+      wakeup.wait_after(revision)
+    }
+  }
+}

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1,11 +1,11 @@
 ///|
 fn RuntimeSession::RuntimeSession(
   runtime : @native.Runtime,
+  event_pump : RuntimeEventPump,
   locale_preferences : @locale.LocalePreferences,
   definitions : Array[PreparedWindow],
   windows : Array[RunningWindow],
   command_host : CommandHostRuntime?,
-  dialog_completions : DialogCompletionStore,
   wakeup : RuntimeWakeup,
   forward_menu_events : Bool,
   monitor_bridge : Bool,
@@ -34,13 +34,13 @@ fn RuntimeSession::RuntimeSession(
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
+    event_pump,
     locale_preferences,
     definitions,
     windows,
     has_created_window: windows.length() > 0,
     command_host,
     pending_bridge: [],
-    dialog_completions,
     wakeup,
     forward_menu_events,
     monitor_bridge,
@@ -2039,22 +2039,14 @@ async fn RuntimeSession::wait_for_bridge_startup(
   timeout_ms : Int,
 ) -> Unit raise AppRunError {
   let completed = @async.with_timeout_opt(timeout_ms, () => {
-    while true {
-      let revision = self.wakeup.revision()
-      let did_work = self.pump_once(monitor_bridge=false)
-      if self.is_quitting() {
-        return
-      }
-      match refresh_bridge_startup_states(self.windows) {
-        None => return
-        Some(_) =>
-          if did_work {
-            @async.pause()
-          } else {
-            self.wakeup.wait_after(revision)
-          }
-      }
-    }
+    drive_wakeup_until(
+      self.wakeup,
+      () => {
+        self.is_quitting() ||
+        refresh_bridge_startup_states(self.windows) is None
+      },
+      () => self.pump_once(monitor_bridge=false),
+    )
   }) catch {
     error => raise normalize_async_run_error(error)
   }
@@ -2080,17 +2072,9 @@ async fn RuntimeSession::wait_for_bridge_startup(
 
 ///|
 async fn RuntimeSession::run(self : RuntimeSession) -> Unit raise AppRunError {
-  while !self.quit_complete() {
-    let revision = self.wakeup.revision()
-    let did_work = self.pump_once(monitor_bridge=self.monitor_bridge)
-    if did_work {
-      @async.pause() catch {
-        error => raise normalize_async_run_error(error)
-      }
-    } else {
-      self.wakeup.wait_after(revision)
-    }
-  }
+  drive_wakeup_until(self.wakeup, () => self.quit_complete(), () => {
+    self.pump_once(monitor_bridge=self.monitor_bridge)
+  })
   self.cancel_all_bridge_tasks()
   self.close_coordinator.cancel_all()
   self.cancel_all_browser_requests()
@@ -2102,25 +2086,16 @@ async fn RuntimeSession::drive_until_complete(
   self : RuntimeSession,
   task : @async.Task[Unit],
 ) -> Unit raise AppRunError {
-  while true {
-    let revision = self.wakeup.revision()
-    let completed = task.try_wait() catch {
-      error => raise normalize_async_run_error(error)
-    }
-    match completed {
-      Some(_) => return
-      None => {
-        let did_work = self.pump_once(monitor_bridge=self.monitor_bridge)
-        if did_work {
-          @async.pause() catch {
-            error => raise normalize_async_run_error(error)
-          }
-        } else {
-          self.wakeup.wait_after(revision)
-        }
+  drive_wakeup_until(
+    self.wakeup,
+    () => {
+      let completed = task.try_wait() catch {
+        error => raise normalize_async_run_error(error)
       }
-    }
-  }
+      completed is Some(_)
+    },
+    () => self.pump_once(monitor_bridge=self.monitor_bridge),
+  )
 }
 
 ///|
@@ -2280,21 +2255,9 @@ fn RuntimeSession::forward_extension_event_to_granted_windows(
 fn RuntimeSession::drain_runtime_events(
   self : RuntimeSession,
 ) -> Bool raise AppRunError {
-  let mut did_work = false
-  let mut polling = true
-  while polling {
-    let event = self.runtime.poll_event() catch {
-      error => raise native_run_error("poll event", error)
-    }
-    match event {
-      None => polling = false
-      Some(event) => {
-        did_work = true
-        self.dispatch_runtime_event(event)
-      }
-    }
-  }
-  did_work
+  self.event_pump.drain_session_events(event => {
+    self.dispatch_runtime_event(event)
+  })
 }
 
 ///|
@@ -2312,7 +2275,6 @@ fn RuntimeSession::dispatch_runtime_event(
   self.dispatch_notification_event(event)
   self.dispatch_launch_input_event(event)
   self.dispatch_menu_event(event)
-  self.dialog_completions.complete(event.dialog_completion())
   match event.bridge_request() {
     Some(request) => self.start_bridge_request(request)
     None => ()
@@ -3012,7 +2974,7 @@ fn RuntimeSession::start_bridge_request(
             host,
             request,
             self.wakeup.signal,
-            self.dialog_completions,
+            self.event_pump.dialog_completions,
             self.locale_preferences,
           )
         },

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -65,8 +65,8 @@ fn RuntimeSession::RuntimeSession(
     certificate_handler,
     media_handler,
     download_event_handlers,
-    quit_requested: false,
-    quit_close_started: false,
+    shutdown_state: SessionRunning,
+    pending_quit_decisions: [],
   }
 }
 
@@ -966,7 +966,7 @@ async fn RuntimeSession::request_open_window(
   self : RuntimeSession,
   id : String,
 ) -> WindowHandle raise WindowSessionError {
-  if self.quit_requested {
+  if self.is_quitting() {
     raise ApplicationQuitting
   }
   let completion = WindowOpenCompletion()
@@ -1028,7 +1028,7 @@ fn RuntimeSession::process_window_commands(self : RuntimeSession) -> Bool {
   self.window_commands.clear()
   for command in commands {
     let Open(id, completion) = command
-    if self.quit_requested {
+    if self.is_quitting() {
       completion.fail(ApplicationQuitting)
       continue
     }
@@ -1987,7 +1987,7 @@ async fn RuntimeSession::wait_for_bridge_startup(
     while true {
       let revision = self.wakeup.revision()
       let did_work = self.pump_once(monitor_bridge=false)
-      if self.quit_requested {
+      if self.is_quitting() {
         return
       }
       match refresh_bridge_startup_states(self.windows) {
@@ -2007,7 +2007,7 @@ async fn RuntimeSession::wait_for_bridge_startup(
     Some(_) => ()
     None => {
       ignore(self.pump_once(monitor_bridge=false))
-      if self.quit_requested {
+      if self.is_quitting() {
         return
       }
       match refresh_bridge_startup_states(self.windows) {
@@ -2711,6 +2711,12 @@ fn RuntimeSession::start_window_close_request(
 ) -> Unit {
   guard self.window_close_handler is Some(handler) else { return }
   guard self.find_window_by_native_id(window_id) is Some(window) else { return }
+  for pending in self.pending_quit_decisions {
+    if pending.window == window_id {
+      pending.native_request = Some(request_id)
+      return
+    }
+  }
   window.state = WindowCloseRequested
   let handle = self.window_handle(window)
   let task = self.window_tasks.spawn(
@@ -2756,10 +2762,6 @@ fn RuntimeSession::complete_window_close_requests(
               window.state = WindowCloseRequested
             } else {
               window.state = WindowOpen
-              if self.quit_requested {
-                self.quit_requested = false
-                self.quit_close_started = false
-              }
             }
           }
           _ => ()
@@ -2839,7 +2841,7 @@ fn RuntimeSession::dispatch_launch_input_event(
 ) -> Unit raise AppRunError {
   match event.launch_input() {
     Some(native_input) => {
-      guard !self.quit_requested else { return }
+      guard !self.is_quitting() else { return }
       let input = match native_input {
         @native.RuntimeLaunchInput::OpenUrls(urls) =>
           RuntimeLaunchInput::OpenUrls(urls)
@@ -2947,7 +2949,7 @@ fn RuntimeSession::dispatch_menu_event(
 fn RuntimeSession::check_bridge_failures(
   self : RuntimeSession,
 ) -> Unit raise AppRunError {
-  guard !self.quit_requested else { return }
+  guard !self.is_quitting() else { return }
   for running in self.windows {
     if !running.is_active() {
       continue
@@ -3110,6 +3112,7 @@ fn RuntimeSession::retire_closed_window(
   }
   guard index >= 0 else { return }
   let running = self.windows[index]
+  self.cancel_quit_decision_for_window(window_id)
   running.state = WindowClosed
   running.lifetime.close()
   running.window.destroy() catch {
@@ -3136,12 +3139,23 @@ fn should_quit_after_last_window(
 }
 
 ///|
+fn should_commit_application_close(
+  decisions : Array[WindowCloseDecision],
+) -> Bool {
+  decisions.all(fn(decision) { decision == WindowCloseDecision::Allow })
+}
+
+///|
 fn RuntimeSession::request_quit(self : RuntimeSession) -> Unit {
-  if !self.quit_requested {
-    self.quit_requested = true
-    self.quit_close_started = false
+  if self.shutdown_state == SessionRunning {
+    self.shutdown_state = SessionQuitRequested
     self.wakeup.signal.notify()
   }
+}
+
+///|
+fn RuntimeSession::is_quitting(self : RuntimeSession) -> Bool {
+  self.shutdown_state != SessionRunning
 }
 
 ///|
@@ -3149,7 +3163,7 @@ fn RuntimeSession::advance_application_lifetime(
   self : RuntimeSession,
 ) -> Bool raise AppRunError {
   let mut did_work = false
-  if !self.quit_requested &&
+  if self.shutdown_state == SessionRunning &&
     should_quit_after_last_window(
       self.last_window_closed_policy,
       self.has_created_window,
@@ -3158,29 +3172,198 @@ fn RuntimeSession::advance_application_lifetime(
     self.request_quit()
     did_work = true
   }
-  if self.quit_requested && !self.quit_close_started {
-    self.quit_close_started = true
-    did_work = true
-    for running in self.windows {
-      if !running.is_active() {
-        continue
-      }
-      running.window.close() catch {
-        error => raise native_run_error("close window " + running.id, error)
-      }
-      running.state = WindowCloseRequested
+  match self.shutdown_state {
+    SessionQuitRequested => {
+      self.begin_quit_decisions()
+      did_work = true
     }
+    SessionCollectingCloseDecisions =>
+      if self.advance_quit_decisions() {
+        did_work = true
+      }
+    SessionRunning | SessionClosingWindows => ()
   }
   did_work
 }
 
 ///|
+fn RuntimeSession::begin_quit_decisions(
+  self : RuntimeSession,
+) -> Unit raise AppRunError {
+  guard self.window_close_handler is Some(handler) else {
+    self.commit_application_close()
+    return
+  }
+  self.pending_quit_decisions.clear()
+  for pending in self.pending_window_closes {
+    self.pending_quit_decisions.push(PendingQuitDecision::{
+      window: pending.window,
+      task: pending.task,
+      decision: None,
+      native_request: Some(pending.request_id),
+    })
+  }
+  self.pending_window_closes.clear()
+  for running in self.windows {
+    guard running.is_active() else { continue }
+    let window_id = running.window.id()
+    guard !self.has_pending_quit_decision(window_id) else { continue }
+    let handle = self.window_handle(running)
+    let task = self.window_tasks.spawn(
+      () => {
+        defer self.wakeup.signal.notify()
+        handler(handle)
+      },
+      no_wait=true,
+    )
+    self.pending_quit_decisions.push(PendingQuitDecision::{
+      window: window_id,
+      task,
+      decision: None,
+      native_request: None,
+    })
+  }
+  if self.pending_quit_decisions.is_empty() {
+    self.commit_application_close()
+  } else {
+    self.shutdown_state = SessionCollectingCloseDecisions
+  }
+}
+
+///|
+fn RuntimeSession::has_pending_quit_decision(
+  self : RuntimeSession,
+  window_id : Int64,
+) -> Bool {
+  self.pending_quit_decisions.any(fn(pending) { pending.window == window_id })
+}
+
+///|
+fn RuntimeSession::advance_quit_decisions(
+  self : RuntimeSession,
+) -> Bool raise AppRunError {
+  let mut did_work = false
+  let mut waiting = false
+  let decisions : Array[WindowCloseDecision] = []
+  for pending in self.pending_quit_decisions {
+    if pending.decision is None {
+      let completed = pending.task.try_wait() catch {
+        _ => Some(WindowCloseDecision::Allow)
+      }
+      match completed {
+        Some(decision) => {
+          pending.decision = Some(decision)
+          did_work = true
+        }
+        None => waiting = true
+      }
+    }
+    match pending.decision {
+      Some(decision) => decisions.push(decision)
+      None => waiting = true
+    }
+  }
+  if waiting {
+    return did_work
+  }
+  if !should_commit_application_close(decisions) {
+    for pending in self.pending_quit_decisions {
+      guard pending.decision is Some(decision) else { continue }
+      if pending.native_request is Some(_) {
+        self.respond_quit_native_requests(pending, decision)
+      }
+    }
+    self.pending_quit_decisions.clear()
+    self.shutdown_state = SessionRunning
+  } else {
+    self.commit_application_close()
+  }
+  true
+}
+
+///|
+fn RuntimeSession::respond_quit_native_requests(
+  self : RuntimeSession,
+  pending : PendingQuitDecision,
+  decision : WindowCloseDecision,
+) -> Unit raise AppRunError {
+  match self.find_window_by_native_id(pending.window) {
+    Some(window) if !window.is_closed() => {
+      match pending.native_request {
+        Some(request_id) =>
+          window.window.respond_close_request(
+            request_id,
+            decision == WindowCloseDecision::Allow,
+          ) catch {
+            error =>
+              if !error.is_stale_window_request() {
+                raise native_run_error("respond to window close request", error)
+              }
+          }
+        None => ()
+      }
+      window.state = if decision == WindowCloseDecision::Allow {
+        WindowCloseRequested
+      } else {
+        WindowOpen
+      }
+    }
+    _ => ()
+  }
+  pending.native_request = None
+}
+
+///|
+fn RuntimeSession::cancel_quit_decision_for_window(
+  self : RuntimeSession,
+  window_id : Int64,
+) -> Unit {
+  let remaining : Array[PendingQuitDecision] = []
+  for pending in self.pending_quit_decisions {
+    if pending.window == window_id {
+      pending.task.cancel()
+    } else {
+      remaining.push(pending)
+    }
+  }
+  self.pending_quit_decisions.clear()
+  for pending in remaining {
+    self.pending_quit_decisions.push(pending)
+  }
+}
+
+///|
+fn RuntimeSession::commit_application_close(
+  self : RuntimeSession,
+) -> Unit raise AppRunError {
+  self.shutdown_state = SessionClosingWindows
+  self.pending_quit_decisions.clear()
+  for running in self.windows {
+    guard running.is_active() else { continue }
+    if self.window_close_handler is Some(_) {
+      running.window.set_close_interception(false) catch {
+        error =>
+          raise native_run_error(
+            "commit close interception for " + running.id,
+            error,
+          )
+      }
+    }
+    running.window.close() catch {
+      error => raise native_run_error("close window " + running.id, error)
+    }
+    running.state = WindowCloseRequested
+  }
+}
+
+///|
 fn RuntimeSession::quit_complete(self : RuntimeSession) -> Bool {
-  self.quit_requested &&
+  self.shutdown_state == SessionClosingWindows &&
   self.windows.all(fn(window) { window.is_closed() }) &&
   self.window_commands.length() == 0 &&
   self.pending_window_opens.length() == 0 &&
-  self.pending_window_closes.length() == 0
+  self.pending_window_closes.length() == 0 &&
+  self.pending_quit_decisions.length() == 0
 }
 
 ///|

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -56,7 +56,6 @@ fn RuntimeSession::RuntimeSession(
     bridge_startup_timeout_ms,
     window_commands: [],
     pending_window_opens: [],
-    pending_window_closes: [],
     pending_browser_requests: [],
     pending_resource_requests: [],
     navigation_handler,
@@ -65,9 +64,65 @@ fn RuntimeSession::RuntimeSession(
     certificate_handler,
     media_handler,
     download_event_handlers,
-    shutdown_state: SessionRunning,
-    pending_quit_decisions: [],
+    close_coordinator: CloseCoordinator(),
   }
+}
+
+///|
+fn CloseCoordinator::CloseCoordinator() -> CloseCoordinator {
+  CloseCoordinator::{ state: CloseRunning, pending: [], }
+}
+
+///|
+fn CloseCoordinator::request_quit(self : CloseCoordinator) -> Bool {
+  guard self.state == CloseRunning else { return false }
+  self.state = CloseQuitRequested
+  true
+}
+
+///|
+fn CloseCoordinator::is_quitting(self : CloseCoordinator) -> Bool {
+  self.state != CloseRunning
+}
+
+///|
+fn CloseCoordinator::find(
+  self : CloseCoordinator,
+  window_id : Int64,
+) -> PendingCloseDecision? {
+  for pending in self.pending {
+    if pending.window == window_id {
+      return Some(pending)
+    }
+  }
+  None
+}
+
+///|
+fn CloseCoordinator::cancel(
+  self : CloseCoordinator,
+  window_id : Int64?,
+) -> Unit {
+  let remaining : Array[PendingCloseDecision] = []
+  for pending in self.pending {
+    if window_id == Some(pending.window) {
+      pending.task.cancel()
+    } else {
+      remaining.push(pending)
+    }
+  }
+  self.pending.clear()
+  for pending in remaining {
+    self.pending.push(pending)
+  }
+}
+
+///|
+fn CloseCoordinator::cancel_all(self : CloseCoordinator) -> Unit {
+  for pending in self.pending {
+    pending.task.cancel()
+  }
+  self.pending.clear()
 }
 
 ///|
@@ -2037,7 +2092,7 @@ async fn RuntimeSession::run(self : RuntimeSession) -> Unit raise AppRunError {
     }
   }
   self.cancel_all_bridge_tasks()
-  self.cancel_all_window_close_requests()
+  self.close_coordinator.cancel_all()
   self.cancel_all_browser_requests()
   self.cancel_all_resource_requests()
 }
@@ -2087,9 +2142,6 @@ fn RuntimeSession::pump_once(
     did_work = true
   }
   if self.advance_window_opens() {
-    did_work = true
-  }
-  if self.complete_window_close_requests() {
     did_work = true
   }
   if self.complete_browser_requests() {
@@ -2276,7 +2328,7 @@ fn RuntimeSession::dispatch_window_event(
   if event.is_window_closed() {
     let window_id = event.window_id()
     runtime_session_cancel_window_bridge_tasks(self.pending_bridge, window_id)
-    self.cancel_window_close_requests(window_id)
+    self.close_coordinator.cancel(window_id)
     self.cancel_browser_requests(window_id)
     self.cancel_resource_requests_for_window(window_id)
     self.retire_closed_window(window_id)
@@ -2711,11 +2763,12 @@ fn RuntimeSession::start_window_close_request(
 ) -> Unit {
   guard self.window_close_handler is Some(handler) else { return }
   guard self.find_window_by_native_id(window_id) is Some(window) else { return }
-  for pending in self.pending_quit_decisions {
-    if pending.window == window_id {
+  match self.close_coordinator.find(window_id) {
+    Some(pending) => {
       pending.native_request = Some(request_id)
       return
     }
+    None => ()
   }
   window.state = WindowCloseRequested
   let handle = self.window_handle(window)
@@ -2726,83 +2779,35 @@ fn RuntimeSession::start_window_close_request(
     },
     no_wait=true,
   )
-  self.pending_window_closes.push(PendingWindowClose::{
+  self.close_coordinator.pending.push(PendingCloseDecision::{
     window: window_id,
-    request_id,
     task,
+    decision: None,
+    native_request: Some(request_id),
   })
 }
 
 ///|
-fn RuntimeSession::complete_window_close_requests(
+fn RuntimeSession::advance_individual_close_decisions(
   self : RuntimeSession,
 ) -> Bool raise AppRunError {
-  let remaining : Array[PendingWindowClose] = []
+  let remaining : Array[PendingCloseDecision] = []
   let mut did_work = false
-  for pending in self.pending_window_closes {
+  for pending in self.close_coordinator.pending {
     let completed = pending.task.try_wait() catch { _ => Some(Allow) }
     match completed {
       None => remaining.push(pending)
       Some(decision) => {
         did_work = true
-        match self.find_window_by_native_id(pending.window) {
-          Some(window) if !window.is_closed() => {
-            window.window.respond_close_request(
-              pending.request_id,
-              decision == Allow,
-            ) catch {
-              error =>
-                if !error.is_stale_window_request() {
-                  raise native_run_error(
-                    "respond to window close request", error,
-                  )
-                }
-            }
-            if decision == Allow {
-              window.state = WindowCloseRequested
-            } else {
-              window.state = WindowOpen
-            }
-          }
-          _ => ()
-        }
+        self.respond_close_decision(pending, decision)
       }
     }
   }
-  self.pending_window_closes.clear()
+  self.close_coordinator.pending.clear()
   for pending in remaining {
-    self.pending_window_closes.push(pending)
+    self.close_coordinator.pending.push(pending)
   }
   did_work
-}
-
-///|
-fn RuntimeSession::cancel_window_close_requests(
-  self : RuntimeSession,
-  window_id : Int64?,
-) -> Unit {
-  let remaining : Array[PendingWindowClose] = []
-  for pending in self.pending_window_closes {
-    if window_id == Some(pending.window) {
-      pending.task.cancel()
-    } else {
-      remaining.push(pending)
-    }
-  }
-  self.pending_window_closes.clear()
-  for pending in remaining {
-    self.pending_window_closes.push(pending)
-  }
-}
-
-///|
-fn RuntimeSession::cancel_all_window_close_requests(
-  self : RuntimeSession,
-) -> Unit {
-  for pending in self.pending_window_closes {
-    pending.task.cancel()
-  }
-  self.pending_window_closes.clear()
 }
 
 ///|
@@ -3112,7 +3117,6 @@ fn RuntimeSession::retire_closed_window(
   }
   guard index >= 0 else { return }
   let running = self.windows[index]
-  self.cancel_quit_decision_for_window(window_id)
   running.state = WindowClosed
   running.lifetime.close()
   running.window.destroy() catch {
@@ -3147,15 +3151,14 @@ fn should_commit_application_close(
 
 ///|
 fn RuntimeSession::request_quit(self : RuntimeSession) -> Unit {
-  if self.shutdown_state == SessionRunning {
-    self.shutdown_state = SessionQuitRequested
+  if self.close_coordinator.request_quit() {
     self.wakeup.signal.notify()
   }
 }
 
 ///|
 fn RuntimeSession::is_quitting(self : RuntimeSession) -> Bool {
-  self.shutdown_state != SessionRunning
+  self.close_coordinator.is_quitting()
 }
 
 ///|
@@ -3163,7 +3166,7 @@ fn RuntimeSession::advance_application_lifetime(
   self : RuntimeSession,
 ) -> Bool raise AppRunError {
   let mut did_work = false
-  if self.shutdown_state == SessionRunning &&
+  if self.close_coordinator.state == CloseRunning &&
     should_quit_after_last_window(
       self.last_window_closed_policy,
       self.has_created_window,
@@ -3172,42 +3175,36 @@ fn RuntimeSession::advance_application_lifetime(
     self.request_quit()
     did_work = true
   }
-  match self.shutdown_state {
-    SessionQuitRequested => {
-      self.begin_quit_decisions()
-      did_work = true
-    }
-    SessionCollectingCloseDecisions =>
-      if self.advance_quit_decisions() {
+  match self.close_coordinator.state {
+    CloseRunning =>
+      if self.advance_individual_close_decisions() {
         did_work = true
       }
-    SessionRunning | SessionClosingWindows => ()
+    CloseQuitRequested => {
+      self.begin_application_close_decisions()
+      did_work = true
+    }
+    CloseCollecting =>
+      if self.advance_application_close_decisions() {
+        did_work = true
+      }
+    CloseCommitted => ()
   }
   did_work
 }
 
 ///|
-fn RuntimeSession::begin_quit_decisions(
+fn RuntimeSession::begin_application_close_decisions(
   self : RuntimeSession,
 ) -> Unit raise AppRunError {
   guard self.window_close_handler is Some(handler) else {
     self.commit_application_close()
     return
   }
-  self.pending_quit_decisions.clear()
-  for pending in self.pending_window_closes {
-    self.pending_quit_decisions.push(PendingQuitDecision::{
-      window: pending.window,
-      task: pending.task,
-      decision: None,
-      native_request: Some(pending.request_id),
-    })
-  }
-  self.pending_window_closes.clear()
   for running in self.windows {
     guard running.is_active() else { continue }
     let window_id = running.window.id()
-    guard !self.has_pending_quit_decision(window_id) else { continue }
+    guard self.close_coordinator.find(window_id) is None else { continue }
     let handle = self.window_handle(running)
     let task = self.window_tasks.spawn(
       () => {
@@ -3216,36 +3213,28 @@ fn RuntimeSession::begin_quit_decisions(
       },
       no_wait=true,
     )
-    self.pending_quit_decisions.push(PendingQuitDecision::{
+    self.close_coordinator.pending.push(PendingCloseDecision::{
       window: window_id,
       task,
       decision: None,
       native_request: None,
     })
   }
-  if self.pending_quit_decisions.is_empty() {
+  if self.close_coordinator.pending.is_empty() {
     self.commit_application_close()
   } else {
-    self.shutdown_state = SessionCollectingCloseDecisions
+    self.close_coordinator.state = CloseCollecting
   }
 }
 
 ///|
-fn RuntimeSession::has_pending_quit_decision(
-  self : RuntimeSession,
-  window_id : Int64,
-) -> Bool {
-  self.pending_quit_decisions.any(fn(pending) { pending.window == window_id })
-}
-
-///|
-fn RuntimeSession::advance_quit_decisions(
+fn RuntimeSession::advance_application_close_decisions(
   self : RuntimeSession,
 ) -> Bool raise AppRunError {
   let mut did_work = false
   let mut waiting = false
   let decisions : Array[WindowCloseDecision] = []
-  for pending in self.pending_quit_decisions {
+  for pending in self.close_coordinator.pending {
     if pending.decision is None {
       let completed = pending.task.try_wait() catch {
         _ => Some(WindowCloseDecision::Allow)
@@ -3267,14 +3256,14 @@ fn RuntimeSession::advance_quit_decisions(
     return did_work
   }
   if !should_commit_application_close(decisions) {
-    for pending in self.pending_quit_decisions {
+    for pending in self.close_coordinator.pending {
       guard pending.decision is Some(decision) else { continue }
       if pending.native_request is Some(_) {
-        self.respond_quit_native_requests(pending, decision)
+        self.respond_close_decision(pending, decision)
       }
     }
-    self.pending_quit_decisions.clear()
-    self.shutdown_state = SessionRunning
+    self.close_coordinator.pending.clear()
+    self.close_coordinator.state = CloseRunning
   } else {
     self.commit_application_close()
   }
@@ -3282,9 +3271,9 @@ fn RuntimeSession::advance_quit_decisions(
 }
 
 ///|
-fn RuntimeSession::respond_quit_native_requests(
+fn RuntimeSession::respond_close_decision(
   self : RuntimeSession,
-  pending : PendingQuitDecision,
+  pending : PendingCloseDecision,
   decision : WindowCloseDecision,
 ) -> Unit raise AppRunError {
   match self.find_window_by_native_id(pending.window) {
@@ -3314,30 +3303,11 @@ fn RuntimeSession::respond_quit_native_requests(
 }
 
 ///|
-fn RuntimeSession::cancel_quit_decision_for_window(
-  self : RuntimeSession,
-  window_id : Int64,
-) -> Unit {
-  let remaining : Array[PendingQuitDecision] = []
-  for pending in self.pending_quit_decisions {
-    if pending.window == window_id {
-      pending.task.cancel()
-    } else {
-      remaining.push(pending)
-    }
-  }
-  self.pending_quit_decisions.clear()
-  for pending in remaining {
-    self.pending_quit_decisions.push(pending)
-  }
-}
-
-///|
 fn RuntimeSession::commit_application_close(
   self : RuntimeSession,
 ) -> Unit raise AppRunError {
-  self.shutdown_state = SessionClosingWindows
-  self.pending_quit_decisions.clear()
+  self.close_coordinator.state = CloseCommitted
+  self.close_coordinator.pending.clear()
   for running in self.windows {
     guard running.is_active() else { continue }
     if self.window_close_handler is Some(_) {
@@ -3358,12 +3328,11 @@ fn RuntimeSession::commit_application_close(
 
 ///|
 fn RuntimeSession::quit_complete(self : RuntimeSession) -> Bool {
-  self.shutdown_state == SessionClosingWindows &&
+  self.close_coordinator.state == CloseCommitted &&
   self.windows.all(fn(window) { window.is_closed() }) &&
   self.window_commands.length() == 0 &&
   self.pending_window_opens.length() == 0 &&
-  self.pending_window_closes.length() == 0 &&
-  self.pending_quit_decisions.length() == 0
+  self.close_coordinator.pending.length() == 0
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -199,6 +199,22 @@ priv struct PendingResourceRequest {
 }
 
 ///|
+priv enum SessionShutdownState {
+  SessionRunning = 0
+  SessionQuitRequested = 1
+  SessionCollectingCloseDecisions = 2
+  SessionClosingWindows = 3
+} derive(Eq)
+
+///|
+priv struct PendingQuitDecision {
+  window : Int64
+  task : @async.Task[WindowCloseDecision]
+  mut decision : WindowCloseDecision?
+  mut native_request : Int64?
+}
+
+///|
 priv enum SessionWindowState {
   WindowStarting = 0
   WindowOpen = 1
@@ -324,8 +340,8 @@ priv struct RuntimeSession {
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
-  mut quit_requested : Bool
-  mut quit_close_started : Bool
+  mut shutdown_state : SessionShutdownState
+  pending_quit_decisions : Array[PendingQuitDecision]
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -309,13 +309,13 @@ priv struct WindowPermissionPolicy {
 /// instead of duplicating native lifecycle state.
 priv struct RuntimeSession {
   runtime : @native.Runtime
+  event_pump : RuntimeEventPump
   locale_preferences : @locale.LocalePreferences
   definitions : Array[PreparedWindow]
   windows : Array[RunningWindow]
   mut has_created_window : Bool
   command_host : CommandHostRuntime?
   pending_bridge : Array[BridgeDispatchTask]
-  dialog_completions : DialogCompletionStore
   wakeup : RuntimeWakeup
   forward_menu_events : Bool
   monitor_bridge : Bool
@@ -364,6 +364,17 @@ priv struct PendingDialogCompletion {
 ///|
 priv struct DialogCompletionStore {
   pending : Array[PendingDialogCompletion]
+}
+
+///|
+/// Sole owner of the native runtime event queue.
+///
+/// Dialog completions are delivered directly to their waiters. Every other
+/// event remains in `session_events` until the runtime session dispatches it.
+priv struct RuntimeEventPump {
+  runtime : @native.Runtime
+  dialog_completions : DialogCompletionStore
+  session_events : Array[@native.RuntimeEvent]
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -199,19 +199,25 @@ priv struct PendingResourceRequest {
 }
 
 ///|
-priv enum SessionShutdownState {
-  SessionRunning = 0
-  SessionQuitRequested = 1
-  SessionCollectingCloseDecisions = 2
-  SessionClosingWindows = 3
+priv enum CloseCoordinatorState {
+  CloseRunning = 0
+  CloseQuitRequested = 1
+  CloseCollecting = 2
+  CloseCommitted = 3
 } derive(Eq)
 
 ///|
-priv struct PendingQuitDecision {
+priv struct PendingCloseDecision {
   window : Int64
   task : @async.Task[WindowCloseDecision]
   mut decision : WindowCloseDecision?
   mut native_request : Int64?
+}
+
+///|
+priv struct CloseCoordinator {
+  mut state : CloseCoordinatorState
+  pending : Array[PendingCloseDecision]
 }
 
 ///|
@@ -329,7 +335,6 @@ priv struct RuntimeSession {
   bridge_startup_timeout_ms : Int
   window_commands : Array[WindowSessionCommand]
   pending_window_opens : Array[PendingWindowOpen]
-  pending_window_closes : Array[PendingWindowClose]
   pending_browser_requests : Array[PendingBrowserRequest]
   pending_resource_requests : Array[PendingResourceRequest]
   navigation_handler : (async (BrowserHandle, NavigationRequest) -> NavigationDecision noraise)?
@@ -340,8 +345,7 @@ priv struct RuntimeSession {
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
-  mut shutdown_state : SessionShutdownState
-  pending_quit_decisions : Array[PendingQuitDecision]
+  close_coordinator : CloseCoordinator
 }
 
 ///|
@@ -387,13 +391,6 @@ priv struct PendingWindowOpen {
   completion : WindowOpenCompletion
   mut activation : @async.Task[Unit]?
   timeout : @async.Task[Unit]
-}
-
-///|
-priv struct PendingWindowClose {
-  window : Int64
-  request_id : Int64
-  task : @async.Task[WindowCloseDecision]
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -1698,27 +1698,49 @@ async test "runtime wakeup preserves notification before suspension" {
 }
 
 ///|
+async test "wake driver preserves notification during state advancement" {
+  let wakeup = RuntimeWakeup::{ signal: @core.RuntimeWakeSignal(), }
+  let advances = Ref(0)
+  let completed = @async.with_timeout_opt(100, () => {
+    drive_wakeup_until(wakeup, () => advances.val == 2, () => {
+      advances.val = advances.val + 1
+      if advances.val == 1 {
+        wakeup.signal.notify()
+      }
+      false
+    })
+  })
+  assert_true(completed is Some(_))
+  assert_eq(advances.val, 2)
+}
+
+///|
 async test "dialog completion wakes only its registered waiter" {
   let completions = DialogCompletionStore()
+  assert_false(completions.route_completion(None))
   @async.with_task_group(group => {
     let waiting = group.spawn(no_wait=true, () => completions.wait(41L))
     while completions.pending.is_empty() {
       @async.pause()
     }
-    completions.complete(
-      Some(@native.NativeDialogCompletion::{
-        dialog: 42L,
-        window: Some(7L),
-        result: Ok("unrelated"),
-      }),
+    assert_true(
+      completions.route_completion(
+        Some(@native.NativeDialogCompletion::{
+          dialog: 42L,
+          window: Some(7L),
+          result: Ok("unrelated"),
+        }),
+      ),
     )
     assert_true(waiting.try_wait() is None)
-    completions.complete(
-      Some(@native.NativeDialogCompletion::{
-        dialog: 41L,
-        window: Some(7L),
-        result: Ok("selected"),
-      }),
+    assert_true(
+      completions.route_completion(
+        Some(@native.NativeDialogCompletion::{
+          dialog: 41L,
+          window: Some(7L),
+          result: Ok("selected"),
+        }),
+      ),
     )
     assert_eq(waiting.wait(), "selected")
     group.return_immediately(())
@@ -1742,12 +1764,14 @@ async test "dialog completion propagates native failure" {
     while completions.pending.is_empty() {
       @async.pause()
     }
-    completions.complete(
-      Some(@native.NativeDialogCompletion::{
-        dialog: 51L,
-        window: None,
-        result: Err(@native.Status(status=-7, message="dialog owner closed")),
-      }),
+    assert_true(
+      completions.route_completion(
+        Some(@native.NativeDialogCompletion::{
+          dialog: 51L,
+          window: None,
+          result: Err(@native.Status(status=-7, message="dialog owner closed")),
+        }),
+      ),
     )
     waiting.wait()
     group.return_immediately(())
@@ -2293,8 +2317,8 @@ test "window content size routes logical dimensions through the handle" {
     content_size=(640, 360),
   )
   window.set_content_size(800, 450)
-  inspect(window.content_size(), content="(640, 360)")
-  inspect(calls, content="[(800, 450)]")
+  debug_inspect(window.content_size(), content="(640, 360)")
+  debug_inspect(calls, content="[(800, 450)]")
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -313,6 +313,23 @@ test "last-window policy defaults to quit and can keep the app running" {
 }
 
 ///|
+test "application close commits only after every window allows it" {
+  assert_true(should_commit_application_close([]))
+  assert_true(
+    should_commit_application_close([
+      WindowCloseDecision::Allow,
+      WindowCloseDecision::Allow,
+    ]),
+  )
+  assert_false(
+    should_commit_application_close([
+      WindowCloseDecision::Allow,
+      WindowCloseDecision::Deny,
+    ]),
+  )
+}
+
+///|
 async test "application context forwards orderly quit requests" {
   let requested = Ref(false)
   @async.with_task_group(group => {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -330,6 +330,15 @@ test "application close commits only after every window allows it" {
 }
 
 ///|
+test "close coordinator starts only one application quit transaction" {
+  let coordinator = CloseCoordinator()
+  assert_false(coordinator.is_quitting())
+  assert_true(coordinator.request_quit())
+  assert_true(coordinator.is_quitting())
+  assert_false(coordinator.request_quit())
+}
+
+///|
 async test "application context forwards orderly quit requests" {
   let requested = Ref(false)
   @async.with_task_group(group => {

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -134,7 +134,21 @@ pub extern "C" fn runtime_create(
 ) -> Int = "proton_internal_runtime_create"
 
 ///|
-pub extern "C" fn proton_runtime_destroy_ffi(runtime : RuntimeHandle) -> Int = "proton_runtime_destroy"
+pub extern "C" fn proton_runtime_begin_destroy_ffi(
+  runtime : RuntimeHandle,
+) -> Int = "proton_runtime_begin_destroy"
+
+///|
+#borrow(out_ready)
+pub extern "C" fn proton_runtime_destroy_ready_ffi(
+  runtime : RuntimeHandle,
+  out_ready : Ref[Int],
+) -> Int = "proton_runtime_destroy_ready"
+
+///|
+pub extern "C" fn proton_runtime_finish_destroy_ffi(
+  runtime : RuntimeHandle,
+) -> Int = "proton_runtime_finish_destroy"
 
 ///|
 /// Safe to call from any thread and takes no handle, which is what lets a

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -94,7 +94,10 @@ int32_t proton_app_instance_attach_runtime(
 int32_t
 proton_app_instance_destroy(proton_app_instance_id_t instance);
 
-int32_t proton_runtime_destroy(proton_runtime_handle_t runtime);
+int32_t proton_runtime_begin_destroy(proton_runtime_handle_t runtime);
+int32_t proton_runtime_destroy_ready(proton_runtime_handle_t runtime,
+                                     int32_t *out_ready);
+int32_t proton_runtime_finish_destroy(proton_runtime_handle_t runtime);
 int32_t proton_runtime_complete_resource_request(
     proton_runtime_handle_t runtime, int64_t request_id, int32_t status,
     const char *mime_type, const uint8_t *data, int32_t data_len);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -107,11 +107,15 @@ pub fn proton_notification_set_badge_count_ffi(Int) -> Int
 
 pub fn proton_notification_show_ffi(Bytes, Bytes, Bytes, Int) -> Int
 
+pub fn proton_runtime_begin_destroy_ffi(RuntimeHandle) -> Int
+
 pub fn proton_runtime_begin_message_dialog_ffi(RuntimeHandle, Bytes, Int, Bytes, Int, Int, @ref.Ref[Int64]) -> Int
 
-pub fn proton_runtime_destroy_ffi(RuntimeHandle) -> Int
+pub fn proton_runtime_destroy_ready_ffi(RuntimeHandle, @ref.Ref[Int]) -> Int
 
 pub fn proton_runtime_event_wakeup_callback_ffi() -> @proton_ffi.EventWakeup
+
+pub fn proton_runtime_finish_destroy_ffi(RuntimeHandle) -> Int
 
 pub fn proton_runtime_platform_id_ffi(FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -3,6 +3,7 @@
 
 /* Private contracts shared by the Linux engine translation units. */
 #include "../../proton_engine.h"
+#include "../../proton_event.h"
 #include "../cef_common/bridge_lifecycle.h"
 #include "../cef_common/browser_session.h"
 #include "../cef_common/view_events.h"
@@ -109,7 +110,7 @@ struct proton_engine_window {
   int enabled;
   int zoom_percent;
   int close_interception_enabled;
-  int close_interception_bypass;
+  int close_authorized;
   int close_request_pending;
   uint64_t close_request_id;
   proton_browser_session_t *browser_session;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
@@ -897,37 +897,8 @@ static int proton_engine_runtime_has_windows(
   return 0;
 }
 
-static int32_t proton_engine_runtime_close_windows(
-    proton_engine_runtime_t *runtime, char *error, size_t error_len) {
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    if (window->runtime != runtime || window->browser == NULL) {
-      continue;
-    }
-    window->destroy_requested = 1;
-    window->closing = 1;
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
-    if (host != NULL) {
-      host->close_browser(host, 1);
-      host->base.release((cef_base_ref_counted_t *)host);
-    }
-  }
-
-  while (proton_engine_runtime_has_windows(runtime)) {
-    int32_t status = proton_engine_runtime_do_message_loop_work(
-        runtime, error, error_len);
-    if (status != PROTON_OK || !proton_engine_runtime_has_windows(runtime)) {
-      return status;
-    }
-    uint32_t ready_mask = PROTON_WAIT_NONE;
-    status = proton_engine_runtime_wait(
-        runtime, PROTON_WAIT_PLATFORM, PROTON_WAIT_TIMEOUT_INFINITE,
-        &ready_mask, error, error_len);
-    if (status != PROTON_OK) {
-      return status;
-    }
-  }
-  return PROTON_OK;
+int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
+  return runtime != NULL && !proton_engine_runtime_has_windows(runtime);
 }
 
 int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
@@ -939,10 +910,10 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
   }
   proton_engine_dialog_cancel_runtime(runtime);
   if (runtime->owns_cef_runtime) {
-    int32_t status =
-        proton_engine_runtime_close_windows(runtime, error, error_len);
-    if (status != PROTON_OK) {
-      return status;
+    if (!proton_engine_runtime_destroy_ready(runtime)) {
+      proton_engine_set_message(error, error_len,
+                                "runtime still owns closing browser windows");
+      return PROTON_ERR_BUSY;
     }
     proton_engine_bridge_pending_clear_all();
     proton_engine_cef_shutdown();

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -89,18 +89,19 @@ static gboolean proton_engine_on_window_delete(GtkWidget *widget,
     return FALSE;
   }
   if (window->close_interception_enabled &&
-      !window->close_interception_bypass) {
+      !window->close_authorized) {
     if (!window->close_request_pending) {
       window->close_request_id++;
       if (window->close_request_id == 0) {
         window->close_request_id = 1;
       }
       window->close_request_pending = 1;
+      (void)proton_event_publish_window_close_requested(
+          window->public_window_id, window->close_request_id);
       proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     }
     return TRUE;
   }
-  window->close_interception_bypass = 0;
   if (window->browser != NULL) {
     cef_browser_host_t *host = window->browser->get_host(window->browser);
     if (host != NULL) {
@@ -727,18 +728,19 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   if (window->headless && window->close_interception_enabled &&
-      !window->close_interception_bypass) {
+      !window->close_authorized) {
     if (!window->close_request_pending) {
       window->close_request_id++;
       if (window->close_request_id == 0) {
         window->close_request_id = 1;
       }
       window->close_request_pending = 1;
+      (void)proton_event_publish_window_close_requested(
+          window->public_window_id, window->close_request_id);
       proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     }
     return PROTON_OK;
   }
-  window->close_interception_bypass = 0;
   if (!window->headless) {
     gtk_window_close(GTK_WINDOW(window->window));
     return PROTON_OK;
@@ -1500,23 +1502,12 @@ int32_t proton_engine_window_set_close_interception(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   window->close_interception_enabled = enabled != 0;
+  if (window->close_interception_enabled) {
+    window->close_authorized = 0;
+  }
   if (!window->close_interception_enabled) {
     window->close_request_pending = 0;
   }
-  return PROTON_OK;
-}
-
-int32_t proton_engine_window_get_close_request(
-    proton_engine_window_t *window, uint64_t *out_request_id,
-    int32_t *out_pending, char *error, size_t error_len) {
-  if (window == NULL || out_request_id == NULL || out_pending == NULL) {
-    proton_engine_set_message(
-        error, error_len,
-        "window, out_request_id, and out_pending are required");
-    return PROTON_ERR_INVALID_ARGUMENT;
-  }
-  *out_request_id = window->close_request_id;
-  *out_pending = window->close_request_pending;
   return PROTON_OK;
 }
 
@@ -1535,13 +1526,15 @@ int32_t proton_engine_window_respond_close_request(
   }
   window->close_request_pending = 0;
   if (allow && !window->closed) {
-    window->close_interception_bypass = 1;
+    window->close_authorized = 1;
     if (window->headless) {
       return proton_engine_window_close(window, error, error_len);
     }
     if (window->window != NULL) {
       gtk_window_close(GTK_WINDOW(window->window));
     }
+  } else if (!allow) {
+    window->close_authorized = 0;
   }
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -3,6 +3,7 @@
 
 /* Private contracts shared by the macOS engine translation units. */
 #include "../../proton_engine.h"
+#include "../../proton_event.h"
 
 #include "../cef_common/bridge_lifecycle.h"
 #include "../cef_common/browser_session.h"
@@ -135,7 +136,7 @@ struct proton_engine_window {
   int browser_close_requested;
   int cef_allows_appkit_close;
   int close_interception_enabled;
-  int close_interception_bypass;
+  int close_authorized;
   int close_request_pending;
   int closable;
   int programmatic_close_pending;
@@ -238,7 +239,7 @@ int proton_engine_runtime_has_pending_platform_work(
     proton_engine_runtime_t *runtime);
 void proton_engine_runtime_create_pending_browsers(
     proton_engine_runtime_t *runtime);
-int proton_engine_window_has_any(void);
+int proton_engine_runtime_has_windows(proton_engine_runtime_t *runtime);
 proton_engine_client_t *proton_engine_client_from_base(cef_client_t *client);
 void proton_engine_window_release_browser(proton_engine_window_t *window);
 int proton_engine_send_bridge_response_to_frame(

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_runtime.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_runtime.m
@@ -96,11 +96,6 @@ static atomic_uint g_wait_source_ready_mask = PROTON_WAIT_NONE;
 static CFRunLoopRef g_wait_run_loop = NULL;
 static CFRunLoopSourceRef g_wait_source = NULL;
 
-static int32_t proton_engine_drain_browser_closes(
-    proton_engine_runtime_t *runtime,
-    char *error,
-    size_t error_len);
-
 int proton_engine_runtime_initialized(void) {
   return g_proton_cef_initialized;
 }
@@ -862,12 +857,12 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
   proton_engine_dialog_dispose_runtime(runtime);
   proton_engine_menu_clear_runtime(runtime);
   if (runtime->owns_cef_runtime) {
-    proton_engine_bridge_pending_clear_all();
-    int32_t status =
-        proton_engine_drain_browser_closes(runtime, error, error_len);
-    if (status != PROTON_OK) {
-      return status;
+    if (!proton_engine_runtime_destroy_ready(runtime)) {
+      proton_engine_set_message(error, error_len,
+                                "runtime still owns closing browser windows");
+      return PROTON_ERR_BUSY;
     }
+    proton_engine_bridge_pending_clear_all();
     proton_engine_cef_shutdown();
     proton_engine_reset_external_message_pump();
     runtime->owns_cef_runtime = 0;
@@ -875,6 +870,10 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
   g_proton_cef_runtime_active = 0;
   free(runtime);
   return PROTON_OK;
+}
+
+int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
+  return runtime != NULL && !proton_engine_runtime_has_windows(runtime);
 }
 
 static void proton_engine_pump_appkit_cef_once(void) {
@@ -916,25 +915,6 @@ static void proton_engine_run_external_message_pump_once(void) {
   proton_engine_reset_scheduled_pump();
   proton_engine_pump_appkit_cef_once();
   atomic_store_explicit(&g_message_pump_active, false, memory_order_release);
-}
-
-static int32_t proton_engine_drain_browser_closes(
-    proton_engine_runtime_t *runtime, char *error, size_t error_len) {
-  while (proton_engine_window_has_any()) {
-    int32_t status = proton_engine_runtime_do_message_loop_work(
-        runtime, error, error_len);
-    if (status != PROTON_OK || !proton_engine_window_has_any()) {
-      return status;
-    }
-    uint32_t ready_mask = PROTON_WAIT_NONE;
-    status = proton_engine_runtime_wait(
-        runtime, PROTON_WAIT_PLATFORM, PROTON_WAIT_TIMEOUT_INFINITE,
-        &ready_mask, error, error_len);
-    if (status != PROTON_OK) {
-      return status;
-    }
-  }
-  return PROTON_OK;
 }
 
 int32_t proton_engine_runtime_do_message_loop_work(

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -144,8 +144,18 @@ static void proton_engine_window_list_remove(proton_engine_window_t *window) {
   proton_engine_window_unlock();
 }
 
-int proton_engine_window_has_any(void) {
-  return g_windows != NULL;
+int proton_engine_runtime_has_windows(proton_engine_runtime_t *runtime) {
+  int has_windows = 0;
+  proton_engine_window_lock();
+  for (proton_engine_window_t *window = g_windows; window != NULL;
+       window = window->next) {
+    if (window->runtime == runtime) {
+      has_windows = 1;
+      break;
+    }
+  }
+  proton_engine_window_unlock();
+  return has_windows;
 }
 
 proton_engine_window_t *proton_engine_window_from_browser(
@@ -585,18 +595,19 @@ static void proton_engine_window_update_zoom_button(
     return YES;
   }
   if (window->close_interception_enabled &&
-      !window->close_interception_bypass) {
+      !window->close_authorized) {
     if (!window->close_request_pending) {
       window->close_request_id++;
       if (window->close_request_id == 0) {
         window->close_request_id = 1;
       }
       window->close_request_pending = 1;
+      (void)proton_event_publish_window_close_requested(
+          window->public_window_id, window->close_request_id);
       proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     }
     return NO;
   }
-  window->close_interception_bypass = 0;
   if (window->browser == NULL) {
     proton_engine_window_commit_appkit_close(window, native_window);
     return YES;
@@ -1079,18 +1090,19 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   if (window->headless && window->close_interception_enabled &&
-      !window->close_interception_bypass) {
+      !window->close_authorized) {
     if (!window->close_request_pending) {
       window->close_request_id++;
       if (window->close_request_id == 0) {
         window->close_request_id = 1;
       }
       window->close_request_pending = 1;
+      (void)proton_event_publish_window_close_requested(
+          window->public_window_id, window->close_request_id);
       proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     }
     return PROTON_OK;
   }
-  window->close_interception_bypass = 0;
   if (!window->headless) {
     window->programmatic_close_pending = 1;
     proton_engine_window_apply_closable_style(window);
@@ -2035,26 +2047,14 @@ int32_t proton_engine_window_set_close_interception(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   window->close_interception_enabled = enabled != 0;
+  if (window->close_interception_enabled) {
+    window->close_authorized = 0;
+  }
   if (!window->close_interception_enabled) {
     window->close_request_pending = 0;
     window->programmatic_close_pending = 0;
     proton_engine_window_apply_closable_style(window);
   }
-  return PROTON_OK;
-}
-
-int32_t proton_engine_window_get_close_request(
-    proton_engine_window_t *window, uint64_t *out_request_id,
-    int32_t *out_pending, char *error, size_t error_len) {
-
-  if (window == NULL || out_request_id == NULL || out_pending == NULL) {
-    proton_engine_set_message(
-        error, error_len,
-        "window, out_request_id, and out_pending are required");
-    return PROTON_ERR_INVALID_ARGUMENT;
-  }
-  *out_request_id = window->close_request_id;
-  *out_pending = window->close_request_pending;
   return PROTON_OK;
 }
 
@@ -2074,12 +2074,13 @@ int32_t proton_engine_window_respond_close_request(
   }
   window->close_request_pending = 0;
   if (allow && !window->closed) {
-    window->close_interception_bypass = 1;
+    window->close_authorized = 1;
     if (window->headless) {
       return proton_engine_window_close(window, error, error_len);
     }
     [window->window performClose:nil];
   } else if (!allow) {
+    window->close_authorized = 0;
     window->programmatic_close_pending = 0;
     proton_engine_window_apply_closable_style(window);
   }

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -1188,6 +1188,16 @@ void proton_engine_free_closed_windows(void) {
   }
 }
 
+int proton_engine_closed_windows_ready_for_shutdown(void) {
+  for (proton_engine_window_t *window = g_proton_engine_closed_windows;
+       window != NULL; window = window->next) {
+    if (window->hwnd != NULL) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
 static int CEF_CALLBACK proton_engine_on_before_popup(
     cef_life_span_handler_t *self,
     cef_browser_t *browser,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -3,6 +3,7 @@
 
 /* Private contracts shared by the Windows engine translation units. */
 #include "../../proton_engine.h"
+#include "../../proton_event.h"
 #include "../cef_common/bridge_lifecycle.h"
 #include "../cef_common/browser_session.h"
 #include "../cef_common/view_events.h"
@@ -108,7 +109,7 @@ struct proton_engine_window {
   int draggable_regions_reported;
   int browser_close_requested;
   int close_interception_enabled;
-  int close_interception_bypass;
+  int close_authorized;
   int close_request_pending;
   uint64_t close_request_id;
   proton_browser_session_t *browser_session;
@@ -287,6 +288,7 @@ void proton_engine_set_command_line_paths(
 int proton_engine_register_scheme_factory(void);
 void proton_engine_bridge_pending_clear_all(void);
 void proton_engine_free_closed_windows(void);
+int proton_engine_closed_windows_ready_for_shutdown(void);
 void proton_engine_overlay_subclass_browser(proton_engine_window_t *window,
                                             HWND browser_hwnd);
 int proton_engine_overlay_frame_top_thickness(HWND hwnd);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
@@ -616,25 +616,24 @@ static void proton_engine_dispose_runtime_state(
   free(runtime);
 }
 
-static int32_t proton_engine_drain_browser_closes(
-    proton_engine_runtime_t *runtime,
-    char *error,
-    size_t error_len) {
-  while (g_proton_engine_windows != NULL) {
-    int32_t status = proton_engine_runtime_do_message_loop_work(
-        runtime, error, error_len);
-    if (status != PROTON_OK || g_proton_engine_windows == NULL) {
-      return status;
-    }
-    uint32_t ready_mask = PROTON_WAIT_NONE;
-    status = proton_engine_runtime_wait(
-        runtime, PROTON_WAIT_PLATFORM, INFINITE, &ready_mask, error,
-        error_len);
-    if (status != PROTON_OK) {
-      return status;
+int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
+  if (runtime == NULL) {
+    return 0;
+  }
+  if (!g_proton_engine_window_lock_initialized) {
+    return g_proton_engine_windows == NULL;
+  }
+  int32_t ready = 1;
+  EnterCriticalSection(&g_proton_engine_window_lock);
+  for (proton_engine_window_t *window = g_proton_engine_windows;
+       window != NULL; window = window->next) {
+    if (window->runtime == runtime) {
+      ready = 0;
+      break;
     }
   }
-  return PROTON_OK;
+  LeaveCriticalSection(&g_proton_engine_window_lock);
+  return ready && proton_engine_closed_windows_ready_for_shutdown();
 }
 
 int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
@@ -646,17 +645,10 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
   }
   proton_engine_dialog_cancel_runtime(runtime);
   if (runtime->owns_cef_runtime) {
-    int32_t status =
-        proton_engine_drain_browser_closes(runtime, error, error_len);
-    if (status != PROTON_OK) {
-      return status;
-    }
-    // Flush deferred frame destruction posted by OnBeforeClose so no frame
-    // window outlives the browser teardown.
-    status = proton_engine_runtime_do_message_loop_work(runtime, error,
-                                                        error_len);
-    if (status != PROTON_OK) {
-      return status;
+    if (!proton_engine_runtime_destroy_ready(runtime)) {
+      proton_engine_set_message(error, error_len,
+                                "runtime still owns closing browser windows");
+      return PROTON_ERR_BUSY;
     }
     proton_engine_cef_shutdown();
     proton_engine_free_closed_windows();

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -300,19 +300,20 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
   case WM_CLOSE:
     if (window != NULL) {
       if (window->close_interception_enabled &&
-          !window->close_interception_bypass) {
+          !window->close_authorized) {
         if (!window->close_request_pending) {
           window->close_request_id++;
           if (window->close_request_id == 0) {
             window->close_request_id = 1;
           }
           window->close_request_pending = 1;
+          (void)proton_event_publish_window_close_requested(
+              window->public_window_id, window->close_request_id);
           proton_engine_signal_wait_source(window->runtime,
                                            PROTON_WAIT_PLATFORM);
         }
         return 0;
       }
-      window->close_interception_bypass = 0;
       if (window->browser != NULL) {
         cef_browser_host_t *host = window->browser->get_host(window->browser);
         if (host != NULL) {
@@ -657,20 +658,6 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
     proton_engine_set_message(error, error_len, "window is not initialized");
     return PROTON_ERR_INVALID_HANDLE;
   }
-  if (window->headless && window->close_interception_enabled &&
-      !window->close_interception_bypass) {
-    if (!window->close_request_pending) {
-      window->close_request_id++;
-      if (window->close_request_id == 0) {
-        window->close_request_id = 1;
-      }
-      window->close_request_pending = 1;
-      proton_engine_signal_wait_source(window->runtime,
-                                       PROTON_WAIT_PLATFORM);
-    }
-    return PROTON_OK;
-  }
-  window->close_interception_bypass = 0;
   if (window->headless) {
     window->headless_hidden = 0;
     if (window->browser != NULL) {
@@ -1066,6 +1053,21 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
   if (window == NULL || (!window->headless && window->hwnd == NULL)) {
     proton_engine_set_message(error, error_len, "window is not initialized");
     return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (window->headless && window->close_interception_enabled &&
+      !window->close_authorized) {
+    if (!window->close_request_pending) {
+      window->close_request_id++;
+      if (window->close_request_id == 0) {
+        window->close_request_id = 1;
+      }
+      window->close_request_pending = 1;
+      (void)proton_event_publish_window_close_requested(
+          window->public_window_id, window->close_request_id);
+      proton_engine_signal_wait_source(window->runtime,
+                                       PROTON_WAIT_PLATFORM);
+    }
+    return PROTON_OK;
   }
   if (window->headless) {
     if (window->browser != NULL) {
@@ -1702,23 +1704,12 @@ int32_t proton_engine_window_set_close_interception(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   window->close_interception_enabled = enabled != 0;
+  if (window->close_interception_enabled) {
+    window->close_authorized = 0;
+  }
   if (!window->close_interception_enabled) {
     window->close_request_pending = 0;
   }
-  return PROTON_OK;
-}
-
-int32_t proton_engine_window_get_close_request(
-    proton_engine_window_t *window, uint64_t *out_request_id,
-    int32_t *out_pending, char *error, size_t error_len) {
-  if (window == NULL || out_request_id == NULL || out_pending == NULL) {
-    proton_engine_set_message(
-        error, error_len,
-        "window, out_request_id, and out_pending are required");
-    return PROTON_ERR_INVALID_ARGUMENT;
-  }
-  *out_request_id = window->close_request_id;
-  *out_pending = window->close_request_pending;
   return PROTON_OK;
 }
 
@@ -1737,13 +1728,15 @@ int32_t proton_engine_window_respond_close_request(
   }
   window->close_request_pending = 0;
   if (allow && !window->closed) {
-    window->close_interception_bypass = 1;
+    window->close_authorized = 1;
     if (window->headless) {
       return proton_engine_window_close(window, error, error_len);
     }
     if (window->hwnd != NULL) {
       PostMessageW(window->hwnd, WM_CLOSE, 0, 0);
     }
+  } else if (!allow) {
+    window->close_authorized = 0;
   }
   proton_engine_signal_wait_source(window->runtime, PROTON_WAIT_PLATFORM);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -245,7 +245,7 @@ int32_t proton_internal_runtime_create(
   return PROTON_OK;
 }
 
-int32_t proton_runtime_destroy(proton_runtime_handle_t runtime) {
+int32_t proton_runtime_begin_destroy(proton_runtime_handle_t runtime) {
   proton_runtime_slot_t *slot = NULL;
   int32_t status = proton_get_runtime_for_destroy(runtime, &slot);
   if (status == PROTON_ERR_DESTROYED) {
@@ -253,6 +253,10 @@ int32_t proton_runtime_destroy(proton_runtime_handle_t runtime) {
   }
   if (status != PROTON_OK) {
     return status;
+  }
+  if (slot->destroy_prepared) {
+    g_last_error[0] = '\0';
+    return PROTON_OK;
   }
   proton_runtime_slot_begin_destroy(slot);
 
@@ -265,6 +269,52 @@ int32_t proton_runtime_destroy(proton_runtime_handle_t runtime) {
     return status;
   }
   proton_engine_cancel_resource_requests();
+  slot->destroy_prepared = true;
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_runtime_destroy_ready(proton_runtime_handle_t runtime,
+                                     int32_t *out_ready) {
+  proton_runtime_slot_t *slot = NULL;
+  int32_t status = proton_get_runtime_for_destroy(runtime, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (out_ready == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "out_ready is required");
+  }
+  if (!slot->destroy_prepared) {
+    return proton_set_error(PROTON_ERR_DESTROYED,
+                            "runtime destroy has not begun");
+  }
+  *out_ready = slot->engine_runtime == NULL ||
+                       proton_engine_runtime_destroy_ready(slot->engine_runtime)
+                   ? 1
+                   : 0;
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_runtime_finish_destroy(proton_runtime_handle_t runtime) {
+  proton_runtime_slot_t *slot = NULL;
+  int32_t status = proton_get_runtime_for_destroy(runtime, &slot);
+  if (status == PROTON_ERR_DESTROYED) {
+    return PROTON_OK;
+  }
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (!slot->destroy_prepared) {
+    return proton_set_error(PROTON_ERR_DESTROYED,
+                            "runtime destroy has not begun");
+  }
+  if (slot->engine_runtime != NULL &&
+      !proton_engine_runtime_destroy_ready(slot->engine_runtime)) {
+    return proton_set_error(PROTON_ERR_BUSY,
+                            "runtime still owns closing browser windows");
+  }
   if (slot->engine_runtime != NULL) {
     char engine_error[512] = {0};
     status = proton_engine_runtime_destroy(slot->engine_runtime, engine_error,
@@ -449,10 +499,6 @@ int32_t proton_internal_runtime_poll_event(proton_runtime_handle_t runtime,
   proton_runtime_sync_engine_closed_windows(slot);
   if (!proton_runtime_has_events(slot)) {
     status = proton_runtime_sync_engine_window_states(slot);
-    if (status != PROTON_OK) {
-      return status;
-    }
-    status = proton_runtime_sync_engine_close_requests(slot);
     if (status != PROTON_OK) {
       return status;
     }
@@ -1676,9 +1722,6 @@ int32_t proton_window_set_close_interception(proton_window_handle_t window,
       slot->engine_window, enabled, engine_error, sizeof(engine_error));
   if (status != PROTON_OK) {
     return proton_set_engine_status(status, engine_error);
-  }
-  if (!enabled) {
-    slot->close_request_notified_revision = 0;
   }
   g_last_error[0] = '\0';
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -125,6 +125,7 @@ int32_t proton_engine_runtime_create(
 int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
                                       char *error,
                                       size_t error_len);
+int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime);
 int32_t proton_engine_complete_resource_request(
     int64_t request_id, int32_t status, const char *mime_type,
     const void *data, size_t data_len);
@@ -300,9 +301,6 @@ int32_t proton_engine_window_get_state(
 int32_t proton_engine_window_set_close_interception(
     proton_engine_window_t *window, int32_t enabled, char *error,
     size_t error_len);
-int32_t proton_engine_window_get_close_request(
-    proton_engine_window_t *window, uint64_t *out_request_id,
-    int32_t *out_pending, char *error, size_t error_len);
 int32_t proton_engine_window_respond_close_request(
     proton_engine_window_t *window, uint64_t request_id, int32_t allow,
     char *error, size_t error_len);

--- a/proton/internal/native/ffi/src/proton_event.c
+++ b/proton/internal/native/ffi/src/proton_event.c
@@ -306,3 +306,14 @@ bool proton_event_publish(proton_event_t *event) {
   proton_event_destroy(event);
   return false;
 }
+
+bool proton_event_publish_window_close_requested(int64_t window,
+                                                 uint64_t request_id) {
+  proton_event_t *event = proton_event_create_window(
+      PROTON_EVENT_WINDOW_CLOSE_REQUESTED, window);
+  if (event == NULL) {
+    return false;
+  }
+  event->request_id = (int64_t)request_id;
+  return proton_event_publish(event);
+}

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -103,5 +103,7 @@ PROTON_INTERNAL void proton_event_bind_sink(proton_event_sink_fn sink,
 PROTON_INTERNAL void proton_event_unbind_sink(void *user_data);
 PROTON_INTERNAL bool proton_event_try_publish(proton_event_t *event);
 PROTON_INTERNAL bool proton_event_publish(proton_event_t *event);
+PROTON_INTERNAL bool proton_event_publish_window_close_requested(
+    int64_t window, uint64_t request_id);
 
 #endif

--- a/proton/internal/native/ffi/src/proton_state.c
+++ b/proton/internal/native/ffi/src/proton_state.c
@@ -378,43 +378,6 @@ int32_t proton_runtime_sync_engine_window_states(
   return PROTON_OK;
 }
 
-int32_t proton_runtime_sync_engine_close_requests(
-    proton_runtime_slot_t *runtime) {
-  for (proton_window_slot_t *window = runtime->windows; window != NULL;
-       window = window->next) {
-    if (window->lifecycle == PROTON_WINDOW_DESTROYING ||
-        window->lifecycle == PROTON_WINDOW_DESTROYED ||
-        window->engine_window == NULL) {
-      continue;
-    }
-    uint64_t request_id = 0;
-    int32_t pending = 0;
-    char engine_error[512] = {0};
-    int32_t status = proton_engine_window_get_close_request(
-        window->engine_window, &request_id, &pending, engine_error,
-        sizeof(engine_error));
-    if (status != PROTON_OK) {
-      return proton_set_engine_status(status, engine_error);
-    }
-    if (!pending || request_id == 0 ||
-        request_id == window->close_request_notified_revision) {
-      continue;
-    }
-    proton_event_t *event = proton_event_create_window(
-        PROTON_EVENT_WINDOW_CLOSE_REQUESTED, window->logical_id);
-    if (event == NULL) {
-      return proton_set_error(PROTON_ERR_ENGINE,
-                              "failed to allocate window close event");
-    }
-    event->request_id = (int64_t)request_id;
-    if (!proton_runtime_enqueue_event(runtime, event)) {
-      return PROTON_OK;
-    }
-    window->close_request_notified_revision = request_id;
-  }
-  return PROTON_OK;
-}
-
 void proton_runtime_sync_engine_bridge_lifecycle(
     proton_runtime_slot_t *runtime) {
   for (proton_window_slot_t *window = runtime->windows; window != NULL;

--- a/proton/internal/native/ffi/src/proton_state.h
+++ b/proton/internal/native/ffi/src/proton_state.h
@@ -46,6 +46,7 @@ typedef enum proton_view_lifecycle {
 
 struct proton_runtime_slot {
   proton_runtime_lifecycle_t lifecycle;
+  bool destroy_prepared;
   proton_engine_runtime_t *engine_runtime;
   int64_t app_instance;
   proton_thread_id_t owner_thread;
@@ -63,7 +64,6 @@ struct proton_window_slot {
   bool closed_event_sent;
   bool state_valid;
   uint64_t bridge_notified_revision;
-  uint64_t close_request_notified_revision;
   int64_t logical_id;
   proton_runtime_slot_t *runtime;
   proton_engine_window_t *engine_window;
@@ -143,8 +143,6 @@ PROTON_INTERNAL int32_t proton_window_enqueue_closed_once(
 PROTON_INTERNAL void proton_runtime_sync_engine_closed_windows(
     proton_runtime_slot_t *runtime);
 PROTON_INTERNAL int32_t proton_runtime_sync_engine_window_states(
-    proton_runtime_slot_t *runtime);
-PROTON_INTERNAL int32_t proton_runtime_sync_engine_close_requests(
     proton_runtime_slot_t *runtime);
 PROTON_INTERNAL void proton_runtime_sync_engine_bridge_lifecycle(
     proton_runtime_slot_t *runtime);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -485,18 +485,44 @@ pub fn Runtime::Runtime(
 }
 
 ///|
-pub fn Runtime::destroy(self : Runtime) -> Unit raise NativeError {
+pub fn Runtime::begin_destroy(self : Runtime) -> Unit raise NativeError {
   match self.lifecycle {
     RuntimeDestroyed => return
     RuntimeActive | RuntimeDestroying => self.lifecycle = RuntimeDestroying
   }
-  let status = @native_ffi.proton_runtime_destroy_ffi(self.handle)
-  if status < 0 {
-    raise native_error(status)
-  } else {
-    self.handle = @native_ffi.runtime_null()
-    self.lifecycle = RuntimeDestroyed
+  check_status(@native_ffi.proton_runtime_begin_destroy_ffi(self.handle))
+}
+
+///|
+pub fn Runtime::destroy_ready(self : Runtime) -> Bool raise NativeError {
+  match self.lifecycle {
+    RuntimeDestroying => ()
+    RuntimeActive =>
+      raise Status(
+        status=proton_err_invalid_state,
+        message="runtime destroy has not begun",
+      )
+    RuntimeDestroyed => return true
   }
+  let ready = Ref(0)
+  check_status(@native_ffi.proton_runtime_destroy_ready_ffi(self.handle, ready))
+  ready.val != 0
+}
+
+///|
+pub fn Runtime::finish_destroy(self : Runtime) -> Unit raise NativeError {
+  match self.lifecycle {
+    RuntimeDestroyed => return
+    RuntimeDestroying => ()
+    RuntimeActive =>
+      raise Status(
+        status=proton_err_invalid_state,
+        message="runtime destroy has not begun",
+      )
+  }
+  check_status(@native_ffi.proton_runtime_finish_destroy_ffi(self.handle))
+  self.handle = @native_ffi.runtime_null()
+  self.lifecycle = RuntimeDestroyed
 }
 
 ///|

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -394,9 +394,11 @@ pub fn RemoteDebugging::to_repr(Self) -> @debug.Repr
 
 type Runtime
 pub fn Runtime::Runtime(config? : RuntimeConfig) -> Self raise NativeError
+pub fn Runtime::begin_destroy(Self) -> Unit raise NativeError
 pub fn Runtime::begin_message_dialog(Self, String?, String, DialogLevel) -> Int64 raise NativeError
 pub fn Runtime::complete_resource_request(Self, Int64, Int, String, Bytes) -> Unit raise NativeError
-pub fn Runtime::destroy(Self) -> Unit raise NativeError
+pub fn Runtime::destroy_ready(Self) -> Bool raise NativeError
+pub fn Runtime::finish_destroy(Self) -> Unit raise NativeError
 pub fn Runtime::poll_event(Self) -> RuntimeEvent? raise NativeError
 pub fn Runtime::respond_bridge_request(Self, BridgeResponse) -> Unit raise NativeError
 pub fn Runtime::set_menu(Self, MenuBar) -> Unit raise NativeError

--- a/proton/moon.pkg
+++ b/proton/moon.pkg
@@ -54,6 +54,7 @@ options(
     "facade_permissions.mbt": [ "native" ],
     "facade_resource.mbt": [ "native" ],
     "facade_runtime.mbt": [ "native" ],
+    "facade_runtime_events.mbt": [ "native" ],
     "facade_session.mbt": [ "native" ],
     "facade_test.mbt": [ "native" ],
     "facade_runtime_wakeup.mbt": [ "native" ],


### PR DESCRIPTION
## Background

Runtime shutdown and event delivery had accumulated several independent pump/wait loops. Some paths consumed the shared native event queue while only handling one event kind, which could discard unrelated window or bridge events. Browser close coordination also mixed synchronous waiting with platform-specific lifecycle state.

## Changes

- make application shutdown an asynchronous lifecycle driven by native events
- centralize runtime event pumping so bridge, window, dialog, menu, and shutdown events have one consumer
- unify browser-close coordination across macOS, Windows, and Linux
- narrow the Proton prebuild hook to deterministic CEF SDK resolution plus native compile/link parameters

## Validation

- `moon fmt`
- `moon info`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test --target native --diagnostic-limit 80` (599 passed)
- `node scripts/verify_generated.mjs`
- GitHub Actions: format and full macOS, Ubuntu, and Windows jobs passed
