### PR TITLE
feat(browser): add editing commands

### DIFF
--- a/examples/73_editing_commands/README.md
+++ b/examples/73_editing_commands/README.md
@@ -1,0 +1,25 @@
+# Editing Commands
+
+Manual review for Electron-style editing commands on both `BrowserHandle` and
+`ViewHandle`.
+
+```sh
+moon -C examples run 73_editing_commands --target native
+```
+
+1. Choose **Host browser** on the left, focus a host editor, type a suffix,
+   then use **Undo** and **Redo**. Repeat after choosing **Web contents view**
+   and focusing an editor on the right.
+2. With the matching target selected, select a phrase and use **Cut**,
+   **Undo**, **Copy**, and **Paste**. The selection readout and editor contents
+   should track each operation.
+3. Select a phrase and use **Delete**, then **Undo**. The deleted selection
+   should return in that target only.
+4. Focus either editor and use **Select all**. The active editor's content
+   should become selected without affecting the other pane.
+5. Select styled text in one rich editor and copy it. Select the other target,
+   focus its rich editor, then compare **Paste** with **Paste match style**
+   after resetting; the latter should use the destination formatting.
+
+Repeat on macOS, Windows, and Linux. Each pane has its own focused frame and
+editing history, so operations in one target must not modify the other.

--- a/examples/73_editing_commands/main.mbt
+++ b/examples/73_editing_commands/main.mbt
@@ -1,0 +1,164 @@
+///|
+struct EditRequest {
+  target : String
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend EditRequest with ToJson::{to_json}
+
+///|
+pub extend EditRequest with FromJson::{from_json}
+
+///|
+struct EditReply {
+  ok : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend EditReply with ToJson::{to_json}
+
+///|
+pub extend EditReply with FromJson::{from_json}
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/editing-commands",
+  js_namespace="editingReview",
+)
+
+///|
+let edit_command : @proton_contract.Command[EditRequest, EditReply] = contract.command(
+  "edit",
+)
+
+///|
+let browser_slot : Ref[@proton.BrowserHandle?] = { val: None, }
+
+///|
+let view_slot : Ref[@proton.ViewHandle?] = { val: None, }
+
+///|
+fn run_browser_edit(
+  browser : @proton.BrowserHandle,
+  action : String,
+) -> Bool raise @proton.WindowSessionError {
+  match action {
+    "undo" => browser.undo()
+    "redo" => browser.redo()
+    "cut" => browser.cut()
+    "copy" => browser.copy()
+    "paste" => browser.paste()
+    "paste_and_match_style" => browser.paste_and_match_style()
+    "delete" => browser.delete()
+    "select_all" => browser.select_all()
+    _ => return false
+  }
+  true
+}
+
+///|
+fn run_view_edit(
+  view : @proton.ViewHandle,
+  action : String,
+) -> Bool raise @proton.WindowSessionError {
+  view.focus()
+  match action {
+    "undo" => view.undo()
+    "redo" => view.redo()
+    "cut" => view.cut()
+    "copy" => view.copy()
+    "paste" => view.paste()
+    "paste_and_match_style" => view.paste_and_match_style()
+    "delete" => view.delete()
+    "select_all" => view.select_all()
+    _ => return false
+  }
+  true
+}
+
+///|
+fn edit(request : EditRequest) -> EditReply {
+  try {
+    let known = match request.target {
+      "host" =>
+        match browser_slot.val {
+          Some(browser) => run_browser_edit(browser, request.action)
+          None => return { ok: false, message: "host browser is unavailable", }
+        }
+      "view" =>
+        match view_slot.val {
+          Some(view) => run_view_edit(view, request.action)
+          None => return { ok: false, message: "view is unavailable", }
+        }
+      _ => return { ok: false, message: "unknown editing target", }
+    }
+    if known {
+      { ok: true, message: request.action + " dispatched", }
+    } else {
+      { ok: false, message: "unknown editing command", }
+    }
+  } catch {
+    error => { ok: false, message: error.to_string(), }
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(edit_command, (_context, request) => edit(request))
+}
+
+///|
+let view_page =
+  #|data:text/html,<html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>View editor</title><style>*{box-sizing:border-box}html{font-family:system-ui,sans-serif;color:rgb(29,36,42);background:rgb(236,240,242)}body{margin:0;min-height:100vh;padding:26px 30px;border-left:1px solid rgb(143,154,160)}.eyebrow{font:700 11px monospace;color:rgb(20,111,90)}h1{margin:6px 0 22px;font-size:27px}.editors{display:grid;grid-template-columns:1fr 1fr;gap:12px}.panel{min-width:0}.panel-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:7px}.panel-head strong{font-size:13px}button{min-height:28px;padding:0 10px;border:1px solid rgb(111,124,131);border-radius:3px;background:white;color:rgb(29,36,42);font-weight:700;cursor:pointer}textarea,.rich{width:100%;height:300px;border:2px solid rgb(157,167,172);border-radius:3px;background:white;padding:14px;font:15px/1.55 system-ui,sans-serif;outline:none;resize:none}.rich{overflow:auto}.rich strong{color:rgb(171,52,82);font:700 20px Georgia,serif}.rich em{background:rgb(255,229,133);font-style:normal}.rich:focus,textarea:focus{border-color:rgb(20,111,90);box-shadow:0 0 0 3px rgba(20,111,90,.14)}.state{display:grid;grid-template-columns:auto 1fr;gap:5px 12px;margin-top:16px;padding:11px;border:1px solid rgb(157,167,172);background:white;font:12px/1.4 monospace}.state span:nth-child(even){overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgb(20,90,108)}.footer{margin-top:12px}</style></head><body><span class='eyebrow'>WEB CONTENTS VIEW TARGET / REVIEW 73</span><h1>Independent editing surface</h1><div class='editors'><section class='panel'><div class='panel-head'><strong>Plain text</strong><button data-focus='plain'>Focus</button></div><textarea id='plain'>View text starts here. Select a phrase, then use the command toolbar on the left.</textarea></section><section class='panel'><div class='panel-head'><strong>Rich text</strong><button data-focus='rich'>Focus</button></div><div id='rich' class='rich' contenteditable='true'><strong>Crimson source</strong><p><em>Highlighted phrase</em> for clipboard style review.</p><p>Paste here with matching style.</p></div></section></div><div class='state'><span>Active</span><span id='active'>none</span><span>Selection</span><span id='selection'>none</span></div><div class='footer'><button id='reset'>Reset view editors</button></div><script>const plain=document.getElementById('plain'),rich=document.getElementById('rich'),active=document.getElementById('active'),selection=document.getElementById('selection');const initialPlain=plain.value,initialRich=rich.innerHTML;function sync(){const element=document.activeElement;active.textContent=element===plain?'plain text':element===rich||rich.contains(element)?'rich text':element?.tagName?.toLowerCase()||'none';let selected='';if(element===plain)selected=plain.value.slice(plain.selectionStart,plain.selectionEnd);else selected=getSelection()?.toString()||'';selection.textContent=selected||'none'}document.querySelectorAll('[data-focus]').forEach(button=>button.onclick=()=>{(button.dataset.focus==='plain'?plain:rich).focus();sync()});document.getElementById('reset').onclick=()=>{plain.value=initialPlain;rich.innerHTML=initialRich;plain.focus();sync()};document.addEventListener('selectionchange',sync);plain.addEventListener('input',sync);rich.addEventListener('input',sync);plain.focus();sync()</script></body></html>
+
+///|
+fn host_page() -> String {
+  (
+    #|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Editing commands</title>
+    #|<style>*{box-sizing:border-box}:root{font-family:system-ui,sans-serif;color:#252e34;background:#e7ecee}body{margin:0;width:520px;min-height:100vh;padding:26px 28px;background:#f5f7f8}.eyebrow{font:700 11px monospace;color:#9a314d}h1{margin:6px 0 14px;font-size:27px}.targets{display:grid;grid-template-columns:1fr 1fr;gap:7px;margin-bottom:10px}.targets button.selected{background:#252e34;border-color:#252e34;color:white}.toolbar{display:grid;grid-template-columns:repeat(4,1fr);gap:7px;margin-bottom:18px}button{min-height:36px;border:1px solid #6f7c83;border-radius:3px;background:white;color:#252e34;font-weight:700;cursor:pointer}button.primary{background:#9a314d;border-color:#9a314d;color:white}.editors{display:grid;grid-template-columns:1fr 1fr;gap:12px}.panel{min-width:0}.panel-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:7px}.panel-head strong{font-size:13px}.focus{min-height:28px;padding:0 9px;font-size:11px}textarea,.rich{width:100%;height:190px;border:2px solid #9da7ac;border-radius:3px;background:white;padding:14px;font:15px/1.55 system-ui,sans-serif;outline:none;resize:none}.rich{overflow:auto}.rich strong{color:#146f5a;font:700 20px Georgia,serif}.rich em{background:#ffe585;font-style:normal}.rich:focus,textarea:focus{border-color:#9a314d;box-shadow:0 0 0 3px #9a314d24}.state{display:grid;grid-template-columns:auto 1fr;gap:5px 12px;margin-top:16px;padding:11px;border:1px solid #9da7ac;background:white;font:12px/1.4 monospace}.state span:nth-child(even){overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#315f78}.footer{display:flex;gap:8px;align-items:center;margin-top:12px}.footer button{padding:0 12px}#status{margin:0;font:12px/1.4 monospace;color:#9a314d}</style></head>
+    #|<body><span class="eyebrow">COMMAND CONSOLE / REVIEW 73</span><h1>Editing commands</h1><div class="targets"><button class="selected" data-target="host">Host browser</button><button data-target="view">Web contents view</button></div><div class="toolbar"><button data-action="undo">Undo</button><button data-action="redo">Redo</button><button data-action="cut">Cut</button><button data-action="copy">Copy</button><button data-action="paste">Paste</button><button data-action="paste_and_match_style" class="primary">Paste match style</button><button data-action="delete">Delete</button><button data-action="select_all">Select all</button></div><div class="editors"><section class="panel"><div class="panel-head"><strong>Host plain text</strong><button class="focus" data-focus="plain">Focus</button></div><textarea id="plain">Host text starts here. Select a phrase, then run a command.</textarea></section><section class="panel"><div class="panel-head"><strong>Host rich text</strong><button class="focus" data-focus="rich">Focus</button></div><div id="rich" class="rich" contenteditable="true"><strong>Green source</strong><p><em>Highlighted phrase</em> for clipboard style review.</p><p>Paste here with matching style.</p></div></section></div><div class="state"><span>Target</span><span id="target-state">host browser</span><span>Active</span><span id="active">none</span><span>Selection</span><span id="selection">none</span></div><div class="footer"><button id="reset">Reset host editors</button><p id="status">Ready</p></div>
+    #|<script>let target='host';const plain=document.querySelector('#plain'),rich=document.querySelector('#rich'),active=document.querySelector('#active'),selection=document.querySelector('#selection'),status=document.querySelector('#status'),targetState=document.querySelector('#target-state');const initialPlain=plain.value,initialRich=rich.innerHTML;function sync(){const element=document.activeElement;active.textContent=element===plain?'plain text':element===rich||rich.contains(element)?'rich text':element?.tagName?.toLowerCase()||'none';let selected='';if(element===plain)selected=plain.value.slice(plain.selectionStart,plain.selectionEnd);else selected=getSelection()?.toString()||'';selection.textContent=selected||'none'}async function run(action){status.textContent=target+': '+action+'...';try{const reply=await window.__MoonBit__.core.invokeOp('ext:editingReview/edit',{target,action});status.textContent=reply.message;setTimeout(sync,30)}catch(error){status.textContent=String(error)}}document.querySelectorAll('[data-action]').forEach(button=>{button.addEventListener('pointerdown',event=>event.preventDefault());button.addEventListener('click',()=>void run(button.dataset.action))});document.querySelectorAll('[data-target]').forEach(button=>button.onclick=()=>{target=button.dataset.target;targetState.textContent=target==='host'?'host browser':'web contents view';document.querySelectorAll('[data-target]').forEach(item=>item.classList.toggle('selected',item===button));status.textContent=targetState.textContent+' selected'});document.querySelectorAll('[data-focus]').forEach(button=>button.onclick=()=>{target='host';document.querySelector('[data-target="host"]').click();(button.dataset.focus==='plain'?plain:rich).focus();sync()});document.querySelector('#reset').onclick=()=>{plain.value=initialPlain;rich.innerHTML=initialRich;plain.focus();sync()};document.addEventListener('selectionchange',sync);plain.addEventListener('input',sync);rich.addEventListener('input',sync);plain.focus();sync()</script></body></html>
+  )
+}
+
+///|
+fn open_review_view(window : @proton.WindowHandle) -> Unit {
+  let view = window.add_view(
+    "editing",
+    @proton.view(view_page, x=520, y=0, width=680, height=760),
+  ) catch {
+    error => {
+      println("add editing view failed: " + error.message())
+      return
+    }
+  }
+  view_slot.val = Some(view)
+}
+
+///|
+async fn main {
+  @proton.html(
+    "Editing Commands",
+    host_page(),
+    width=1200,
+    height=760,
+    debug=true,
+  )
+  .commands(register_commands)
+  .window_lifecycle(
+    on_ready=context => {
+      let window = context.handle()
+      browser_slot.val = Some(window.browser())
+      open_review_view(window)
+      window
+    },
+    on_close=fn(_window) {
+      view_slot.val = None
+      browser_slot.val = None
+    },
+  )
+  .identifier("dev.proton.73-editing-commands")
+  .run_or_abort()
+}

--- a/examples/73_editing_commands/moon.pkg
+++ b/examples/73_editing_commands/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+warnings = "-unused_async"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/73_editing_commands/pkg.generated.mbti
+++ b/examples/73_editing_commands/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/73_editing_commands"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type EditReply derive(ToJson, @json.FromJson)
+pub fn EditReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn EditReply::to_json(Self) -> Json
+
+type EditRequest derive(ToJson, @json.FromJson)
+pub fn EditRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn EditRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -131,6 +131,8 @@ moon -C examples run 01_run --target native
   automatic and dialog destinations, progress events, and cancellation.
 - `72_print_pdf`: manual Electron-style system print and PDF review with typed
   page settings, request ids, completion events, and printable calibration pages.
+- `73_editing_commands`: manual Electron-style undo, redo, clipboard, delete,
+  and select-all review for both the main browser and a web contents view.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -2312,6 +2312,58 @@ pub fn ViewHandle::stop(self : ViewHandle) -> Unit raise WindowSessionError {
 }
 
 ///|
+/// Undoes the most recent edit in the focused frame.
+pub fn ViewHandle::undo(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("undo", None)
+}
+
+///|
+/// Redoes the most recently undone edit in the focused frame.
+pub fn ViewHandle::redo(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("redo", None)
+}
+
+///|
+/// Cuts the current selection in the focused frame.
+pub fn ViewHandle::cut(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("cut", None)
+}
+
+///|
+/// Copies the current selection in the focused frame.
+pub fn ViewHandle::copy(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("copy", None)
+}
+
+///|
+/// Pastes clipboard contents into the focused frame.
+pub fn ViewHandle::paste(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("paste", None)
+}
+
+///|
+/// Pastes clipboard contents using the destination's current style.
+pub fn ViewHandle::paste_and_match_style(
+  self : ViewHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_view_command)("paste_and_match_style", None)
+}
+
+///|
+/// Deletes the current selection in the focused frame.
+pub fn ViewHandle::delete(self : ViewHandle) -> Unit raise WindowSessionError {
+  (self.send_view_command)("delete", None)
+}
+
+///|
+/// Selects all editable content in the focused frame.
+pub fn ViewHandle::select_all(
+  self : ViewHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_view_command)("select_all", None)
+}
+
+///|
 /// Focuses this view's web page, matching Electron `webContents.focus()`.
 pub fn ViewHandle::focus(self : ViewHandle) -> Unit raise WindowSessionError {
   (self.focus_view)()
@@ -2551,6 +2603,70 @@ pub fn BrowserHandle::stop(
   self : BrowserHandle,
 ) -> Unit raise WindowSessionError {
   (self.send_browser_command)("stop", None)
+}
+
+///|
+/// Undoes the most recent edit in the focused frame.
+pub fn BrowserHandle::undo(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("undo", None)
+}
+
+///|
+/// Redoes the most recently undone edit in the focused frame.
+pub fn BrowserHandle::redo(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("redo", None)
+}
+
+///|
+/// Cuts the current selection in the focused frame.
+pub fn BrowserHandle::cut(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("cut", None)
+}
+
+///|
+/// Copies the current selection in the focused frame.
+pub fn BrowserHandle::copy(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("copy", None)
+}
+
+///|
+/// Pastes clipboard contents into the focused frame.
+pub fn BrowserHandle::paste(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("paste", None)
+}
+
+///|
+/// Pastes clipboard contents using the destination's current style.
+pub fn BrowserHandle::paste_and_match_style(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("paste_and_match_style", None)
+}
+
+///|
+/// Deletes the current selection in the focused frame.
+pub fn BrowserHandle::delete(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("delete", None)
+}
+
+///|
+/// Selects all editable content in the focused frame.
+pub fn BrowserHandle::select_all(
+  self : BrowserHandle,
+) -> Unit raise WindowSessionError {
+  (self.send_browser_command)("select_all", None)
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -2468,6 +2468,23 @@ test "view handle routes operations through its closures" {
 }
 
 ///|
+test "view handle routes editing commands" {
+  let calls : Array[String] = []
+  let view = test_view_handle("panel", 7L, calls)
+  view.undo()
+  view.redo()
+  view.cut()
+  view.copy()
+  view.paste()
+  view.paste_and_match_style()
+  view.delete()
+  view.select_all()
+  assert_eq(calls, [
+    "undo", "redo", "cut", "copy", "paste", "paste_and_match_style", "delete", "select_all",
+  ])
+}
+
+///|
 test "browser handle exposes the current page state" {
   let window = test_window_handle("main", 17L)
   let state = window.browser().state()
@@ -2499,6 +2516,23 @@ test "browser handle routes focus and DevTools controls" {
     calls,
     content="[\"focus\", \"open_devtools\", \"toggle_devtools\", \"close_devtools\"]",
   )
+}
+
+///|
+test "browser handle routes editing commands" {
+  let calls : Array[String] = []
+  let browser = test_window_handle("main", 17L, browser_control_calls=calls).browser()
+  browser.undo()
+  browser.redo()
+  browser.cut()
+  browser.copy()
+  browser.paste()
+  browser.paste_and_match_style()
+  browser.delete()
+  browser.select_all()
+  assert_eq(calls, [
+    "undo", "redo", "cut", "copy", "paste", "paste_and_match_style", "delete", "select_all",
+  ])
 }
 
 ///|

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -964,6 +964,41 @@ static int proton_browser_read_command(const char *command_json,
   return 1;
 }
 
+static int32_t proton_browser_execute_edit_command(
+    cef_browser_t *browser, const char *command, char *error,
+    size_t error_len) {
+  cef_frame_t *frame = browser->get_focused_frame(browser);
+  if (frame == NULL) {
+    proton_browser_set_message(error, error_len,
+                               "focused browser frame is unavailable");
+    return PROTON_ERR_ENGINE;
+  }
+  if (strcmp(command, "undo") == 0) {
+    frame->undo(frame);
+  } else if (strcmp(command, "redo") == 0) {
+    frame->redo(frame);
+  } else if (strcmp(command, "cut") == 0) {
+    frame->cut(frame);
+  } else if (strcmp(command, "copy") == 0) {
+    frame->copy(frame);
+  } else if (strcmp(command, "paste") == 0) {
+    frame->paste(frame);
+  } else if (strcmp(command, "paste_and_match_style") == 0) {
+    frame->paste_and_match_style(frame);
+  } else if (strcmp(command, "delete") == 0) {
+    frame->del(frame);
+  } else if (strcmp(command, "select_all") == 0) {
+    frame->select_all(frame);
+  } else {
+    frame->base.release((cef_base_ref_counted_t *)frame);
+    proton_browser_set_message(error, error_len,
+                               "unknown browser editing command");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  frame->base.release((cef_base_ref_counted_t *)frame);
+  return PROTON_OK;
+}
+
 int32_t proton_browser_session_command_json(
     proton_browser_session_t *session, cef_browser_t *browser,
     const char *command_json, char *error, size_t error_len) {
@@ -1008,6 +1043,16 @@ int32_t proton_browser_session_command_json(
     }
     host->set_focus(host, 1);
     host->base.release((cef_base_ref_counted_t *)host);
+  } else if (strcmp(command, "undo") == 0 ||
+             strcmp(command, "redo") == 0 ||
+             strcmp(command, "cut") == 0 ||
+             strcmp(command, "copy") == 0 ||
+             strcmp(command, "paste") == 0 ||
+             strcmp(command, "paste_and_match_style") == 0 ||
+             strcmp(command, "delete") == 0 ||
+             strcmp(command, "select_all") == 0) {
+    return proton_browser_execute_edit_command(browser, command, error,
+                                               error_len);
   } else if (strcmp(command, "open_devtools") == 0 ||
              strcmp(command, "close_devtools") == 0 ||
              strcmp(command, "toggle_devtools") == 0) {

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2091,6 +2091,10 @@ pub fn Window::eval(self : Window, script : String) -> Unit raise NativeError {
 }
 
 ///|
+/// Sends a browser control command to the main page: `back`, `forward`,
+/// `reload`, `reload_ignore_cache`, `stop`, `focus`, `undo`, `redo`, `cut`,
+/// `copy`, `paste`, `paste_and_match_style`, `delete`, `select_all`,
+/// `open_devtools`, `close_devtools`, `toggle_devtools`, or `cancel_download`.
 pub fn Window::browser_command(
   self : Window,
   command : String,
@@ -3088,8 +3092,9 @@ pub fn View::eval(self : View, script : String) -> Unit raise NativeError {
 
 ///|
 /// Sends a browser control command to the view: `back`, `forward`, `reload`,
-/// `reload_ignore_cache`, `stop`, `focus`, `open_devtools`, `close_devtools`,
-/// or `toggle_devtools`.
+/// `reload_ignore_cache`, `stop`, `focus`, `undo`, `redo`, `cut`, `copy`,
+/// `paste`, `paste_and_match_style`, `delete`, `select_all`, `open_devtools`,
+/// `close_devtools`, or `toggle_devtools`.
 pub fn View::browser_command(
   self : View,
   command : String,

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -279,6 +279,9 @@ pub fn BrowserHandle::can_go_back(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::cancel_download(Self, Int) -> Unit raise WindowSessionError
 pub fn BrowserHandle::close_devtools(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::copy(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::cut(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::delete(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::download_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::eval(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
@@ -290,9 +293,13 @@ pub fn BrowserHandle::is_focused(Self) -> Bool raise WindowSessionError
 pub fn BrowserHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn BrowserHandle::open_devtools(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::paste(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::paste_and_match_style(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::print(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::print_to_pdf(Self, String, options? : PdfPrintOptions) -> Int raise WindowSessionError
+pub fn BrowserHandle::redo(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::reload(Self, ignore_cache? : Bool) -> Unit raise WindowSessionError
+pub fn BrowserHandle::select_all(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::session(Self) -> SessionHandle
 pub fn BrowserHandle::set_audio_muted(Self, Bool) -> Unit raise WindowSessionError
 pub fn BrowserHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
@@ -300,6 +307,7 @@ pub fn BrowserHandle::state(Self) -> BrowserState raise WindowSessionError
 pub fn BrowserHandle::stop(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
 pub fn BrowserHandle::toggle_devtools(Self) -> Unit raise WindowSessionError
+pub fn BrowserHandle::undo(Self) -> Unit raise WindowSessionError
 pub fn BrowserHandle::window_id(Self) -> String
 pub fn BrowserHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
@@ -686,6 +694,9 @@ pub fn ViewHandle::can_go_back(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::can_go_forward(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::close(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::close_devtools(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::copy(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::cut(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::delete(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::eval(Self, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::find_in_page(Self, String, forward? : Bool, match_case? : Bool, find_next? : Bool) -> Int raise WindowSessionError
 pub fn ViewHandle::focus(Self) -> Unit raise WindowSessionError
@@ -697,7 +708,11 @@ pub fn ViewHandle::is_focused(Self) -> Bool raise WindowSessionError
 pub fn ViewHandle::load_html(Self, String, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::load_url(Self, String) -> Unit raise WindowSessionError
 pub fn ViewHandle::open_devtools(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::paste(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::paste_and_match_style(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::redo(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::reload(Self, ignore_cache? : Bool) -> Unit raise WindowSessionError
+pub fn ViewHandle::select_all(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_audio_muted(Self, Bool) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_bounds(Self, x~ : Int, y~ : Int, width~ : Int, height~ : Int) -> Unit raise WindowSessionError
 pub fn ViewHandle::set_visible(Self, Bool) -> Unit raise WindowSessionError
@@ -707,6 +722,7 @@ pub fn ViewHandle::state(Self) -> ViewState raise WindowSessionError
 pub fn ViewHandle::stop(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::stop_find_in_page(Self, clear_selection? : Bool) -> Unit raise WindowSessionError
 pub fn ViewHandle::toggle_devtools(Self) -> Unit raise WindowSessionError
+pub fn ViewHandle::undo(Self) -> Unit raise WindowSessionError
 pub fn ViewHandle::zoom_percent(Self) -> Int raise WindowSessionError
 
 pub(all) struct ViewState {


### PR DESCRIPTION
## Summary

- add Electron-style `undo()`, `redo()`, `cut()`, `copy()`, `paste()`, `paste_and_match_style()`, `delete()`, and `select_all()` to both `BrowserHandle` and `ViewHandle`
- execute all editing operations through CEF's focused frame so iframe and independent web-contents editing state follows Electron semantics
- add `examples/73_editing_commands` for manual host-browser and `WebContentsView` review, including plain-text and rich-text targets

## Platform impact

- all platforms use the same CEF focused-frame command path; no platform-specific ABI changes are required
- macOS behavior was exercised locally against the source-built CEF runtime for both the main browser and a dynamically created view
- Windows and Linux behavior will be validated by CI

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C proton check --target native --diagnostic-limit 100`
- `moon -C proton test --target native --diagnostic-limit 100` (622/622)
- `moon -C examples build 73_editing_commands --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native`
- macOS CDP/manual review of host/view rendering plus independent undo, redo, delete, undo restoration, and select-all behavior
