### PR TITLE
feat(view): add independent zoom controls

### DIFF
--- a/examples/52_web_contents_view/app/index.html
+++ b/examples/52_web_contents_view/app/index.html
@@ -17,6 +17,15 @@
         <input id="url" placeholder="example.com" />
         <button id="go">Go</button>
       </div>
+      <label id="zoom-control">
+        <span>Zoom</span>
+        <select id="zoom" title="Page zoom">
+          <option value="75">75%</option>
+          <option value="100" selected>100%</option>
+          <option value="125">125%</option>
+          <option value="150">150%</option>
+        </select>
+      </label>
       <button data-url="https://example.com">Example</button>
       <button data-url="https://moonbitlang.com">MoonBit</button>
       <button data-url="https://developer.mozilla.org">MDN</button>
@@ -25,7 +34,7 @@
       <p class="hint">
         The area on the right is a web contents view: an independent native
         browser hosted inside this window. Navigation events flow back into
-        the sidebar; back/forward/reload use per-view browser commands.
+        the sidebar; navigation and zoom controls target that browser only.
       </p>
     </div>
     <script src="sidebar.js"></script>

--- a/examples/52_web_contents_view/app/sidebar.css
+++ b/examples/52_web_contents_view/app/sidebar.css
@@ -24,7 +24,8 @@ body {
 }
 
 #sidebar input,
-#sidebar button {
+#sidebar button,
+#sidebar select {
   -webkit-app-region: no-drag;
 }
 
@@ -47,6 +48,25 @@ h1 {
 #bar {
   display: flex;
   gap: 6px;
+}
+
+#zoom-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: #6e6e73;
+}
+
+#zoom {
+  min-width: 88px;
+  padding: 5px 8px;
+  border: 1px solid #c8c8cf;
+  border-radius: 6px;
+  background: #fff;
+  font: inherit;
+  color: #1d1d1f;
 }
 
 #url {

--- a/examples/52_web_contents_view/app/sidebar.js
+++ b/examples/52_web_contents_view/app/sidebar.js
@@ -24,3 +24,9 @@ document.querySelector("#forward").onclick = () =>
   window.__MoonBit__.browser.forward();
 document.querySelector("#reload").onclick = () =>
   window.__MoonBit__.browser.reload();
+
+document.querySelector("#zoom").onchange = async (event) => {
+  const percent = Number(event.target.value);
+  const reply = await window.__MoonBit__.browser.zoom({ percent });
+  status.textContent = reply.ok ? `Zoom ${reply.percent}%` : "zoom failed";
+};

--- a/examples/52_web_contents_view/main.mbt
+++ b/examples/52_web_contents_view/main.mbt
@@ -39,6 +39,29 @@ pub extend SimpleReply with ToJson::{to_json}
 pub extend SimpleReply with FromJson::{from_json}
 
 ///|
+struct ZoomPayload {
+  percent : Int
+} derive(ToJson, FromJson)
+
+///|
+pub extend ZoomPayload with ToJson::{to_json}
+
+///|
+pub extend ZoomPayload with FromJson::{from_json}
+
+///|
+struct ZoomReply {
+  ok : Bool
+  percent : Int
+} derive(ToJson, FromJson)
+
+///|
+pub extend ZoomReply with ToJson::{to_json}
+
+///|
+pub extend ZoomReply with FromJson::{from_json}
+
+///|
 let browser_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
   id="examples/web-contents-view-browser",
   js_namespace="browser",
@@ -62,6 +85,11 @@ let forward_command : @proton_contract.Command[Json, SimpleReply] = browser_cont
 ///|
 let reload_command : @proton_contract.Command[Json, SimpleReply] = browser_contract.command(
   "reload",
+)
+
+///|
+let zoom_command : @proton_contract.Command[ZoomPayload, ZoomReply] = browser_contract.command(
+  "zoom",
 )
 
 ///|
@@ -110,6 +138,22 @@ fn panel_command(action : (@proton.ViewHandle) -> Unit raise) -> SimpleReply {
 }
 
 ///|
+fn set_panel_zoom(payload : ZoomPayload) -> ZoomReply {
+  match panel_slot.val {
+    Some(view) => {
+      view.set_zoom_percent(payload.percent) catch {
+        _ => return ZoomReply::{ ok: false, percent: payload.percent, }
+      }
+      let percent = view.zoom_percent() catch {
+        _ => return ZoomReply::{ ok: false, percent: payload.percent, }
+      }
+      ZoomReply::{ ok: true, percent, }
+    }
+    None => ZoomReply::{ ok: false, percent: payload.percent, }
+  }
+}
+
+///|
 fn browser_extension() -> @proton_extension.Extension {
   @proton_extension.typed(
     browser_contract,
@@ -118,6 +162,7 @@ fn browser_extension() -> @proton_extension.Extension {
       back_command.contract_route(),
       forward_command.contract_route(),
       reload_command.contract_route(),
+      zoom_command.contract_route(),
     ],
     fn(registrar) raise {
       registrar.bind(navigate_command, (_context, payload) => navigate(payload))
@@ -129,6 +174,9 @@ fn browser_extension() -> @proton_extension.Extension {
       })
       registrar.bind(reload_command, (_context, _payload) => {
         panel_command(view => view.reload())
+      })
+      registrar.bind(zoom_command, (_context, payload) => {
+        set_panel_zoom(payload)
       })
     },
   )

--- a/examples/52_web_contents_view/pkg.generated.mbti
+++ b/examples/52_web_contents_view/pkg.generated.mbti
@@ -22,6 +22,14 @@ type SimpleReply derive(ToJson, @json.FromJson)
 pub fn SimpleReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SimpleReply::to_json(Self) -> Json
 
+type ZoomPayload derive(ToJson, @json.FromJson)
+pub fn ZoomPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ZoomPayload::to_json(Self) -> Json
+
+type ZoomReply derive(ToJson, @json.FromJson)
+pub fn ZoomReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ZoomReply::to_json(Self) -> Json
+
 // Type aliases
 
 // Traits

--- a/examples/69_window_controls/pkg.generated.mbti
+++ b/examples/69_window_controls/pkg.generated.mbti
@@ -10,6 +10,14 @@ import {
 // Errors
 
 // Types and methods
+type AdvancedReply derive(ToJson, @json.FromJson)
+pub fn AdvancedReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AdvancedReply::to_json(Self) -> Json
+
+type AdvancedRequest derive(ToJson, @json.FromJson)
+pub fn AdvancedRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AdvancedRequest::to_json(Self) -> Json
+
 type Reply derive(ToJson, @json.FromJson)
 pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Reply::to_json(Self) -> Json

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -81,7 +81,8 @@ moon -C examples run 01_run --target native
   request for macOS close-lifecycle regression testing.
 - `52_web_contents_view`: Codex-style built-in browser: an asset-loaded
   sidebar host page drives an embedded web contents view through a command
-  extension, with view events keeping the sidebar in sync.
+  extension, with independent zoom controls and view events keeping the
+  sidebar in sync.
 - `53_view_minimal`: the minimal declarative web contents view example:
   `with_view` plus `@proton.view`, no lifecycle hooks required.
 - `54_devtools`: opens CEF DevTools programmatically through

--- a/examples/e2e_fixtures/web_contents_view.mbt
+++ b/examples/e2e_fixtures/web_contents_view.mbt
@@ -48,6 +48,10 @@ async fn run_web_contents_view_app() -> Result[Unit, String] {
             z_order=1,
           ),
         )
+        left.set_zoom_percent(125)
+        if left.zoom_percent() != 125 {
+          abort("web contents view zoom did not persist")
+        }
         left.load_url(wcv_left_url)
         right.load_html(wcv_right_html, wcv_right_url)
       },

--- a/proton/README.md
+++ b/proton/README.md
@@ -106,7 +106,8 @@ the native frame. `content_size` reads that area back in logical pixels.
 `set_menu` replaces or clears the runtime menu, `set_icon` loads a native icon
 from a file path, and `set_parent` establishes a native owner/transient or modal
 relationship. `set_window_button_visibility` controls standard title-bar buttons
-on macOS and is a successful no-op on other platforms.
+on macOS and is a successful no-op on other platforms. Web contents views expose
+independent `set_zoom_percent` and `zoom_percent` controls for their own browser.
 
 ## Logging
 

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -406,6 +406,28 @@ fn RuntimeSession::view_handle(
         view => view.set_z_order(z_order),
       )
     },
+    set_view_zoom_percent: zoom_percent => {
+      self.control_view(
+        window_id,
+        window_native_id,
+        id,
+        native_id,
+        "set zoom of",
+        view => view.set_zoom_percent(zoom_percent),
+      )
+    },
+    read_view_zoom_percent: () => {
+      let running = self.resolve_view(
+        window_id, window_native_id, id, native_id,
+      )
+      running.view.zoom_percent() catch {
+        error =>
+          raise window_operation_failed(
+            "read zoom of view " + id + " in window " + window_id,
+            error,
+          )
+      }
+    },
     load_view_url: url => {
       self.control_view(
         window_id,
@@ -1871,6 +1893,23 @@ pub fn ViewHandle::set_z_order(
   z_order : Int,
 ) -> Unit raise WindowSessionError {
   (self.set_view_z_order)(z_order)
+}
+
+///|
+/// Sets this view's browser zoom from 25% through 500%.
+pub fn ViewHandle::set_zoom_percent(
+  self : ViewHandle,
+  zoom_percent : Int,
+) -> Unit raise WindowSessionError {
+  (self.set_view_zoom_percent)(zoom_percent)
+}
+
+///|
+/// Returns this view's browser zoom percentage.
+pub fn ViewHandle::zoom_percent(
+  self : ViewHandle,
+) -> Int raise WindowSessionError {
+  (self.read_view_zoom_percent)()
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -444,6 +444,8 @@ pub struct ViewHandle {
   set_view_bounds : (Int, Int, Int, Int) -> Unit raise WindowSessionError
   set_view_visible : (Bool) -> Unit raise WindowSessionError
   set_view_z_order : (Int) -> Unit raise WindowSessionError
+  set_view_zoom_percent : (Int) -> Unit raise WindowSessionError
+  read_view_zoom_percent : () -> Int raise WindowSessionError
   load_view_url : (String) -> Unit raise WindowSessionError
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -2260,6 +2260,10 @@ fn test_view_handle(
     },
     set_view_visible: fn(visible) { calls.push("set_visible:\{visible}") },
     set_view_z_order: fn(z_order) { calls.push("set_z_order:\{z_order}") },
+    set_view_zoom_percent: fn(zoom_percent) {
+      calls.push("set_zoom_percent:\{zoom_percent}")
+    },
+    read_view_zoom_percent: fn() { 125 },
     load_view_url: fn(url) { calls.push("load_url:\{url}") },
     load_view_html: fn(_html, _base_url) {  },
     eval_view_script: fn(_script) {  },
@@ -2280,6 +2284,8 @@ test "view handle routes operations through its closures" {
   view.set_bounds(x=1, y=2, width=300, height=200)
   view.set_visible(false)
   view.set_z_order(2)
+  view.set_zoom_percent(125)
+  inspect(view.zoom_percent(), content="125")
   view.load_url("https://example.com/")
   assert_true(view.can_go_back())
   assert_false(view.can_go_forward())
@@ -2294,6 +2300,7 @@ test "view handle routes operations through its closures" {
       #|  "set_bounds:1,2,300,200",
       #|  "set_visible:false",
       #|  "set_z_order:2",
+      #|  "set_zoom_percent:125",
       #|  "load_url:https://example.com/",
       #|  "close",
       #|]

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -826,6 +826,19 @@ pub extern "C" fn proton_view_set_z_order_ffi(
 ) -> Int = "proton_view_set_z_order"
 
 ///|
+pub extern "C" fn proton_view_set_zoom_percent_ffi(
+  view : ViewHandle,
+  zoom_percent : Int,
+) -> Int = "proton_view_set_zoom_percent"
+
+///|
+#borrow(out_zoom_percent)
+pub extern "C" fn proton_view_get_zoom_percent_ffi(
+  view : ViewHandle,
+  out_zoom_percent : Ref[Int],
+) -> Int = "proton_view_get_zoom_percent"
+
+///|
 #borrow(url)
 pub extern "C" fn proton_view_load_url_ffi(
   view : ViewHandle,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -391,6 +391,10 @@ int32_t proton_view_set_visible(proton_view_handle_t view,
                                            int32_t visible);
 int32_t proton_view_set_z_order(proton_view_handle_t view,
                                            int32_t z_order);
+int32_t proton_view_set_zoom_percent(proton_view_handle_t view,
+                                     int32_t zoom_percent);
+int32_t proton_view_get_zoom_percent(proton_view_handle_t view,
+                                     int32_t *out_zoom_percent);
 int32_t proton_view_load_url(proton_view_handle_t view,
                                         const char *url);
 int32_t proton_view_eval(proton_view_handle_t view, const char *script);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -149,7 +149,11 @@ pub fn proton_view_destroy_ffi(ViewHandle) -> Int
 
 pub fn proton_view_eval_ffi(ViewHandle, Bytes) -> Int
 
+pub fn proton_view_get_navigation_state_ffi(ViewHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
+
 pub fn proton_view_get_state_ffi(ViewHandle, FixedArray[Int], Int) -> Int
+
+pub fn proton_view_get_zoom_percent_ffi(ViewHandle, @ref.Ref[Int]) -> Int
 
 pub fn proton_view_load_url_ffi(ViewHandle, Bytes) -> Int
 
@@ -158,6 +162,8 @@ pub fn proton_view_set_bounds_ffi(ViewHandle, Int, Int, Int, Int) -> Int
 pub fn proton_view_set_visible_ffi(ViewHandle, Int) -> Int
 
 pub fn proton_view_set_z_order_ffi(ViewHandle, Int) -> Int
+
+pub fn proton_view_set_zoom_percent_ffi(ViewHandle, Int) -> Int
 
 pub fn proton_window_begin_choose_directory_dialog_ffi(WindowHandle, Bytes, Int, Bytes, Int, @ref.Ref[Int64]) -> Int
 
@@ -198,6 +204,8 @@ pub fn proton_window_flash_frame_ffi(WindowHandle, Int) -> Int
 pub fn proton_window_focus_ffi(WindowHandle) -> Int
 
 pub fn proton_window_get_content_size_ffi(WindowHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
+
+pub fn proton_window_get_navigation_state_ffi(WindowHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
 
 pub fn proton_window_get_state_ffi(WindowHandle, FixedArray[Int], Int) -> Int
 
@@ -278,6 +286,8 @@ pub fn proton_window_set_visible_on_all_workspaces_ffi(WindowHandle, Int) -> Int
 pub fn proton_window_set_zoom_percent_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_show_ffi(WindowHandle) -> Int
+
+pub fn proton_window_show_inactive_ffi(WindowHandle) -> Int
 
 pub fn proton_window_take_bridge_failure_json_ffi(WindowHandle, FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -6,6 +6,7 @@
 #include "include/capi/cef_download_item_capi.h"
 #include "include/internal/cef_string.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -819,5 +820,25 @@ int32_t proton_browser_navigation_state(
   }
   *out_can_go_back = browser->can_go_back(browser) ? 1 : 0;
   *out_can_go_forward = browser->can_go_forward(browser) ? 1 : 0;
+  return PROTON_OK;
+}
+
+int32_t proton_browser_set_zoom_percent(
+    cef_browser_t *browser, int32_t zoom_percent,
+    char *error, size_t error_len) {
+  if (browser == NULL || zoom_percent < 25 || zoom_percent > 500) {
+    proton_browser_set_message(error, error_len,
+                               "browser and zoom from 25 to 500 are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser host is unavailable");
+    return PROTON_ERR_ENGINE;
+  }
+  double factor = (double)zoom_percent / 100.0;
+  host->set_zoom_level(host, log(factor) / log(1.2));
+  host->base.release((cef_base_ref_counted_t *)host);
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -48,6 +48,9 @@ int32_t proton_browser_session_command_json(
 int32_t proton_browser_navigation_state(
     cef_browser_t *browser, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len);
+int32_t proton_browser_set_zoom_percent(
+    cef_browser_t *browser, int32_t zoom_percent,
+    char *error, size_t error_len);
 
 int proton_browser_session_before_browse(
     proton_browser_session_t *session, cef_frame_t *frame,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -185,6 +185,7 @@ struct proton_engine_view {
   int32_t width;
   int32_t height;
   int32_t z_order;
+  int32_t zoom_percent;
   int visible;
   uint64_t native_id;
   char initial_url[PROTON_ENGINE_MAX_URL_BYTES];

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -302,6 +302,8 @@ static int32_t proton_engine_view_create_browser(
   view->browser_id = proton_engine_browser_id(view->browser);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {
+    double factor = (double)view->zoom_percent / 100.0;
+    host->set_zoom_level(host, log(factor) / log(1.2));
     if (window->headless) {
       if (!view->visible && host->was_hidden != NULL) {
         host->was_hidden(host, 1);
@@ -367,6 +369,7 @@ int32_t proton_engine_view_create(
   view->width = config.width;
   view->height = config.height;
   view->z_order = config.z_order;
+  view->zoom_percent = 100;
   view->visible = config.visible;
   view->has_background_color = config.has_background_color;
   view->background_color = config.background_color;
@@ -512,6 +515,24 @@ int32_t proton_engine_view_set_z_order(proton_engine_view_t *view,
   }
   view->z_order = z_order;
   proton_engine_window_layout_views(view->window);
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
+                                            int32_t zoom_percent,
+                                            char *error,
+                                            size_t error_len) {
+  if (view == NULL || view->closed) {
+    proton_engine_set_message(error, error_len, "view is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  int32_t status = proton_browser_set_zoom_percent(
+      view->browser, zoom_percent, error, error_len);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  view->zoom_percent = zoom_percent;
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -200,6 +200,7 @@ struct proton_engine_view {
   int32_t width;
   int32_t height;
   int32_t z_order;
+  int32_t zoom_percent;
   int visible;
   uint64_t native_id;
   char *initial_url;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -391,6 +391,8 @@ void proton_engine_view_on_after_created(proton_engine_view_t *view,
   view->browser_id = browser->get_identifier(browser);
   view->browser_create_scheduled = 0;
   if (host != NULL) {
+    double factor = (double)view->zoom_percent / 100.0;
+    host->set_zoom_level(host, log(factor) / log(1.2));
     if (window->headless) {
       if (!view->visible && host->was_hidden != NULL) {
         host->was_hidden(host, 1);
@@ -508,6 +510,7 @@ int32_t proton_engine_view_create(
   view->width = config.width;
   view->height = config.height;
   view->z_order = config.z_order;
+  view->zoom_percent = 100;
   view->visible = config.visible;
   view->client = proton_engine_view_client_create(view);
   if (view->client == NULL) {
@@ -659,6 +662,26 @@ int32_t proton_engine_view_set_z_order(proton_engine_view_t *view,
   }
   view->z_order = z_order;
   proton_engine_window_layout_views(view->window);
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
+                                            int32_t zoom_percent,
+                                            char *error,
+                                            size_t error_len) {
+  if (view == NULL || view->closed) {
+    proton_engine_set_message(error, error_len, "view is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (view->browser != NULL) {
+    int32_t status = proton_browser_set_zoom_percent(
+        view->browser, zoom_percent, error, error_len);
+    if (status != PROTON_OK) {
+      return status;
+    }
+  }
+  view->zoom_percent = zoom_percent;
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -252,6 +252,7 @@ struct proton_engine_view {
   int32_t width;
   int32_t height;
   int32_t z_order;
+  int32_t zoom_percent;
   int visible;
   uint64_t native_id;
   char initial_url[PROTON_ENGINE_MAX_URL_BYTES];

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -309,6 +309,8 @@ static int32_t proton_engine_view_create_browser(
   view->browser_id = proton_engine_browser_id(view->browser);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {
+    double factor = (double)view->zoom_percent / 100.0;
+    host->set_zoom_level(host, log(factor) / log(1.2));
     if (window->headless) {
       if (!view->visible && host->was_hidden != NULL) {
         host->was_hidden(host, 1);
@@ -374,6 +376,7 @@ int32_t proton_engine_view_create(
   view->width = config.width;
   view->height = config.height;
   view->z_order = config.z_order;
+  view->zoom_percent = 100;
   view->visible = config.visible;
   view->has_background_color = config.has_background_color;
   view->background_color = config.background_color;
@@ -518,6 +521,25 @@ int32_t proton_engine_view_set_z_order(proton_engine_view_t *view,
   }
   view->z_order = z_order;
   proton_engine_window_layout_views(view->window);
+  proton_engine_signal_wait_source(view->window->runtime,
+                                   PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
+                                            int32_t zoom_percent,
+                                            char *error,
+                                            size_t error_len) {
+  if (view == NULL || view->closed) {
+    proton_engine_set_message(error, error_len, "view is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  int32_t status = proton_browser_set_zoom_percent(
+      view->browser, zoom_percent, error, error_len);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  view->zoom_percent = zoom_percent;
   proton_engine_signal_wait_source(view->window->runtime,
                                    PROTON_WAIT_PLATFORM);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -2581,6 +2581,46 @@ int32_t proton_view_set_z_order(proton_view_handle_t view, int32_t z_order) {
   return PROTON_OK;
 }
 
+int32_t proton_view_set_zoom_percent(proton_view_handle_t view,
+                                     int32_t zoom_percent) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (zoom_percent < 25 || zoom_percent > 500) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "zoom_percent must be between 25 and 500");
+  }
+  if (slot->engine_view != NULL) {
+    char engine_error[512] = {0};
+    status = proton_engine_view_set_zoom_percent(
+        slot->engine_view, zoom_percent, engine_error, sizeof(engine_error));
+    if (status != PROTON_OK) {
+      return proton_set_engine_status(status, engine_error);
+    }
+  }
+  slot->zoom_percent = zoom_percent;
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_get_zoom_percent(proton_view_handle_t view,
+                                     int32_t *out_zoom_percent) {
+  if (out_zoom_percent == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "out_zoom_percent is required");
+  }
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  *out_zoom_percent = slot->zoom_percent;
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_view_load_url(proton_view_handle_t view, const char *url) {
   proton_view_slot_t *slot = NULL;
   int32_t status = proton_get_view(view, &slot);

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -410,6 +410,10 @@ int32_t proton_engine_view_set_z_order(proton_engine_view_t *view,
                                        int32_t z_order,
                                        char *error,
                                        size_t error_len);
+int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
+                                            int32_t zoom_percent,
+                                            char *error,
+                                            size_t error_len);
 int32_t proton_engine_view_load_url(proton_engine_view_t *view,
                                     const char *url,
                                     char *error,

--- a/proton/internal/native/ffi/src/proton_state.c
+++ b/proton/internal/native/ffi/src/proton_state.c
@@ -449,6 +449,7 @@ int32_t proton_view_slot_create(proton_window_slot_t *window,
   view->width = width;
   view->height = height;
   view->z_order = z_order;
+  view->zoom_percent = 100;
   view->visible = visible;
   view->logical_id = logical_id;
   view->next = window->runtime->views;

--- a/proton/internal/native/ffi/src/proton_state.h
+++ b/proton/internal/native/ffi/src/proton_state.h
@@ -84,6 +84,7 @@ struct proton_view_slot {
   int32_t width;
   int32_t height;
   int32_t z_order;
+  int32_t zoom_percent;
   bool visible;
   proton_view_slot_t *next;
 };

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2678,6 +2678,34 @@ pub fn View::set_z_order(self : View, z_order : Int) -> Unit raise NativeError {
 }
 
 ///|
+pub fn View::set_zoom_percent(
+  self : View,
+  zoom_percent : Int,
+) -> Unit raise NativeError {
+  if zoom_percent < 25 || zoom_percent > 500 {
+    raise invalid_argument("zoom_percent must be between 25 and 500")
+  }
+  check_status(
+    @native_ffi.proton_view_set_zoom_percent_ffi(
+      self.live_handle(),
+      zoom_percent,
+    ),
+  )
+}
+
+///|
+pub fn View::zoom_percent(self : View) -> Int raise NativeError {
+  let zoom_percent : Ref[Int] = { val: 100, }
+  check_status(
+    @native_ffi.proton_view_get_zoom_percent_ffi(
+      self.live_handle(),
+      zoom_percent,
+    ),
+  )
+  zoom_percent.val
+}
+
+///|
 pub fn View::load_url(self : View, url : String) -> Unit raise NativeError {
   if url.is_empty() {
     raise invalid_argument("url must not be empty")

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -381,6 +381,21 @@ test "invalid handle returns structured native error" {
 }
 
 ///|
+test "view zoom rejects percentages outside the supported range" {
+  let view = View::{
+    handle: @native_ffi.view_null(),
+    id: 1L,
+    lifecycle: ViewLive,
+  }
+  let low = expect_native_error(() => view.set_zoom_percent(24))
+  inspect(low.status(), content="-1")
+  assert_true(low.message().contains("between 25 and 500"))
+  let high = expect_native_error(() => view.set_zoom_percent(501))
+  inspect(high.status(), content="-1")
+  assert_true(high.message().contains("between 25 and 500"))
+}
+
+///|
 test "runtime config rejects a relative cache directory" {
   let error = expect_native_error(() => {
     Runtime(

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -513,10 +513,13 @@ pub fn View::destroy(Self) -> Unit raise NativeError
 pub fn View::eval(Self, String) -> Unit raise NativeError
 pub fn View::id(Self) -> Int64
 pub fn View::load_url(Self, String) -> Unit raise NativeError
+pub fn View::navigation_state(Self) -> (Bool, Bool) raise NativeError
 pub fn View::set_bounds(Self, x~ : Int, y~ : Int, width~ : Int, height~ : Int) -> Unit raise NativeError
 pub fn View::set_visible(Self, Bool) -> Unit raise NativeError
 pub fn View::set_z_order(Self, Int) -> Unit raise NativeError
+pub fn View::set_zoom_percent(Self, Int) -> Unit raise NativeError
 pub fn View::state(Self) -> ViewState raise NativeError
+pub fn View::zoom_percent(Self) -> Int raise NativeError
 
 type ViewConfig derive(Eq, @debug.Debug)
 pub fn ViewConfig::ViewConfig(width~ : Int, height~ : Int, x? : Int, y? : Int, visible? : Bool, z_order? : Int, initial_url? : String, background_color? : String) -> Self
@@ -569,6 +572,7 @@ pub fn Window::id(Self) -> Int64
 pub fn Window::load_url(Self, String) -> Unit raise NativeError
 pub fn Window::maximize(Self) -> Unit raise NativeError
 pub fn Window::minimize(Self) -> Unit raise NativeError
+pub fn Window::navigation_state(Self) -> (Bool, Bool) raise NativeError
 pub fn Window::popup_menu(Self, MenuBar, Int, Int) -> Unit raise NativeError
 pub fn Window::respond_browser_request(Self, Int64, String, path? : String) -> Unit raise NativeError
 pub fn Window::respond_close_request(Self, Int64, Bool) -> Unit raise NativeError
@@ -605,6 +609,7 @@ pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_visible_on_all_workspaces(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError
 pub fn Window::show(Self) -> Unit raise NativeError
+pub fn Window::show_inactive(Self) -> Unit raise NativeError
 pub fn Window::state(Self) -> WindowState raise NativeError
 pub fn Window::take_bridge_failure(Self) -> BridgeDiagnostic? raise NativeError
 

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -245,8 +245,13 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
+  read_browser_zoom_percent : () -> Int raise WindowSessionError
+  read_browser_navigation_state : () -> (Bool, Bool) raise WindowSessionError
 }
 pub fn BrowserHandle::back(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::can_go_back(Self) -> Bool raise WindowSessionError
+pub fn BrowserHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::cancel_download(Self, Int) -> Unit raise WindowSessionError
 pub fn BrowserHandle::close_devtools(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::eval(Self, String) -> Unit raise WindowSessionError
@@ -255,8 +260,10 @@ pub fn BrowserHandle::load_html(Self, String, String) -> Unit raise WindowSessio
 pub fn BrowserHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::open_devtools(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::reload(Self, ignore_cache? : Bool) -> Unit raise WindowSessionError
+pub fn BrowserHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn BrowserHandle::stop(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::window_id(Self) -> String
+pub fn BrowserHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub(all) enum BrowserPermissionDecision {
   Allow
@@ -512,14 +519,19 @@ pub struct ViewHandle {
   set_view_bounds : (Int, Int, Int, Int) -> Unit raise WindowSessionError
   set_view_visible : (Bool) -> Unit raise WindowSessionError
   set_view_z_order : (Int) -> Unit raise WindowSessionError
+  set_view_zoom_percent : (Int) -> Unit raise WindowSessionError
+  read_view_zoom_percent : () -> Int raise WindowSessionError
   load_view_url : (String) -> Unit raise WindowSessionError
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
+  read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
 }
 pub fn ViewHandle::back(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::can_go_back(Self) -> Bool raise WindowSessionError
+pub fn ViewHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::close(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::close_devtools(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::eval(Self, String) -> Unit raise WindowSessionError
@@ -532,8 +544,10 @@ pub fn ViewHandle::reload(Self, ignore_cache? : Bool) -> Unit raise WindowSessio
 pub fn ViewHandle::set_bounds(Self, x~ : Int, y~ : Int, width~ : Int, height~ : Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_visible(Self, Bool) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_z_order(Self, Int) -> Unit raise WindowSessionError
+pub fn ViewHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::state(Self) -> ViewState raise WindowSessionError
 pub fn ViewHandle::stop(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub(all) struct ViewState {
   x : Int
@@ -587,6 +601,7 @@ pub struct WindowHandle {
   id : String
   native_id : Int64
   show_window : () -> Unit raise WindowSessionError
+  show_window_inactive : () -> Unit raise WindowSessionError
   hide_window : () -> Unit raise WindowSessionError
   close_window : () -> Unit raise WindowSessionError
   focus_window : () -> Unit raise WindowSessionError
@@ -635,6 +650,7 @@ pub struct WindowHandle {
   find_view : (String) -> ViewHandle?
 }
 pub fn WindowHandle::add_view(Self, String, ViewConfig) -> ViewHandle raise WindowSessionError
+pub fn WindowHandle::bounds(Self) -> (Int, Int, Int, Int) raise WindowSessionError
 pub fn WindowHandle::browser(Self) -> BrowserHandle
 pub fn WindowHandle::center(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::close(Self) -> Unit raise WindowSessionError
@@ -643,6 +659,8 @@ pub fn WindowHandle::flash_frame(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::focus(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::hide(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::id(Self) -> String
+pub fn WindowHandle::is_focused(Self) -> Bool raise WindowSessionError
+pub fn WindowHandle::is_visible(Self) -> Bool raise WindowSessionError
 pub fn WindowHandle::maximize(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::minimize(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
@@ -650,6 +668,7 @@ pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_aspect_ratio(Self, Double) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_background_color(Self, String) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_bounds(Self, x~ : Int, y~ : Int, width~ : Int, height~ : Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_closable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_protection(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_content_size(Self, Int, Int) -> Unit raise WindowSessionError
@@ -679,9 +698,11 @@ pub fn WindowHandle::set_visible_on_all_workspaces(Self, Bool) -> Unit raise Win
 pub fn WindowHandle::set_window_button_visibility(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::show(Self) -> Unit raise WindowSessionError
+pub fn WindowHandle::show_inactive(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::state(Self) -> WindowState raise WindowSessionError
 pub fn WindowHandle::view(Self, String) -> ViewHandle?
 pub fn WindowHandle::views(Self) -> Array[ViewHandle]
+pub fn WindowHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub struct WindowManager {
   open_window : async (String) -> WindowHandle raise WindowSessionError


### PR DESCRIPTION
## Summary

- add `ViewHandle::set_zoom_percent` and `ViewHandle::zoom_percent` for independent WebContentsView browser zoom
- keep zoom state in the typed native view boundary and apply it consistently on macOS, Windows, and Linux
- preserve zoom set before macOS finishes asynchronous view browser creation
- add interactive zoom controls to `52_web_contents_view` for manual review
- exercise set/get during the existing WebContentsView self-hosted e2e lifecycle
- refresh generated interfaces, including APIs merged immediately before this branch

## Platform impact

- macOS: stores pending zoom and applies it when CEF reports the view browser as created
- Windows: applies zoom to the child browser host immediately
- Linux: applies zoom to the child browser host immediately
- all platforms enforce the existing 25% to 500% range used by window/browser zoom

## Validation

- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100` (602 passed)
- `moon -C examples build --target native --diagnostic-limit 100`
- `moon -C e2e build --target native --diagnostic-limit 200`
- `moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`
- `moon check --target native --diagnostic-limit 100`
- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

Run `moon -C examples run 52_web_contents_view --target native`, then change the Zoom selector in the sidebar. The embedded browser on the right should change scale independently, and the status line should report the value read back from `ViewHandle::zoom_percent`.
