### PR TITLE
feat(browser): add programmatic URL downloads

### DIFF
--- a/examples/70_find_in_page/pkg.generated.mbti
+++ b/examples/70_find_in_page/pkg.generated.mbti
@@ -1,0 +1,27 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/70_find_in_page"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type FindRequest derive(ToJson, @json.FromJson)
+pub fn FindRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FindRequest::to_json(Self) -> Json
+
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type StopRequest derive(ToJson, @json.FromJson)
+pub fn StopRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StopRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/71_download_url/README.md
+++ b/examples/71_download_url/README.md
@@ -1,0 +1,22 @@
+# Programmatic Download
+
+Manual review for Electron-style `BrowserHandle::download_url`, using Proton's
+existing download approval, progress, and cancellation handlers.
+
+```sh
+moon -C examples run 71_download_url --target native
+```
+
+1. Keep **Temporary review file** selected, start the inline `data:` URL, and
+   confirm the page reports approval, progress, and `complete` without
+   navigating away.
+2. Open the reported temporary path and confirm it contains
+   `Hello from Proton downloadUrl`.
+3. Select **Save dialog**, start the inline URL again, choose a destination,
+   and confirm the saved content and terminal event.
+4. Select **Use 250 MB test URL**, start the download, then press
+   **Cancel active** while progress is visible and confirm a `cancelled` event.
+
+Repeat the same checks on macOS, Windows, and Linux. The 250 MB cancellation
+check requires network access. Electron's optional custom `downloadURL`
+request headers are intentionally absent because CEF does not expose them.

--- a/examples/71_download_url/main.mbt
+++ b/examples/71_download_url/main.mbt
@@ -1,0 +1,192 @@
+///|
+struct StartRequest {
+  url : String
+  show_dialog : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend StartRequest with ToJson::{to_json}
+
+///|
+pub extend StartRequest with FromJson::{from_json}
+
+///|
+struct Reply {
+  ok : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Reply with ToJson::{to_json}
+
+///|
+pub extend Reply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/download-url",
+  js_namespace="downloadReview",
+)
+
+///|
+let start_command : @proton_contract.Command[StartRequest, Reply] = contract.command(
+  "start",
+)
+
+///|
+let cancel_command : @proton_contract.Command[Unit, Reply] = contract.command(
+  "cancel",
+)
+
+///|
+let browser_slot : Ref[@proton.BrowserHandle?] = { val: None, }
+
+///|
+let last_download_id : Ref[Int?] = { val: None, }
+
+///|
+let show_dialog : Ref[Bool] = { val: false, }
+
+///|
+fn temporary_directory() -> String {
+  let variable = if @path.sep == '\\' { "TEMP" } else { "TMPDIR" }
+  @env.get_env_var(variable).unwrap_or_else(() => {
+    if @path.sep == '\\' {
+      @env.current_dir().unwrap_or(".")
+    } else {
+      "/tmp"
+    }
+  })
+}
+
+///|
+let automatic_download_path : String = {
+  let directory = temporary_directory()
+  if directory.has_suffix(@path.sep.to_string()) {
+    directory + "proton-programmatic-download.txt"
+  } else {
+    directory + @path.sep.to_string() + "proton-programmatic-download.txt"
+  }
+}
+
+///|
+fn js_escape(text : String) -> String {
+  text
+  .replace_all(old="\\", new="\\\\")
+  .replace_all(old="\"", new="\\\"")
+  .replace_all(old="\n", new="\\n")
+  .replace_all(old="\r", new="\\r")
+}
+
+///|
+fn show_status(message : String) -> Unit {
+  match browser_slot.val {
+    Some(browser) =>
+      browser.eval(
+        "document.querySelector(\"#status\").dataset.nativeUpdate = \"true\"; document.querySelector(\"#status\").textContent = \"\{js_escape(message)}\";",
+      ) catch {
+        _ => ()
+      }
+    None => ()
+  }
+}
+
+///|
+fn start_download(request : StartRequest) -> Reply {
+  match browser_slot.val {
+    Some(browser) => {
+      show_dialog.val = request.show_dialog
+      try {
+        browser.download_url(request.url)
+        {
+          ok: true,
+          message: "Programmatic download requested; waiting for approval event",
+        }
+      } catch {
+        error => { ok: false, message: error.to_string(), }
+      }
+    }
+    None => { ok: false, message: "browser is not ready", }
+  }
+}
+
+///|
+fn cancel_download() -> Reply {
+  match (browser_slot.val, last_download_id.val) {
+    (Some(browser), Some(download_id)) =>
+      try {
+        browser.cancel_download(download_id)
+        {
+          ok: true,
+          message: "Cancellation requested for download \{download_id}",
+        }
+      } catch {
+        error => { ok: false, message: error.to_string(), }
+      }
+    (_, None) => { ok: false, message: "no download is available to cancel", }
+    (None, _) => { ok: false, message: "browser is not ready", }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(start_command, (_context, request) => start_download(request))
+  registrar.bind(cancel_command, (_context, _request) => cancel_download())
+}
+
+///|
+fn page() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Programmatic download</title>
+    #|<style>:root{font-family:system-ui,sans-serif;color:#20282f;background:#e7ecef}*{box-sizing:border-box}body{margin:0}main{max-width:780px;margin:auto;padding:46px 24px}.eyebrow{font:700 11px ui-monospace,monospace;color:#315f78}h1{font-size:38px;margin:6px 0 12px}.summary{color:#4b5961;line-height:1.55}.panel{margin-top:26px;border:1px solid #7d8990;background:#f8fafb;padding:24px}.field{display:grid;gap:7px;margin-bottom:18px}label,legend{font-size:13px;font-weight:700}input[type=text]{width:100%;height:42px;border:1px solid #738088;background:white;padding:0 12px;color:#20282f}.choice{display:flex;gap:22px;border:0;padding:0;margin:0 0 18px}.choice label{font-weight:500}.actions{display:flex;gap:10px;flex-wrap:wrap}button{height:42px;border:1px solid #315f78;background:#edf2f5;color:#20282f;padding:0 16px;font-weight:700;cursor:pointer}button.primary{background:#315f78;color:white}#status{min-height:58px;margin:22px 0 0;padding-top:18px;border-top:1px solid #c4ccd1;color:#315f78;font:12px/1.55 ui-monospace,monospace;white-space:pre-wrap}</style></head>
+    #|<body><main><p class="eyebrow">ELECTRON WEB CONTENTS / REVIEW 71</p><h1>Programmatic download</h1><p class="summary">Start a download from MoonBit without navigating this page. Review request approval, destination selection, progress, completion, and cancellation.</p><section class="panel"><div class="field"><label for="url">Download URL</label><input id="url" type="text" value="data:text/plain;charset=utf-8,Hello%20from%20Proton%20downloadUrl%0A"></div><fieldset class="choice"><legend>Destination</legend><label><input type="radio" name="destination" value="automatic" checked> Temporary review file</label><label><input type="radio" name="destination" value="dialog"> Save dialog</label></fieldset><div class="actions"><button class="primary" id="start">Start download</button><button id="large">Use 250 MB test URL</button><button id="cancel">Cancel active</button></div><p id="status" role="status" aria-live="polite">Ready. Automatic path: \{automatic_download_path}</p></section></main>
+    #|<script>const status=document.querySelector('#status'),url=document.querySelector('#url');async function invoke(name,payload){return window.__MoonBit__.core.invokeOp('ext:downloadReview/'+name,payload)}document.querySelector('#start').onclick=async()=>{status.dataset.nativeUpdate='false';status.textContent='Starting programmatic download...';try{const reply=await invoke('start',{url:url.value,show_dialog:document.querySelector('input[name=destination]:checked').value==='dialog'});if(!reply.ok||status.dataset.nativeUpdate!=='true')status.textContent=reply.message}catch(error){status.textContent=String(error)}};document.querySelector('#large').onclick=()=>{url.value='https://speed.cloudflare.com/__down?bytes=250000000';status.textContent='250 MB URL selected. Start it, then use Cancel active while progress is visible.'};document.querySelector('#cancel').onclick=async()=>{try{const reply=await invoke('cancel',null);if(!reply.ok)status.textContent=reply.message}catch(error){status.textContent=String(error)}}</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html(
+    "Programmatic Download",
+    page(),
+    width=840,
+    height=620,
+    debug=true,
+  )
+  .commands(register_commands)
+  .on_download_request(fn(_browser, request) {
+    last_download_id.val = Some(request.id)
+    let destination = if show_dialog.val {
+      "system save dialog"
+    } else {
+      automatic_download_path
+    }
+    show_status(
+      "Approved download \{request.id}\nURL: \{request.url}\nSuggested name: \{request.suggested_name}\nDestination: \{destination}",
+    )
+    if show_dialog.val {
+      @proton.DownloadDecision::ShowSaveDialog
+    } else {
+      @proton.DownloadDecision::SaveTo(automatic_download_path)
+    }
+  })
+  .on_download_event(fn(_browser, event) {
+    last_download_id.val = Some(event.id)
+    show_status(
+      "Download \{event.id}: \{event.state}\nProgress: \{event.percent}%\nReceived: \{event.received_bytes} / \{event.total_bytes} bytes\nAutomatic path: \{automatic_download_path}",
+    )
+  })
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      browser_slot.val = Some(window.browser())
+      window
+    },
+    on_close=fn(_window) {
+      browser_slot.val = None
+      last_download_id.val = None
+    },
+  )
+  .identifier("dev.proton.71-download-url")
+  .run_or_abort()
+}

--- a/examples/71_download_url/moon.pkg
+++ b/examples/71_download_url/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/x/path",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+warnings = "-unused_async"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/71_download_url/pkg.generated.mbti
+++ b/examples/71_download_url/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/71_download_url"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type StartRequest derive(ToJson, @json.FromJson)
+pub fn StartRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StartRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -126,6 +126,8 @@ moon -C examples run 01_run --target native
 - `70_find_in_page`: manual Electron-style page search review for both the main
   browser and a web contents view, including direction, case matching, result
   events, and stop behavior.
+- `71_download_url`: manual Electron-style programmatic download review with
+  automatic and dialog destinations, progress events, and cancellation.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -730,6 +730,11 @@ fn RuntimeSession::browser_handle(
         window.browser_command(command, download_id?)
       })
     },
+    download_browser_url: url => {
+      self.control_window(id, native_id, "download URL in", window => {
+        window.download_url(url)
+      })
+    },
     find_browser_in_page: (text, forward, match_case, find_next) => {
       let running = match self.find_active_window(id) {
         Some(running) if running.window.id() == native_id => running
@@ -2272,6 +2277,17 @@ pub fn BrowserHandle::stop_find_in_page(
 }
 
 ///|
+/// Starts downloading `url` without navigating the page. The request uses the
+/// app's download approval and progress handlers. CEF does not support
+/// Electron's optional custom request headers for this operation.
+pub fn BrowserHandle::download_url(
+  self : BrowserHandle,
+  url : String,
+) -> Unit raise WindowSessionError {
+  (self.download_browser_url)(url)
+}
+
+///|
 pub fn BrowserHandle::back(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
@@ -2764,32 +2780,42 @@ fn RuntimeSession::dispatch_browser_event(
           let browser = self.browser_handle(window)
           let observed = match (event.event_type(), info, find_result) {
             ("browser_loading_changed", Some(info), _) =>
-              BrowserEvent::LoadingChanged(
-                is_loading=info.is_loading.unwrap_or(false),
+              Some(
+                BrowserEvent::LoadingChanged(
+                  is_loading=info.is_loading.unwrap_or(false),
+                ),
               )
             ("browser_navigated", Some(info), _) =>
-              BrowserEvent::Navigated(url=info.url.unwrap_or(""))
+              Some(BrowserEvent::Navigated(url=info.url.unwrap_or("")))
             ("browser_title_updated", Some(info), _) =>
-              BrowserEvent::TitleUpdated(title=info.title.unwrap_or(""))
+              Some(BrowserEvent::TitleUpdated(title=info.title.unwrap_or("")))
             ("browser_load_failed", Some(info), _) =>
-              BrowserEvent::LoadFailed(
-                url=info.url.unwrap_or(""),
-                error_code=info.error_code.unwrap_or(0),
-                error_text=info.error_text.unwrap_or(""),
+              Some(
+                BrowserEvent::LoadFailed(
+                  url=info.url.unwrap_or(""),
+                  error_code=info.error_code.unwrap_or(0),
+                  error_text=info.error_text.unwrap_or(""),
+                ),
               )
             ("browser_found_in_page", _, Some(result)) =>
-              BrowserEvent::FoundInPage(
-                result=FindInPageResult::from_native(result),
+              Some(
+                BrowserEvent::FoundInPage(
+                  result=FindInPageResult::from_native(result),
+                ),
               )
-            _ => return
+            _ => None
           }
-          for handler in self.browser_event_handlers {
-            ignore(
-              self.window_tasks.spawn(
-                () => handler(browser, observed),
-                no_wait=true,
-              ),
-            )
+          match observed {
+            Some(observed) =>
+              for handler in self.browser_event_handlers {
+                ignore(
+                  self.window_tasks.spawn(
+                    () => handler(browser, observed),
+                    no_wait=true,
+                  ),
+                )
+              }
+            None => ()
           }
         }
         None => ()

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -450,6 +450,7 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  download_browser_url : (String) -> Unit raise WindowSessionError
   find_browser_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
   stop_browser_find : (Bool) -> Unit raise WindowSessionError
   set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -87,6 +87,7 @@ fn test_window_handle(
   browser_audio_calls? : Array[Bool],
   browser_audio_muted? : Bool = false,
   browser_find_calls? : Array[String],
+  browser_download_calls? : Array[String],
   window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
@@ -96,6 +97,12 @@ fn test_window_handle(
     load_browser_html: fn(_html, _base_url) {  },
     eval_browser_script: fn(_script) {  },
     send_browser_command: fn(_command, _download_id) {  },
+    download_browser_url: fn(url) {
+      match browser_download_calls {
+        Some(calls) => calls.push(url)
+        None => ()
+      }
+    },
     find_browser_in_page: fn(text, forward, match_case, find_next) {
       match browser_find_calls {
         Some(calls) =>
@@ -2446,6 +2453,14 @@ test "browser handle routes page find operations" {
   inspect(browser.find_in_page("MoonBit", match_case=true), content="7")
   browser.stop_find_in_page(clear_selection=false)
   assert_eq(calls, ["find:MoonBit:true:true:false", "stop:false"])
+}
+
+///|
+test "browser handle starts programmatic downloads" {
+  let calls : Array[String] = []
+  let browser = test_window_handle("main", 17L, browser_download_calls=calls).browser()
+  browser.download_url("https://example.test/archive.zip")
+  assert_eq(calls, ["https://example.test/archive.zip"])
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -659,6 +659,13 @@ pub extern "C" fn proton_window_browser_command_json_ffi(
 ) -> Int = "proton_window_browser_command_json"
 
 ///|
+#borrow(url)
+pub extern "C" fn proton_window_download_url_ffi(
+  window : WindowHandle,
+  url : Bytes,
+) -> Int = "proton_window_download_url"
+
+///|
 #borrow(text, out_request_id)
 pub extern "C" fn proton_window_find_in_page_ffi(
   window : WindowHandle,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -240,6 +240,8 @@ int32_t proton_window_eval(proton_window_handle_t window,
                                       const char *script);
 int32_t proton_window_browser_command_json(
     proton_window_handle_t window, const char *command_json);
+int32_t proton_window_download_url(
+    proton_window_handle_t window, const char *url);
 int32_t proton_window_find_in_page(
     proton_window_handle_t window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -149,6 +149,8 @@ pub fn proton_view_destroy_ffi(ViewHandle) -> Int
 
 pub fn proton_view_eval_ffi(ViewHandle, Bytes) -> Int
 
+pub fn proton_view_find_in_page_ffi(ViewHandle, Bytes, Int, Int, Int, @ref.Ref[Int]) -> Int
+
 pub fn proton_view_get_navigation_state_ffi(ViewHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
 
 pub fn proton_view_get_state_ffi(ViewHandle, FixedArray[Int], Int) -> Int
@@ -168,6 +170,8 @@ pub fn proton_view_set_visible_ffi(ViewHandle, Int) -> Int
 pub fn proton_view_set_z_order_ffi(ViewHandle, Int) -> Int
 
 pub fn proton_view_set_zoom_percent_ffi(ViewHandle, Int) -> Int
+
+pub fn proton_view_stop_find_in_page_ffi(ViewHandle, Int) -> Int
 
 pub fn proton_window_begin_choose_directory_dialog_ffi(WindowHandle, Bytes, Int, Bytes, Int, @ref.Ref[Int64]) -> Int
 
@@ -199,9 +203,13 @@ pub fn proton_window_cookie_set_ffi(WindowHandle, Bytes, Bytes, Bytes, Bytes, By
 
 pub fn proton_window_destroy_ffi(WindowHandle) -> Int
 
+pub fn proton_window_download_url_ffi(WindowHandle, Bytes) -> Int
+
 pub fn proton_window_emit_bridge_event_json_ffi(WindowHandle, Bytes) -> Int
 
 pub fn proton_window_eval_ffi(WindowHandle, Bytes) -> Int
+
+pub fn proton_window_find_in_page_ffi(WindowHandle, Bytes, Int, Int, Int, @ref.Ref[Int]) -> Int
 
 pub fn proton_window_flash_frame_ffi(WindowHandle, Int) -> Int
 
@@ -302,6 +310,8 @@ pub fn proton_window_set_zoom_percent_ffi(WindowHandle, Int) -> Int
 pub fn proton_window_show_ffi(WindowHandle) -> Int
 
 pub fn proton_window_show_inactive_ffi(WindowHandle) -> Int
+
+pub fn proton_window_stop_find_in_page_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_take_bridge_failure_json_ffi(WindowHandle, FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -1011,6 +1011,35 @@ int32_t proton_browser_is_audio_muted(
   return PROTON_OK;
 }
 
+int32_t proton_browser_download_url(
+    cef_browser_t *browser, const char *url, char *error, size_t error_len) {
+  if (browser == NULL || url == NULL || url[0] == '\0') {
+    proton_browser_set_message(error, error_len,
+                               "browser and non-empty URL are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL || host->start_download == NULL) {
+    if (host != NULL) {
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    proton_browser_set_message(error, error_len,
+                               "programmatic download is unavailable");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  cef_string_t download_url = {0};
+  if (!cef_string_utf8_to_utf16(url, strlen(url), &download_url)) {
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_set_message(error, error_len,
+                               "failed to encode download URL as UTF-16");
+    return PROTON_ERR_ENGINE;
+  }
+  host->start_download(host, &download_url);
+  cef_string_clear(&download_url);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
 int32_t proton_browser_find_in_page(
     proton_browser_session_t *session, cef_browser_t *browser,
     const char *text, int32_t forward, int32_t match_case,

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -76,6 +76,8 @@ int32_t proton_browser_set_audio_muted(
 int32_t proton_browser_is_audio_muted(
     cef_browser_t *browser, int32_t *out_muted, char *error,
     size_t error_len);
+int32_t proton_browser_download_url(
+    cef_browser_t *browser, const char *url, char *error, size_t error_len);
 int32_t proton_browser_find_in_page(
     proton_browser_session_t *session, cef_browser_t *browser,
     const char *text, int32_t forward, int32_t match_case,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1620,6 +1620,16 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_download_url(
+    proton_engine_window_t *window, const char *url, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_download_url(window->browser, url, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -2193,6 +2193,16 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_download_url(
+    proton_engine_window_t *window, const char *url, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_download_url(window->browser, url, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1827,6 +1827,16 @@ int32_t proton_engine_window_get_navigation_state(
       window->browser, out_can_go_back, out_can_go_forward, error, error_len);
 }
 
+int32_t proton_engine_window_download_url(
+    proton_engine_window_t *window, const char *url, char *error,
+    size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_download_url(window->browser, url, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1923,6 +1923,31 @@ int32_t proton_window_get_navigation_state(
   return PROTON_OK;
 }
 
+int32_t proton_window_download_url(
+    proton_window_handle_t window, const char *url) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (url == NULL || url[0] == '\0') {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "non-empty download URL is required");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "programmatic download requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_download_url(
+      slot->engine_window, url, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_find_in_page(
     proton_window_handle_t window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -317,6 +317,9 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
 int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len);
+int32_t proton_engine_window_download_url(
+    proton_engine_window_t *window, const char *url, char *error,
+    size_t error_len);
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2108,6 +2108,22 @@ pub fn Window::browser_command(
 }
 
 ///|
+pub fn Window::download_url(
+  self : Window,
+  url : String,
+) -> Unit raise NativeError {
+  if url.is_empty() {
+    raise invalid_argument("download URL must not be empty")
+  }
+  check_status(
+    @native_ffi.proton_window_download_url_ffi(
+      self.live_handle(),
+      @ffi.to_cstr(url),
+    ),
+  )
+}
+
+///|
 pub fn Window::find_in_page(
   self : Window,
   text : String,

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -201,6 +201,21 @@ test "find rejects empty text before native dispatch" {
 }
 
 ///|
+test "programmatic download rejects an empty URL before native dispatch" {
+  let window = Window::{
+    handle: @native_ffi.window_null(),
+    id: 0L,
+    lifecycle: WindowLive,
+  }
+  let error = expect_native_error(() => window.download_url(""))
+  match error {
+    InvalidArgument(message~) =>
+      assert_eq(message, "download URL must not be empty")
+    _ => fail("expected invalid argument")
+  }
+}
+
+///|
 test "native ABI version and availability" {
   inspect(abi_version(), content="1")
 }

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -356,6 +356,20 @@ pub fn NativeDownloadUpdate::equal(Self, Self) -> Bool
 pub fn NativeDownloadUpdate::not_equal(Self, Self) -> Bool
 pub fn NativeDownloadUpdate::to_repr(Self) -> @debug.Repr
 
+pub(all) struct NativeFindInPageResult {
+  request_id : Int
+  active_match_ordinal : Int
+  matches : Int
+  selection_x : Int
+  selection_y : Int
+  selection_width : Int
+  selection_height : Int
+  final_update : Bool
+} derive(Eq, @debug.Debug)
+pub fn NativeFindInPageResult::equal(Self, Self) -> Bool
+pub fn NativeFindInPageResult::not_equal(Self, Self) -> Bool
+pub fn NativeFindInPageResult::to_repr(Self) -> @debug.Repr
+
 type NativeImage
 pub fn NativeImage::add_bitmap(Self, Bytes, Int, Int, scale_factor? : Double) -> Unit raise NativeError
 pub fn NativeImage::add_jpeg(Self, Bytes, scale_factor? : Double) -> Unit raise NativeError
@@ -436,6 +450,7 @@ pub fn RuntimeEvent::cookie_get_completion(Self) -> NativeCookieGetCompletion?
 pub fn RuntimeEvent::dialog_completion(Self) -> NativeDialogCompletion?
 pub fn RuntimeEvent::equal(Self, Self) -> Bool
 pub fn RuntimeEvent::event_type(Self) -> String
+pub fn RuntimeEvent::find_in_page_result(Self) -> NativeFindInPageResult?
 pub fn RuntimeEvent::has_window(Self) -> Bool
 pub fn RuntimeEvent::is_bridge_lifecycle_changed(Self) -> Bool
 pub fn RuntimeEvent::is_quit_requested(Self) -> Bool
@@ -528,6 +543,7 @@ pub fn View::View(Window, ViewConfig) -> Self raise NativeError
 pub fn View::browser_command(Self, String, download_id? : Int) -> Unit raise NativeError
 pub fn View::destroy(Self) -> Unit raise NativeError
 pub fn View::eval(Self, String) -> Unit raise NativeError
+pub fn View::find_in_page(Self, String, Bool, Bool, Bool) -> Int raise NativeError
 pub fn View::id(Self) -> Int64
 pub fn View::is_audio_muted(Self) -> Bool raise NativeError
 pub fn View::load_url(Self, String) -> Unit raise NativeError
@@ -538,6 +554,7 @@ pub fn View::set_visible(Self, Bool) -> Unit raise NativeError
 pub fn View::set_z_order(Self, Int) -> Unit raise NativeError
 pub fn View::set_zoom_percent(Self, Int) -> Unit raise NativeError
 pub fn View::state(Self) -> ViewState raise NativeError
+pub fn View::stop_find_in_page(Self, Bool) -> Unit raise NativeError
 pub fn View::zoom_percent(Self) -> Int raise NativeError
 
 type ViewConfig derive(Eq, @debug.Debug)
@@ -583,8 +600,10 @@ pub fn Window::cookie_delete(Self, String?, String?) -> Unit raise NativeError
 pub fn Window::cookie_flush(Self) -> Unit raise NativeError
 pub fn Window::cookie_set(Self, String, String, String, domain? : String, path? : String, secure? : Bool, http_only? : Bool, same_site? : CookieSameSite) -> Unit raise NativeError
 pub fn Window::destroy(Self) -> Unit raise NativeError
+pub fn Window::download_url(Self, String) -> Unit raise NativeError
 pub fn Window::emit_bridge_event_json(Self, String) -> Unit raise NativeError
 pub fn Window::eval(Self, String) -> Unit raise NativeError
+pub fn Window::find_in_page(Self, String, Bool, Bool, Bool) -> Int raise NativeError
 pub fn Window::flash_frame(Self, Bool) -> Unit raise NativeError
 pub fn Window::focus(Self) -> Unit raise NativeError
 pub fn Window::hide(Self) -> Unit raise NativeError
@@ -633,6 +652,7 @@ pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError
 pub fn Window::show(Self) -> Unit raise NativeError
 pub fn Window::show_inactive(Self) -> Unit raise NativeError
 pub fn Window::state(Self) -> WindowState raise NativeError
+pub fn Window::stop_find_in_page(Self, Bool) -> Unit raise NativeError
 pub fn Window::take_bridge_failure(Self) -> BridgeDiagnostic? raise NativeError
 
 type WindowConfig derive(Eq, @debug.Debug)

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -244,6 +244,7 @@ pub(all) enum BrowserEvent {
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  FoundInPage(result~ : FindInPageResult)
 } derive(Eq, @debug.Debug)
 pub fn BrowserEvent::equal(Self, Self) -> Bool
 pub fn BrowserEvent::not_equal(Self, Self) -> Bool
@@ -256,6 +257,9 @@ pub struct BrowserHandle {
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
+  download_browser_url : (String) -> Unit raise WindowSessionError
+  find_browser_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
+  stop_browser_find : (Bool) -> Unit raise WindowSessionError
   set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
   read_browser_zoom_percent : () -> Int raise WindowSessionError
   set_browser_audio_muted : (Bool) -> Unit raise WindowSessionError
@@ -269,7 +273,9 @@ pub fn BrowserHandle::can_go_back(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::cancel_download(Self, Int) -> Unit raise WindowSessionError
 pub fn BrowserHandle::close_devtools(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::download_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::eval(Self, String) -> Unit raise WindowSessionError
+pub fn BrowserHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
 pub fn BrowserHandle::forward(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::is_audio_muted(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
@@ -281,6 +287,7 @@ pub fn BrowserHandle::set_audio_muted(Self, Bool) -> Unit raise WindowSessionErr
 pub fn BrowserHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn BrowserHandle::state(Self) -> BrowserState raise WindowSessionError
 pub fn BrowserHandle::stop(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
 pub fn BrowserHandle::window_id(Self) -> String
 pub fn BrowserHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
@@ -363,6 +370,20 @@ pub(all) struct DownloadRequest {
 pub fn DownloadRequest::equal(Self, Self) -> Bool
 pub fn DownloadRequest::not_equal(Self, Self) -> Bool
 pub fn DownloadRequest::to_repr(Self) -> @debug.Repr
+
+pub(all) struct FindInPageResult {
+  request_id : Int
+  active_match_ordinal : Int
+  matches : Int
+  selection_x : Int
+  selection_y : Int
+  selection_width : Int
+  selection_height : Int
+  final_update : Bool
+} derive(Eq, @debug.Debug)
+pub fn FindInPageResult::equal(Self, Self) -> Bool
+pub fn FindInPageResult::not_equal(Self, Self) -> Bool
+pub fn FindInPageResult::to_repr(Self) -> @debug.Repr
 
 pub(all) enum LastWindowClosedPolicy {
   Quit
@@ -580,6 +601,7 @@ pub(all) enum ViewEvent {
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
+  FoundInPage(result~ : FindInPageResult)
   Closed
 } derive(Eq, @debug.Debug)
 pub fn ViewEvent::equal(Self, Self) -> Bool
@@ -600,6 +622,8 @@ pub struct ViewHandle {
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
+  find_view_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
+  stop_view_find : (Bool) -> Unit raise WindowSessionError
   read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
@@ -610,6 +634,7 @@ pub fn ViewHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::close(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::close_devtools(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::eval(Self, String) -> Unit raise WindowSessionError
+pub fn ViewHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
 pub fn ViewHandle::forward(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::id(Self) -> String
 pub fn ViewHandle::is_audio_muted(Self) -> Bool raise WindowSessionError
@@ -624,6 +649,7 @@ pub fn ViewHandle::set_z_order(Self, Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::state(Self) -> ViewState raise WindowSessionError
 pub fn ViewHandle::stop(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
 pub fn ViewHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub(all) struct ViewState {


### PR DESCRIPTION
## Summary

- add Electron-aligned `BrowserHandle::download_url(url)` for main web contents
- route programmatic downloads through Proton's existing approval, destination, progress, and cancellation handlers
- fix browser event dispatch so download request and progress events are not skipped by lifecycle-event matching
- add `71_download_url` for manual review of automatic destinations, save dialogs, progress, completion, and cancellation
- refresh generated MoonBit interfaces, including the interfaces missed by the merged in-page-find PR

## Electron alignment

This implements the URL-only portion of Electron's `webContents.downloadURL`. CEF exposes a URL to `start_download` but no custom-header parameter, so Electron's optional request headers are intentionally unsupported.

The API is main-browser scoped because Proton's existing download request and progress callbacks use `BrowserHandle`. WebContentsView downloads need a separate event ownership design and are not included here.

## Platform impact

The same native ABI is implemented for macOS, Windows, and Linux over the shared CEF browser-session helper.

## Validation

- `moon -C proton test internal/native --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native`
- `moon -C examples build 71_download_url --target native --diagnostic-limit 80`
- `moon fmt --check`
- `moon info`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## macOS manual review

- confirmed a programmatic `data:` download completes without navigating the page
- confirmed the 30-byte file contains `Hello from Proton downloadUrl`
- confirmed progress events expose received and total bytes
- confirmed cancellation of a throttled 100 MiB local HTTP download reports `cancelled`

Windows and Linux behavior remains to be manually reviewed with `examples/71_download_url`; CI provides compile and automated coverage on all three platforms.
