### PR TITLE
feat(browser): add Electron-style in-page find support

### DIFF
--- a/examples/52_web_contents_view/main.mbt
+++ b/examples/52_web_contents_view/main.mbt
@@ -365,6 +365,7 @@ async fn main {
           error=Some("load failed: " + error_text),
         )
       LoadingChanged(..) => ()
+      FoundInPage(..) => ()
       Closed => panel_slot.val = None
     }
   })

--- a/examples/70_find_in_page/README.md
+++ b/examples/70_find_in_page/README.md
@@ -1,0 +1,20 @@
+# Find In Page
+
+Manual review for Electron-style `BrowserHandle::find_in_page`,
+`ViewHandle::find_in_page`, their result events, and stop behavior.
+
+```sh
+moon -C examples run 70_find_in_page --target native
+```
+
+1. Search the host page for `Proton` and confirm multiple matches are
+   highlighted in the left pane.
+2. Confirm the first search selects an active match, then use **Next** and
+   **Previous** and confirm the active match and request id change for each call.
+3. Search the web contents view and confirm only the right pane is highlighted.
+4. Enable case matching and compare `Proton` with `proton`.
+5. Use **Stop and keep selection**, then **Stop and clear selection**, and
+   confirm the current highlight is respectively preserved and removed.
+
+Repeat the same checks on macOS, Windows, and Linux. The status line reports
+selection rectangles in the target web contents coordinate space.

--- a/examples/70_find_in_page/main.mbt
+++ b/examples/70_find_in_page/main.mbt
@@ -1,0 +1,226 @@
+///|
+struct FindRequest {
+  target : String
+  text : String
+  forward : Bool
+  match_case : Bool
+  find_next : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend FindRequest with ToJson::{to_json}
+
+///|
+pub extend FindRequest with FromJson::{from_json}
+
+///|
+struct StopRequest {
+  target : String
+  clear_selection : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend StopRequest with ToJson::{to_json}
+
+///|
+pub extend StopRequest with FromJson::{from_json}
+
+///|
+struct Reply {
+  ok : Bool
+  request_id : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Reply with ToJson::{to_json}
+
+///|
+pub extend Reply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/find-in-page",
+  js_namespace="findReview",
+)
+
+///|
+let find_command : @proton_contract.Command[FindRequest, Reply] = contract.command(
+  "find",
+)
+
+///|
+let stop_command : @proton_contract.Command[StopRequest, Reply] = contract.command(
+  "stop",
+)
+
+///|
+let window_slot : Ref[@proton.WindowHandle?] = { val: None, }
+
+///|
+let view_slot : Ref[@proton.ViewHandle?] = { val: None, }
+
+///|
+fn target_find(request : FindRequest) -> Reply {
+  try {
+    let request_id = match request.target {
+      "host" =>
+        match window_slot.val {
+          Some(window) =>
+            window
+            .browser()
+            .find_in_page(
+              request.text,
+              forward=request.forward,
+              match_case=request.match_case,
+              find_next=request.find_next,
+            )
+          None =>
+            return { ok: false, request_id: 0, message: "host unavailable", }
+        }
+      "view" =>
+        match view_slot.val {
+          Some(view) =>
+            view.find_in_page(
+              request.text,
+              forward=request.forward,
+              match_case=request.match_case,
+              find_next=request.find_next,
+            )
+          None =>
+            return { ok: false, request_id: 0, message: "view unavailable", }
+        }
+      _ => return { ok: false, request_id: 0, message: "unknown target", }
+    }
+    { ok: true, request_id, message: "find request started", }
+  } catch {
+    error => { ok: false, request_id: 0, message: error.to_string(), }
+  }
+}
+
+///|
+fn target_stop(request : StopRequest) -> Reply {
+  try {
+    match request.target {
+      "host" =>
+        match window_slot.val {
+          Some(window) =>
+            window
+            .browser()
+            .stop_find_in_page(clear_selection=request.clear_selection)
+          None =>
+            return { ok: false, request_id: 0, message: "host unavailable", }
+        }
+      "view" =>
+        match view_slot.val {
+          Some(view) =>
+            view.stop_find_in_page(clear_selection=request.clear_selection)
+          None =>
+            return { ok: false, request_id: 0, message: "view unavailable", }
+        }
+      _ => return { ok: false, request_id: 0, message: "unknown target", }
+    }
+    {
+      ok: true,
+      request_id: 0,
+      message: if request.clear_selection {
+        "find stopped and selection cleared"
+      } else {
+        "find stopped and selection preserved"
+      },
+    }
+  } catch {
+    error => { ok: false, request_id: 0, message: error.to_string(), }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(find_command, (_context, request) => target_find(request))
+  registrar.bind(stop_command, (_context, request) => target_stop(request))
+}
+
+///|
+fn js_escape(text : String) -> String {
+  text.replace_all(old="\\", new="\\\\").replace_all(old="\"", new="\\\"")
+}
+
+///|
+fn show_result(target : String, result : @proton.FindInPageResult) -> Unit {
+  match window_slot.val {
+    Some(window) => {
+      let message = target +
+        " request=" +
+        result.request_id.to_string() +
+        " match=" +
+        result.active_match_ordinal.to_string() +
+        "/" +
+        result.matches.to_string() +
+        " rect=" +
+        result.selection_x.to_string() +
+        "," +
+        result.selection_y.to_string() +
+        " " +
+        result.selection_width.to_string() +
+        "x" +
+        result.selection_height.to_string() +
+        (if result.final_update { " final" } else { " updating" })
+      window
+      .browser()
+      .eval(
+        "document.querySelector(\"#status\").textContent = \"\{js_escape(message)}\";",
+      ) catch {
+        _ => ()
+      }
+    }
+    None => ()
+  }
+}
+
+///|
+let view_url =
+  #|data:text/html,<body style='font-family:system-ui,sans-serif;margin:0;padding:48px;background:%23f4f6f8;color:%2320282f'><p style='font:700 12px monospace;color:%23406a83'>WEB CONTENTS VIEW</p><h1>Find Proton in this view</h1><p>Proton keeps browser controls close to MoonBit.</p><p>Searching Proton highlights every matching word in this independent page.</p><p>The lowercase word proton is useful for reviewing case-sensitive search.</p><p>Proton Proton Proton</p></body>
+
+///|
+fn page() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Find in page</title>
+    #|<style>:root{font-family:system-ui,sans-serif;color:#20282f;background:#e7ecef}*{box-sizing:border-box}body{margin:0;width:360px;min-height:100vh;padding:30px;border-right:1px solid #8c989f}h1{font-size:28px;margin:4px 0 12px}.eyebrow{font:700 11px monospace;color:#406a83}.copy{line-height:1.55;color:#4b5961}.controls{display:grid;gap:10px;margin-top:24px}input,select,button{height:40px;border:1px solid #738088;background:#f8fafb;color:#20282f;padding:0 12px}button{cursor:pointer;font-weight:700}button.primary{background:#315f78;color:white}.row{display:grid;grid-template-columns:1fr 1fr;gap:8px}.check{display:flex;align-items:center;gap:8px;font-size:13px}.check input{width:16px;height:16px}#status{min-height:42px;font:12px/1.5 monospace;color:#315f78}</style></head>
+    #|<body><p class="eyebrow">ELECTRON WEB CONTENTS / REVIEW 70</p><h1>Find in page</h1><p class="copy">Search Proton in this host page or the independent web contents view. Proton appears here several times; lowercase proton verifies case matching.</p><div class="controls"><select id="target"><option value="host">Host browser</option><option value="view">Web contents view</option></select><input id="text" value="Proton" aria-label="Search text"><label class="check"><input id="case" type="checkbox"> Match case</label><button class="primary" id="first">Find</button><div class="row"><button id="previous">Previous</button><button id="next">Next</button></div><div class="row"><button id="keep">Stop and keep</button><button id="clear">Stop and clear</button></div><p id="status" role="status">Ready</p></div>
+    #|<script>const status=document.querySelector('#status');const payload=(forward,find_next)=>({target:document.querySelector('#target').value,text:document.querySelector('#text').value,forward,match_case:document.querySelector('#case').checked,find_next});async function find(forward,find_next){try{const reply=await window.__MoonBit__.core.invokeOp('ext:findReview/find',payload(forward,find_next));status.textContent=reply.ok?`request ${reply.request_id} started`:reply.message}catch(error){status.textContent=String(error)}}async function stop(clear_selection){try{const reply=await window.__MoonBit__.core.invokeOp('ext:findReview/stop',{target:document.querySelector('#target').value,clear_selection});status.textContent=reply.message}catch(error){status.textContent=String(error)}}document.querySelector('#first').onclick=()=>void find(true,true);document.querySelector('#previous').onclick=()=>void find(false,false);document.querySelector('#next').onclick=()=>void find(true,false);document.querySelector('#keep').onclick=()=>void stop(false);document.querySelector('#clear').onclick=()=>void stop(true);document.querySelector('#text').onkeydown=event=>{if(event.key==='Enter')void find(true,true)}</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Find In Page", page(), width=1100, height=700, debug=true)
+  .with_view(
+    "content",
+    @proton.view(view_url, x=360, y=0, width=740, height=700),
+  )
+  .commands(register_commands)
+  .on_browser_event(async fn(_browser, event) noraise {
+    if event is @proton.BrowserEvent::FoundInPage(result~) {
+      show_result("host", result)
+    }
+  })
+  .on_view_event(async fn(_view, event) noraise {
+    if event is @proton.ViewEvent::FoundInPage(result~) {
+      show_result("view", result)
+    }
+  })
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      window_slot.val = Some(window)
+      view_slot.val = window.view("content")
+      window
+    },
+    on_close=fn(_window) {
+      view_slot.val = None
+      window_slot.val = None
+    },
+  )
+  .identifier("dev.proton.70-find-in-page")
+  .run_or_abort()
+}

--- a/examples/70_find_in_page/moon.pkg
+++ b/examples/70_find_in_page/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+warnings = "-unused_async"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -123,6 +123,9 @@ moon -C examples run 01_run --target native
   Includes focus/fullscreen/shadow plus mouse ignoring, background color,
   kiosk, workspace visibility, enabled-state, content-size, menu, icon,
   parent/modal, and native button-visibility controls.
+- `70_find_in_page`: manual Electron-style page search review for both the main
+  browser and a web contents view, including direction, case matching, result
+  events, and stop behavior.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/examples/e2e_fixtures/web_contents_view.mbt
+++ b/examples/e2e_fixtures/web_contents_view.mbt
@@ -89,6 +89,8 @@ fn web_contents_view_event_line(event : @proton.ViewEvent) -> String {
       error_code.to_string() +
       " error_text=" +
       error_text
+    FoundInPage(result~) =>
+      "view_found_in_page matches=" + result.matches.to_string()
     Closed => "view_closed"
   }
 }

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -379,8 +379,9 @@ pub fn App::with_view(self : App, id : String, config : ViewConfig) -> App {
 }
 
 ///|
-/// Observes lifecycle events for every running web contents view: loading
-/// changes, main-frame navigations, title updates, and load failures.
+/// Observes events for every running web contents view: loading changes,
+/// main-frame navigations, title updates, load failures, page-search results,
+/// and close.
 pub fn App::on_view_event(
   self : App,
   handler : async (ViewHandle, ViewEvent) -> Unit noraise,
@@ -390,8 +391,8 @@ pub fn App::on_view_event(
 }
 
 ///|
-/// Observes lifecycle events for every main browser page: loading changes,
-/// main-frame navigations, title updates, and load failures.
+/// Observes events for every main browser page: loading changes, main-frame
+/// navigations, title updates, load failures, and page-search results.
 pub fn App::on_browser_event(
   self : App,
   handler : async (BrowserHandle, BrowserEvent) -> Unit noraise,

--- a/proton/facade_native_types.mbt
+++ b/proton/facade_native_types.mbt
@@ -132,6 +132,22 @@ fn BrowserState::from_native(state : @native.BrowserState) -> BrowserState {
 }
 
 ///|
+fn FindInPageResult::from_native(
+  result : @native.NativeFindInPageResult,
+) -> FindInPageResult {
+  {
+    request_id: result.request_id,
+    active_match_ordinal: result.active_match_ordinal,
+    matches: result.matches,
+    selection_x: result.selection_x,
+    selection_y: result.selection_y,
+    selection_width: result.selection_width,
+    selection_height: result.selection_height,
+    final_update: result.final_update,
+  }
+}
+
+///|
 /// Information about one connected display.
 pub(all) struct ScreenInfo {
   id : Int

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -489,6 +489,28 @@ fn RuntimeSession::view_handle(
         view => view.browser_command(command, download_id?),
       )
     },
+    find_view_in_page: (text, forward, match_case, find_next) => {
+      let running = self.resolve_view(
+        window_id, window_native_id, id, native_id,
+      )
+      running.view.find_in_page(text, forward, match_case, find_next) catch {
+        error =>
+          raise window_operation_failed(
+            "find in view " + id + " in window " + window_id,
+            error,
+          )
+      }
+    },
+    stop_view_find: clear_selection => {
+      self.control_view(
+        window_id,
+        window_native_id,
+        id,
+        native_id,
+        "stop find in",
+        view => view.stop_find_in_page(clear_selection),
+      )
+    },
     read_view_navigation_state: () => {
       let running = self.resolve_view(
         window_id, window_native_id, id, native_id,
@@ -706,6 +728,24 @@ fn RuntimeSession::browser_handle(
     send_browser_command: (command, download_id) => {
       self.control_window(id, native_id, command + " in", window => {
         window.browser_command(command, download_id?)
+      })
+    },
+    find_browser_in_page: (text, forward, match_case, find_next) => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.find_in_page(text, forward, match_case, find_next) catch {
+        error =>
+          raise window_operation_failed(
+            "find in browser for window " + id,
+            error,
+          )
+      }
+    },
+    stop_browser_find: clear_selection => {
+      self.control_window(id, native_id, "stop browser find in", window => {
+        window.stop_find_in_page(clear_selection)
       })
     },
     set_browser_zoom_percent: zoom_percent => {
@@ -2080,6 +2120,30 @@ pub fn ViewHandle::eval(
 }
 
 ///|
+/// Starts or advances a page search and returns its request id. Set
+/// `find_next=true` to begin a new search session, matching Electron's
+/// `findInPage` option; leave it false to advance the current session.
+pub fn ViewHandle::find_in_page(
+  self : ViewHandle,
+  text : String,
+  forward? : Bool = true,
+  match_case? : Bool = false,
+  find_next? : Bool = false,
+) -> Int raise WindowSessionError {
+  (self.find_view_in_page)(text, forward, match_case, find_next)
+}
+
+///|
+/// Stops the active page search. Set `clear_selection=false` to preserve the
+/// current match highlight.
+pub fn ViewHandle::stop_find_in_page(
+  self : ViewHandle,
+  clear_selection? : Bool = true,
+) -> Unit raise WindowSessionError {
+  (self.stop_view_find)(clear_selection)
+}
+
+///|
 pub fn ViewHandle::back(self : ViewHandle) -> Unit raise WindowSessionError {
   (self.send_view_command)("back", None)
 }
@@ -2181,6 +2245,30 @@ pub fn BrowserHandle::eval(
   script : String,
 ) -> Unit raise WindowSessionError {
   (self.eval_browser_script)(script)
+}
+
+///|
+/// Starts or advances a page search and returns its request id. Set
+/// `find_next=true` to begin a new search session, matching Electron's
+/// `findInPage` option; leave it false to advance the current session.
+pub fn BrowserHandle::find_in_page(
+  self : BrowserHandle,
+  text : String,
+  forward? : Bool = true,
+  match_case? : Bool = false,
+  find_next? : Bool = false,
+) -> Int raise WindowSessionError {
+  (self.find_browser_in_page)(text, forward, match_case, find_next)
+}
+
+///|
+/// Stops the active page search. Set `clear_selection=false` to preserve the
+/// current match highlight.
+pub fn BrowserHandle::stop_find_in_page(
+  self : BrowserHandle,
+  clear_selection? : Bool = true,
+) -> Unit raise WindowSessionError {
+  (self.stop_browser_find)(clear_selection)
 }
 
 ///|
@@ -2609,10 +2697,6 @@ fn RuntimeSession::dispatch_view_event(
   if self.view_event_handlers.is_empty() && !closes_view {
     return
   }
-  let info = match event.view_event() {
-    Some(info) => info
-    None => return
-  }
   let (window_native_id, view_native_id) = match
     (event.window_id(), event.view_id()) {
     (Some(window_id), Some(view_id)) => (window_id, view_id)
@@ -2625,19 +2709,23 @@ fn RuntimeSession::dispatch_view_event(
   for index, view in running.views {
     if view.view.id() == view_native_id {
       let handle = self.view_handle(running, view)
-      let view_event = match event.event_type() {
-        "view_loading_changed" =>
+      let view_event = match
+        (event.event_type(), event.view_event(), event.find_in_page_result()) {
+        ("view_loading_changed", Some(info), _) =>
           ViewEvent::LoadingChanged(is_loading=info.is_loading.unwrap_or(false))
-        "view_navigated" => ViewEvent::Navigated(url=info.url.unwrap_or(""))
-        "view_title_updated" =>
+        ("view_navigated", Some(info), _) =>
+          ViewEvent::Navigated(url=info.url.unwrap_or(""))
+        ("view_title_updated", Some(info), _) =>
           ViewEvent::TitleUpdated(title=info.title.unwrap_or(""))
-        "view_load_failed" =>
+        ("view_load_failed", Some(info), _) =>
           ViewEvent::LoadFailed(
             url=info.url.unwrap_or(""),
             error_code=info.error_code.unwrap_or(0),
             error_text=info.error_text.unwrap_or(""),
           )
-        "view_closed" => ViewEvent::Closed
+        ("view_found_in_page", _, Some(result)) =>
+          ViewEvent::FoundInPage(result=FindInPageResult::from_native(result))
+        ("view_closed", Some(_), _) => ViewEvent::Closed
         _ => return
       }
       if closes_view {
@@ -2668,25 +2756,30 @@ fn RuntimeSession::dispatch_browser_event(
   self : RuntimeSession,
   event : @native.RuntimeEvent,
 ) -> Unit {
-  match (event.window_id(), event.browser_event()) {
-    (Some(window_id), Some(info)) =>
+  match
+    (event.window_id(), event.browser_event(), event.find_in_page_result()) {
+    (Some(window_id), info, find_result) =>
       match self.find_window_by_native_id(window_id) {
         Some(window) => {
           let browser = self.browser_handle(window)
-          let observed = match event.event_type() {
-            "browser_loading_changed" =>
+          let observed = match (event.event_type(), info, find_result) {
+            ("browser_loading_changed", Some(info), _) =>
               BrowserEvent::LoadingChanged(
                 is_loading=info.is_loading.unwrap_or(false),
               )
-            "browser_navigated" =>
+            ("browser_navigated", Some(info), _) =>
               BrowserEvent::Navigated(url=info.url.unwrap_or(""))
-            "browser_title_updated" =>
+            ("browser_title_updated", Some(info), _) =>
               BrowserEvent::TitleUpdated(title=info.title.unwrap_or(""))
-            "browser_load_failed" =>
+            ("browser_load_failed", Some(info), _) =>
               BrowserEvent::LoadFailed(
                 url=info.url.unwrap_or(""),
                 error_code=info.error_code.unwrap_or(0),
                 error_text=info.error_text.unwrap_or(""),
+              )
+            ("browser_found_in_page", _, Some(result)) =>
+              BrowserEvent::FoundInPage(
+                result=FindInPageResult::from_native(result),
               )
             _ => return
           }

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -450,6 +450,8 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  find_browser_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
+  stop_browser_find : (Bool) -> Unit raise WindowSessionError
   set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
   read_browser_zoom_percent : () -> Int raise WindowSessionError
   set_browser_audio_muted : (Bool) -> Unit raise WindowSessionError
@@ -503,6 +505,8 @@ pub struct ViewHandle {
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
+  find_view_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
+  stop_view_find : (Bool) -> Unit raise WindowSessionError
   read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
@@ -586,13 +590,14 @@ pub extend WindowEvent with Eq::{not_equal, equal}
 pub extend WindowEvent with Debug::{to_repr}
 
 ///|
-/// An observed change to a running web contents view, following the Electron
-/// `webContents` lifecycle events.
+/// An observed change to a running web contents view, following Electron
+/// `webContents` lifecycle and page-search events.
 pub(all) enum ViewEvent {
   LoadingChanged(is_loading~ : Bool)
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  FoundInPage(result~ : FindInPageResult)
   Closed
 } derive(Debug, Eq)
 
@@ -601,6 +606,26 @@ pub extend ViewEvent with Eq::{not_equal, equal}
 
 ///|
 pub extend ViewEvent with Debug::{to_repr}
+
+///|
+/// One update from an active page search. The selection rectangle uses the
+/// target web contents coordinate space.
+pub(all) struct FindInPageResult {
+  request_id : Int
+  active_match_ordinal : Int
+  matches : Int
+  selection_x : Int
+  selection_y : Int
+  selection_width : Int
+  selection_height : Int
+  final_update : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend FindInPageResult with Eq::{not_equal, equal}
+
+///|
+pub extend FindInPageResult with Debug::{to_repr}
 
 ///|
 /// The result of an asynchronous native close request.
@@ -780,6 +805,7 @@ pub(all) enum BrowserEvent {
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  FoundInPage(result~ : FindInPageResult)
 } derive(Debug, Eq)
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -86,6 +86,7 @@ fn test_window_handle(
   content_size? : (Int, Int),
   browser_audio_calls? : Array[Bool],
   browser_audio_muted? : Bool = false,
+  browser_find_calls? : Array[String],
   window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
@@ -95,6 +96,20 @@ fn test_window_handle(
     load_browser_html: fn(_html, _base_url) {  },
     eval_browser_script: fn(_script) {  },
     send_browser_command: fn(_command, _download_id) {  },
+    find_browser_in_page: fn(text, forward, match_case, find_next) {
+      match browser_find_calls {
+        Some(calls) =>
+          calls.push("find:\{text}:\{forward}:\{match_case}:\{find_next}")
+        None => ()
+      }
+      7
+    },
+    stop_browser_find: fn(clear_selection) {
+      match browser_find_calls {
+        Some(calls) => calls.push("stop:\{clear_selection}")
+        None => ()
+      }
+    },
     set_browser_zoom_percent: fn(_zoom_percent) {  },
     read_browser_zoom_percent: fn() { 100 },
     set_browser_audio_muted: muted => {
@@ -2342,6 +2357,13 @@ fn test_view_handle(
     load_view_html: fn(_html, _base_url) {  },
     eval_view_script: fn(_script) {  },
     send_view_command: fn(_command, _download_id) {  },
+    find_view_in_page: fn(text, forward, match_case, find_next) {
+      calls.push("find:\{text}:\{forward}:\{match_case}:\{find_next}")
+      9
+    },
+    stop_view_find: fn(clear_selection) {
+      calls.push("stop_find:\{clear_selection}")
+    },
     read_view_navigation_state: fn() { (true, false) },
     read_view_state: fn() {
       { x: 1, y: 2, width: 300, height: 200, visible: true, z_order: 1, }
@@ -2363,6 +2385,11 @@ test "view handle routes operations through its closures" {
   view.set_audio_muted(true)
   assert_true(view.is_audio_muted())
   view.load_url("https://example.com/")
+  inspect(
+    view.find_in_page("Proton", forward=false, match_case=true, find_next=true),
+    content="9",
+  )
+  view.stop_find_in_page(clear_selection=false)
   assert_true(view.can_go_back())
   assert_false(view.can_go_forward())
   let state = view.state()
@@ -2379,6 +2406,8 @@ test "view handle routes operations through its closures" {
       #|  "set_zoom_percent:125",
       #|  "set_audio_muted:true",
       #|  "load_url:https://example.com/",
+      #|  "find:Proton:false:true:true",
+      #|  "stop_find:false",
       #|  "close",
       #|]
     ),
@@ -2408,6 +2437,15 @@ test "browser handle controls and reads audio mute state" {
   browser.set_audio_muted(true)
   assert_eq(calls, [true])
   assert_true(browser.is_audio_muted())
+}
+
+///|
+test "browser handle routes page find operations" {
+  let calls : Array[String] = []
+  let browser = test_window_handle("main", 17L, browser_find_calls=calls).browser()
+  inspect(browser.find_in_page("MoonBit", match_case=true), content="7")
+  browser.stop_find_in_page(clear_selection=false)
+  assert_eq(calls, ["find:MoonBit:true:true:false", "stop:false"])
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -659,6 +659,23 @@ pub extern "C" fn proton_window_browser_command_json_ffi(
 ) -> Int = "proton_window_browser_command_json"
 
 ///|
+#borrow(text, out_request_id)
+pub extern "C" fn proton_window_find_in_page_ffi(
+  window : WindowHandle,
+  text : Bytes,
+  forward : Int,
+  match_case : Int,
+  find_next : Int,
+  out_request_id : Ref[Int],
+) -> Int = "proton_window_find_in_page"
+
+///|
+pub extern "C" fn proton_window_stop_find_in_page_ffi(
+  window : WindowHandle,
+  clear_selection : Int,
+) -> Int = "proton_window_stop_find_in_page"
+
+///|
 #borrow(out_can_go_back, out_can_go_forward)
 pub extern "C" fn proton_window_get_navigation_state_ffi(
   window : WindowHandle,
@@ -921,6 +938,23 @@ pub extern "C" fn proton_view_browser_command_json_ffi(
   view : ViewHandle,
   command_json : Bytes,
 ) -> Int = "proton_view_browser_command_json"
+
+///|
+#borrow(text, out_request_id)
+pub extern "C" fn proton_view_find_in_page_ffi(
+  view : ViewHandle,
+  text : Bytes,
+  forward : Int,
+  match_case : Int,
+  find_next : Int,
+  out_request_id : Ref[Int],
+) -> Int = "proton_view_find_in_page"
+
+///|
+pub extern "C" fn proton_view_stop_find_in_page_ffi(
+  view : ViewHandle,
+  clear_selection : Int,
+) -> Int = "proton_view_stop_find_in_page"
 
 ///|
 #borrow(out_can_go_back, out_can_go_forward)

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -240,6 +240,11 @@ int32_t proton_window_eval(proton_window_handle_t window,
                                       const char *script);
 int32_t proton_window_browser_command_json(
     proton_window_handle_t window, const char *command_json);
+int32_t proton_window_find_in_page(
+    proton_window_handle_t window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id);
+int32_t proton_window_stop_find_in_page(
+    proton_window_handle_t window, int32_t clear_selection);
 int32_t proton_window_get_navigation_state(
     proton_window_handle_t window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward);
@@ -416,6 +421,11 @@ int32_t proton_view_load_url(proton_view_handle_t view,
 int32_t proton_view_eval(proton_view_handle_t view, const char *script);
 int32_t proton_view_browser_command_json(
     proton_view_handle_t view, const char *command_json);
+int32_t proton_view_find_in_page(
+    proton_view_handle_t view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id);
+int32_t proton_view_stop_find_in_page(
+    proton_view_handle_t view, int32_t clear_selection);
 int32_t proton_view_get_navigation_state(
     proton_view_handle_t view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward);

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -6,6 +6,7 @@
 #include "include/capi/cef_download_item_capi.h"
 #include "include/internal/cef_string.h"
 
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,6 +57,8 @@ struct proton_browser_session {
   char *url;
   char *title;
   int32_t is_loading;
+  int32_t next_find_request_id;
+  int32_t active_find_request_id;
 };
 
 static void proton_browser_set_message(char *error, size_t error_len,
@@ -1006,4 +1009,113 @@ int32_t proton_browser_is_audio_muted(
   *out_muted = host->is_audio_muted(host) ? 1 : 0;
   host->base.release((cef_base_ref_counted_t *)host);
   return PROTON_OK;
+}
+
+int32_t proton_browser_find_in_page(
+    proton_browser_session_t *session, cef_browser_t *browser,
+    const char *text, int32_t forward, int32_t match_case,
+    int32_t find_next, int32_t *out_request_id, char *error,
+    size_t error_len) {
+  if (session == NULL || browser == NULL || text == NULL || text[0] == '\0' ||
+      out_request_id == NULL) {
+    proton_browser_set_message(
+        error, error_len,
+        "browser session, browser, non-empty text, and request output are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if ((forward != 0 && forward != 1) ||
+      (match_case != 0 && match_case != 1) ||
+      (find_next != 0 && find_next != 1)) {
+    proton_browser_set_message(error, error_len,
+                               "find flags must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL || host->find == NULL ||
+      (find_next && host->stop_finding == NULL)) {
+    if (host != NULL) {
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    proton_browser_set_message(error, error_len,
+                               "browser find is unavailable");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  cef_string_t search_text = {0};
+  if (!cef_string_utf8_to_utf16(text, strlen(text), &search_text)) {
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_set_message(error, error_len,
+                               "failed to encode find text as UTF-16");
+    return PROTON_ERR_ENGINE;
+  }
+  /* Electron uses findNext to start a new session. CEF infers sessions and
+     uses its final flag to request an active match. */
+  if (find_next) {
+    host->stop_finding(host, 1);
+  }
+  if (session->next_find_request_id == INT32_MAX) {
+    session->next_find_request_id = 1;
+  } else {
+    session->next_find_request_id++;
+  }
+  session->active_find_request_id = session->next_find_request_id;
+  *out_request_id = session->active_find_request_id;
+  host->find(host, &search_text, forward, match_case, 1);
+  cef_string_clear(&search_text);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
+int32_t proton_browser_stop_find_in_page(
+    cef_browser_t *browser, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (browser == NULL ||
+      (clear_selection != 0 && clear_selection != 1)) {
+    proton_browser_set_message(
+        error, error_len,
+        "browser is required and clear_selection must be 0 or 1");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL || host->stop_finding == NULL) {
+    if (host != NULL) {
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    proton_browser_set_message(error, error_len,
+                               "browser find is unavailable");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  host->stop_finding(host, clear_selection);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
+int32_t proton_browser_session_find_request_id(
+    proton_browser_session_t *session, int32_t cef_identifier) {
+  if (session != NULL && session->active_find_request_id > 0) {
+    return session->active_find_request_id;
+  }
+  return cef_identifier;
+}
+
+void proton_browser_session_find_result(
+    proton_browser_session_t *session, int32_t cef_identifier,
+    int32_t count, int32_t x, int32_t y, int32_t width,
+    int32_t height, int32_t active_match_ordinal, int32_t final_update) {
+  if (session == NULL) {
+    return;
+  }
+  proton_event_t *event = proton_event_create_window(
+      PROTON_EVENT_BROWSER_FIND_RESULT, session->window);
+  if (event != NULL) {
+    event->request_id =
+        proton_browser_session_find_request_id(session, cef_identifier);
+    event->int_a = count;
+    event->int_b = active_match_ordinal;
+    event->int_c = x;
+    event->int64_a = y;
+    event->int64_b = width;
+    event->revision = height;
+    event->bool_a = final_update != 0 ? 1 : 0;
+  }
+  (void)proton_browser_enqueue_event(session, event);
 }

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -76,6 +76,20 @@ int32_t proton_browser_set_audio_muted(
 int32_t proton_browser_is_audio_muted(
     cef_browser_t *browser, int32_t *out_muted, char *error,
     size_t error_len);
+int32_t proton_browser_find_in_page(
+    proton_browser_session_t *session, cef_browser_t *browser,
+    const char *text, int32_t forward, int32_t match_case,
+    int32_t find_next, int32_t *out_request_id, char *error,
+    size_t error_len);
+int32_t proton_browser_stop_find_in_page(
+    cef_browser_t *browser, int32_t clear_selection, char *error,
+    size_t error_len);
+int32_t proton_browser_session_find_request_id(
+    proton_browser_session_t *session, int32_t cef_identifier);
+void proton_browser_session_find_result(
+    proton_browser_session_t *session, int32_t cef_identifier,
+    int32_t count, int32_t x, int32_t y, int32_t width,
+    int32_t height, int32_t active_match_ordinal, int32_t final_update);
 
 int proton_browser_session_before_browse(
     proton_browser_session_t *session, cef_frame_t *frame,

--- a/proton/internal/native/ffi/src/engine/cef_common/view_events.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/view_events.c
@@ -164,6 +164,28 @@ void proton_view_events_load_failed(proton_view_events_t *events,
   proton_view_events_enqueue(events, event, 0);
 }
 
+void proton_view_events_find_result(
+    proton_view_events_t *events, int32_t request_id, int32_t count,
+    int32_t x, int32_t y, int32_t width, int32_t height,
+    int32_t active_match_ordinal, int32_t final_update) {
+  if (events == NULL) {
+    return;
+  }
+  proton_event_t *event = proton_event_create(PROTON_EVENT_VIEW_FIND_RESULT);
+  if (event == NULL) {
+    return;
+  }
+  event->request_id = request_id;
+  event->int_a = count;
+  event->int_b = active_match_ordinal;
+  event->int_c = x;
+  event->int64_a = y;
+  event->int64_b = width;
+  event->revision = height;
+  event->bool_a = final_update != 0 ? 1 : 0;
+  proton_view_events_enqueue(events, event, 0);
+}
+
 void proton_view_events_closed(proton_view_events_t *events) {
   proton_view_events_enqueue(
       events, proton_event_create(PROTON_EVENT_VIEW_CLOSED), 1);

--- a/proton/internal/native/ffi/src/engine/cef_common/view_events.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/view_events.h
@@ -33,6 +33,10 @@ void proton_view_events_load_failed(proton_view_events_t *events,
                                     const char *url,
                                     int32_t error_code,
                                     const char *error_text);
+void proton_view_events_find_result(
+    proton_view_events_t *events, int32_t request_id, int32_t count,
+    int32_t x, int32_t y, int32_t width, int32_t height,
+    int32_t active_match_ordinal, int32_t final_update);
 void proton_view_events_closed(proton_view_events_t *events);
 
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -36,6 +36,7 @@
 #include "include/capi/cef_display_handler_capi.h"
 #include "include/capi/cef_drag_handler_capi.h"
 #include "include/capi/cef_download_handler_capi.h"
+#include "include/capi/cef_find_handler_capi.h"
 #include "include/capi/cef_frame_capi.h"
 #include "include/capi/cef_life_span_handler_capi.h"
 #include "include/capi/cef_load_handler_capi.h"
@@ -70,6 +71,11 @@ typedef struct proton_engine_bridge_pending {
   struct proton_engine_bridge_pending *next;
 } proton_engine_bridge_pending_t;
 
+typedef struct {
+  cef_find_handler_t handler;
+  proton_engine_ref_counted_t refs;
+} proton_engine_find_handler_t;
+
 static proton_engine_app_t g_app;
 static proton_engine_browser_process_handler_t g_browser_process_handler;
 static proton_engine_render_process_handler_t g_render_process_handler;
@@ -79,6 +85,7 @@ static proton_engine_load_handler_t g_load_handler;
 static proton_engine_drag_handler_t g_drag_handler;
 static proton_engine_request_handler_t g_request_handler;
 static proton_engine_download_handler_t g_download_handler;
+static proton_engine_find_handler_t g_find_handler;
 static proton_engine_permission_handler_t g_permission_handler;
 static proton_engine_render_handler_t g_render_handler;
 static proton_engine_scheme_factory_t g_scheme_factory;
@@ -566,6 +573,12 @@ proton_engine_client_get_download_handler(cef_client_t *self) {
   return &g_download_handler.handler;
 }
 
+static cef_find_handler_t *CEF_CALLBACK
+proton_engine_client_get_find_handler(cef_client_t *self) {
+  (void)self;
+  return &g_find_handler.handler;
+}
+
 static cef_permission_handler_t *CEF_CALLBACK
 proton_engine_client_get_permission_handler(cef_client_t *self) {
   (void)self;
@@ -658,6 +671,10 @@ static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
     uint32_t requested_permissions, cef_media_access_callback_t *callback);
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update);
 
 void proton_engine_init_handlers(void) {
   static int initialized = 0;
@@ -732,6 +749,11 @@ void proton_engine_init_handlers(void) {
       proton_engine_on_before_download;
   g_download_handler.handler.on_download_updated =
       proton_engine_on_download_updated;
+
+  proton_engine_init_ref_counted(
+      (cef_base_ref_counted_t *)&g_find_handler.handler.base,
+      sizeof(g_find_handler.handler), &g_find_handler.refs);
+  g_find_handler.handler.on_find_result = proton_engine_on_find_result;
 
   proton_engine_init_ref_counted(
       (cef_base_ref_counted_t *)&g_permission_handler.handler.base,
@@ -1296,6 +1318,30 @@ static void CEF_CALLBACK proton_engine_on_download_updated(
       callback);
 }
 
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update) {
+  (void)self;
+  int x = selection_rect != NULL ? selection_rect->x : 0;
+  int y = selection_rect != NULL ? selection_rect->y : 0;
+  int width = selection_rect != NULL ? selection_rect->width : 0;
+  int height = selection_rect != NULL ? selection_rect->height : 0;
+  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
+  if (view != NULL) {
+    proton_view_events_find_result(
+        view->events,
+        proton_browser_session_find_request_id(view->browser_session,
+                                               identifier),
+        count, x, y, width, height, active_match_ordinal, final_update);
+    return;
+  }
+  proton_engine_window_t *window = proton_engine_window_from_browser(browser);
+  proton_browser_session_find_result(
+      window != NULL ? window->browser_session : NULL, identifier, count,
+      x, y, width, height, active_match_ordinal, final_update);
+}
+
 static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
@@ -1365,6 +1411,7 @@ proton_engine_client_t *proton_engine_client_create(
       proton_engine_client_get_request_handler;
   client->client.get_download_handler =
       proton_engine_client_get_download_handler;
+  client->client.get_find_handler = proton_engine_client_get_find_handler;
   client->client.get_permission_handler =
       proton_engine_client_get_permission_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -248,11 +248,14 @@ static proton_engine_client_t *proton_engine_view_client_create(
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Navigation
-  // policy, bridge, downloads, and permissions stay window-scoped for now.
+  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // permissions stay window-scoped for now.
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
+  client->client.get_find_handler =
+      view->window->client->client.get_find_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -658,6 +661,31 @@ int32_t proton_engine_view_get_navigation_state(
   }
   return proton_browser_navigation_state(
       view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
+int32_t proton_engine_view_find_in_page(
+    proton_engine_view_t *view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      view->browser_session, view->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_view_stop_find_in_page(
+    proton_engine_view_t *view, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      view->browser, clear_selection, error, error_len);
 }
 
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -247,8 +247,8 @@ static proton_engine_client_t *proton_engine_view_client_create(
   client->view = view;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
-  // and the render handler gives headless (OSR) views a viewport. Navigation
-  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // and the render handler gives headless (OSR) views a viewport. Find results
+  // are view-scoped. Navigation policy, bridge, downloads, and
   // permissions stay window-scoped for now.
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1620,6 +1620,31 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_find_in_page(
+    proton_engine_window_t *window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      window->browser_session, window->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_window_stop_find_in_page(
+    proton_engine_window_t *window, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      window->browser, clear_selection, error, error_len);
+}
+
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_client.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_client.m
@@ -29,6 +29,7 @@
 #include "mac_launch_input.h"
 
 #include "include/capi/cef_browser_capi.h"
+#include "include/capi/cef_find_handler_capi.h"
 #include "include/capi/cef_frame_capi.h"
 #include "include/capi/cef_task_capi.h"
 #include "include/capi/cef_values_capi.h"
@@ -52,6 +53,11 @@ typedef struct proton_engine_bridge_pending {
   struct proton_engine_bridge_pending *next;
 } proton_engine_bridge_pending_t;
 
+typedef struct {
+  cef_find_handler_t handler;
+  proton_engine_ref_counted_t refs;
+} proton_engine_find_handler_t;
+
 static proton_engine_bridge_pending_t *g_bridge_pending = NULL;
 static proton_engine_app_t g_app;
 static proton_engine_browser_process_handler_t g_browser_process_handler;
@@ -61,6 +67,7 @@ static proton_engine_life_span_handler_t g_life_span_handler;
 static proton_engine_load_handler_t g_load_handler;
 static proton_engine_request_handler_t g_request_handler;
 static proton_engine_download_handler_t g_download_handler;
+static proton_engine_find_handler_t g_find_handler;
 static proton_engine_permission_handler_t g_permission_handler;
 static proton_engine_render_handler_t g_render_handler;
 static proton_engine_display_handler_t g_display_handler;
@@ -370,6 +377,14 @@ proton_engine_client_get_download_handler(cef_client_t *self) {
   return &g_download_handler.handler;
 }
 
+static cef_find_handler_t *CEF_CALLBACK
+proton_engine_client_get_find_handler(cef_client_t *self) {
+  (void)self;
+  g_find_handler.handler.base.add_ref(
+      (cef_base_ref_counted_t *)&g_find_handler.handler);
+  return &g_find_handler.handler;
+}
+
 static cef_permission_handler_t *CEF_CALLBACK
 proton_engine_client_get_permission_handler(cef_client_t *self) {
   (void)self;
@@ -489,6 +504,10 @@ static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
     uint32_t requested_permissions, cef_media_access_callback_t *callback);
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update);
 
 void proton_engine_init_handlers(void) {
   static int initialized = 0;
@@ -564,6 +583,11 @@ void proton_engine_init_handlers(void) {
       proton_engine_on_before_download;
   g_download_handler.handler.on_download_updated =
       proton_engine_on_download_updated;
+
+  proton_engine_init_ref_counted(
+      (cef_base_ref_counted_t *)&g_find_handler.handler.base,
+      sizeof(g_find_handler.handler), &g_find_handler.refs);
+  g_find_handler.handler.on_find_result = proton_engine_on_find_result;
 
   proton_engine_init_ref_counted(
       (cef_base_ref_counted_t *)&g_permission_handler.handler.base,
@@ -1134,6 +1158,30 @@ static void CEF_CALLBACK proton_engine_on_download_updated(
       callback);
 }
 
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update) {
+  (void)self;
+  int x = selection_rect != NULL ? selection_rect->x : 0;
+  int y = selection_rect != NULL ? selection_rect->y : 0;
+  int width = selection_rect != NULL ? selection_rect->width : 0;
+  int height = selection_rect != NULL ? selection_rect->height : 0;
+  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
+  if (view != NULL) {
+    proton_view_events_find_result(
+        view->events,
+        proton_browser_session_find_request_id(view->browser_session,
+                                               identifier),
+        count, x, y, width, height, active_match_ordinal, final_update);
+    return;
+  }
+  proton_engine_window_t *window = proton_engine_window_from_browser(browser);
+  proton_browser_session_find_result(
+      window != NULL ? window->browser_session : NULL, identifier, count,
+      x, y, width, height, active_match_ordinal, final_update);
+}
+
 static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
@@ -1200,6 +1248,7 @@ proton_engine_client_t *proton_engine_client_create(
       proton_engine_client_get_request_handler;
   client->client.get_download_handler =
       proton_engine_client_get_download_handler;
+  client->client.get_find_handler = proton_engine_client_get_find_handler;
   client->client.get_permission_handler =
       proton_engine_client_get_permission_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -462,8 +462,8 @@ static proton_engine_client_t *proton_engine_view_client_create(
   client->view = view;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
-  // and the render handler gives headless (OSR) views a viewport. Navigation
-  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // and the render handler gives headless (OSR) views a viewport. Find results
+  // are view-scoped. Navigation policy, bridge, downloads, and
   // permissions stay window-scoped for now,
   // and CEF defaults (cancel popups, no bridge bootstrap) apply to view
   // browsers.

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -463,13 +463,16 @@ static proton_engine_client_t *proton_engine_view_client_create(
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Navigation
-  // policy, bridge, downloads, and permissions stay window-scoped for now,
+  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // permissions stay window-scoped for now,
   // and CEF defaults (cancel popups, no bridge bootstrap) apply to view
   // browsers.
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
+  client->client.get_find_handler =
+      view->window->client->client.get_find_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -821,6 +824,31 @@ int32_t proton_engine_view_get_navigation_state(
   }
   return proton_browser_navigation_state(
       view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
+int32_t proton_engine_view_find_in_page(
+    proton_engine_view_t *view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      view->browser_session, view->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_view_stop_find_in_page(
+    proton_engine_view_t *view, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      view->browser, clear_selection, error, error_len);
 }
 
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -2193,6 +2193,31 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_find_in_page(
+    proton_engine_window_t *window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      window->browser_session, window->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_window_stop_find_in_page(
+    proton_engine_window_t *window, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      window->browser, clear_selection, error, error_len);
+}
+
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -33,6 +33,7 @@
 #include "include/capi/cef_display_handler_capi.h"
 #include "include/capi/cef_drag_handler_capi.h"
 #include "include/capi/cef_download_handler_capi.h"
+#include "include/capi/cef_find_handler_capi.h"
 #include "include/capi/cef_frame_capi.h"
 #include "include/capi/cef_life_span_handler_capi.h"
 #include "include/capi/cef_load_handler_capi.h"
@@ -72,6 +73,11 @@ static proton_engine_life_span_handler_t g_proton_engine_life_span_handler;
 static proton_engine_drag_handler_t g_proton_engine_drag_handler;
 static proton_engine_request_handler_t g_proton_engine_request_handler;
 static proton_engine_download_handler_t g_proton_engine_download_handler;
+typedef struct {
+  cef_find_handler_t handler;
+  proton_engine_ref_counted_t refs;
+} proton_engine_find_handler_t;
+static proton_engine_find_handler_t g_proton_engine_find_handler;
 static proton_engine_permission_handler_t g_proton_engine_permission_handler;
 static proton_engine_render_handler_t g_proton_engine_render_handler;
 static proton_engine_scheme_factory_t g_proton_engine_scheme_factory;
@@ -138,6 +144,10 @@ static void CEF_CALLBACK proton_engine_on_download_updated(
     cef_download_handler_t *self, cef_browser_t *browser,
     cef_download_item_t *download_item,
     cef_download_item_callback_t *callback);
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update);
 static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
@@ -152,6 +162,8 @@ static cef_request_handler_t *CEF_CALLBACK
 proton_engine_client_get_request_handler(cef_client_t *self);
 static cef_download_handler_t *CEF_CALLBACK
 proton_engine_client_get_download_handler(cef_client_t *self);
+static cef_find_handler_t *CEF_CALLBACK
+proton_engine_client_get_find_handler(cef_client_t *self);
 static cef_permission_handler_t *CEF_CALLBACK
 proton_engine_client_get_permission_handler(cef_client_t *self);
 
@@ -840,6 +852,10 @@ void proton_engine_init_app(void) {
       sizeof(g_proton_engine_download_handler.handler),
       &g_proton_engine_download_handler.refs);
   proton_engine_init_ref_counted(
+      (cef_base_ref_counted_t *)&g_proton_engine_find_handler.handler.base,
+      sizeof(g_proton_engine_find_handler.handler),
+      &g_proton_engine_find_handler.refs);
+  proton_engine_init_ref_counted(
       (cef_base_ref_counted_t *)&g_proton_engine_permission_handler.handler.base,
       sizeof(g_proton_engine_permission_handler.handler),
       &g_proton_engine_permission_handler.refs);
@@ -888,6 +904,8 @@ void proton_engine_init_app(void) {
       proton_engine_on_before_download;
   g_proton_engine_download_handler.handler.on_download_updated =
       proton_engine_on_download_updated;
+  g_proton_engine_find_handler.handler.on_find_result =
+      proton_engine_on_find_result;
   g_proton_engine_permission_handler.handler.on_request_media_access_permission =
       proton_engine_on_media_permission;
   g_proton_engine_render_handler.handler.get_view_rect =
@@ -1130,6 +1148,7 @@ proton_engine_client_t *proton_engine_client_new(
       proton_engine_client_get_request_handler;
   client->client.get_download_handler =
       proton_engine_client_get_download_handler;
+  client->client.get_find_handler = proton_engine_client_get_find_handler;
   client->client.get_permission_handler =
       proton_engine_client_get_permission_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
@@ -1529,6 +1548,32 @@ static void CEF_CALLBACK proton_engine_on_download_updated(
       callback);
 }
 
+static void CEF_CALLBACK proton_engine_on_find_result(
+    cef_find_handler_t *self, cef_browser_t *browser, int identifier,
+    int count, const cef_rect_t *selection_rect, int active_match_ordinal,
+    int final_update) {
+  (void)self;
+  int x = selection_rect != NULL ? selection_rect->x : 0;
+  int y = selection_rect != NULL ? selection_rect->y : 0;
+  int width = selection_rect != NULL ? selection_rect->width : 0;
+  int height = selection_rect != NULL ? selection_rect->height : 0;
+  int browser_id = proton_engine_browser_id(browser);
+  proton_engine_view_t *view = proton_engine_find_view_by_browser_id(browser_id);
+  if (view != NULL) {
+    proton_view_events_find_result(
+        view->events,
+        proton_browser_session_find_request_id(view->browser_session,
+                                               identifier),
+        count, x, y, width, height, active_match_ordinal, final_update);
+    return;
+  }
+  proton_engine_window_t *window =
+      proton_engine_find_window_by_browser_id(browser_id);
+  proton_browser_session_find_result(
+      window != NULL ? window->browser_session : NULL, identifier, count,
+      x, y, width, height, active_match_ordinal, final_update);
+}
+
 static int CEF_CALLBACK proton_engine_on_media_permission(
     cef_permission_handler_t *self, cef_browser_t *browser,
     cef_frame_t *frame, const cef_string_t *requesting_origin,
@@ -1602,6 +1647,12 @@ static cef_download_handler_t *CEF_CALLBACK
 proton_engine_client_get_download_handler(cef_client_t *self) {
   (void)self;
   return &g_proton_engine_download_handler.handler;
+}
+
+static cef_find_handler_t *CEF_CALLBACK
+proton_engine_client_get_find_handler(cef_client_t *self) {
+  (void)self;
+  return &g_proton_engine_find_handler.handler;
 }
 
 static cef_permission_handler_t *CEF_CALLBACK

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -263,15 +263,14 @@ static proton_engine_client_t *proton_engine_view_client_create(
   client->view = view;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
-  // and the render handler gives headless (OSR) views a viewport. Navigation
-  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // and the render handler gives headless (OSR) views a viewport. Find results
+  // are view-scoped. Navigation policy, bridge, downloads, and
   // permissions stay window-scoped for now.
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
-  client->client.get_find_handler =
-      view->window->client->client.get_find_handler;
+  client->client.get_find_handler = view->window->client->get_find_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -264,11 +264,14 @@ static proton_engine_client_t *proton_engine_view_client_create(
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Navigation
-  // policy, bridge, downloads, and permissions stay window-scoped for now.
+  // Find results are view-scoped. Navigation policy, bridge, downloads, and
+  // permissions stay window-scoped for now.
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
+  client->client.get_find_handler =
+      view->window->client->client.get_find_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -669,6 +672,31 @@ int32_t proton_engine_view_get_navigation_state(
   }
   return proton_browser_navigation_state(
       view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+}
+
+int32_t proton_engine_view_find_in_page(
+    proton_engine_view_t *view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      view->browser_session, view->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_view_stop_find_in_page(
+    proton_engine_view_t *view, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      view->browser, clear_selection, error, error_len);
 }
 
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1827,6 +1827,31 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_find_in_page(
+    proton_engine_window_t *window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_find_in_page(
+      window->browser_session, window->browser, text, forward, match_case,
+      find_next, out_request_id, error, error_len);
+}
+
+int32_t proton_engine_window_stop_find_in_page(
+    proton_engine_window_t *window, int32_t clear_selection, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_stop_find_in_page(
+      window->browser, clear_selection, error, error_len);
+}
+
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1923,6 +1923,56 @@ int32_t proton_window_get_navigation_state(
   return PROTON_OK;
 }
 
+int32_t proton_window_find_in_page(
+    proton_window_handle_t window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (text == NULL || text[0] == '\0' || out_request_id == NULL) {
+    return proton_set_error(
+        PROTON_ERR_INVALID_ARGUMENT,
+        "non-empty find text and request output are required");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser find requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_find_in_page(
+      slot->engine_window, text, forward, match_case, find_next,
+      out_request_id, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_stop_find_in_page(
+    proton_window_handle_t window, int32_t clear_selection) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser find requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_stop_find_in_page(
+      slot->engine_window, clear_selection, engine_error,
+      sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_get_browser_url(proton_window_handle_t window,
                                        char *buffer, int32_t buffer_len,
                                        int32_t *out_required_len) {
@@ -2864,6 +2914,56 @@ int32_t proton_view_get_navigation_state(
       slot->engine_view, out_can_go_back, out_can_go_forward, engine_error,
       sizeof(engine_error));
   if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_find_in_page(
+    proton_view_handle_t view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (text == NULL || text[0] == '\0' || out_request_id == NULL) {
+    return proton_set_error(
+        PROTON_ERR_INVALID_ARGUMENT,
+        "non-empty find text and request output are required");
+  }
+  if (slot->engine_view == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser find requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_view_find_in_page(
+      slot->engine_view, text, forward, match_case, find_next,
+      out_request_id, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_stop_find_in_page(
+    proton_view_handle_t view, int32_t clear_selection) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_view == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser find requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_view_stop_find_in_page(
+      slot->engine_view, clear_selection, engine_error,
+      sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
   g_last_error[0] = '\0';
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -317,6 +317,13 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
 int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len);
+int32_t proton_engine_window_find_in_page(
+    proton_engine_window_t *window, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len);
+int32_t proton_engine_window_stop_find_in_page(
+    proton_engine_window_t *window, int32_t clear_selection, char *error,
+    size_t error_len);
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len);
@@ -447,6 +454,13 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 const char *command_json,
                                                 char *error,
                                                 size_t error_len);
+int32_t proton_engine_view_find_in_page(
+    proton_engine_view_t *view, const char *text, int32_t forward,
+    int32_t match_case, int32_t find_next, int32_t *out_request_id,
+    char *error, size_t error_len);
+int32_t proton_engine_view_stop_find_in_page(
+    proton_engine_view_t *view, int32_t clear_selection, char *error,
+    size_t error_len);
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len);

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -50,6 +50,8 @@ typedef enum proton_event_kind {
   PROTON_EVENT_BROWSER_NAVIGATED = 31,
   PROTON_EVENT_BROWSER_TITLE_UPDATED = 32,
   PROTON_EVENT_BROWSER_LOAD_FAILED = 33,
+  PROTON_EVENT_BROWSER_FIND_RESULT = 34,
+  PROTON_EVENT_VIEW_FIND_RESULT = 35,
 } proton_event_kind_t;
 
 typedef struct proton_event {

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1074,6 +1074,35 @@ fn decode_native_runtime_event(
           require_native_event_text(event, 1, "browser load error"),
         ),
       )
+    34 =>
+      BrowserEvent(
+        window,
+        FindResult({
+          request_id: @native_ffi.event_int64(event, 2).to_int(),
+          active_match_ordinal: @native_ffi.event_int(event, 1),
+          matches: @native_ffi.event_int(event, 0),
+          selection_x: @native_ffi.event_int(event, 2),
+          selection_y: @native_ffi.event_int64(event, 4).to_int(),
+          selection_width: @native_ffi.event_int64(event, 5).to_int(),
+          selection_height: @native_ffi.event_int64(event, 3).to_int(),
+          final_update: @native_ffi.event_int(event, 3) != 0,
+        }),
+      )
+    35 =>
+      ViewEvent(
+        window,
+        @native_ffi.event_int64(event, 1),
+        FindResult({
+          request_id: @native_ffi.event_int64(event, 2).to_int(),
+          active_match_ordinal: @native_ffi.event_int(event, 1),
+          matches: @native_ffi.event_int(event, 0),
+          selection_x: @native_ffi.event_int(event, 2),
+          selection_y: @native_ffi.event_int64(event, 4).to_int(),
+          selection_width: @native_ffi.event_int64(event, 5).to_int(),
+          selection_height: @native_ffi.event_int64(event, 3).to_int(),
+          final_update: @native_ffi.event_int(event, 3) != 0,
+        }),
+      )
     kind =>
       raise InvalidPayload(
         context="runtime event",
@@ -2079,6 +2108,60 @@ pub fn Window::browser_command(
 }
 
 ///|
+pub fn Window::find_in_page(
+  self : Window,
+  text : String,
+  forward : Bool,
+  match_case : Bool,
+  find_next : Bool,
+) -> Int raise NativeError {
+  if text.is_empty() {
+    raise invalid_argument("find text must not be empty")
+  }
+  let request_id : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_find_in_page_ffi(
+      self.live_handle(),
+      @ffi.to_cstr(text),
+      if forward {
+        1
+      } else {
+        0
+      },
+      if match_case {
+        1
+      } else {
+        0
+      },
+      if find_next {
+        1
+      } else {
+        0
+      },
+      request_id,
+    ),
+  )
+  request_id.val
+}
+
+///|
+pub fn Window::stop_find_in_page(
+  self : Window,
+  clear_selection : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_stop_find_in_page_ffi(
+      self.live_handle(),
+      if clear_selection {
+        1
+      } else {
+        0
+      },
+    ),
+  )
+}
+
+///|
 pub fn Window::respond_browser_request(
   self : Window,
   request_id : Int64,
@@ -2899,6 +2982,60 @@ pub fn View::browser_command(
     @native_ffi.proton_view_browser_command_json_ffi(
       self.live_handle(),
       @ffi.to_cstr(Json::object(fields).stringify()),
+    ),
+  )
+}
+
+///|
+pub fn View::find_in_page(
+  self : View,
+  text : String,
+  forward : Bool,
+  match_case : Bool,
+  find_next : Bool,
+) -> Int raise NativeError {
+  if text.is_empty() {
+    raise invalid_argument("find text must not be empty")
+  }
+  let request_id : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_view_find_in_page_ffi(
+      self.live_handle(),
+      @ffi.to_cstr(text),
+      if forward {
+        1
+      } else {
+        0
+      },
+      if match_case {
+        1
+      } else {
+        0
+      },
+      if find_next {
+        1
+      } else {
+        0
+      },
+      request_id,
+    ),
+  )
+  request_id.val
+}
+
+///|
+pub fn View::stop_find_in_page(
+  self : View,
+  clear_selection : Bool,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_view_stop_find_in_page_ffi(
+      self.live_handle(),
+      if clear_selection {
+        1
+      } else {
+        0
+      },
     ),
   )
 }

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -162,6 +162,45 @@ test "browser page events preserve window ids and payloads" {
 }
 
 ///|
+test "find result events preserve targets and match details" {
+  let result = NativeFindInPageResult::{
+    request_id: 4,
+    active_match_ordinal: 2,
+    matches: 6,
+    selection_x: 10,
+    selection_y: 20,
+    selection_width: 30,
+    selection_height: 12,
+    final_update: true,
+  }
+  let browser = RuntimeEvent::BrowserEvent(7L, FindResult(result))
+  assert_eq(browser.event_type(), "browser_found_in_page")
+  assert_eq(browser.find_in_page_result(), Some(result))
+  let view = RuntimeEvent::ViewEvent(7L, 11L, FindResult(result))
+  assert_eq(view.event_type(), "view_found_in_page")
+  assert_eq(view.window_id(), Some(7L))
+  assert_eq(view.view_id(), Some(11L))
+  assert_eq(view.find_in_page_result(), Some(result))
+}
+
+///|
+test "find rejects empty text before native dispatch" {
+  let window = Window::{
+    handle: @native_ffi.window_null(),
+    id: 0L,
+    lifecycle: WindowLive,
+  }
+  let error = expect_native_error(() => {
+    ignore(window.find_in_page("", true, false, false))
+  })
+  match error {
+    InvalidArgument(message~) =>
+      assert_eq(message, "find text must not be empty")
+    _ => fail("expected invalid argument")
+  }
+}
+
+///|
 test "native ABI version and availability" {
   inspect(abi_version(), content="1")
 }

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -191,11 +191,30 @@ pub extend NativeResourceRequest with Eq::{not_equal, equal}
 pub extend NativeResourceRequest with Debug::{to_repr}
 
 ///|
+pub(all) struct NativeFindInPageResult {
+  request_id : Int
+  active_match_ordinal : Int
+  matches : Int
+  selection_x : Int
+  selection_y : Int
+  selection_width : Int
+  selection_height : Int
+  final_update : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend NativeFindInPageResult with Eq::{not_equal, equal}
+
+///|
+pub extend NativeFindInPageResult with Debug::{to_repr}
+
+///|
 enum NativeViewEvent {
   LoadingChanged(Bool)
   Navigated(String)
   TitleUpdated(String)
   LoadFailed(String, Int, String)
+  FindResult(NativeFindInPageResult)
   Closed
 } derive(Debug, Eq)
 
@@ -382,6 +401,7 @@ enum NativeBrowserEvent {
   Navigated(String)
   TitleUpdated(String)
   LoadFailed(String, Int, String)
+  FindResult(NativeFindInPageResult)
 } derive(Debug, Eq)
 
 ///|
@@ -699,10 +719,12 @@ pub fn RuntimeEvent::event_type(self : RuntimeEvent) -> String {
     BrowserEvent(_, Navigated(_)) => "browser_navigated"
     BrowserEvent(_, TitleUpdated(_)) => "browser_title_updated"
     BrowserEvent(_, LoadFailed(_, _, _)) => "browser_load_failed"
+    BrowserEvent(_, FindResult(_)) => "browser_found_in_page"
     ViewEvent(_, _, LoadingChanged(_)) => "view_loading_changed"
     ViewEvent(_, _, Navigated(_)) => "view_navigated"
     ViewEvent(_, _, TitleUpdated(_)) => "view_title_updated"
     ViewEvent(_, _, LoadFailed(_, _, _)) => "view_load_failed"
+    ViewEvent(_, _, FindResult(_)) => "view_found_in_page"
     ViewEvent(_, _, Closed) => "view_closed"
     ResourceRequested(_) => "resource_requested"
     ResourceRequestCancelled(_) => "resource_request_cancelled"
@@ -873,6 +895,17 @@ pub fn RuntimeEvent::browser_event(self : RuntimeEvent) -> ViewEventInfo? {
         error_code: Some(error_code),
         error_text: Some(error_text),
       })
+    _ => None
+  }
+}
+
+///|
+pub fn RuntimeEvent::find_in_page_result(
+  self : RuntimeEvent,
+) -> NativeFindInPageResult? {
+  match self {
+    BrowserEvent(_, FindResult(result)) | ViewEvent(_, _, FindResult(result)) =>
+      Some(result)
     _ => None
   }
 }


### PR DESCRIPTION
## Summary

- add `find_in_page` and `stop_find_in_page` to main browser and web contents view handles
- emit typed `FoundInPage` events with match counts, active match, selection bounds, request id, and final-update state
- wire CEF find handlers and event routing on macOS, Windows, and Linux
- add `examples/70_find_in_page` for manual host/view review

## Electron alignment

- `find_next=true` starts a new search session; follow-up next/previous calls leave it false
- CEF is adapted to select an active result for every request, including the initial search
- stop supports Electron's clear-selection and keep-selection behavior
- `activateSelection` is not exposed because CEF does not provide an equivalent action

## Platform impact

- macOS: implemented, compiled, and manually reviewed
- Windows: implemented; compilation and behavior are covered by CI, manual review pending
- Linux: implemented; compilation and behavior are covered by CI, manual review pending

## Validation

- `moon -C proton test internal/native --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native`
- `node scripts/verify_generated.mjs`
- `moon fmt --check`
- `git diff origin/main...HEAD --check`

macOS manual review confirmed:

- host initial/next/previous results: `1/4`, `2/4`, `1/4`
- view initial result: `1/7`
- case-sensitive view results: lowercase `1/1`, capitalized `1/6`
- selection rectangles are reported for host and view results
- keep-selection and clear-selection stop actions both complete
