### PR TITLE
feat(browser): add print and PDF output

### DIFF
--- a/examples/72_print_pdf/README.md
+++ b/examples/72_print_pdf/README.md
@@ -1,0 +1,22 @@
+# Print And PDF
+
+Manual review for Electron-style `BrowserHandle::print` and
+`BrowserHandle::print_to_pdf`, including PDF options and completion events.
+
+```sh
+moon -C examples run 72_print_pdf --target native
+```
+
+1. Use **System print** and confirm the platform print flow opens with two
+   printable pages and no dark control bar. Cancel the dialog after review.
+2. Create the standard PDF and confirm the status reports `complete`, the
+   request id matches, backgrounds render, and header/footer page numbers are
+   present.
+3. Create the landscape PDF and confirm wide paper, compact margins, and the
+   four-color calibration strip.
+4. Create the CSS A4 PDF and confirm the `@page` size is preferred and content
+   remains unclipped across both pages.
+
+Repeat on macOS, Windows, and Linux. PDF output is cross-platform. Linux uses
+CEF's required PDF paper-size handler; interactive system printing still
+depends on the desktop print stack available in the session.

--- a/examples/72_print_pdf/main.mbt
+++ b/examples/72_print_pdf/main.mbt
@@ -1,0 +1,189 @@
+///|
+struct Request {
+  action : String
+  profile : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Request with ToJson::{to_json}
+
+///|
+pub extend Request with FromJson::{from_json}
+
+///|
+struct Reply {
+  ok : Bool
+  request_id : Int
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend Reply with ToJson::{to_json}
+
+///|
+pub extend Reply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/print-pdf",
+  js_namespace="printReview",
+)
+
+///|
+let command : @proton_contract.Command[Request, Reply] = contract.command("run")
+
+///|
+let browser_slot : Ref[@proton.BrowserHandle?] = { val: None, }
+
+///|
+fn temporary_directory() -> String {
+  let variable = if @path.sep == '\\' { "TEMP" } else { "TMPDIR" }
+  @env.get_env_var(variable).unwrap_or_else(() => {
+    if @path.sep == '\\' {
+      @env.current_dir().unwrap_or(".")
+    } else {
+      "/tmp"
+    }
+  })
+}
+
+///|
+let pdf_path : String = {
+  let directory = temporary_directory()
+  if directory.has_suffix(@path.sep.to_string()) {
+    directory + "proton-print-review.pdf"
+  } else {
+    directory + @path.sep.to_string() + "proton-print-review.pdf"
+  }
+}
+
+///|
+fn js_escape(text : String) -> String {
+  text
+  .replace_all(old="\\", new="\\\\")
+  .replace_all(old="\"", new="\\\"")
+  .replace_all(old="\n", new="\\n")
+  .replace_all(old="\r", new="\\r")
+}
+
+///|
+fn show_status(message : String) -> Unit {
+  match browser_slot.val {
+    Some(browser) =>
+      browser.eval(
+        "document.querySelector(\"#status\").textContent = \"\{js_escape(message)}\";",
+      ) catch {
+        _ => ()
+      }
+    None => ()
+  }
+}
+
+///|
+fn pdf_options(profile : String) -> @proton.PdfPrintOptions {
+  match profile {
+    "landscape" =>
+      @proton.PdfPrintOptions(
+        landscape=true,
+        print_background=true,
+        scale=0.9,
+        paper_width=8.5,
+        paper_height=11.0,
+        margins=@proton.PdfPrintMargins::Custom(
+          top=0.35,
+          right=0.35,
+          bottom=0.35,
+          left=0.35,
+        ),
+        generate_tagged_pdf=true,
+        generate_document_outline=true,
+      )
+    "css" =>
+      @proton.PdfPrintOptions(
+        print_background=true,
+        prefer_css_page_size=true,
+        margins=@proton.PdfPrintMargins::NoMargins,
+        generate_tagged_pdf=true,
+        generate_document_outline=true,
+      )
+    _ =>
+      @proton.PdfPrintOptions(
+        print_background=true,
+        margins=@proton.PdfPrintMargins::Custom(
+          top=0.5,
+          right=0.5,
+          bottom=0.55,
+          left=0.5,
+        ),
+        display_header_footer=true,
+        header_template="<div style='font-size:8px;width:100%;text-align:center;color:#53616a'><span class='title'></span></div>",
+        footer_template="<div style='font-size:8px;width:100%;text-align:center;color:#53616a'><span class='pageNumber'></span> / <span class='totalPages'></span></div>",
+        generate_tagged_pdf=true,
+        generate_document_outline=true,
+      )
+  }
+}
+
+///|
+fn run(request : Request) -> Reply {
+  match browser_slot.val {
+    Some(browser) =>
+      try {
+        if request.action == "print" {
+          browser.print()
+          { ok: true, request_id: 0, message: "System print flow opened", }
+        } else {
+          let request_id = browser.print_to_pdf(
+            pdf_path,
+            options=pdf_options(request.profile),
+          )
+          {
+            ok: true,
+            request_id,
+            message: "PDF request \{request_id} started",
+          }
+        }
+      } catch {
+        error => { ok: false, request_id: 0, message: error.to_string(), }
+      }
+    None => { ok: false, request_id: 0, message: "browser is not ready", }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(command, (_context, request) => run(request))
+}
+
+///|
+fn page() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Proton Print Calibration</title>
+    #|<style>:root{font-family:"Avenir Next",Avenir,Arial,sans-serif;color:#18242b;background:#dfe5e7}*{box-sizing:border-box}body{margin:0}.controls{position:sticky;top:0;z-index:2;display:grid;grid-template-columns:1fr auto;gap:18px;align-items:center;padding:16px 24px;background:#18242b;color:#f7f7f2;border-bottom:4px solid #1d7a8c}.controls strong{font-size:15px}.controls small{display:block;color:#b9c5c9;margin-top:3px}.actions{display:flex;gap:8px;align-items:center}select,button{height:38px;border:1px solid #8fa1a7;border-radius:3px;background:#f7f7f2;color:#18242b;padding:0 12px;font-weight:700}button{cursor:pointer}button.primary{background:#1d7a8c;color:white;border-color:#1d7a8c}#status{grid-column:1/-1;margin:0;color:#d2e7eb;font:12px/1.4 "SFMono-Regular",Consolas,monospace}.document{padding:34px}.sheet{width:min(100%,820px);min-height:980px;margin:0 auto 28px;background:#f7f7f2;padding:58px 64px;box-shadow:0 8px 30px #18242b26}.masthead{display:grid;grid-template-columns:1fr auto;align-items:end;border-bottom:5px solid #18242b;padding-bottom:18px}.kicker{font:700 11px "SFMono-Regular",Consolas,monospace;color:#1d7a8c}.masthead h1{margin:5px 0 0;font:700 46px/1.05 Georgia,serif}.edition{text-align:right;font:12px/1.45 "SFMono-Regular",Consolas,monospace}.lead{font:22px/1.45 Georgia,serif;margin:38px 0}.lead code{font:0.78em "SFMono-Regular",Consolas,monospace}.calibration{display:grid;grid-template-columns:repeat(4,1fr);height:42px;margin:28px 0}.calibration span:nth-child(1){background:#1d7a8c}.calibration span:nth-child(2){background:#b33f62}.calibration span:nth-child(3){background:#e1b341}.calibration span:nth-child(4){background:#18242b}.grid{display:grid;grid-template-columns:1.4fr 1fr;gap:36px}.grid h2{font:700 24px Georgia,serif;margin:0 0 12px}.grid p,.grid li{font-size:14px;line-height:1.65}.metrics{border-left:2px solid #18242b;padding-left:24px}.metric{border-bottom:1px solid #9eaaae;padding:13px 0}.metric b{display:block;font:700 22px Georgia,serif}.page-two{page-break-before:always}.proof{margin-top:40px;border-top:1px solid #18242b;border-bottom:1px solid #18242b;padding:24px 0;display:grid;grid-template-columns:repeat(3,1fr);gap:22px}.proof b{font:700 30px Georgia,serif}.footer-mark{margin-top:70px;font:11px "SFMono-Regular",Consolas,monospace;color:#53616a}@media(max-width:700px){.controls{grid-template-columns:1fr}.actions{flex-wrap:wrap}.document{padding:14px}.sheet{padding:34px 28px}.masthead,.grid{grid-template-columns:1fr}.edition{text-align:left;margin-top:16px}.masthead h1{font-size:36px}}@media print{:root,body,.document{background:#fff}.controls{display:none}.document{padding:0}.sheet{width:auto;min-height:0;margin:0;box-shadow:none;padding:0}.page-two{page-break-before:always}}</style></head>
+    #|<body><section class="controls"><div><strong>Print calibration</strong><small>System dialog and PDF output use the same browser contents.</small></div><div class="actions"><select id="profile"><option value="standard">Letter + header/footer</option><option value="landscape">Landscape + background</option><option value="css">CSS A4 page size</option></select><button id="print">System print</button><button class="primary" id="pdf">Create PDF</button></div><p id="status" role="status" aria-live="polite">Ready. PDF path: \{pdf_path}</p></section><main class="document"><article class="sheet"><header class="masthead"><div><div class="kicker">PROTON OUTPUT LAB / REVIEW 72</div><h1>Browser print proof</h1></div><div class="edition">MOONBIT NATIVE<br>COLOR EDITION</div></header><p class="lead">A practical sheet for checking page geometry, background graphics, typography, and asynchronous completion.</p><div class="calibration" aria-label="Cyan magenta yellow and black calibration strip"><span></span><span></span><span></span><span></span></div><section class="grid"><div><h2>What this page proves</h2><p>The browser remains on screen while Proton opens the platform print flow or writes a PDF to a chosen path. The PDF callback reports the original request id and final status.</p><ul><li>Dark ink remains crisp against the paper field.</li><li>The four-color strip confirms background printing.</li><li>Headings and body copy expose font substitution or clipping.</li></ul></div><aside class="metrics"><div class="metric"><b>8.5 x 11</b>standard paper in inches</div><div class="metric"><b>1-2</b>expected pages</div><div class="metric"><b>100%</b>default scale</div></aside></section><p class="footer-mark">PAGE ONE / GEOMETRY AND COLOR</p></article><article class="sheet page-two"><header class="masthead"><div><div class="kicker">SECOND PAGE / RANGE CHECK</div><h1>Pagination stays deliberate</h1></div><div class="edition">OUTLINE<br>TAGGED PDF</div></header><div class="proof"><div><b>01</b><p>Page break begins a clean second sheet.</p></div><div><b>02</b><p>Margins keep every edge comfortably visible.</p></div><div><b>03</b><p>Footer numbering should report two pages.</p></div></div><p class="lead">Use the CSS A4 profile to confirm that <code>@page</code> overrides the default paper size without scaling this layout into an unexpected frame.</p><p class="footer-mark">PAGE TWO / PAGINATION AND METADATA</p></article></main>
+    #|<script>const status=document.querySelector('#status');function applyPageProfile(profile){document.querySelector('#css-page-size')?.remove();if(profile==='css'){const style=document.createElement('style');style.id='css-page-size';style.textContent='@page{size:A4;margin:14mm}';document.head.appendChild(style)}}async function run(action){const profile=document.querySelector('#profile').value;applyPageProfile(profile);status.textContent=action==='print'?'Opening system print flow...':'Creating PDF...';try{const reply=await window.__MoonBit__.core.invokeOp('ext:printReview/run',{action,profile});status.textContent=reply.message}catch(error){status.textContent=String(error)}}document.querySelector('#print').onclick=()=>void run('print');document.querySelector('#pdf').onclick=()=>void run('pdf')</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html("Print and PDF", page(), width=1040, height=760, debug=true)
+  .commands(register_commands)
+  .on_browser_event(async fn(_browser, event) noraise {
+    if event is @proton.BrowserEvent::PdfPrinted(result~) {
+      show_status(
+        "PDF request \{result.request_id}: \{if result.success { "complete" } else { "failed" }}\nPath: \{result.path}",
+      )
+    }
+  })
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      browser_slot.val = Some(window.browser())
+      window
+    },
+    on_close=fn(_window) { browser_slot.val = None },
+  )
+  .identifier("dev.proton.72-print-pdf")
+  .run_or_abort()
+}

--- a/examples/72_print_pdf/moon.pkg
+++ b/examples/72_print_pdf/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/x/path",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+warnings = "-unused_async"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/72_print_pdf/pkg.generated.mbti
+++ b/examples/72_print_pdf/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/72_print_pdf"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply derive(ToJson, @json.FromJson)
+pub fn Reply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Reply::to_json(Self) -> Json
+
+type Request derive(ToJson, @json.FromJson)
+pub fn Request::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Request::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -128,6 +128,8 @@ moon -C examples run 01_run --target native
   events, and stop behavior.
 - `71_download_url`: manual Electron-style programmatic download review with
   automatic and dialog destinations, progress events, and cancellation.
+- `72_print_pdf`: manual Electron-style system print and PDF review with typed
+  page settings, request ids, completion events, and printable calibration pages.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -735,6 +735,24 @@ fn RuntimeSession::browser_handle(
         window.download_url(url)
       })
     },
+    print_browser: () => {
+      self.control_window(id, native_id, "print browser in", window => {
+        window.print()
+      })
+    },
+    print_browser_to_pdf: (path, options) => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.print_to_pdf(path, options.to_native()) catch {
+        error =>
+          raise window_operation_failed(
+            "print browser to PDF in window " + id,
+            error,
+          )
+      }
+    },
     find_browser_in_page: (text, forward, match_case, find_next) => {
       let running = match self.find_active_window(id) {
         Some(running) if running.window.id() == native_id => running
@@ -816,6 +834,38 @@ fn RuntimeSession::browser_handle(
       }
     },
     session_handle,
+  }
+}
+
+///|
+fn PdfPrintOptions::to_native(
+  self : PdfPrintOptions,
+) -> @native.PdfPrintSettings {
+  let (margin_type, margin_top, margin_right, margin_bottom, margin_left) = match
+    self.margins {
+    PdfPrintMargins::Default => (0, 0.0, 0.0, 0.0, 0.0)
+    PdfPrintMargins::NoMargins => (1, 0.0, 0.0, 0.0, 0.0)
+    PdfPrintMargins::Custom(top~, right~, bottom~, left~) =>
+      (2, top, right, bottom, left)
+  }
+  {
+    landscape: self.landscape,
+    print_background: self.print_background,
+    scale: self.scale,
+    paper_width: self.paper_width,
+    paper_height: self.paper_height,
+    prefer_css_page_size: self.prefer_css_page_size,
+    margin_type,
+    margin_top,
+    margin_right,
+    margin_bottom,
+    margin_left,
+    page_ranges: self.page_ranges,
+    display_header_footer: self.display_header_footer,
+    header_template: self.header_template,
+    footer_template: self.footer_template,
+    generate_tagged_pdf: self.generate_tagged_pdf,
+    generate_document_outline: self.generate_document_outline,
   }
 }
 
@@ -2288,6 +2338,25 @@ pub fn BrowserHandle::download_url(
 }
 
 ///|
+/// Opens the platform print flow for the main browser contents.
+pub fn BrowserHandle::print(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.print_browser)()
+}
+
+///|
+/// Starts printing the main browser contents to `path` and returns a request
+/// id. Completion is delivered as `BrowserEvent::PdfPrinted`.
+pub fn BrowserHandle::print_to_pdf(
+  self : BrowserHandle,
+  path : String,
+  options? : PdfPrintOptions = PdfPrintOptions(),
+) -> Int raise WindowSessionError {
+  (self.print_browser_to_pdf)(path, options)
+}
+
+///|
 pub fn BrowserHandle::back(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
@@ -2773,23 +2842,29 @@ fn RuntimeSession::dispatch_browser_event(
   event : @native.RuntimeEvent,
 ) -> Unit {
   match
-    (event.window_id(), event.browser_event(), event.find_in_page_result()) {
-    (Some(window_id), info, find_result) =>
+    (
+      event.window_id(),
+      event.browser_event(),
+      event.find_in_page_result(),
+      event.pdf_print_result(),
+    ) {
+    (Some(window_id), info, find_result, pdf_result) =>
       match self.find_window_by_native_id(window_id) {
         Some(window) => {
           let browser = self.browser_handle(window)
-          let observed = match (event.event_type(), info, find_result) {
-            ("browser_loading_changed", Some(info), _) =>
+          let observed = match
+            (event.event_type(), info, find_result, pdf_result) {
+            ("browser_loading_changed", Some(info), _, _) =>
               Some(
                 BrowserEvent::LoadingChanged(
                   is_loading=info.is_loading.unwrap_or(false),
                 ),
               )
-            ("browser_navigated", Some(info), _) =>
+            ("browser_navigated", Some(info), _, _) =>
               Some(BrowserEvent::Navigated(url=info.url.unwrap_or("")))
-            ("browser_title_updated", Some(info), _) =>
+            ("browser_title_updated", Some(info), _, _) =>
               Some(BrowserEvent::TitleUpdated(title=info.title.unwrap_or("")))
-            ("browser_load_failed", Some(info), _) =>
+            ("browser_load_failed", Some(info), _, _) =>
               Some(
                 BrowserEvent::LoadFailed(
                   url=info.url.unwrap_or(""),
@@ -2797,11 +2872,19 @@ fn RuntimeSession::dispatch_browser_event(
                   error_text=info.error_text.unwrap_or(""),
                 ),
               )
-            ("browser_found_in_page", _, Some(result)) =>
+            ("browser_found_in_page", _, Some(result), _) =>
               Some(
                 BrowserEvent::FoundInPage(
                   result=FindInPageResult::from_native(result),
                 ),
+              )
+            ("browser_pdf_print_finished", _, _, Some(result)) =>
+              Some(
+                BrowserEvent::PdfPrinted(result={
+                  request_id: result.request_id,
+                  path: result.path,
+                  success: result.success,
+                }),
               )
             _ => None
           }

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -451,6 +451,8 @@ pub struct BrowserHandle {
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
   download_browser_url : (String) -> Unit raise WindowSessionError
+  print_browser : () -> Unit raise WindowSessionError
+  print_browser_to_pdf : (String, PdfPrintOptions) -> Int raise WindowSessionError
   find_browser_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
   stop_browser_find : (Bool) -> Unit raise WindowSessionError
   set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
@@ -627,6 +629,93 @@ pub extend FindInPageResult with Eq::{not_equal, equal}
 
 ///|
 pub extend FindInPageResult with Debug::{to_repr}
+
+///|
+/// Margins used when printing browser contents to PDF.
+pub(all) enum PdfPrintMargins {
+  Default
+  NoMargins
+  Custom(top~ : Double, right~ : Double, bottom~ : Double, left~ : Double)
+} derive(Debug, Eq)
+
+///|
+pub extend PdfPrintMargins with Eq::{not_equal, equal}
+
+///|
+pub extend PdfPrintMargins with Debug::{to_repr}
+
+///|
+/// Electron-style PDF print settings. Paper dimensions and custom margins use
+/// inches, and scale must be between `0.1` and `2.0`. An empty page range
+/// prints the complete document.
+pub(all) struct PdfPrintOptions {
+  landscape : Bool
+  print_background : Bool
+  scale : Double
+  paper_width : Double
+  paper_height : Double
+  prefer_css_page_size : Bool
+  margins : PdfPrintMargins
+  page_ranges : String
+  display_header_footer : Bool
+  header_template : String
+  footer_template : String
+  generate_tagged_pdf : Bool
+  generate_document_outline : Bool
+} derive(Debug, Eq)
+
+///|
+pub fn PdfPrintOptions::PdfPrintOptions(
+  landscape? : Bool = false,
+  print_background? : Bool = false,
+  scale? : Double = 1.0,
+  paper_width? : Double = 8.5,
+  paper_height? : Double = 11.0,
+  prefer_css_page_size? : Bool = false,
+  margins? : PdfPrintMargins = PdfPrintMargins::Default,
+  page_ranges? : String = "",
+  display_header_footer? : Bool = false,
+  header_template? : String = "",
+  footer_template? : String = "",
+  generate_tagged_pdf? : Bool = false,
+  generate_document_outline? : Bool = false,
+) -> PdfPrintOptions {
+  {
+    landscape,
+    print_background,
+    scale,
+    paper_width,
+    paper_height,
+    prefer_css_page_size,
+    margins,
+    page_ranges,
+    display_header_footer,
+    header_template,
+    footer_template,
+    generate_tagged_pdf,
+    generate_document_outline,
+  }
+}
+
+///|
+pub extend PdfPrintOptions with Eq::{not_equal, equal}
+
+///|
+pub extend PdfPrintOptions with Debug::{to_repr}
+
+///|
+/// Completion of one `print_to_pdf` request.
+pub(all) struct PdfPrintResult {
+  request_id : Int
+  path : String
+  success : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend PdfPrintResult with Eq::{not_equal, equal}
+
+///|
+pub extend PdfPrintResult with Debug::{to_repr}
 
 ///|
 /// The result of an asynchronous native close request.
@@ -807,6 +896,7 @@ pub(all) enum BrowserEvent {
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
   FoundInPage(result~ : FindInPageResult)
+  PdfPrinted(result~ : PdfPrintResult)
 } derive(Debug, Eq)
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -88,6 +88,7 @@ fn test_window_handle(
   browser_audio_muted? : Bool = false,
   browser_find_calls? : Array[String],
   browser_download_calls? : Array[String],
+  browser_print_calls? : Array[String],
   window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
@@ -102,6 +103,22 @@ fn test_window_handle(
         Some(calls) => calls.push(url)
         None => ()
       }
+    },
+    print_browser: fn() {
+      match browser_print_calls {
+        Some(calls) => calls.push("print")
+        None => ()
+      }
+    },
+    print_browser_to_pdf: fn(path, options) {
+      match browser_print_calls {
+        Some(calls) =>
+          calls.push(
+            "pdf:\{path}:\{options.landscape}:\{options.print_background}:\{options.scale}",
+          )
+        None => ()
+      }
+      9
     },
     find_browser_in_page: fn(text, forward, match_case, find_next) {
       match browser_find_calls {
@@ -2461,6 +2478,31 @@ test "browser handle starts programmatic downloads" {
   let browser = test_window_handle("main", 17L, browser_download_calls=calls).browser()
   browser.download_url("https://example.test/archive.zip")
   assert_eq(calls, ["https://example.test/archive.zip"])
+}
+
+///|
+test "browser handle routes print and PDF operations" {
+  let calls : Array[String] = []
+  let browser = test_window_handle("main", 17L, browser_print_calls=calls).browser()
+  browser.print()
+  let request_id = browser.print_to_pdf(
+    "/tmp/review.pdf",
+    options=PdfPrintOptions(landscape=true, print_background=true, scale=0.75),
+  )
+  assert_eq(request_id, 9)
+  assert_eq(calls, ["print", "pdf:/tmp/review.pdf:true:true:0.75"])
+}
+
+///|
+test "PDF print options map custom margins to the CEF custom type" {
+  let settings = PdfPrintOptions(
+    margins=PdfPrintMargins::Custom(top=0.1, right=0.2, bottom=0.3, left=0.4),
+  ).to_native()
+  assert_eq(settings.margin_type, 2)
+  assert_eq(settings.margin_top, 0.1)
+  assert_eq(settings.margin_right, 0.2)
+  assert_eq(settings.margin_bottom, 0.3)
+  assert_eq(settings.margin_left, 0.4)
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -666,6 +666,34 @@ pub extern "C" fn proton_window_download_url_ffi(
 ) -> Int = "proton_window_download_url"
 
 ///|
+pub extern "C" fn proton_window_print_ffi(window : WindowHandle) -> Int = "proton_window_print"
+
+///|
+#borrow(path, page_ranges, header_template, footer_template, out_request_id)
+pub extern "C" fn proton_window_print_to_pdf_ffi(
+  window : WindowHandle,
+  path : Bytes,
+  landscape : Int,
+  print_background : Int,
+  scale : Double,
+  paper_width : Double,
+  paper_height : Double,
+  prefer_css_page_size : Int,
+  margin_type : Int,
+  margin_top : Double,
+  margin_right : Double,
+  margin_bottom : Double,
+  margin_left : Double,
+  page_ranges : Bytes,
+  display_header_footer : Int,
+  header_template : Bytes,
+  footer_template : Bytes,
+  generate_tagged_pdf : Int,
+  generate_document_outline : Int,
+  out_request_id : Ref[Int],
+) -> Int = "proton_window_print_to_pdf"
+
+///|
 #borrow(text, out_request_id)
 pub extern "C" fn proton_window_find_in_page_ffi(
   window : WindowHandle,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -242,6 +242,16 @@ int32_t proton_window_browser_command_json(
     proton_window_handle_t window, const char *command_json);
 int32_t proton_window_download_url(
     proton_window_handle_t window, const char *url);
+int32_t proton_window_print(proton_window_handle_t window);
+int32_t proton_window_print_to_pdf(
+    proton_window_handle_t window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id);
 int32_t proton_window_find_in_page(
     proton_window_handle_t window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -237,6 +237,10 @@ pub fn proton_window_maximize_ffi(WindowHandle) -> Int
 
 pub fn proton_window_minimize_ffi(WindowHandle) -> Int
 
+pub fn proton_window_print_ffi(WindowHandle) -> Int
+
+pub fn proton_window_print_to_pdf_ffi(WindowHandle, Bytes, Int, Int, Double, Double, Double, Int, Int, Double, Double, Double, Double, Bytes, Int, Bytes, Bytes, Int, Int, @ref.Ref[Int]) -> Int
+
 pub fn proton_window_respond_browser_request_json_ffi(WindowHandle, Bytes) -> Int
 
 pub fn proton_window_respond_close_request_ffi(WindowHandle, Int64, Int) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -4,6 +4,7 @@
 #include "../../proton_event.h"
 
 #include "include/capi/cef_download_item_capi.h"
+#include "include/capi/cef_browser_capi.h"
 #include "include/internal/cef_string.h"
 
 #include <limits.h>
@@ -11,6 +12,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <stdatomic.h>
+#endif
 
 typedef enum {
   PROTON_BROWSER_REQUEST_NAVIGATION = 1,
@@ -39,6 +46,17 @@ typedef struct proton_browser_download {
   struct proton_browser_download *next;
 } proton_browser_download_t;
 
+typedef struct proton_pdf_print_callback {
+  cef_pdf_print_callback_t callback;
+#ifdef _WIN32
+  volatile LONG refs;
+#else
+  atomic_int refs;
+#endif
+  proton_window_id_t window;
+  int32_t request_id;
+} proton_pdf_print_callback_t;
+
 typedef struct proton_browser_navigation_bypass {
   char *url;
   char *method;
@@ -59,7 +77,84 @@ struct proton_browser_session {
   int32_t is_loading;
   int32_t next_find_request_id;
   int32_t active_find_request_id;
+  int32_t next_pdf_request_id;
 };
+
+static char *proton_browser_cef_string_to_utf8(const cef_string_t *value);
+
+static proton_pdf_print_callback_t *proton_pdf_print_callback_from_base(
+    cef_base_ref_counted_t *base) {
+  return (proton_pdf_print_callback_t *)base;
+}
+
+static void CEF_CALLBACK proton_pdf_print_add_ref(
+    cef_base_ref_counted_t *base) {
+  proton_pdf_print_callback_t *callback =
+      proton_pdf_print_callback_from_base(base);
+#ifdef _WIN32
+  (void)InterlockedIncrement(&callback->refs);
+#else
+  (void)atomic_fetch_add_explicit(&callback->refs, 1, memory_order_relaxed);
+#endif
+}
+
+static int CEF_CALLBACK proton_pdf_print_release(
+    cef_base_ref_counted_t *base) {
+  proton_pdf_print_callback_t *callback =
+      proton_pdf_print_callback_from_base(base);
+#ifdef _WIN32
+  LONG refs = InterlockedDecrement(&callback->refs);
+#else
+  int refs = atomic_fetch_sub_explicit(
+                 &callback->refs, 1, memory_order_acq_rel) -
+             1;
+#endif
+  if (refs == 0) {
+    free(callback);
+    return 1;
+  }
+  return 0;
+}
+
+static int CEF_CALLBACK proton_pdf_print_has_one_ref(
+    cef_base_ref_counted_t *base) {
+  proton_pdf_print_callback_t *callback =
+      proton_pdf_print_callback_from_base(base);
+#ifdef _WIN32
+  return callback->refs == 1;
+#else
+  return atomic_load_explicit(&callback->refs, memory_order_acquire) == 1;
+#endif
+}
+
+static int CEF_CALLBACK proton_pdf_print_has_at_least_one_ref(
+    cef_base_ref_counted_t *base) {
+  proton_pdf_print_callback_t *callback =
+      proton_pdf_print_callback_from_base(base);
+#ifdef _WIN32
+  return callback->refs > 0;
+#else
+  return atomic_load_explicit(&callback->refs, memory_order_acquire) > 0;
+#endif
+}
+
+static void CEF_CALLBACK proton_pdf_print_finished(
+    cef_pdf_print_callback_t *self, const cef_string_t *path, int ok) {
+  proton_pdf_print_callback_t *callback =
+      (proton_pdf_print_callback_t *)self;
+  char *result_path = proton_browser_cef_string_to_utf8(path);
+  proton_event_t *event = proton_event_create_window(
+      PROTON_EVENT_BROWSER_PDF_PRINT_FINISHED, callback->window);
+  if (event != NULL && result_path != NULL &&
+      proton_event_set_text(&event->text_a, result_path)) {
+    event->request_id = callback->request_id;
+    event->bool_a = ok != 0 ? 1 : 0;
+    (void)proton_event_publish(event);
+  } else {
+    proton_event_destroy(event);
+  }
+  free(result_path);
+}
 
 static void proton_browser_set_message(char *error, size_t error_len,
                                        const char *message) {
@@ -125,6 +220,7 @@ proton_browser_session_t *proton_browser_session_create(
   }
   session->policy = *policy;
   session->next_request_id = 1;
+  session->next_pdf_request_id = 1;
   session->signal = signal;
   session->signal_user_data = signal_user_data;
   return session;
@@ -1036,6 +1132,121 @@ int32_t proton_browser_download_url(
   }
   host->start_download(host, &download_url);
   cef_string_clear(&download_url);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
+int32_t proton_browser_print(
+    cef_browser_t *browser, char *error, size_t error_len) {
+  if (browser == NULL) {
+    proton_browser_set_message(error, error_len, "browser is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL || host->print == NULL) {
+    if (host != NULL) {
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    proton_browser_set_message(error, error_len, "browser printing is unavailable");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  host->print(host);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
+int32_t proton_browser_print_to_pdf(
+    proton_browser_session_t *session, cef_browser_t *browser,
+    const char *path, int32_t landscape, int32_t print_background,
+    double scale, double paper_width, double paper_height,
+    int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (session == NULL || browser == NULL || path == NULL || path[0] == '\0' ||
+      page_ranges == NULL || header_template == NULL || footer_template == NULL ||
+      out_request_id == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser, session, path, settings, and request output are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL || host->print_to_pdf == NULL) {
+    if (host != NULL) {
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    proton_browser_set_message(error, error_len,
+                               "browser PDF printing is unavailable");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  proton_pdf_print_callback_t *callback =
+      (proton_pdf_print_callback_t *)calloc(1, sizeof(*callback));
+  if (callback == NULL) {
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_set_message(error, error_len,
+                               "failed to allocate PDF print callback");
+    return PROTON_ERR_ENGINE;
+  }
+  callback->callback.base.size = sizeof(callback->callback);
+  callback->callback.base.add_ref = proton_pdf_print_add_ref;
+  callback->callback.base.release = proton_pdf_print_release;
+  callback->callback.base.has_one_ref = proton_pdf_print_has_one_ref;
+  callback->callback.base.has_at_least_one_ref =
+      proton_pdf_print_has_at_least_one_ref;
+#ifdef _WIN32
+  callback->refs = 1;
+#else
+  atomic_init(&callback->refs, 1);
+#endif
+  callback->window = session->window;
+  callback->request_id = session->next_pdf_request_id;
+  if (session->next_pdf_request_id == INT32_MAX) {
+    session->next_pdf_request_id = 1;
+  } else {
+    session->next_pdf_request_id++;
+  }
+  callback->callback.on_pdf_print_finished = proton_pdf_print_finished;
+
+  cef_string_t output_path = {0};
+  cef_pdf_print_settings_t settings = {0};
+  settings.size = sizeof(settings);
+  settings.landscape = landscape;
+  settings.print_background = print_background;
+  settings.scale = scale;
+  settings.paper_width = paper_width;
+  settings.paper_height = paper_height;
+  settings.prefer_css_page_size = prefer_css_page_size;
+  settings.margin_type = (cef_pdf_print_margin_type_t)margin_type;
+  settings.margin_top = margin_top;
+  settings.margin_right = margin_right;
+  settings.margin_bottom = margin_bottom;
+  settings.margin_left = margin_left;
+  settings.display_header_footer = display_header_footer;
+  settings.generate_tagged_pdf = generate_tagged_pdf;
+  settings.generate_document_outline = generate_document_outline;
+  if (!cef_string_utf8_to_utf16(path, strlen(path), &output_path) ||
+      !cef_string_utf8_to_utf16(page_ranges, strlen(page_ranges), &settings.page_ranges) ||
+      !cef_string_utf8_to_utf16(header_template, strlen(header_template), &settings.header_template) ||
+      !cef_string_utf8_to_utf16(footer_template, strlen(footer_template), &settings.footer_template)) {
+    cef_string_clear(&output_path);
+    cef_string_clear(&settings.page_ranges);
+    cef_string_clear(&settings.header_template);
+    cef_string_clear(&settings.footer_template);
+    callback->callback.base.release(&callback->callback.base);
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_set_message(error, error_len,
+                               "failed to encode PDF print settings as UTF-16");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_request_id = callback->request_id;
+  host->print_to_pdf(host, &output_path, &settings, &callback->callback);
+  cef_string_clear(&output_path);
+  cef_string_clear(&settings.page_ranges);
+  cef_string_clear(&settings.header_template);
+  cef_string_clear(&settings.footer_template);
   host->base.release((cef_base_ref_counted_t *)host);
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -78,6 +78,19 @@ int32_t proton_browser_is_audio_muted(
     size_t error_len);
 int32_t proton_browser_download_url(
     cef_browser_t *browser, const char *url, char *error, size_t error_len);
+int32_t proton_browser_print(
+    cef_browser_t *browser, char *error, size_t error_len);
+int32_t proton_browser_print_to_pdf(
+    proton_browser_session_t *session, cef_browser_t *browser,
+    const char *path, int32_t landscape, int32_t print_background,
+    double scale, double paper_width, double paper_height,
+    int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len);
 int32_t proton_browser_find_in_page(
     proton_browser_session_t *session, cef_browser_t *browser,
     const char *text, int32_t forward, int32_t match_case,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -42,6 +42,7 @@
 #include "include/capi/cef_load_handler_capi.h"
 #include "include/capi/cef_process_message_capi.h"
 #include "include/capi/cef_permission_handler_capi.h"
+#include "include/capi/cef_print_handler_capi.h"
 #include "include/capi/cef_render_handler_capi.h"
 #include "include/capi/cef_render_process_handler_capi.h"
 #include "include/capi/cef_request_handler_capi.h"
@@ -76,6 +77,11 @@ typedef struct {
   proton_engine_ref_counted_t refs;
 } proton_engine_find_handler_t;
 
+typedef struct {
+  cef_print_handler_t handler;
+  proton_engine_ref_counted_t refs;
+} proton_engine_print_handler_t;
+
 static proton_engine_app_t g_app;
 static proton_engine_browser_process_handler_t g_browser_process_handler;
 static proton_engine_render_process_handler_t g_render_process_handler;
@@ -86,6 +92,7 @@ static proton_engine_drag_handler_t g_drag_handler;
 static proton_engine_request_handler_t g_request_handler;
 static proton_engine_download_handler_t g_download_handler;
 static proton_engine_find_handler_t g_find_handler;
+static proton_engine_print_handler_t g_print_handler;
 static proton_engine_permission_handler_t g_permission_handler;
 static proton_engine_render_handler_t g_render_handler;
 static proton_engine_scheme_factory_t g_scheme_factory;
@@ -579,6 +586,25 @@ proton_engine_client_get_find_handler(cef_client_t *self) {
   return &g_find_handler.handler;
 }
 
+static cef_size_t CEF_CALLBACK proton_engine_get_pdf_paper_size(
+    cef_print_handler_t *self, cef_browser_t *browser,
+    int device_units_per_inch) {
+  (void)self;
+  (void)browser;
+  cef_size_t size = {0};
+  if (device_units_per_inch > 0) {
+    size.width = (int)lround(8.5 * (double)device_units_per_inch);
+    size.height = 11 * device_units_per_inch;
+  }
+  return size;
+}
+
+static cef_print_handler_t *CEF_CALLBACK
+proton_engine_client_get_print_handler(cef_client_t *self) {
+  (void)self;
+  return &g_print_handler.handler;
+}
+
 static cef_permission_handler_t *CEF_CALLBACK
 proton_engine_client_get_permission_handler(cef_client_t *self) {
   (void)self;
@@ -754,6 +780,12 @@ void proton_engine_init_handlers(void) {
       (cef_base_ref_counted_t *)&g_find_handler.handler.base,
       sizeof(g_find_handler.handler), &g_find_handler.refs);
   g_find_handler.handler.on_find_result = proton_engine_on_find_result;
+
+  proton_engine_init_ref_counted(
+      (cef_base_ref_counted_t *)&g_print_handler.handler.base,
+      sizeof(g_print_handler.handler), &g_print_handler.refs);
+  g_print_handler.handler.get_pdf_paper_size =
+      proton_engine_get_pdf_paper_size;
 
   proton_engine_init_ref_counted(
       (cef_base_ref_counted_t *)&g_permission_handler.handler.base,
@@ -1412,6 +1444,7 @@ proton_engine_client_t *proton_engine_client_create(
   client->client.get_download_handler =
       proton_engine_client_get_download_handler;
   client->client.get_find_handler = proton_engine_client_get_find_handler;
+  client->client.get_print_handler = proton_engine_client_get_print_handler;
   client->client.get_permission_handler =
       proton_engine_client_get_permission_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1630,6 +1630,38 @@ int32_t proton_engine_window_download_url(
   return proton_browser_download_url(window->browser, url, error, error_len);
 }
 
+int32_t proton_engine_window_print(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print(window->browser, error, error_len);
+}
+
+int32_t proton_engine_window_print_to_pdf(
+    proton_engine_window_t *window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print_to_pdf(
+      window->browser_session, window->browser, path, landscape,
+      print_background, scale, paper_width, paper_height,
+      prefer_css_page_size, margin_type, margin_top, margin_right,
+      margin_bottom, margin_left, page_ranges, display_header_footer,
+      header_template, footer_template, generate_tagged_pdf,
+      generate_document_outline, out_request_id, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -2203,6 +2203,38 @@ int32_t proton_engine_window_download_url(
   return proton_browser_download_url(window->browser, url, error, error_len);
 }
 
+int32_t proton_engine_window_print(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print(window->browser, error, error_len);
+}
+
+int32_t proton_engine_window_print_to_pdf(
+    proton_engine_window_t *window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print_to_pdf(
+      window->browser_session, window->browser, path, landscape,
+      print_background, scale, paper_width, paper_height,
+      prefer_css_page_size, margin_type, margin_top, margin_right,
+      margin_bottom, margin_left, page_ranges, display_header_footer,
+      header_template, footer_template, generate_tagged_pdf,
+      generate_document_outline, out_request_id, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1837,6 +1837,38 @@ int32_t proton_engine_window_download_url(
   return proton_browser_download_url(window->browser, url, error, error_len);
 }
 
+int32_t proton_engine_window_print(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print(window->browser, error, error_len);
+}
+
+int32_t proton_engine_window_print_to_pdf(
+    proton_engine_window_t *window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len, "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_print_to_pdf(
+      window->browser_session, window->browser, path, landscape,
+      print_background, scale, paper_width, paper_height,
+      prefer_css_page_size, margin_type, margin_top, margin_right,
+      margin_bottom, margin_left, page_ranges, display_header_footer,
+      header_template, footer_template, generate_tagged_pdf,
+      generate_document_outline, out_request_id, error, error_len);
+}
+
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1948,6 +1948,65 @@ int32_t proton_window_download_url(
   return PROTON_OK;
 }
 
+int32_t proton_window_print(proton_window_handle_t window) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "printing requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_print(
+      slot->engine_window, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_print_to_pdf(
+    proton_window_handle_t window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) {
+    return status;
+  }
+  if (path == NULL || path[0] == '\0' || page_ranges == NULL ||
+      header_template == NULL || footer_template == NULL ||
+      out_request_id == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "PDF path, settings strings, and request output are required");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "PDF printing requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_print_to_pdf(
+      slot->engine_window, path, landscape, print_background, scale,
+      paper_width, paper_height, prefer_css_page_size, margin_type,
+      margin_top, margin_right, margin_bottom, margin_left, page_ranges,
+      display_header_footer, header_template, footer_template,
+      generate_tagged_pdf, generate_document_outline, out_request_id,
+      engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) {
+    return proton_set_engine_status(status, engine_error);
+  }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_find_in_page(
     proton_window_handle_t window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -320,6 +320,18 @@ int32_t proton_engine_window_browser_command_json(
 int32_t proton_engine_window_download_url(
     proton_engine_window_t *window, const char *url, char *error,
     size_t error_len);
+int32_t proton_engine_window_print(
+    proton_engine_window_t *window, char *error, size_t error_len);
+int32_t proton_engine_window_print_to_pdf(
+    proton_engine_window_t *window, const char *path, int32_t landscape,
+    int32_t print_background, double scale, double paper_width,
+    double paper_height, int32_t prefer_css_page_size, int32_t margin_type,
+    double margin_top, double margin_right, double margin_bottom,
+    double margin_left, const char *page_ranges,
+    int32_t display_header_footer, const char *header_template,
+    const char *footer_template, int32_t generate_tagged_pdf,
+    int32_t generate_document_outline, int32_t *out_request_id,
+    char *error, size_t error_len);
 int32_t proton_engine_window_find_in_page(
     proton_engine_window_t *window, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -52,6 +52,7 @@ typedef enum proton_event_kind {
   PROTON_EVENT_BROWSER_LOAD_FAILED = 33,
   PROTON_EVENT_BROWSER_FIND_RESULT = 34,
   PROTON_EVENT_VIEW_FIND_RESULT = 35,
+  PROTON_EVENT_BROWSER_PDF_PRINT_FINISHED = 36,
 } proton_event_kind_t;
 
 typedef struct proton_event {

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1103,6 +1103,12 @@ fn decode_native_runtime_event(
           final_update: @native_ffi.event_int(event, 3) != 0,
         }),
       )
+    36 =>
+      BrowserPdfPrinted(window, {
+        request_id: @native_ffi.event_int64(event, 2).to_int(),
+        path: require_native_event_text(event, 0, "PDF print path"),
+        success: @native_ffi.event_int(event, 3) != 0,
+      })
     kind =>
       raise InvalidPayload(
         context="runtime event",
@@ -2121,6 +2127,86 @@ pub fn Window::download_url(
       @ffi.to_cstr(url),
     ),
   )
+}
+
+///|
+pub fn Window::print(self : Window) -> Unit raise NativeError {
+  check_status(@native_ffi.proton_window_print_ffi(self.live_handle()))
+}
+
+///|
+pub fn Window::print_to_pdf(
+  self : Window,
+  path : String,
+  settings : PdfPrintSettings,
+) -> Int raise NativeError {
+  if path.is_empty() {
+    raise invalid_argument("PDF output path must not be empty")
+  }
+  if settings.scale < 0.1 || settings.scale > 2.0 {
+    raise invalid_argument("PDF scale must be between 0.1 and 2")
+  }
+  if settings.paper_width <= 0.0 || settings.paper_height <= 0.0 {
+    raise invalid_argument("PDF paper dimensions must be positive")
+  }
+  if settings.margin_type < 0 ||
+    settings.margin_type > 2 ||
+    settings.margin_top < 0.0 ||
+    settings.margin_right < 0.0 ||
+    settings.margin_bottom < 0.0 ||
+    settings.margin_left < 0.0 {
+    raise invalid_argument("PDF margins are invalid")
+  }
+  let out_request_id : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_print_to_pdf_ffi(
+      self.live_handle(),
+      @ffi.to_cstr(path),
+      if settings.landscape {
+        1
+      } else {
+        0
+      },
+      if settings.print_background {
+        1
+      } else {
+        0
+      },
+      settings.scale,
+      settings.paper_width,
+      settings.paper_height,
+      if settings.prefer_css_page_size {
+        1
+      } else {
+        0
+      },
+      settings.margin_type,
+      settings.margin_top,
+      settings.margin_right,
+      settings.margin_bottom,
+      settings.margin_left,
+      @ffi.to_cstr(settings.page_ranges),
+      if settings.display_header_footer {
+        1
+      } else {
+        0
+      },
+      @ffi.to_cstr(settings.header_template),
+      @ffi.to_cstr(settings.footer_template),
+      if settings.generate_tagged_pdf {
+        1
+      } else {
+        0
+      },
+      if settings.generate_document_outline {
+        1
+      } else {
+        0
+      },
+      out_request_id,
+    ),
+  )
+  out_request_id.val
 }
 
 ///|

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -184,6 +184,19 @@ test "find result events preserve targets and match details" {
 }
 
 ///|
+test "PDF print events preserve window and completion details" {
+  let result = NativePdfPrintResult::{
+    request_id: 5,
+    path: "/tmp/review.pdf",
+    success: true,
+  }
+  let event = RuntimeEvent::BrowserPdfPrinted(7L, result)
+  assert_eq(event.event_type(), "browser_pdf_print_finished")
+  assert_eq(event.window_id(), Some(7L))
+  assert_eq(event.pdf_print_result(), Some(result))
+}
+
+///|
 test "find rejects empty text before native dispatch" {
   let window = Window::{
     handle: @native_ffi.window_null(),
@@ -211,6 +224,55 @@ test "programmatic download rejects an empty URL before native dispatch" {
   match error {
     InvalidArgument(message~) =>
       assert_eq(message, "download URL must not be empty")
+    _ => fail("expected invalid argument")
+  }
+}
+
+///|
+fn default_pdf_settings() -> PdfPrintSettings {
+  {
+    landscape: false,
+    print_background: false,
+    scale: 1.0,
+    paper_width: 8.5,
+    paper_height: 11.0,
+    prefer_css_page_size: false,
+    margin_type: 0,
+    margin_top: 0.0,
+    margin_right: 0.0,
+    margin_bottom: 0.0,
+    margin_left: 0.0,
+    page_ranges: "",
+    display_header_footer: false,
+    header_template: "",
+    footer_template: "",
+    generate_tagged_pdf: false,
+    generate_document_outline: false,
+  }
+}
+
+///|
+test "PDF printing validates path and scale before native dispatch" {
+  let window = Window::{
+    handle: @native_ffi.window_null(),
+    id: 0L,
+    lifecycle: WindowLive,
+  }
+  let empty_path = expect_native_error(() => {
+    ignore(window.print_to_pdf("", default_pdf_settings()))
+  })
+  match empty_path {
+    InvalidArgument(message~) =>
+      assert_eq(message, "PDF output path must not be empty")
+    _ => fail("expected invalid argument")
+  }
+  let settings = default_pdf_settings()
+  let invalid_scale = expect_native_error(() => {
+    ignore(window.print_to_pdf("review.pdf", { ..settings, scale: 0.09, }))
+  })
+  match invalid_scale {
+    InvalidArgument(message~) =>
+      assert_eq(message, "PDF scale must be between 0.1 and 2")
     _ => fail("expected invalid argument")
   }
 }

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -390,6 +390,15 @@ pub fn NativeNotificationResult::equal(Self, Self) -> Bool
 pub fn NativeNotificationResult::not_equal(Self, Self) -> Bool
 pub fn NativeNotificationResult::to_repr(Self) -> @debug.Repr
 
+pub(all) struct NativePdfPrintResult {
+  request_id : Int
+  path : String
+  success : Bool
+} derive(Eq, @debug.Debug)
+pub fn NativePdfPrintResult::equal(Self, Self) -> Bool
+pub fn NativePdfPrintResult::not_equal(Self, Self) -> Bool
+pub fn NativePdfPrintResult::to_repr(Self) -> @debug.Repr
+
 pub(all) struct NativeResourceRequest {
   request_id : Int64
   window : Int64
@@ -404,6 +413,29 @@ type NativeViewEvent derive(Eq, @debug.Debug)
 pub fn NativeViewEvent::equal(Self, Self) -> Bool
 pub fn NativeViewEvent::not_equal(Self, Self) -> Bool
 pub fn NativeViewEvent::to_repr(Self) -> @debug.Repr
+
+pub(all) struct PdfPrintSettings {
+  landscape : Bool
+  print_background : Bool
+  scale : Double
+  paper_width : Double
+  paper_height : Double
+  prefer_css_page_size : Bool
+  margin_type : Int
+  margin_top : Double
+  margin_right : Double
+  margin_bottom : Double
+  margin_left : Double
+  page_ranges : String
+  display_header_footer : Bool
+  header_template : String
+  footer_template : String
+  generate_tagged_pdf : Bool
+  generate_document_outline : Bool
+} derive(Eq, @debug.Debug)
+pub fn PdfPrintSettings::equal(Self, Self) -> Bool
+pub fn PdfPrintSettings::not_equal(Self, Self) -> Bool
+pub fn PdfPrintSettings::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ProcessResult {
   MainProcess
@@ -462,6 +494,7 @@ pub fn RuntimeEvent::menu_command_id(Self) -> String?
 pub fn RuntimeEvent::not_equal(Self, Self) -> Bool
 pub fn RuntimeEvent::notification_click(Self) -> String??
 pub fn RuntimeEvent::notification_result(Self) -> NativeNotificationResult?
+pub fn RuntimeEvent::pdf_print_result(Self) -> NativePdfPrintResult?
 pub fn RuntimeEvent::resource_request(Self) -> NativeResourceRequest?
 pub fn RuntimeEvent::resource_request_cancellation(Self) -> Int64?
 pub fn RuntimeEvent::to_repr(Self) -> @debug.Repr
@@ -614,6 +647,8 @@ pub fn Window::maximize(Self) -> Unit raise NativeError
 pub fn Window::minimize(Self) -> Unit raise NativeError
 pub fn Window::navigation_state(Self) -> (Bool, Bool) raise NativeError
 pub fn Window::popup_menu(Self, MenuBar, Int, Int) -> Unit raise NativeError
+pub fn Window::print(Self) -> Unit raise NativeError
+pub fn Window::print_to_pdf(Self, String, PdfPrintSettings) -> Int raise NativeError
 pub fn Window::respond_browser_request(Self, Int64, String, path? : String) -> Unit raise NativeError
 pub fn Window::respond_close_request(Self, Int64, Bool) -> Unit raise NativeError
 pub fn Window::restore(Self) -> Unit raise NativeError

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -169,6 +169,7 @@ enum RuntimeEvent {
   NotificationClicked(String?)
   BrowserRequest(Int64, NativeBrowserRequest)
   BrowserDownloadUpdated(Int64, NativeDownloadUpdate)
+  BrowserPdfPrinted(Int64, NativePdfPrintResult)
   BrowserEvent(Int64, NativeBrowserEvent)
   ViewEvent(Int64, Int64, NativeViewEvent)
   ResourceRequested(NativeResourceRequest)
@@ -207,6 +208,33 @@ pub extend NativeFindInPageResult with Eq::{not_equal, equal}
 
 ///|
 pub extend NativeFindInPageResult with Debug::{to_repr}
+
+///|
+pub(all) struct PdfPrintSettings {
+  landscape : Bool
+  print_background : Bool
+  scale : Double
+  paper_width : Double
+  paper_height : Double
+  prefer_css_page_size : Bool
+  margin_type : Int
+  margin_top : Double
+  margin_right : Double
+  margin_bottom : Double
+  margin_left : Double
+  page_ranges : String
+  display_header_footer : Bool
+  header_template : String
+  footer_template : String
+  generate_tagged_pdf : Bool
+  generate_document_outline : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend PdfPrintSettings with Eq::{not_equal, equal}
+
+///|
+pub extend PdfPrintSettings with Debug::{to_repr}
 
 ///|
 enum NativeViewEvent {
@@ -301,6 +329,19 @@ pub extend NativeDownloadUpdate with Eq::{not_equal, equal}
 
 ///|
 pub extend NativeDownloadUpdate with Debug::{to_repr}
+
+///|
+pub(all) struct NativePdfPrintResult {
+  request_id : Int
+  path : String
+  success : Bool
+} derive(Debug, Eq)
+
+///|
+pub extend NativePdfPrintResult with Eq::{not_equal, equal}
+
+///|
+pub extend NativePdfPrintResult with Debug::{to_repr}
 
 ///|
 pub(all) struct BridgeLifecycleState {
@@ -715,6 +756,7 @@ pub fn RuntimeEvent::event_type(self : RuntimeEvent) -> String {
     BrowserRequest(_, Certificate(..)) => "browser_certificate_error"
     BrowserRequest(_, Media(..)) => "browser_media_permission_requested"
     BrowserDownloadUpdated(_, _) => "browser_download_updated"
+    BrowserPdfPrinted(_, _) => "browser_pdf_print_finished"
     BrowserEvent(_, LoadingChanged(_)) => "browser_loading_changed"
     BrowserEvent(_, Navigated(_)) => "browser_navigated"
     BrowserEvent(_, TitleUpdated(_)) => "browser_title_updated"
@@ -749,6 +791,7 @@ pub fn RuntimeEvent::window_id(self : RuntimeEvent) -> Int64? {
     | BridgeLifecycleChanged(window, _)
     | BrowserRequest(window, _)
     | BrowserDownloadUpdated(window, _)
+    | BrowserPdfPrinted(window, _)
     | BrowserEvent(window, _)
     | ViewEvent(window, _, _) => Some(window)
     ResourceRequested(request) => Some(request.window)
@@ -962,6 +1005,16 @@ pub fn RuntimeEvent::browser_download_update(
 ) -> NativeDownloadUpdate? {
   match self {
     BrowserDownloadUpdated(_, update) => Some(update)
+    _ => None
+  }
+}
+
+///|
+pub fn RuntimeEvent::pdf_print_result(
+  self : RuntimeEvent,
+) -> NativePdfPrintResult? {
+  match self {
+    BrowserPdfPrinted(_, result) => Some(result)
     _ => None
   }
 }

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -245,6 +245,7 @@ pub(all) enum BrowserEvent {
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
   FoundInPage(result~ : FindInPageResult)
+  PdfPrinted(result~ : PdfPrintResult)
 } derive(Eq, @debug.Debug)
 pub fn BrowserEvent::equal(Self, Self) -> Bool
 pub fn BrowserEvent::not_equal(Self, Self) -> Bool
@@ -258,6 +259,8 @@ pub struct BrowserHandle {
   eval_browser_script : (String) -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
   download_browser_url : (String) -> Unit raise WindowSessionError
+  print_browser : () -> Unit raise WindowSessionError
+  print_browser_to_pdf : (String, PdfPrintOptions) -> Int raise WindowSessionError
   find_browser_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
   stop_browser_find : (Bool) -> Unit raise WindowSessionError
   set_browser_zoom_percent : (Int) -> Unit raise WindowSessionError
@@ -281,6 +284,8 @@ pub fn BrowserHandle::is_audio_muted(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::open_devtools(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::print(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::print_to_pdf(Self, String, options? : PdfPrintOptions) -> Int raise WindowSessionError
 pub fn BrowserHandle::reload(Self, ignore_cache? : Bool) -> Unit raise WindowSessionError
 pub fn BrowserHandle::session(Self) -> SessionHandle
 pub fn BrowserHandle::set_audio_muted(Self, Bool) -> Unit raise WindowSessionError
@@ -479,6 +484,44 @@ pub(all) struct NavigationRequest {
 pub fn NavigationRequest::equal(Self, Self) -> Bool
 pub fn NavigationRequest::not_equal(Self, Self) -> Bool
 pub fn NavigationRequest::to_repr(Self) -> @debug.Repr
+
+pub(all) enum PdfPrintMargins {
+  Default
+  NoMargins
+  Custom(top~ : Double, right~ : Double, bottom~ : Double, left~ : Double)
+} derive(Eq, @debug.Debug)
+pub fn PdfPrintMargins::equal(Self, Self) -> Bool
+pub fn PdfPrintMargins::not_equal(Self, Self) -> Bool
+pub fn PdfPrintMargins::to_repr(Self) -> @debug.Repr
+
+pub(all) struct PdfPrintOptions {
+  landscape : Bool
+  print_background : Bool
+  scale : Double
+  paper_width : Double
+  paper_height : Double
+  prefer_css_page_size : Bool
+  margins : PdfPrintMargins
+  page_ranges : String
+  display_header_footer : Bool
+  header_template : String
+  footer_template : String
+  generate_tagged_pdf : Bool
+  generate_document_outline : Bool
+} derive(Eq, @debug.Debug)
+pub fn PdfPrintOptions::PdfPrintOptions(landscape? : Bool, print_background? : Bool, scale? : Double, paper_width? : Double, paper_height? : Double, prefer_css_page_size? : Bool, margins? : PdfPrintMargins, page_ranges? : String, display_header_footer? : Bool, header_template? : String, footer_template? : String, generate_tagged_pdf? : Bool, generate_document_outline? : Bool) -> Self
+pub fn PdfPrintOptions::equal(Self, Self) -> Bool
+pub fn PdfPrintOptions::not_equal(Self, Self) -> Bool
+pub fn PdfPrintOptions::to_repr(Self) -> @debug.Repr
+
+pub(all) struct PdfPrintResult {
+  request_id : Int
+  path : String
+  success : Bool
+} derive(Eq, @debug.Debug)
+pub fn PdfPrintResult::equal(Self, Self) -> Bool
+pub fn PdfPrintResult::not_equal(Self, Self) -> Bool
+pub fn PdfPrintResult::to_repr(Self) -> @debug.Repr
 
 pub struct PendingUpdate {
   version : String


### PR DESCRIPTION
## Summary

- add `BrowserHandle::print` for the platform print flow
- add asynchronous `BrowserHandle::print_to_pdf` with typed PDF options, request ids, and `BrowserEvent::PdfPrinted` completion events
- implement the shared CEF PDF callback and macOS, Windows, and Linux native forwarding, including the Linux PDF paper-size handler
- add `examples/72_print_pdf` for manual system-print and PDF review

## Platform impact

- macOS, Windows, and Linux use the same CEF print/PDF ABI
- Linux PDF output installs the CEF-required paper-size handler
- interactive Linux printing still depends on the desktop print stack available in the session

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 100` (36 passed)
- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native`
- `node scripts/verify_generated.mjs`
- `moon info`
- `git diff --check`

macOS runtime review completed three sequential PDF requests without a crash:

- standard: 2-page Letter portrait, tagged PDF, header/footer numbering
- landscape: 2-page Letter landscape with backgrounds and custom margins
- CSS: 2-page A4 from `@page`, tagged PDF

All six rendered pages were inspected with Poppler for page size, clipping, overlap, backgrounds, and unexpected blank-page color.