### PR TITLE
feat(browser): add focus and DevTools state controls

### DIFF
--- a/examples/54_devtools/README.md
+++ b/examples/54_devtools/README.md
@@ -1,0 +1,22 @@
+# DevTools and focus review
+
+Manual review for Electron-style web contents focus and DevTools controls on
+both the main browser and an embedded `WebContentsView`.
+
+Run from the repository root:
+
+```sh
+moon -C examples run 54_devtools --target native
+```
+
+Review checklist:
+
+1. Click **Focus view**. The right page should gain its green focus border,
+   `View focused` should become `true`, and `Host focused` should become
+   `false`.
+2. Click **Focus page**. The host focus marker should return and the two native
+   focus states should swap.
+3. Open, close, and toggle host DevTools. Only `Host DevTools` should change.
+4. Open, close, and toggle view DevTools. Only `View DevTools` should change.
+5. Close either DevTools window directly and click **Refresh state**. The
+   matching state should report `false` while the application remains open.

--- a/examples/54_devtools/main.mbt
+++ b/examples/54_devtools/main.mbt
@@ -1,47 +1,179 @@
 ///|
-let page =
-  #|<!doctype html>
-  #|<html lang="en">
-  #|  <head>
-  #|    <meta charset="utf-8">
-  #|    <meta name="viewport" content="width=device-width, initial-scale=1">
-  #|    <title>Proton DevTools API</title>
-  #|    <style>
-  #|      :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
-  #|      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #111827; color: #f9fafb; }
-  #|      main { width: min(680px, calc(100vw - 64px)); padding: 40px; border: 1px solid #374151; border-radius: 20px; background: #1f2937; box-shadow: 0 24px 60px #0006; }
-  #|      h1 { margin-top: 0; font-size: 32px; }
-  #|      code { color: #93c5fd; }
-  #|      li { margin: 12px 0; line-height: 1.5; }
-  #|      .status { display: inline-block; padding: 6px 10px; border-radius: 999px; background: #064e3b; color: #a7f3d0; font-size: 13px; }
-  #|    </style>
-  #|  </head>
-  #|  <body>
-  #|    <main>
-  #|      <span class="status">open_devtools called</span>
-  #|      <h1 id="probe-title">Proton DevTools API</h1>
-  #|      <p>This example calls <code>BrowserHandle::open_devtools()</code> when the main window becomes ready.</p>
-  #|      <ol>
-  #|        <li>Confirm that a separate DevTools window opened automatically.</li>
-  #|        <li>Use the Elements panel to inspect <code>#probe-title</code>.</li>
-  #|        <li>Close DevTools and confirm that this window remains open.</li>
-  #|      </ol>
-  #|    </main>
-  #|  </body>
-  #|</html>
-  #|
+struct ControlRequest {
+  target : String
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend ControlRequest with ToJson::{to_json}
+
+///|
+pub extend ControlRequest with FromJson::{from_json}
+
+///|
+struct ControlReply {
+  ok : Bool
+  message : String
+  host_focused : Bool
+  host_devtools_opened : Bool
+  view_focused : Bool
+  view_devtools_opened : Bool
+} derive(ToJson, FromJson)
+
+///|
+pub extend ControlReply with ToJson::{to_json}
+
+///|
+pub extend ControlReply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/devtools-focus",
+  js_namespace="devtoolsReview",
+)
+
+///|
+let control_command : @proton_contract.Command[ControlRequest, ControlReply] = contract.command(
+  "control",
+)
+
+///|
+let browser_slot : Ref[@proton.BrowserHandle?] = { val: None, }
+
+///|
+let view_slot : Ref[@proton.ViewHandle?] = { val: None, }
+
+///|
+fn read_state(message : String, ok? : Bool = true) -> ControlReply {
+  let (host_focused, host_devtools_opened) = match browser_slot.val {
+    Some(browser) =>
+      (
+        browser.is_focused() catch {
+          _ => false
+        },
+        browser.is_devtools_opened() catch {
+          _ => false
+        },
+      )
+    None => (false, false)
+  }
+  let (view_focused, view_devtools_opened) = match view_slot.val {
+    Some(view) =>
+      (
+        view.is_focused() catch {
+          _ => false
+        },
+        view.is_devtools_opened() catch {
+          _ => false
+        },
+      )
+    None => (false, false)
+  }
+  {
+    ok,
+    message,
+    host_focused,
+    host_devtools_opened,
+    view_focused,
+    view_devtools_opened,
+  }
+}
+
+///|
+fn control(request : ControlRequest) -> ControlReply {
+  if request.action == "refresh" {
+    return read_state("State refreshed")
+  }
+  try {
+    match request.target {
+      "host" =>
+        match browser_slot.val {
+          Some(browser) =>
+            match request.action {
+              "focus" => browser.focus()
+              "open" => browser.open_devtools()
+              "close" => browser.close_devtools()
+              "toggle" => browser.toggle_devtools()
+              _ => return read_state("Unknown action", ok=false)
+            }
+          None => return read_state("Host browser is unavailable", ok=false)
+        }
+      "view" =>
+        match view_slot.val {
+          Some(view) =>
+            match request.action {
+              "focus" => view.focus()
+              "open" => view.open_devtools()
+              "close" => view.close_devtools()
+              "toggle" => view.toggle_devtools()
+              _ => return read_state("Unknown action", ok=false)
+            }
+          None =>
+            return read_state("Web contents view is unavailable", ok=false)
+        }
+      _ => return read_state("Unknown target", ok=false)
+    }
+    read_state("{request.target}: {request.action}")
+  } catch {
+    error => read_state(error.to_string(), ok=false)
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(control_command, (_context, request) => control(request))
+}
+
+///|
+let view_page =
+  #|data:text/html,<html><head><meta charset='utf-8'><style>*{box-sizing:border-box}body{margin:0;min-height:100vh;padding:48px;font-family:system-ui,sans-serif;background:%23f1f4f6;color:%231b242a;border:8px solid transparent;transition:border-color .15s}body.focused{border-color:%231f7a68}.eyebrow{font:700 11px monospace;color:%231f7a68}.badge{display:inline-block;padding:5px 8px;border:1px solid %2393a1a8;font:700 11px monospace}h1{font-size:38px;line-height:1.05;margin:16px 0}p{max-width:580px;line-height:1.6;color:%234c5b63}input{width:min(100%25,480px);height:44px;border:1px solid %2379848a;background:white;padding:0 12px;font-size:15px}</style></head><body><span class='eyebrow'>WEB CONTENTS VIEW / REVIEW 54</span><h1>Independent focus target</h1><span id='badge' class='badge'>window blur</span><p>Use the host controls to focus this view and open its own DevTools window. The green border and badge follow page focus events.</p><input placeholder='Type here after focusing the view'><script>const badge=document.querySelector('%23badge');function sync(){const focused=document.hasFocus();document.body.classList.toggle('focused',focused);badge.textContent=focused?'window focus':'window blur'}addEventListener('focus',sync);addEventListener('blur',sync);sync()</script></body></html>
+
+///|
+fn open_review_view(window : @proton.WindowHandle) -> Unit {
+  let view = window.add_view(
+    "review",
+    @proton.view(view_page, x=400, y=0, width=700, height=700),
+  ) catch {
+    error => {
+      println("add review view failed: " + error.message())
+      return
+    }
+  }
+  view_slot.val = Some(view)
+}
+
+///|
+fn host_page() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Proton DevTools and Focus</title>
+    #|<style>:root{font-family:system-ui,sans-serif;color:#192329;background:#e3e8ea}*{box-sizing:border-box}body{margin:0;width:400px;min-height:100vh;padding:28px;border-right:1px solid #8b989e;transition:box-shadow .15s}body.focused{box-shadow:inset 6px 0 #ba3d57}.eyebrow{font:700 11px monospace;color:#8f2941}h1{font-size:29px;line-height:1.08;margin:8px 0 12px}.copy{font-size:14px;line-height:1.55;color:#4d5b62}.page-focus{display:inline-block;padding:5px 8px;border:1px solid #8b989e;font:700 11px monospace}.target{margin-top:20px;padding-top:18px;border-top:1px solid #9ba6ab}.target h2{font-size:15px;margin:0 0 10px}.actions{display:grid;grid-template-columns:1fr 1fr;gap:8px}button{height:38px;border:1px solid #6f7d84;background:#f8fafb;color:#192329;font-weight:700;cursor:pointer}button.primary{background:#275c70;color:white;border-color:#275c70}.state{display:grid;grid-template-columns:1fr auto;gap:5px 12px;margin-top:18px;padding:12px;background:#f8fafb;border:1px solid #9ba6ab;font:12px/1.4 monospace}.value.true{color:#146b57;font-weight:700}.value.false{color:#8f2941;font-weight:700}#status{min-height:36px;font:12px/1.45 monospace;color:#275c70}.refresh{width:100%;margin-top:10px}</style></head>
+    #|<body><span class="eyebrow">ELECTRON WEB CONTENTS / REVIEW 54</span><h1>Focus and DevTools</h1><span id="page-focus" class="page-focus">host window focus</span><p class="copy">Control the host browser and the independent view on the right. Each target owns its own DevTools state.</p><section class="target"><h2>Host browser</h2><div class="actions"><button data-target="host" data-action="focus">Focus page</button><button class="primary" data-target="host" data-action="toggle">Toggle DevTools</button><button data-target="host" data-action="open">Open DevTools</button><button data-target="host" data-action="close">Close DevTools</button></div></section><section class="target"><h2>Web contents view</h2><div class="actions"><button data-target="view" data-action="focus">Focus view</button><button class="primary" data-target="view" data-action="toggle">Toggle DevTools</button><button data-target="view" data-action="open">Open DevTools</button><button data-target="view" data-action="close">Close DevTools</button></div></section><div class="state"><span>Host focused</span><span id="host-focused" class="value">-</span><span>Host DevTools</span><span id="host-devtools" class="value">-</span><span>View focused</span><span id="view-focused" class="value">-</span><span>View DevTools</span><span id="view-devtools" class="value">-</span></div><button id="refresh" class="refresh">Refresh state</button><p id="status" role="status">Ready</p>
+    #|<script>const status=document.querySelector('#status');function paint(id,value){const node=document.querySelector(id);node.textContent=String(value);node.className=`value ${value}`}function apply(reply){paint('#host-focused',reply.host_focused);paint('#host-devtools',reply.host_devtools_opened);paint('#view-focused',reply.view_focused);paint('#view-devtools',reply.view_devtools_opened);status.textContent=reply.message}async function run(target,action){status.textContent=`${target}: ${action}...`;try{apply(await window.__MoonBit__.core.invokeOp('ext:devtoolsReview/control',{target,action}));if(action!=='refresh')setTimeout(()=>void run(target,'refresh'),250)}catch(error){status.textContent=String(error)}}document.querySelectorAll('[data-action]').forEach(button=>button.onclick=()=>void run(button.dataset.target,button.dataset.action));document.querySelector('#refresh').onclick=()=>void run('host','refresh');const focusBadge=document.querySelector('#page-focus');function focusState(){const focused=document.hasFocus();document.body.classList.toggle('focused',focused);focusBadge.textContent=focused?'host window focus':'host window blur'}addEventListener('focus',focusState);addEventListener('blur',focusState);focusState();void run('host','refresh')</script></body></html>
+  )
+}
 
 ///|
 async fn main {
-  @proton.html("DevTools API", page, width=900, height=700, debug=true)
+  @proton.html(
+    "DevTools and Focus",
+    host_page(),
+    width=1100,
+    height=700,
+    debug=true,
+  )
+  .commands(register_commands)
   .window_lifecycle(
     on_ready=context => {
-      let browser = context.handle().browser()
-      browser.open_devtools()
-      browser
+      let window = context.handle()
+      browser_slot.val = Some(window.browser())
+      open_review_view(window)
+      window
     },
-    on_close=fn(browser) { browser.close_devtools() catch { _ => () } },
+    on_close=fn(_window) {
+      view_slot.val = None
+      browser_slot.val = None
+    },
   )
-  .identifier("dev.proton.54-devtools")
+  .identifier("dev.proton.54-devtools-focus")
   .run_or_abort()
 }

--- a/examples/54_devtools/moon.pkg
+++ b/examples/54_devtools/moon.pkg
@@ -1,9 +1,13 @@
 import {
   "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
   "moonbit-community/proton",
 }
 
 supported_targets = "native"
+
+warnings = "-unused_async"
 
 pkgtype(kind: "executable")
 

--- a/examples/54_devtools/pkg.generated.mbti
+++ b/examples/54_devtools/pkg.generated.mbti
@@ -1,11 +1,22 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbit-community/proton/examples/54_devtools"
 
+import {
+  "moonbitlang/core/json",
+}
+
 // Values
 
 // Errors
 
 // Types and methods
+type ControlReply derive(ToJson, @json.FromJson)
+pub fn ControlReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ControlReply::to_json(Self) -> Json
+
+type ControlRequest derive(ToJson, @json.FromJson)
+pub fn ControlRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ControlRequest::to_json(Self) -> Json
 
 // Type aliases
 

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -86,8 +86,9 @@ moon -C examples run 01_run --target native
   sidebar in sync. The manual review tones verify main-browser and view mute.
 - `53_view_minimal`: the minimal declarative web contents view example:
   `with_view` plus `@proton.view`, no lifecycle hooks required.
-- `54_devtools`: opens CEF DevTools programmatically through
-  `BrowserHandle::open_devtools` and closes it with the window lifecycle.
+- `54_devtools`: manual Electron-style focus and DevTools review for both the
+  main browser and a web contents view, including open, close, toggle, and
+  synchronous state queries.
 - `55_desktop_showcase`: presentation-ready macOS desktop capability console
   combining native dialogs, clipboard access, notifications, and tray menus.
 - `56_i18n`: one explicit application locale observed through MoonBit command

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -479,6 +479,17 @@ fn RuntimeSession::view_handle(
         view => view.eval(script),
       )
     },
+    focus_view: () => {
+      self.control_window(
+        window_id,
+        window_native_id,
+        "focus for view " + id + " in",
+        window => window.focus(),
+      )
+      self.control_view(window_id, window_native_id, id, native_id, "focus", view => {
+        view.browser_command("focus")
+      })
+    },
     send_view_command: (command, download_id) => {
       self.control_view(
         window_id,
@@ -519,6 +530,30 @@ fn RuntimeSession::view_handle(
         error =>
           raise window_operation_failed(
             "read navigation state of view " + id + " in window " + window_id,
+            error,
+          )
+      }
+    },
+    read_view_focused: () => {
+      let running = self.resolve_view(
+        window_id, window_native_id, id, native_id,
+      )
+      running.view.browser_is_focused() catch {
+        error =>
+          raise window_operation_failed(
+            "read focus of view " + id + " in window " + window_id,
+            error,
+          )
+      }
+    },
+    read_view_devtools_opened: () => {
+      let running = self.resolve_view(
+        window_id, window_native_id, id, native_id,
+      )
+      running.view.is_devtools_opened() catch {
+        error =>
+          raise window_operation_failed(
+            "read DevTools state of view " + id + " in window " + window_id,
             error,
           )
       }
@@ -725,6 +760,12 @@ fn RuntimeSession::browser_handle(
         window.eval(script)
       })
     },
+    focus_browser: () => {
+      self.control_window(id, native_id, "focus browser in", window => {
+        window.focus()
+        window.browser_command("focus")
+      })
+    },
     send_browser_command: (command, download_id) => {
       self.control_window(id, native_id, command + " in", window => {
         window.browser_command(command, download_id?)
@@ -816,6 +857,32 @@ fn RuntimeSession::browser_handle(
         error =>
           raise window_operation_failed(
             "read browser navigation state in window " + id,
+            error,
+          )
+      }
+    },
+    read_browser_focused: () => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.browser_is_focused() catch {
+        error =>
+          raise window_operation_failed(
+            "read browser focus in window " + id,
+            error,
+          )
+      }
+    },
+    read_browser_devtools_opened: () => {
+      let running = match self.find_active_window(id) {
+        Some(running) if running.window.id() == native_id => running
+        _ => raise StaleWindow(id~)
+      }
+      running.window.is_devtools_opened() catch {
+        error =>
+          raise window_operation_failed(
+            "read browser DevTools state in window " + id,
             error,
           )
       }
@@ -2245,6 +2312,20 @@ pub fn ViewHandle::stop(self : ViewHandle) -> Unit raise WindowSessionError {
 }
 
 ///|
+/// Focuses this view's web page, matching Electron `webContents.focus()`.
+pub fn ViewHandle::focus(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.focus_view)()
+}
+
+///|
+/// Returns whether this view's web page currently owns focus.
+pub fn ViewHandle::is_focused(
+  self : ViewHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_view_focused)()
+}
+
+///|
 pub fn ViewHandle::open_devtools(
   self : ViewHandle,
 ) -> Unit raise WindowSessionError {
@@ -2256,6 +2337,22 @@ pub fn ViewHandle::close_devtools(
   self : ViewHandle,
 ) -> Unit raise WindowSessionError {
   (self.send_view_command)("close_devtools", None)
+}
+
+///|
+/// Toggles the DevTools view for this web contents.
+pub fn ViewHandle::toggle_devtools(
+  self : ViewHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_view_command)("toggle_devtools", None)
+}
+
+///|
+/// Returns whether this web contents currently has an open DevTools view.
+pub fn ViewHandle::is_devtools_opened(
+  self : ViewHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_view_devtools_opened)()
 }
 
 ///|
@@ -2457,6 +2554,22 @@ pub fn BrowserHandle::stop(
 }
 
 ///|
+/// Focuses the web page, matching Electron `webContents.focus()`.
+pub fn BrowserHandle::focus(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.focus_browser)()
+}
+
+///|
+/// Returns whether the web page currently owns focus.
+pub fn BrowserHandle::is_focused(
+  self : BrowserHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_browser_focused)()
+}
+
+///|
 pub fn BrowserHandle::open_devtools(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
@@ -2468,6 +2581,22 @@ pub fn BrowserHandle::close_devtools(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
   (self.send_browser_command)("close_devtools", None)
+}
+
+///|
+/// Toggles the DevTools view for this web contents.
+pub fn BrowserHandle::toggle_devtools(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("toggle_devtools", None)
+}
+
+///|
+/// Returns whether this web contents currently has an open DevTools view.
+pub fn BrowserHandle::is_devtools_opened(
+  self : BrowserHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_browser_devtools_opened)()
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -449,6 +449,7 @@ pub struct BrowserHandle {
   load_browser_url : (String) -> Unit raise WindowSessionError
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
+  focus_browser : () -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
   download_browser_url : (String) -> Unit raise WindowSessionError
   print_browser : () -> Unit raise WindowSessionError
@@ -460,6 +461,8 @@ pub struct BrowserHandle {
   set_browser_audio_muted : (Bool) -> Unit raise WindowSessionError
   read_browser_audio_muted : () -> Bool raise WindowSessionError
   read_browser_navigation_state : () -> (Bool, Bool) raise WindowSessionError
+  read_browser_focused : () -> Bool raise WindowSessionError
+  read_browser_devtools_opened : () -> Bool raise WindowSessionError
   read_browser_state : () -> BrowserState raise WindowSessionError
   session_handle : SessionHandle
 }
@@ -507,10 +510,13 @@ pub struct ViewHandle {
   load_view_url : (String) -> Unit raise WindowSessionError
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
+  focus_view : () -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
   find_view_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
   stop_view_find : (Bool) -> Unit raise WindowSessionError
   read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
+  read_view_focused : () -> Bool raise WindowSessionError
+  read_view_devtools_opened : () -> Bool raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
 }

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -89,6 +89,9 @@ fn test_window_handle(
   browser_find_calls? : Array[String],
   browser_download_calls? : Array[String],
   browser_print_calls? : Array[String],
+  browser_control_calls? : Array[String],
+  browser_focused? : Bool = false,
+  browser_devtools_opened? : Bool = false,
   window_state? : WindowState,
 ) -> WindowHandle {
   let browser = BrowserHandle::{
@@ -97,7 +100,18 @@ fn test_window_handle(
     load_browser_url: fn(_url) {  },
     load_browser_html: fn(_html, _base_url) {  },
     eval_browser_script: fn(_script) {  },
-    send_browser_command: fn(_command, _download_id) {  },
+    focus_browser: fn() {
+      match browser_control_calls {
+        Some(calls) => calls.push("focus")
+        None => ()
+      }
+    },
+    send_browser_command: fn(command, _download_id) {
+      match browser_control_calls {
+        Some(calls) => calls.push(command)
+        None => ()
+      }
+    },
     download_browser_url: fn(url) {
       match browser_download_calls {
         Some(calls) => calls.push(url)
@@ -144,6 +158,8 @@ fn test_window_handle(
     },
     read_browser_audio_muted: fn() { browser_audio_muted },
     read_browser_navigation_state: fn() { (true, false) },
+    read_browser_focused: fn() { browser_focused },
+    read_browser_devtools_opened: fn() { browser_devtools_opened },
     read_browser_state: fn() {
       {
         url: "https://example.test/",
@@ -2380,7 +2396,8 @@ fn test_view_handle(
     load_view_url: fn(url) { calls.push("load_url:\{url}") },
     load_view_html: fn(_html, _base_url) {  },
     eval_view_script: fn(_script) {  },
-    send_view_command: fn(_command, _download_id) {  },
+    focus_view: fn() { calls.push("focus") },
+    send_view_command: fn(command, _download_id) { calls.push(command) },
     find_view_in_page: fn(text, forward, match_case, find_next) {
       calls.push("find:\{text}:\{forward}:\{match_case}:\{find_next}")
       9
@@ -2389,6 +2406,8 @@ fn test_view_handle(
       calls.push("stop_find:\{clear_selection}")
     },
     read_view_navigation_state: fn() { (true, false) },
+    read_view_focused: fn() { true },
+    read_view_devtools_opened: fn() { false },
     read_view_state: fn() {
       { x: 1, y: 2, width: 300, height: 200, visible: true, z_order: 1, }
     },
@@ -2416,6 +2435,12 @@ test "view handle routes operations through its closures" {
   view.stop_find_in_page(clear_selection=false)
   assert_true(view.can_go_back())
   assert_false(view.can_go_forward())
+  view.focus()
+  assert_true(view.is_focused())
+  view.open_devtools()
+  view.toggle_devtools()
+  view.close_devtools()
+  assert_false(view.is_devtools_opened())
   let state = view.state()
   inspect(state.width, content="300")
   inspect(state.z_order, content="1")
@@ -2432,6 +2457,10 @@ test "view handle routes operations through its closures" {
       #|  "load_url:https://example.com/",
       #|  "find:Proton:false:true:true",
       #|  "stop_find:false",
+      #|  "focus",
+      #|  "open_devtools",
+      #|  "toggle_devtools",
+      #|  "close_devtools",
       #|  "close",
       #|]
     ),
@@ -2447,6 +2476,29 @@ test "browser handle exposes the current page state" {
   assert_false(state.is_loading)
   assert_true(state.can_go_back)
   assert_false(state.can_go_forward)
+}
+
+///|
+test "browser handle routes focus and DevTools controls" {
+  let calls : Array[String] = []
+  let window = test_window_handle(
+    "main",
+    17L,
+    browser_control_calls=calls,
+    browser_focused=true,
+    browser_devtools_opened=true,
+  )
+  let browser = window.browser()
+  browser.focus()
+  assert_true(browser.is_focused())
+  browser.open_devtools()
+  browser.toggle_devtools()
+  browser.close_devtools()
+  assert_true(browser.is_devtools_opened())
+  debug_inspect(
+    calls,
+    content="[\"focus\", \"open_devtools\", \"toggle_devtools\", \"close_devtools\"]",
+  )
 }
 
 ///|

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -659,6 +659,20 @@ pub extern "C" fn proton_window_browser_command_json_ffi(
 ) -> Int = "proton_window_browser_command_json"
 
 ///|
+#borrow(out_focused)
+pub extern "C" fn proton_window_get_browser_focus_state_ffi(
+  window : WindowHandle,
+  out_focused : Ref[Int],
+) -> Int = "proton_window_get_browser_focus_state"
+
+///|
+#borrow(out_opened)
+pub extern "C" fn proton_window_get_devtools_state_ffi(
+  window : WindowHandle,
+  out_opened : Ref[Int],
+) -> Int = "proton_window_get_devtools_state"
+
+///|
 #borrow(url)
 pub extern "C" fn proton_window_download_url_ffi(
   window : WindowHandle,
@@ -973,6 +987,20 @@ pub extern "C" fn proton_view_browser_command_json_ffi(
   view : ViewHandle,
   command_json : Bytes,
 ) -> Int = "proton_view_browser_command_json"
+
+///|
+#borrow(out_focused)
+pub extern "C" fn proton_view_get_browser_focus_state_ffi(
+  view : ViewHandle,
+  out_focused : Ref[Int],
+) -> Int = "proton_view_get_browser_focus_state"
+
+///|
+#borrow(out_opened)
+pub extern "C" fn proton_view_get_devtools_state_ffi(
+  view : ViewHandle,
+  out_opened : Ref[Int],
+) -> Int = "proton_view_get_devtools_state"
 
 ///|
 #borrow(text, out_request_id)

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -240,6 +240,10 @@ int32_t proton_window_eval(proton_window_handle_t window,
                                       const char *script);
 int32_t proton_window_browser_command_json(
     proton_window_handle_t window, const char *command_json);
+int32_t proton_window_get_browser_focus_state(
+    proton_window_handle_t window, int32_t *out_focused);
+int32_t proton_window_get_devtools_state(
+    proton_window_handle_t window, int32_t *out_opened);
 int32_t proton_window_download_url(
     proton_window_handle_t window, const char *url);
 int32_t proton_window_print(proton_window_handle_t window);
@@ -433,6 +437,10 @@ int32_t proton_view_load_url(proton_view_handle_t view,
 int32_t proton_view_eval(proton_view_handle_t view, const char *script);
 int32_t proton_view_browser_command_json(
     proton_view_handle_t view, const char *command_json);
+int32_t proton_view_get_browser_focus_state(
+    proton_view_handle_t view, int32_t *out_focused);
+int32_t proton_view_get_devtools_state(
+    proton_view_handle_t view, int32_t *out_opened);
 int32_t proton_view_find_in_page(
     proton_view_handle_t view, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id);

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -151,6 +151,10 @@ pub fn proton_view_eval_ffi(ViewHandle, Bytes) -> Int
 
 pub fn proton_view_find_in_page_ffi(ViewHandle, Bytes, Int, Int, Int, @ref.Ref[Int]) -> Int
 
+pub fn proton_view_get_browser_focus_state_ffi(ViewHandle, @ref.Ref[Int]) -> Int
+
+pub fn proton_view_get_devtools_state_ffi(ViewHandle, @ref.Ref[Int]) -> Int
+
 pub fn proton_view_get_navigation_state_ffi(ViewHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
 
 pub fn proton_view_get_state_ffi(ViewHandle, FixedArray[Int], Int) -> Int
@@ -215,6 +219,8 @@ pub fn proton_window_flash_frame_ffi(WindowHandle, Int) -> Int
 
 pub fn proton_window_focus_ffi(WindowHandle) -> Int
 
+pub fn proton_window_get_browser_focus_state_ffi(WindowHandle, @ref.Ref[Int]) -> Int
+
 pub fn proton_window_get_browser_loading_ffi(WindowHandle, @ref.Ref[Int]) -> Int
 
 pub fn proton_window_get_browser_title_ffi(WindowHandle, FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
@@ -222,6 +228,8 @@ pub fn proton_window_get_browser_title_ffi(WindowHandle, FixedArray[Byte], Int, 
 pub fn proton_window_get_browser_url_ffi(WindowHandle, FixedArray[Byte], Int, @ref.Ref[Int]) -> Int
 
 pub fn proton_window_get_content_size_ffi(WindowHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
+
+pub fn proton_window_get_devtools_state_ffi(WindowHandle, @ref.Ref[Int]) -> Int
 
 pub fn proton_window_get_navigation_state_ffi(WindowHandle, @ref.Ref[Int], @ref.Ref[Int]) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -999,8 +999,18 @@ int32_t proton_browser_session_command_json(
       return PROTON_ERR_STALE_BROWSER_REQUEST;
     }
     download->callback->cancel(download->callback);
+  } else if (strcmp(command, "focus") == 0) {
+    cef_browser_host_t *host = browser->get_host(browser);
+    if (host == NULL) {
+      proton_browser_set_message(error, error_len,
+                                 "browser host is unavailable");
+      return PROTON_ERR_ENGINE;
+    }
+    host->set_focus(host, 1);
+    host->base.release((cef_base_ref_counted_t *)host);
   } else if (strcmp(command, "open_devtools") == 0 ||
-             strcmp(command, "close_devtools") == 0) {
+             strcmp(command, "close_devtools") == 0 ||
+             strcmp(command, "toggle_devtools") == 0) {
     if (!session->policy.devtools) {
       proton_browser_set_message(error, error_len,
                                  "DevTools are disabled by browser policy");
@@ -1012,7 +1022,10 @@ int32_t proton_browser_session_command_json(
                                  "browser host is unavailable");
       return PROTON_ERR_ENGINE;
     }
-    if (strcmp(command, "close_devtools") == 0) {
+    int close_devtools = strcmp(command, "close_devtools") == 0 ||
+                         (strcmp(command, "toggle_devtools") == 0 &&
+                          host->has_dev_tools(host));
+    if (close_devtools) {
       host->close_dev_tools(host);
     } else {
       cef_window_info_t window_info = {0};
@@ -1041,6 +1054,44 @@ int32_t proton_browser_navigation_state(
   }
   *out_can_go_back = browser->can_go_back(browser) ? 1 : 0;
   *out_can_go_forward = browser->can_go_forward(browser) ? 1 : 0;
+  return PROTON_OK;
+}
+
+int32_t proton_browser_is_focused(
+    cef_browser_t *browser, int32_t *out_focused, char *error,
+    size_t error_len) {
+  if (browser == NULL || out_focused == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser and focus output are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_frame_t *frame = browser->get_main_frame(browser);
+  if (frame == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "main frame is unavailable");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_focused = frame->is_focused(frame) ? 1 : 0;
+  frame->base.release((cef_base_ref_counted_t *)frame);
+  return PROTON_OK;
+}
+
+int32_t proton_browser_is_devtools_opened(
+    cef_browser_t *browser, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (browser == NULL || out_opened == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser and DevTools output are required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "browser host is unavailable");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_opened = host->has_dev_tools(host) ? 1 : 0;
+  host->base.release((cef_base_ref_counted_t *)host);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -1057,7 +1057,9 @@ int32_t proton_browser_navigation_state(
   return PROTON_OK;
 }
 
-int32_t proton_browser_is_focused(
+/* Frame focus identifies the active frame inside a browser, so it is only a
+   valid browser-level fallback when no native host window exists. */
+int32_t proton_browser_headless_is_focused(
     cef_browser_t *browser, int32_t *out_focused, char *error,
     size_t error_len) {
   if (browser == NULL || out_focused == NULL) {

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -31,7 +31,6 @@ typedef struct proton_browser_session proton_browser_session_t;
 typedef struct proton_event proton_event_t;
 
 typedef void (*proton_browser_signal_fn)(void *user_data);
-
 proton_browser_session_t *proton_browser_session_create(
     const proton_browser_policy_t *policy, proton_browser_signal_fn signal,
     void *signal_user_data);
@@ -68,6 +67,12 @@ int32_t proton_browser_session_command_json(
 int32_t proton_browser_navigation_state(
     cef_browser_t *browser, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len);
+int32_t proton_browser_is_focused(
+    cef_browser_t *browser, int32_t *out_focused, char *error,
+    size_t error_len);
+int32_t proton_browser_is_devtools_opened(
+    cef_browser_t *browser, int32_t *out_opened,
+    char *error, size_t error_len);
 int32_t proton_browser_set_zoom_percent(
     cef_browser_t *browser, int32_t zoom_percent,
     char *error, size_t error_len);

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -67,7 +67,7 @@ int32_t proton_browser_session_command_json(
 int32_t proton_browser_navigation_state(
     cef_browser_t *browser, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len);
-int32_t proton_browser_is_focused(
+int32_t proton_browser_headless_is_focused(
     cef_browser_t *browser, int32_t *out_focused, char *error,
     size_t error_len);
 int32_t proton_browser_is_devtools_opened(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -136,6 +136,7 @@ int proton_engine_browser_id(cef_browser_t *browser);
 void proton_engine_browser_release(cef_browser_t *browser);
 proton_engine_view_t *proton_engine_view_from_browser(cef_browser_t *browser);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
+int proton_engine_x11_window_is_focused(Display *display, Window browser_window);
 
 cef_life_span_handler_t *CEF_CALLBACK
 proton_engine_client_get_life_span_handler(cef_client_t *self);

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -652,6 +652,31 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_browser_focus_state(
+    proton_engine_view_t *view, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      view->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_view_get_devtools_state(
+    proton_engine_view_t *view, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      view->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -661,8 +661,22 @@ int32_t proton_engine_view_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      view->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (view->window != NULL && view->window->headless) {
+    return proton_browser_headless_is_focused(
+        view->browser, out_focused, error, error_len);
+  }
+  if (view->display == NULL || view->xwindow == None) {
+    proton_engine_set_message(error, error_len,
+                              "browser window is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_focused =
+      proton_engine_x11_window_is_focused(view->display, view->xwindow);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_view_get_devtools_state(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -1609,6 +1609,31 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_browser_focus_state(
+    proton_engine_window_t *window, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      window->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_window_get_devtools_state(
+    proton_engine_window_t *window, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      window->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -50,6 +50,55 @@
 #include <stdlib.h>
 #include <string.h>
 
+int proton_engine_x11_window_is_focused(Display *display,
+                                        Window browser_window) {
+  if (display == NULL || browser_window == None) {
+    return 0;
+  }
+  Window focused = None;
+  int revert_to = RevertToNone;
+  XGetInputFocus(display, &focused, &revert_to);
+  if (focused == None || focused == PointerRoot) {
+    return 0;
+  }
+
+  GdkDisplay *gdk_display = gdk_x11_lookup_xdisplay(display);
+  if (gdk_display != NULL) {
+    gdk_x11_display_error_trap_push(gdk_display);
+  }
+  int is_focused = 0;
+  Window current = focused;
+  while (current != None) {
+    if (current == browser_window) {
+      is_focused = 1;
+      break;
+    }
+    Window root = None;
+    Window parent = None;
+    Window *children = NULL;
+    unsigned int child_count = 0;
+    const int queried = XQueryTree(display, current, &root, &parent, &children,
+                                   &child_count);
+    if (children != NULL) {
+      XFree(children);
+    }
+    if (!queried) {
+      break;
+    }
+    if (parent == None || parent == current) {
+      break;
+    }
+    current = parent;
+  }
+  if (gdk_display != NULL) {
+    XSync(display, False);
+    if (gdk_x11_display_error_trap_pop(gdk_display) != 0) {
+      is_focused = 0;
+    }
+  }
+  return is_focused;
+}
+
 static void proton_engine_apply_size_constraints(
     proton_engine_window_t *window) {
   if (window == NULL || window->window == NULL || window->headless) {
@@ -1618,8 +1667,35 @@ int32_t proton_engine_window_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      window->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    return proton_browser_headless_is_focused(
+        window->browser, out_focused, error, error_len);
+  }
+  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (host == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser host is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  const Window browser_window = (Window)host->get_window_handle(host);
+  host->base.release((cef_base_ref_counted_t *)host);
+  GdkWindow *host_window = window->browser_host == NULL
+                               ? NULL
+                               : gtk_widget_get_window(window->browser_host);
+  Display *display = host_window == NULL ? NULL
+                                         : GDK_WINDOW_XDISPLAY(host_window);
+  if (display == NULL || browser_window == None) {
+    proton_engine_set_message(error, error_len,
+                              "browser window is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_focused =
+      proton_engine_x11_window_is_focused(display, browser_window);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_window_get_devtools_state(

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_internal.h
@@ -298,6 +298,7 @@ void proton_engine_signal_wait_source(uint32_t ready_mask);
 void proton_engine_browser_signal(void *user_data);
 void proton_engine_browser_release(cef_browser_t *browser);
 void proton_engine_window_finalize_if_ready(proton_engine_window_t *window);
+int proton_engine_browser_view_is_focused(NSView *browser_view);
 proton_engine_view_t *proton_engine_view_from_native_id(uint64_t native_id);
 proton_engine_window_t *proton_engine_window_from_browser(
     cef_browser_t *browser);

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -824,8 +824,16 @@ int32_t proton_engine_view_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      view->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (view->window != NULL && view->window->headless) {
+    return proton_browser_headless_is_focused(
+        view->browser, out_focused, error, error_len);
+  }
+  *out_focused = proton_engine_browser_view_is_focused(view->browser_view);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_view_get_devtools_state(

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_view.m
@@ -815,6 +815,31 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_browser_focus_state(
+    proton_engine_view_t *view, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      view->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_view_get_devtools_state(
+    proton_engine_view_t *view, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      view->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -34,6 +34,26 @@ static proton_engine_window_t *g_dock_progress_owner = NULL;
 static NSImageView *g_dock_progress_content = nil;
 static NSProgressIndicator *g_dock_progress_indicator = nil;
 
+int proton_engine_browser_view_is_focused(NSView *browser_view) {
+  if (![NSThread isMainThread]) {
+    __block int focused = 0;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      focused = proton_engine_browser_view_is_focused(browser_view);
+    });
+    return focused;
+  }
+  if (browser_view == nil || browser_view.window == nil ||
+      !browser_view.window.isKeyWindow) {
+    return 0;
+  }
+  NSResponder *responder = browser_view.window.firstResponder;
+  if (responder == browser_view) {
+    return 1;
+  }
+  return [responder isKindOfClass:[NSView class]] &&
+         [(NSView *)responder isDescendantOf:browser_view];
+}
+
 static void proton_engine_apply_size_constraints(
     proton_engine_window_t *window) {
   if (window == NULL || window->window == nil) {
@@ -2191,8 +2211,16 @@ int32_t proton_engine_window_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      window->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    return proton_browser_headless_is_focused(
+        window->browser, out_focused, error, error_len);
+  }
+  *out_focused = proton_engine_browser_view_is_focused(window->browser_view);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_window_get_devtools_state(

--- a/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
+++ b/proton/internal/native/ffi/src/engine/cef_mac/mac_window.m
@@ -2182,6 +2182,31 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_browser_focus_state(
+    proton_engine_window_t *window, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      window->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_window_get_devtools_state(
+    proton_engine_window_t *window, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      window->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -133,6 +133,7 @@ int proton_engine_browser_id(cef_browser_t *browser);
 void proton_engine_browser_release(cef_browser_t *browser);
 proton_engine_view_t *proton_engine_find_view_by_browser_id(int browser_id);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
+int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd);
 void proton_win_menu_dispatch_command(proton_engine_window_t *window,
                                       UINT command_id);
 int32_t proton_win_menu_apply_to_window(

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -662,6 +662,31 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                              error, error_len);
 }
 
+int32_t proton_engine_view_get_browser_focus_state(
+    proton_engine_view_t *view, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser_session == NULL ||
+      view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      view->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_view_get_devtools_state(
+    proton_engine_view_t *view, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (view == NULL || view->closed || view->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      view->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -671,8 +671,21 @@ int32_t proton_engine_view_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      view->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (view->window != NULL && view->window->headless) {
+    return proton_browser_headless_is_focused(
+        view->browser, out_focused, error, error_len);
+  }
+  if (view->hwnd == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser window is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_focused = proton_engine_browser_hwnd_is_focused(view->hwnd);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_view_get_devtools_state(

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1816,6 +1816,31 @@ int32_t proton_engine_window_browser_command_json(
       error_len);
 }
 
+int32_t proton_engine_window_get_browser_focus_state(
+    proton_engine_window_t *window, int32_t *out_focused,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser_session == NULL ||
+      window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_focused(
+      window->browser, out_focused, error, error_len);
+}
+
+int32_t proton_engine_window_get_devtools_state(
+    proton_engine_window_t *window, int32_t *out_opened,
+    char *error, size_t error_len) {
+  if (window == NULL || window->browser == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser is not initialized");
+    return PROTON_ERR_NOT_INITIALIZED;
+  }
+  return proton_browser_is_devtools_opened(
+      window->browser, out_opened, error, error_len);
+}
+
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -55,6 +55,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd) {
+  const HWND focused = GetFocus();
+  return browser_hwnd != NULL && focused != NULL &&
+         (focused == browser_hwnd || IsChild(browser_hwnd, focused));
+}
+
 static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
                                                   UINT msg,
                                                   WPARAM wparam,
@@ -1825,8 +1831,29 @@ int32_t proton_engine_window_get_browser_focus_state(
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_is_focused(
-      window->browser, out_focused, error, error_len);
+  if (out_focused == NULL) {
+    proton_engine_set_message(error, error_len, "focus output is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    return proton_browser_headless_is_focused(
+        window->browser, out_focused, error, error_len);
+  }
+  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (host == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser host is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  const HWND browser_hwnd = host->get_window_handle(host);
+  host->base.release((cef_base_ref_counted_t *)host);
+  if (browser_hwnd == NULL) {
+    proton_engine_set_message(error, error_len,
+                              "browser window is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  *out_focused = proton_engine_browser_hwnd_is_focused(browser_hwnd);
+  return PROTON_OK;
 }
 
 int32_t proton_engine_window_get_devtools_state(

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -1904,6 +1904,48 @@ int32_t proton_window_browser_command_json(proton_window_handle_t window,
   return PROTON_OK;
 }
 
+int32_t proton_window_get_browser_focus_state(
+    proton_window_handle_t window, int32_t *out_focused) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (out_focused == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "browser focus output is required");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser focus state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_get_browser_focus_state(
+      slot->engine_window, out_focused, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_get_devtools_state(
+    proton_window_handle_t window, int32_t *out_opened) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (out_opened == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "DevTools state output is required");
+  }
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "DevTools state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_get_devtools_state(
+      slot->engine_window, out_opened, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_window_get_navigation_state(
     proton_window_handle_t window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward) {
@@ -2979,6 +3021,48 @@ int32_t proton_view_browser_command_json(proton_view_handle_t view,
   if (status != PROTON_OK) {
     return proton_set_engine_status(status, engine_error);
   }
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_get_browser_focus_state(
+    proton_view_handle_t view, int32_t *out_focused) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) return status;
+  if (out_focused == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "browser focus output is required");
+  }
+  if (slot->engine_view == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "browser focus state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_view_get_browser_focus_state(
+      slot->engine_view, out_focused, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_view_get_devtools_state(
+    proton_view_handle_t view, int32_t *out_opened) {
+  proton_view_slot_t *slot = NULL;
+  int32_t status = proton_get_view(view, &slot);
+  if (status != PROTON_OK) return status;
+  if (out_opened == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "DevTools state output is required");
+  }
+  if (slot->engine_view == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "DevTools state requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_view_get_devtools_state(
+      slot->engine_view, out_opened, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
   g_last_error[0] = '\0';
   return PROTON_OK;
 }

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -317,6 +317,12 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
 int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len);
+int32_t proton_engine_window_get_browser_focus_state(
+    proton_engine_window_t *window, int32_t *out_focused,
+    char *error, size_t error_len);
+int32_t proton_engine_window_get_devtools_state(
+    proton_engine_window_t *window, int32_t *out_opened,
+    char *error, size_t error_len);
 int32_t proton_engine_window_download_url(
     proton_engine_window_t *window, const char *url, char *error,
     size_t error_len);
@@ -469,6 +475,12 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 const char *command_json,
                                                 char *error,
                                                 size_t error_len);
+int32_t proton_engine_view_get_browser_focus_state(
+    proton_engine_view_t *view, int32_t *out_focused,
+    char *error, size_t error_len);
+int32_t proton_engine_view_get_devtools_state(
+    proton_engine_view_t *view, int32_t *out_opened,
+    char *error, size_t error_len);
 int32_t proton_engine_view_find_in_page(
     proton_engine_view_t *view, const char *text, int32_t forward,
     int32_t match_case, int32_t find_next, int32_t *out_request_id,

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2114,6 +2114,29 @@ pub fn Window::browser_command(
 }
 
 ///|
+/// Returns whether the main browser currently owns web-content focus.
+pub fn Window::browser_is_focused(self : Window) -> Bool raise NativeError {
+  let focused : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_get_browser_focus_state_ffi(
+      self.live_handle(),
+      focused,
+    ),
+  )
+  focused.val != 0
+}
+
+///|
+/// Returns whether the main browser currently has an associated DevTools view.
+pub fn Window::is_devtools_opened(self : Window) -> Bool raise NativeError {
+  let opened : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_window_get_devtools_state_ffi(self.live_handle(), opened),
+  )
+  opened.val != 0
+}
+
+///|
 pub fn Window::download_url(
   self : Window,
   url : String,
@@ -3065,7 +3088,8 @@ pub fn View::eval(self : View, script : String) -> Unit raise NativeError {
 
 ///|
 /// Sends a browser control command to the view: `back`, `forward`, `reload`,
-/// `reload_ignore_cache`, `stop`, `open_devtools`, or `close_devtools`.
+/// `reload_ignore_cache`, `stop`, `focus`, `open_devtools`, `close_devtools`,
+/// or `toggle_devtools`.
 pub fn View::browser_command(
   self : View,
   command : String,
@@ -3086,6 +3110,29 @@ pub fn View::browser_command(
       @ffi.to_cstr(Json::object(fields).stringify()),
     ),
   )
+}
+
+///|
+/// Returns whether this view currently owns web-content focus.
+pub fn View::browser_is_focused(self : View) -> Bool raise NativeError {
+  let focused : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_view_get_browser_focus_state_ffi(
+      self.live_handle(),
+      focused,
+    ),
+  )
+  focused.val != 0
+}
+
+///|
+/// Returns whether this view currently has an associated DevTools view.
+pub fn View::is_devtools_opened(self : View) -> Bool raise NativeError {
+  let opened : Ref[Int] = { val: 0, }
+  check_status(
+    @native_ffi.proton_view_get_devtools_state_ffi(self.live_handle(), opened),
+  )
+  opened.val != 0
 }
 
 ///|

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -574,11 +574,13 @@ pub fn UpdateStage::write(Self, Bytes) -> Unit raise NativeError
 type View
 pub fn View::View(Window, ViewConfig) -> Self raise NativeError
 pub fn View::browser_command(Self, String, download_id? : Int) -> Unit raise NativeError
+pub fn View::browser_is_focused(Self) -> Bool raise NativeError
 pub fn View::destroy(Self) -> Unit raise NativeError
 pub fn View::eval(Self, String) -> Unit raise NativeError
 pub fn View::find_in_page(Self, String, Bool, Bool, Bool) -> Int raise NativeError
 pub fn View::id(Self) -> Int64
 pub fn View::is_audio_muted(Self) -> Bool raise NativeError
+pub fn View::is_devtools_opened(Self) -> Bool raise NativeError
 pub fn View::load_url(Self, String) -> Unit raise NativeError
 pub fn View::navigation_state(Self) -> (Bool, Bool) raise NativeError
 pub fn View::set_audio_muted(Self, Bool) -> Unit raise NativeError
@@ -624,6 +626,7 @@ pub fn Window::Window(Runtime, config? : WindowConfig) -> Self raise NativeError
 pub fn Window::as_ref(Self) -> WindowRef
 pub fn Window::bridge_lifecycle_state(Self) -> BridgeLifecycleState raise NativeError
 pub fn Window::browser_command(Self, String, download_id? : Int) -> Unit raise NativeError
+pub fn Window::browser_is_focused(Self) -> Bool raise NativeError
 pub fn Window::browser_state(Self) -> BrowserState raise NativeError
 pub fn Window::clear_cache(Self) -> Unit raise NativeError
 pub fn Window::close(Self) -> Unit raise NativeError
@@ -642,6 +645,7 @@ pub fn Window::focus(Self) -> Unit raise NativeError
 pub fn Window::hide(Self) -> Unit raise NativeError
 pub fn Window::id(Self) -> Int64
 pub fn Window::is_audio_muted(Self) -> Bool raise NativeError
+pub fn Window::is_devtools_opened(Self) -> Bool raise NativeError
 pub fn Window::load_url(Self, String) -> Unit raise NativeError
 pub fn Window::maximize(Self) -> Unit raise NativeError
 pub fn Window::minimize(Self) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -257,6 +257,7 @@ pub struct BrowserHandle {
   load_browser_url : (String) -> Unit raise WindowSessionError
   load_browser_html : (String, String) -> Unit raise WindowSessionError
   eval_browser_script : (String) -> Unit raise WindowSessionError
+  focus_browser : () -> Unit raise WindowSessionError
   send_browser_command : (String, Int?) -> Unit raise WindowSessionError
   download_browser_url : (String) -> Unit raise WindowSessionError
   print_browser : () -> Unit raise WindowSessionError
@@ -268,6 +269,8 @@ pub struct BrowserHandle {
   set_browser_audio_muted : (Bool) -> Unit raise WindowSessionError
   read_browser_audio_muted : () -> Bool raise WindowSessionError
   read_browser_navigation_state : () -> (Bool, Bool) raise WindowSessionError
+  read_browser_focused : () -> Bool raise WindowSessionError
+  read_browser_devtools_opened : () -> Bool raise WindowSessionError
   read_browser_state : () -> BrowserState raise WindowSessionError
   session_handle : SessionHandle
 }
@@ -279,8 +282,11 @@ pub fn BrowserHandle::close_devtools(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::download_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::eval(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
+pub fn BrowserHandle::focus(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::forward(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::is_audio_muted(Self) -> Bool raise WindowSessionError
+pub fn BrowserHandle::is_devtools_opened(Self) -> Bool raise WindowSessionError
+pub fn BrowserHandle::is_focused(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::open_devtools(Self) -> Unit raise WindowSessionError
@@ -293,6 +299,7 @@ pub fn BrowserHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionErr
 pub fn BrowserHandle::state(Self) -> BrowserState raise WindowSessionError
 pub fn BrowserHandle::stop(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
+pub fn BrowserHandle::toggle_devtools(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::window_id(Self) -> String
 pub fn BrowserHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
@@ -664,10 +671,13 @@ pub struct ViewHandle {
   load_view_url : (String) -> Unit raise WindowSessionError
   load_view_html : (String, String) -> Unit raise WindowSessionError
   eval_view_script : (String) -> Unit raise WindowSessionError
+  focus_view : () -> Unit raise WindowSessionError
   send_view_command : (String, Int?) -> Unit raise WindowSessionError
   find_view_in_page : (String, Bool, Bool, Bool) -> Int raise WindowSessionError
   stop_view_find : (Bool) -> Unit raise WindowSessionError
   read_view_navigation_state : () -> (Bool, Bool) raise WindowSessionError
+  read_view_focused : () -> Bool raise WindowSessionError
+  read_view_devtools_opened : () -> Bool raise WindowSessionError
   read_view_state : () -> ViewState raise WindowSessionError
   close_view : () -> Unit raise WindowSessionError
 }
@@ -678,9 +688,12 @@ pub fn ViewHandle::close(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::close_devtools(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::eval(Self, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
+pub fn ViewHandle::focus(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::forward(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::id(Self) -> String
 pub fn ViewHandle::is_audio_muted(Self) -> Bool raise WindowSessionError
+pub fn ViewHandle::is_devtools_opened(Self) -> Bool raise WindowSessionError
+pub fn ViewHandle::is_focused(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::open_devtools(Self) -> Unit raise WindowSessionError
@@ -693,6 +706,7 @@ pub fn ViewHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::state(Self) -> ViewState raise WindowSessionError
 pub fn ViewHandle::stop(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
+pub fn ViewHandle::toggle_devtools(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub(all) struct ViewState {


### PR DESCRIPTION
## Summary

- add Electron-style `focus()`, `is_focused()`, `toggle_devtools()`, and `is_devtools_opened()` to both `BrowserHandle` and `ViewHandle`
- query real native web-content focus on macOS (AppKit first responder), Windows (focused HWND subtree), and Linux (X11 input-focus subtree), with a CEF frame fallback only for headless runtimes
- expand `examples/54_devtools` into a manual host-browser and `WebContentsView` review tool covering focus plus open, close, toggle, and state queries

## Platform impact

- macOS behavior was exercised locally with the source-built CEF runtime
- Windows and Linux use their native focus ownership APIs behind the existing shared ABI and will be validated by CI
- DevTools control remains implemented through the shared CEF browser-host path on all platforms

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100` (620/620)
- `moon -C examples build 54_devtools --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native`
- macOS manual/CDP review of host/view focus transfer and all DevTools open, close, and toggle actions
