### PR TITLE
refactor(native): unify CEF browser lifecycle

### DIFF
--- a/e2e/test/devtools_scenario.mbt
+++ b/e2e/test/devtools_scenario.mbt
@@ -11,8 +11,15 @@ async fn run_devtools_scenario_page_probe(
   tasks : @async.TaskGroup[Unit],
   app : SpawnedScenarioApp,
   target : String,
+  browser_web_socket_url : String,
   timeout : Int,
-) -> Unit {
+) -> ShutdownProbeResult {
+  let (host, devtools) = wait_for_devtools_targets(app, target, timeout)
+  let browser = @client.CdpClient::connect_with_timeout(
+    tasks,
+    browser_web_socket_url,
+    timeout_ms=timeout,
+  )
   let page = connect_spawned_page(
     tasks,
     app,
@@ -32,5 +39,54 @@ async fn run_devtools_scenario_page_probe(
   ) else {
     fail("Proton bridge was injected into a DevTools isolated context")
   }
+  guard host.target_id != devtools.target_id else {
+    fail("DevTools must have an independent CEF browser target")
+  }
+
+  let snapshot = snapshot_scenario_process_tree(app)
   page.close()
+  close_page_target(browser, host.target_id)
+  let shutdown = wait_for_scenario_app_shutdown(
+    app, target, snapshot, process_shutdown_timeout_ms,
+  )
+  println(
+    "MoonBit 54_devtools lifecycle passed: helpers=" +
+    shutdown.helper_processes.to_string(),
+  )
+  shutdown
+}
+
+///|
+async fn wait_for_devtools_targets(
+  app : SpawnedScenarioApp,
+  target : String,
+  timeout : Int,
+) -> (@client.CdpDiscoveredTarget, @client.CdpDiscoveredTarget) {
+  let cdp_target = cdp_target_from(target)
+  let mut elapsed = 0
+  while elapsed <= timeout {
+    let targets = discover_targets_for_poll(cdp_target)
+    let mut host : @client.CdpDiscoveredTarget? = None
+    let mut devtools : @client.CdpDiscoveredTarget? = None
+    for item in targets {
+      if item.title == "Proton DevTools API" {
+        host = Some(item)
+      } else if item.url.has_prefix("devtools://") {
+        devtools = Some(item)
+      }
+    }
+    match (host, devtools) {
+      (Some(host), Some(devtools)) => return (host, devtools)
+      _ => {
+        @async.sleep(cdp_start_poll_timeout_ms)
+        elapsed = elapsed + cdp_start_poll_timeout_ms
+      }
+    }
+  }
+  fail(
+    "CEF host and DevTools targets did not become ready within " +
+    timeout.to_string() +
+    "ms" +
+    app_diagnostic_suffix(app),
+  )
 }

--- a/e2e/test/orchestration.mbt
+++ b/e2e/test/orchestration.mbt
@@ -595,17 +595,15 @@ async fn run_scenario_probe_once(
         timeout,
       )
     } else if name == "54_devtools" {
-      run_devtools_scenario_page_probe(group, app, target, timeout)
+      let shutdown = run_devtools_scenario_page_probe(
+        group, app, target, browser_web_socket_url, timeout,
+      )
       match app_exit_code(app.process) {
-        Some(code) =>
-          fail(
-            "scenario app exited before the probe completed: code=" +
-            code.to_string() +
-            app_output_suffix(app.output_path),
-          )
-        None => ()
+        Some(0) => ()
+        Some(code) => fail("scenario app exited with code=" + code.to_string())
+        None => fail("scenario app remained alive after DevTools shutdown")
       }
-      finish_scenario_app(app, target)
+      shutdown
     } else if name == "56_i18n" {
       run_i18n_scenario_page_probe(group, app, target, timeout)
       match app_exit_code(app.process) {

--- a/examples/e2e_fixtures/scenarios.mbt
+++ b/examples/e2e_fixtures/scenarios.mbt
@@ -382,12 +382,8 @@ pub async fn run_devtools() -> Unit {
     debug=true,
   )
   .window_lifecycle(
-    on_ready=context => {
-      let browser = context.handle().browser()
-      browser.open_devtools()
-      browser
-    },
-    on_close=fn(browser) { browser.close_devtools() catch { _ => () } },
+    on_ready=context => context.handle().browser().open_devtools(),
+    on_close=fn(_) { () },
   )
   .identifier("dev.proton.e2e-fixtures")
   .run_or_abort()

--- a/proton/internal/native/ffi/moon.pkg
+++ b/proton/internal/native/ffi/moon.pkg
@@ -20,6 +20,7 @@ options(
     "src/proton_update.c",
     "src/proton.c",
     "src/engine/cef_common/bridge_lifecycle.c",
+    "src/engine/cef_common/browser_lifecycle.c",
     "src/engine/cef_common/browser_session.c",
     "src/engine/cef_common/bridge_policy.c",
     "src/engine/cef_common/bridge_renderer.c",

--- a/proton/internal/native/ffi/src/engine/cef_common/bridge_json.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/bridge_json.h
@@ -1,6 +1,7 @@
 #ifndef PROTON_ENGINE_CEF_COMMON_BRIDGE_JSON_H
 #define PROTON_ENGINE_CEF_COMMON_BRIDGE_JSON_H
 
+#include "../../proton_json.h"
 #include "bridge_policy.h"
 
 #include <stdio.h>

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
@@ -300,6 +300,11 @@ proton_browser_lifecycle_browser(const proton_browser_lifecycle_t *lifecycle) {
   return lifecycle != NULL ? lifecycle->browser : NULL;
 }
 
+cef_client_t *
+proton_browser_lifecycle_client(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->client : NULL;
+}
+
 int proton_browser_lifecycle_browser_id(
     const proton_browser_lifecycle_t *lifecycle) {
   return lifecycle != NULL ? lifecycle->browser_id : 0;

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
@@ -1,0 +1,379 @@
+#include "browser_lifecycle.h"
+
+#include "proton_native.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct proton_browser_lifecycle {
+  proton_browser_registry_t *registry;
+  proton_browser_role_t role;
+  proton_browser_lifecycle_state_t state;
+  void *owner;
+  cef_browser_t *browser;
+  cef_client_t *client;
+  int browser_id;
+  int force_close;
+  proton_browser_lifecycle_t *devtools_parent;
+  proton_browser_lifecycle_t *devtools;
+  proton_browser_lifecycle_t *next;
+};
+
+struct proton_browser_registry {
+  proton_browser_lifecycle_t *browsers;
+  proton_browser_client_factory_fn client_factory;
+  void *context;
+  int shutting_down;
+};
+
+static void proton_browser_lifecycle_set_message(char *error, size_t error_len,
+                                                 const char *message) {
+  if (error != NULL && error_len > 0) {
+    snprintf(error, error_len, "%s", message != NULL ? message : "");
+  }
+}
+
+static void proton_browser_lifecycle_release_browser(
+    proton_browser_lifecycle_t *lifecycle) {
+  if (lifecycle != NULL && lifecycle->browser != NULL) {
+    lifecycle->browser->base.release(
+        (cef_base_ref_counted_t *)lifecycle->browser);
+    lifecycle->browser = NULL;
+    lifecycle->browser_id = 0;
+  }
+}
+
+static void proton_browser_lifecycle_close_bound_browser(
+    proton_browser_lifecycle_t *lifecycle) {
+  if (lifecycle == NULL || lifecycle->browser == NULL) {
+    return;
+  }
+  cef_browser_host_t *host = lifecycle->browser->get_host(lifecycle->browser);
+  if (host != NULL) {
+    host->close_browser(host, lifecycle->force_close);
+    host->base.release((cef_base_ref_counted_t *)host);
+  }
+}
+
+proton_browser_registry_t *
+proton_browser_registry_create(proton_browser_client_factory_fn client_factory,
+                               void *context) {
+  proton_browser_registry_t *registry =
+      (proton_browser_registry_t *)calloc(1, sizeof(*registry));
+  if (registry != NULL) {
+    registry->client_factory = client_factory;
+    registry->context = context;
+  }
+  return registry;
+}
+
+void proton_browser_registry_begin_shutdown(
+    proton_browser_registry_t *registry) {
+  if (registry == NULL) {
+    return;
+  }
+  registry->shutting_down = 1;
+  for (proton_browser_lifecycle_t *browser = registry->browsers;
+       browser != NULL; browser = browser->next) {
+    if (browser->role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+      proton_browser_lifecycle_request_close(browser, 1);
+    }
+  }
+  for (proton_browser_lifecycle_t *browser = registry->browsers;
+       browser != NULL; browser = browser->next) {
+    if (browser->role != PROTON_BROWSER_ROLE_DEVTOOLS) {
+      proton_browser_lifecycle_request_close(browser, 1);
+    }
+  }
+}
+
+int proton_browser_registry_shutdown_ready(
+    const proton_browser_registry_t *registry) {
+  if (registry == NULL) {
+    return 1;
+  }
+  for (const proton_browser_lifecycle_t *browser = registry->browsers;
+       browser != NULL; browser = browser->next) {
+    if (browser->state != PROTON_BROWSER_CLOSED &&
+        browser->state != PROTON_BROWSER_CREATION_FAILED) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+void proton_browser_registry_destroy(proton_browser_registry_t *registry) {
+  if (registry == NULL) {
+    return;
+  }
+  proton_browser_lifecycle_t *browser = registry->browsers;
+  while (browser != NULL) {
+    proton_browser_lifecycle_t *next = browser->next;
+    proton_browser_lifecycle_release_browser(browser);
+    if (browser->client != NULL) {
+      browser->client->base.release((cef_base_ref_counted_t *)browser->client);
+      browser->client = NULL;
+    }
+    free(browser);
+    browser = next;
+  }
+  free(registry);
+}
+
+proton_browser_lifecycle_t *
+proton_browser_lifecycle_create(proton_browser_registry_t *registry,
+                                proton_browser_role_t role, void *owner,
+                                proton_browser_lifecycle_t *devtools_parent) {
+  if (registry == NULL || registry->shutting_down) {
+    return NULL;
+  }
+  proton_browser_lifecycle_t *lifecycle =
+      (proton_browser_lifecycle_t *)calloc(1, sizeof(*lifecycle));
+  if (lifecycle == NULL) {
+    return NULL;
+  }
+  lifecycle->registry = registry;
+  lifecycle->role = role;
+  lifecycle->state = PROTON_BROWSER_CREATING;
+  lifecycle->owner = owner;
+  lifecycle->devtools_parent = devtools_parent;
+  lifecycle->next = registry->browsers;
+  registry->browsers = lifecycle;
+  if (devtools_parent != NULL && role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    devtools_parent->devtools = lifecycle;
+  }
+  return lifecycle;
+}
+
+void proton_browser_lifecycle_set_client(proton_browser_lifecycle_t *lifecycle,
+                                         cef_client_t *client) {
+  if (lifecycle != NULL && lifecycle->client == NULL) {
+    lifecycle->client = client;
+  }
+}
+
+void proton_browser_lifecycle_creation_failed(
+    proton_browser_lifecycle_t *lifecycle) {
+  if (lifecycle == NULL || lifecycle->state == PROTON_BROWSER_CLOSED) {
+    return;
+  }
+  lifecycle->state = PROTON_BROWSER_CREATION_FAILED;
+  if (lifecycle->devtools_parent != NULL &&
+      lifecycle->devtools_parent->devtools == lifecycle) {
+    lifecycle->devtools_parent->devtools = NULL;
+  }
+}
+
+void proton_browser_lifecycle_adopt_created(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser) {
+  if (lifecycle == NULL || browser == NULL) {
+    return;
+  }
+  if (lifecycle->browser == browser) {
+    browser->base.release((cef_base_ref_counted_t *)browser);
+    return;
+  }
+  if (lifecycle->browser != NULL) {
+    browser->base.release((cef_base_ref_counted_t *)browser);
+    return;
+  }
+  lifecycle->browser = browser;
+  lifecycle->browser_id = browser->get_identifier(browser);
+  if (lifecycle->state == PROTON_BROWSER_CREATING) {
+    lifecycle->state = PROTON_BROWSER_LIVE;
+  } else if (lifecycle->state == PROTON_BROWSER_CLOSING) {
+    proton_browser_lifecycle_close_bound_browser(lifecycle);
+  }
+}
+
+void proton_browser_lifecycle_on_after_created(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser) {
+  if (lifecycle == NULL || browser == NULL || lifecycle->browser != NULL) {
+    return;
+  }
+  browser->base.add_ref((cef_base_ref_counted_t *)browser);
+  lifecycle->browser = browser;
+  lifecycle->browser_id = browser->get_identifier(browser);
+  if (lifecycle->state == PROTON_BROWSER_CREATING) {
+    lifecycle->state = PROTON_BROWSER_LIVE;
+  } else if (lifecycle->state == PROTON_BROWSER_CLOSING) {
+    proton_browser_lifecycle_close_bound_browser(lifecycle);
+  }
+}
+
+void proton_browser_lifecycle_request_close(
+    proton_browser_lifecycle_t *lifecycle, int force_close) {
+  if (lifecycle == NULL || lifecycle->state == PROTON_BROWSER_CLOSED ||
+      lifecycle->state == PROTON_BROWSER_CREATION_FAILED) {
+    return;
+  }
+  if (lifecycle->devtools != NULL) {
+    proton_browser_lifecycle_request_close(lifecycle->devtools, force_close);
+  }
+  if (lifecycle->state == PROTON_BROWSER_CLOSING) {
+    if (force_close && !lifecycle->force_close) {
+      lifecycle->force_close = 1;
+      proton_browser_lifecycle_close_bound_browser(lifecycle);
+    }
+    return;
+  }
+  lifecycle->state = PROTON_BROWSER_CLOSING;
+  if (force_close) {
+    lifecycle->force_close = 1;
+  }
+  proton_browser_lifecycle_close_bound_browser(lifecycle);
+}
+
+void proton_browser_lifecycle_note_close_requested(
+    proton_browser_lifecycle_t *lifecycle, int force_close) {
+  if (lifecycle == NULL || lifecycle->state == PROTON_BROWSER_CLOSED ||
+      lifecycle->state == PROTON_BROWSER_CREATION_FAILED) {
+    return;
+  }
+  if (lifecycle->devtools != NULL) {
+    proton_browser_lifecycle_request_close(lifecycle->devtools, force_close);
+  }
+  if (lifecycle->state == PROTON_BROWSER_CLOSING) {
+    if (force_close) {
+      lifecycle->force_close = 1;
+    }
+    return;
+  }
+  lifecycle->state = PROTON_BROWSER_CLOSING;
+  if (force_close) {
+    lifecycle->force_close = 1;
+  }
+}
+
+void proton_browser_lifecycle_on_before_close(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser) {
+  if (lifecycle == NULL || lifecycle->state == PROTON_BROWSER_CLOSED) {
+    return;
+  }
+  if (browser != NULL && lifecycle->browser != NULL &&
+      browser->get_identifier(browser) != lifecycle->browser_id) {
+    return;
+  }
+  if (lifecycle->devtools != NULL) {
+    proton_browser_lifecycle_request_close(lifecycle->devtools, 1);
+  }
+  proton_browser_lifecycle_release_browser(lifecycle);
+  lifecycle->state = PROTON_BROWSER_CLOSED;
+  if (lifecycle->devtools_parent != NULL &&
+      lifecycle->devtools_parent->devtools == lifecycle) {
+    lifecycle->devtools_parent->devtools = NULL;
+  }
+}
+
+proton_browser_role_t
+proton_browser_lifecycle_role(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->role : PROTON_BROWSER_ROLE_MAIN;
+}
+
+proton_browser_lifecycle_state_t
+proton_browser_lifecycle_state(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->state : PROTON_BROWSER_CLOSED;
+}
+
+void *
+proton_browser_lifecycle_owner(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->owner : NULL;
+}
+
+void *
+proton_browser_lifecycle_context(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL && lifecycle->registry != NULL
+             ? lifecycle->registry->context
+             : NULL;
+}
+
+void proton_browser_lifecycle_clear_owner(
+    proton_browser_lifecycle_t *lifecycle) {
+  if (lifecycle != NULL) {
+    lifecycle->owner = NULL;
+  }
+}
+
+cef_browser_t *
+proton_browser_lifecycle_browser(const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->browser : NULL;
+}
+
+int proton_browser_lifecycle_browser_id(
+    const proton_browser_lifecycle_t *lifecycle) {
+  return lifecycle != NULL ? lifecycle->browser_id : 0;
+}
+
+int32_t
+proton_browser_lifecycle_devtools_command(proton_browser_lifecycle_t *lifecycle,
+                                          const char *command, char *error,
+                                          size_t error_len) {
+  if (lifecycle == NULL || lifecycle->browser == NULL || command == NULL) {
+    proton_browser_lifecycle_set_message(error, error_len,
+                                         "browser lifecycle is unavailable");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_host_t *host = lifecycle->browser->get_host(lifecycle->browser);
+  if (host == NULL) {
+    proton_browser_lifecycle_set_message(error, error_len,
+                                         "browser host is unavailable");
+    return PROTON_ERR_ENGINE;
+  }
+  proton_browser_lifecycle_t *devtools = lifecycle->devtools;
+  int devtools_active = devtools != NULL &&
+                        devtools->state != PROTON_BROWSER_CLOSED &&
+                        devtools->state != PROTON_BROWSER_CREATION_FAILED;
+  int close = strcmp(command, "close_devtools") == 0 ||
+              (strcmp(command, "toggle_devtools") == 0 && devtools_active);
+  if (close) {
+    if (devtools_active && devtools->state != PROTON_BROWSER_CLOSING) {
+      proton_browser_lifecycle_note_close_requested(devtools, 1);
+      host->close_dev_tools(host);
+    }
+    host->base.release((cef_base_ref_counted_t *)host);
+    return PROTON_OK;
+  }
+
+  if (devtools_active) {
+    if (devtools->state == PROTON_BROWSER_CLOSING) {
+      host->base.release((cef_base_ref_counted_t *)host);
+      proton_browser_lifecycle_set_message(error, error_len,
+                                           "DevTools are closing");
+      return PROTON_ERR_BUSY;
+    }
+    host->base.release((cef_base_ref_counted_t *)host);
+    return PROTON_OK;
+  }
+
+  {
+    proton_browser_registry_t *registry = lifecycle->registry;
+    devtools = proton_browser_lifecycle_create(
+        registry, PROTON_BROWSER_ROLE_DEVTOOLS, NULL, lifecycle);
+    if (devtools == NULL || registry->client_factory == NULL) {
+      proton_browser_lifecycle_creation_failed(devtools);
+      host->base.release((cef_base_ref_counted_t *)host);
+      proton_browser_lifecycle_set_message(
+          error, error_len, "failed to allocate DevTools lifecycle");
+      return PROTON_ERR_ENGINE;
+    }
+    cef_client_t *client =
+        registry->client_factory(registry->context, devtools);
+    if (client == NULL) {
+      proton_browser_lifecycle_creation_failed(devtools);
+      host->base.release((cef_base_ref_counted_t *)host);
+      proton_browser_lifecycle_set_message(error, error_len,
+                                           "failed to create DevTools client");
+      return PROTON_ERR_ENGINE;
+    }
+    proton_browser_lifecycle_set_client(devtools, client);
+  }
+
+  cef_window_info_t window_info = {0};
+  cef_browser_settings_t settings = {0};
+  window_info.size = sizeof(window_info);
+  settings.size = sizeof(settings);
+  host->show_dev_tools(host, &window_info, devtools->client, &settings, NULL);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
@@ -1,0 +1,78 @@
+#ifndef PROTON_ENGINE_CEF_COMMON_BROWSER_LIFECYCLE_H
+#define PROTON_ENGINE_CEF_COMMON_BROWSER_LIFECYCLE_H
+
+#include "include/capi/cef_browser_capi.h"
+#include "include/capi/cef_client_capi.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  PROTON_BROWSER_ROLE_MAIN = 0,
+  PROTON_BROWSER_ROLE_VIEW = 1,
+  PROTON_BROWSER_ROLE_DEVTOOLS = 2,
+} proton_browser_role_t;
+
+typedef enum {
+  PROTON_BROWSER_CREATING = 0,
+  PROTON_BROWSER_LIVE = 1,
+  PROTON_BROWSER_CLOSING = 2,
+  PROTON_BROWSER_CLOSED = 3,
+  PROTON_BROWSER_CREATION_FAILED = 4,
+} proton_browser_lifecycle_state_t;
+
+typedef struct proton_browser_lifecycle proton_browser_lifecycle_t;
+typedef struct proton_browser_registry proton_browser_registry_t;
+
+typedef cef_client_t *(*proton_browser_client_factory_fn)(
+    void *context, proton_browser_lifecycle_t *lifecycle);
+
+proton_browser_registry_t *
+proton_browser_registry_create(proton_browser_client_factory_fn client_factory,
+                               void *context);
+void proton_browser_registry_begin_shutdown(
+    proton_browser_registry_t *registry);
+int proton_browser_registry_shutdown_ready(
+    const proton_browser_registry_t *registry);
+void proton_browser_registry_destroy(proton_browser_registry_t *registry);
+
+proton_browser_lifecycle_t *
+proton_browser_lifecycle_create(proton_browser_registry_t *registry,
+                                proton_browser_role_t role, void *owner,
+                                proton_browser_lifecycle_t *devtools_parent);
+void proton_browser_lifecycle_set_client(proton_browser_lifecycle_t *lifecycle,
+                                         cef_client_t *client);
+void proton_browser_lifecycle_creation_failed(
+    proton_browser_lifecycle_t *lifecycle);
+void proton_browser_lifecycle_adopt_created(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser);
+void proton_browser_lifecycle_on_after_created(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser);
+void proton_browser_lifecycle_request_close(
+    proton_browser_lifecycle_t *lifecycle, int force_close);
+void proton_browser_lifecycle_note_close_requested(
+    proton_browser_lifecycle_t *lifecycle, int force_close);
+void proton_browser_lifecycle_on_before_close(
+    proton_browser_lifecycle_t *lifecycle, cef_browser_t *browser);
+
+proton_browser_role_t
+proton_browser_lifecycle_role(const proton_browser_lifecycle_t *lifecycle);
+proton_browser_lifecycle_state_t
+proton_browser_lifecycle_state(const proton_browser_lifecycle_t *lifecycle);
+void *
+proton_browser_lifecycle_owner(const proton_browser_lifecycle_t *lifecycle);
+void *
+proton_browser_lifecycle_context(const proton_browser_lifecycle_t *lifecycle);
+void proton_browser_lifecycle_clear_owner(
+    proton_browser_lifecycle_t *lifecycle);
+cef_browser_t *
+proton_browser_lifecycle_browser(const proton_browser_lifecycle_t *lifecycle);
+int proton_browser_lifecycle_browser_id(
+    const proton_browser_lifecycle_t *lifecycle);
+
+int32_t
+proton_browser_lifecycle_devtools_command(proton_browser_lifecycle_t *lifecycle,
+                                          const char *command, char *error,
+                                          size_t error_len);
+
+#endif

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
@@ -67,6 +67,8 @@ void proton_browser_lifecycle_clear_owner(
     proton_browser_lifecycle_t *lifecycle);
 cef_browser_t *
 proton_browser_lifecycle_browser(const proton_browser_lifecycle_t *lifecycle);
+cef_client_t *
+proton_browser_lifecycle_client(const proton_browser_lifecycle_t *lifecycle);
 int proton_browser_lifecycle_browser_id(
     const proton_browser_lifecycle_t *lifecycle);
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -65,6 +65,7 @@ typedef struct proton_browser_navigation_bypass {
 
 struct proton_browser_session {
   proton_browser_policy_t policy;
+  proton_browser_lifecycle_t *lifecycle;
   proton_window_id_t window;
   uint64_t next_request_id;
   proton_browser_pending_t *pending;
@@ -295,6 +296,14 @@ void proton_browser_session_bind_window(proton_browser_session_t *session,
                                          proton_window_id_t window) {
   if (session != NULL) {
     session->window = window;
+  }
+}
+
+void proton_browser_session_bind_lifecycle(
+    proton_browser_session_t *session,
+    proton_browser_lifecycle_t *lifecycle) {
+  if (session != NULL) {
+    session->lifecycle = lifecycle;
   }
 }
 
@@ -1061,25 +1070,8 @@ int32_t proton_browser_session_command_json(
                                  "DevTools are disabled by browser policy");
       return PROTON_ERR_UNSUPPORTED;
     }
-    cef_browser_host_t *host = browser->get_host(browser);
-    if (host == NULL) {
-      proton_browser_set_message(error, error_len,
-                                 "browser host is unavailable");
-      return PROTON_ERR_ENGINE;
-    }
-    int close_devtools = strcmp(command, "close_devtools") == 0 ||
-                         (strcmp(command, "toggle_devtools") == 0 &&
-                          host->has_dev_tools(host));
-    if (close_devtools) {
-      host->close_dev_tools(host);
-    } else {
-      cef_window_info_t window_info = {0};
-      cef_browser_settings_t settings = {0};
-      window_info.size = sizeof(window_info);
-      settings.size = sizeof(settings);
-      host->show_dev_tools(host, &window_info, NULL, &settings, NULL);
-    }
-    host->base.release((cef_base_ref_counted_t *)host);
+    return proton_browser_lifecycle_devtools_command(
+        session->lifecycle, command, error, error_len);
   } else {
     proton_browser_set_message(error, error_len,
                                "unknown browser command");

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -9,6 +9,8 @@
 #include "include/capi/cef_request_capi.h"
 #include "include/capi/cef_request_handler_capi.h"
 
+#include "browser_lifecycle.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -37,6 +39,9 @@ proton_browser_session_t *proton_browser_session_create(
 void proton_browser_session_destroy(proton_browser_session_t *session);
 void proton_browser_session_bind_window(proton_browser_session_t *session,
                                          proton_window_id_t window);
+void proton_browser_session_bind_lifecycle(
+    proton_browser_session_t *session,
+    proton_browser_lifecycle_t *lifecycle);
 
 void proton_browser_session_loading_changed(proton_browser_session_t *session,
                                              const char *url,

--- a/proton/internal/native/ffi/src/engine/cef_common/window_state.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/window_state.h
@@ -28,6 +28,7 @@ proton_engine_window_t *proton_engine_window_lookup_browser(
    refcount unchanged; callers that need to hold it across a message loop
    iteration must call base.add_ref and base.release. */
 cef_browser_t *proton_engine_window_browser(proton_engine_window_t *window);
+cef_browser_t *proton_engine_view_browser(proton_engine_view_t *view);
 proton_window_id_t proton_engine_window_public_id(
     proton_engine_window_t *window);
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -478,16 +478,24 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
   (void)self;
-  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
-  if (view != NULL) {
-    view->browser_before_close_seen = 1;
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL) {
+    return;
+  }
+  proton_browser_role_t role = proton_browser_lifecycle_role(lifecycle);
+  if (role == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    proton_browser_lifecycle_on_before_close(lifecycle, browser);
+    if (view == NULL) {
+      return;
+    }
     view->closed = 1;
     proton_view_events_closed(view->events);
     view->xwindow = 0;
-    if (view->browser != NULL) {
-      proton_engine_browser_release(view->browser);
-      view->browser = NULL;
-    }
+    view->browser = NULL;
+    view->browser_id = 0;
     // A page-initiated close (JS window.close) reaches here without a prior
     // engine destroy; let the cleanup state machine finish so the struct can
     // be reclaimed with its owning window.
@@ -496,7 +504,14 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     return;
   }
-  proton_engine_window_t *window = proton_engine_window_from_browser(browser);
+  if (role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    proton_browser_lifecycle_on_before_close(lifecycle, browser);
+    proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+    return;
+  }
+  proton_engine_window_t *window =
+      (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window != NULL) {
     proton_engine_window_close_views(window);
     proton_engine_window_mark_closed(window);
@@ -505,6 +520,25 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     }
     proton_engine_window_finalize_if_ready(window);
   }
+}
+
+static void CEF_CALLBACK proton_engine_on_after_created(
+    cef_life_span_handler_t *self,
+    cef_browser_t *browser) {
+  (void)self;
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL) {
+    cef_browser_host_t *host = browser != NULL ? browser->get_host(browser)
+                                                : NULL;
+    if (host != NULL) {
+      host->close_browser(host, 1);
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    return;
+  }
+  proton_browser_lifecycle_on_after_created(lifecycle, browser);
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
 
 cef_life_span_handler_t *CEF_CALLBACK
@@ -747,6 +781,7 @@ void proton_engine_init_handlers(void) {
       (cef_base_ref_counted_t *)&g_life_span_handler.handler.base,
       sizeof(g_life_span_handler.handler), &g_life_span_handler.refs);
   g_life_span_handler.handler.on_before_popup = proton_engine_on_before_popup;
+  g_life_span_handler.handler.on_after_created = proton_engine_on_after_created;
   g_life_span_handler.handler.on_before_close = proton_engine_on_before_close;
   g_life_span_handler.handler.do_close = proton_engine_do_close;
 
@@ -1423,8 +1458,22 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
   }
 }
 
+int CEF_CALLBACK proton_engine_client_release(
+    cef_base_ref_counted_t *base) {
+  proton_engine_ref_counted_t *refs =
+      (proton_engine_ref_counted_t *)((char *)base + base->size);
+  int value =
+      atomic_fetch_sub_explicit(&refs->refs, 1, memory_order_acq_rel) - 1;
+  if (value <= 0) {
+    free(base);
+    return 1;
+  }
+  return 0;
+}
+
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window) {
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -1432,7 +1481,9 @@ proton_engine_client_t *proton_engine_client_create(
   }
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
   client->window = window;
+  client->browser_lifecycle = browser_lifecycle;
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
@@ -1453,10 +1504,41 @@ proton_engine_client_t *proton_engine_client_create(
   return client;
 }
 
-void proton_engine_browser_release(cef_browser_t *browser) {
-  if (browser != NULL) {
-    browser->base.release((cef_base_ref_counted_t *)browser);
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle) {
+  (void)context;
+  proton_engine_client_t *client =
+      (proton_engine_client_t *)calloc(1, sizeof(*client));
+  if (client == NULL) {
+    return NULL;
   }
+  proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
+                                 sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
+  client->browser_lifecycle = browser_lifecycle;
+  client->client.get_life_span_handler =
+      proton_engine_client_get_life_span_handler;
+  return &client->client;
+}
+
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
+    cef_browser_t *browser) {
+  if (browser == NULL) {
+    return NULL;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    return NULL;
+  }
+  cef_client_t *cef_client = host->get_client(host);
+  proton_browser_lifecycle_t *lifecycle = NULL;
+  if (cef_client != NULL) {
+    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
+    lifecycle = client->browser_lifecycle;
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
+  }
+  host->base.release((cef_base_ref_counted_t *)host);
+  return lifecycle;
 }
 
 void proton_engine_window_mark_closed(proton_engine_window_t *window) {
@@ -1466,10 +1548,8 @@ void proton_engine_window_mark_closed(proton_engine_window_t *window) {
   window->closed = 1;
   proton_engine_bridge_pending_remove_browser(window->runtime,
                                               window->browser_id);
-  if (window->browser != NULL) {
-    proton_engine_browser_release(window->browser);
-    window->browser = NULL;
-  }
+  window->browser = NULL;
+  window->browser_id = 0;
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -368,7 +368,7 @@ static void CEF_CALLBACK proton_engine_osr_get_view_rect(
   if (view == NULL) {
     // CEF can query the viewport while create_browser_sync is still running,
     // before the view records its browser id; resolve via the client then.
-    view = proton_engine_view_from_browser_client(browser);
+    view = proton_engine_view_from_browser(browser);
   }
   if (view != NULL) {
     rect->width = view->width > 0 ? view->width : 1;
@@ -376,7 +376,7 @@ static void CEF_CALLBACK proton_engine_osr_get_view_rect(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   rect->width = window != NULL && window->width > 0 ? window->width : 1;
   rect->height = window != NULL && window->height > 0 ? window->height : 1;
 }
@@ -405,7 +405,7 @@ static void CEF_CALLBACK proton_engine_osr_on_popup_show(
     int show) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   if (window != NULL) {
     window->osr_popup_visible = show ? 1 : 0;
   }
@@ -417,7 +417,7 @@ static void CEF_CALLBACK proton_engine_osr_on_popup_size(
     const cef_rect_t *rect) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   if (window != NULL && rect != NULL) {
     window->osr_popup_rect = *rect;
   }
@@ -494,8 +494,6 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     view->closed = 1;
     proton_view_events_closed(view->events);
     view->xwindow = 0;
-    view->browser = NULL;
-    view->browser_id = 0;
     // A page-initiated close (JS window.close) reaches here without a prior
     // engine destroy; let the cleanup state machine finish so the struct can
     // be reclaimed with its owning window.
@@ -511,6 +509,10 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   }
   proton_engine_window_t *window =
       (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  if (window != NULL) {
+    proton_engine_bridge_pending_remove_browser(
+        window->runtime, proton_browser_lifecycle_browser_id(lifecycle));
+  }
   proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window != NULL) {
     proton_engine_window_close_views(window);
@@ -651,12 +653,23 @@ proton_engine_client_get_render_handler(cef_client_t *self) {
   if (client == NULL) {
     return NULL;
   }
-  if (client->view != NULL) {
-    if (client->view->window == NULL || !client->view->window->headless) {
+  proton_browser_lifecycle_t *lifecycle = client->browser_lifecycle;
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    return NULL;
+  }
+  if (proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view == NULL || view->window == NULL || !view->window->headless) {
       return NULL;
     }
-  } else if (client->window == NULL || !client->window->headless) {
-    return NULL;
+  } else {
+    proton_engine_window_t *window =
+        (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (window == NULL || !window->headless) {
+      return NULL;
+    }
   }
   g_render_handler.handler.base.add_ref(
       (cef_base_ref_counted_t *)&g_render_handler.handler);
@@ -1472,7 +1485,6 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
@@ -1482,7 +1494,6 @@ proton_engine_client_t *proton_engine_client_create(
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
-  client->window = window;
   client->browser_lifecycle = browser_lifecycle;
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
@@ -1547,9 +1558,7 @@ void proton_engine_window_mark_closed(proton_engine_window_t *window) {
   }
   window->closed = 1;
   proton_engine_bridge_pending_remove_browser(window->runtime,
-                                              window->browser_id);
-  window->browser = NULL;
-  window->browser_id = 0;
+      proton_browser_lifecycle_browser_id(window->browser_lifecycle));
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -87,9 +87,6 @@ struct proton_engine_window {
   char titlebar_maximize_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_restore_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_close_label[PROTON_ENGINE_MAX_LABEL_BYTES];
-  proton_engine_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   proton_window_id_t public_window_id;
   char *bridge_config_json;
@@ -171,8 +168,6 @@ typedef struct {
 struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
-  proton_engine_window_t *window;
-  proton_engine_view_t *view;
   proton_browser_lifecycle_t *browser_lifecycle;
 };
 
@@ -183,9 +178,6 @@ struct proton_engine_client {
    how the view was closed. */
 struct proton_engine_view {
   proton_engine_window_t *window;
-  proton_engine_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   cef_window_handle_t xwindow;
   Display *display;
@@ -217,7 +209,6 @@ void proton_engine_bridge_pending_remove_browser(
     proton_engine_runtime_t *runtime,
     int browser_id);
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle);
 int CEF_CALLBACK proton_engine_client_release(
     cef_base_ref_counted_t *base);
@@ -244,10 +235,6 @@ void proton_engine_append_switch_with_value(cef_command_line_t *command_line,
                                             const char *value);
 void proton_engine_window_list_add(proton_engine_window_t *window);
 proton_engine_window_t *proton_engine_window_from_browser(
-    cef_browser_t *browser);
-proton_engine_window_t *proton_engine_window_from_browser_client(
-    cef_browser_t *browser);
-proton_engine_view_t *proton_engine_view_from_browser_client(
     cef_browser_t *browser);
 void proton_engine_overlay_release_input_windows(
     proton_engine_window_t *window);

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -5,6 +5,7 @@
 #include "../../proton_engine.h"
 #include "../../proton_event.h"
 #include "../cef_common/bridge_lifecycle.h"
+#include "../cef_common/browser_lifecycle.h"
 #include "../cef_common/browser_session.h"
 #include "../cef_common/view_events.h"
 #include "../cef_common/window_state.h"
@@ -66,6 +67,7 @@ struct proton_engine_runtime {
   proton_linux_menu_bar_t *menu_definition;
   char dialog_ok_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
+  proton_browser_registry_t *browsers;
 };
 
 struct proton_engine_window {
@@ -88,6 +90,7 @@ struct proton_engine_window {
   proton_engine_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   proton_window_id_t public_window_id;
   char *bridge_config_json;
   int32_t max_bridge_payload_bytes;
@@ -133,7 +136,8 @@ void proton_engine_dialog_cancel_window(proton_engine_window_t *window);
 void proton_engine_signal_wait_source(uint32_t ready_mask);
 void proton_engine_browser_signal(void *user_data);
 int proton_engine_browser_id(cef_browser_t *browser);
-void proton_engine_browser_release(cef_browser_t *browser);
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
+    cef_browser_t *browser);
 proton_engine_view_t *proton_engine_view_from_browser(cef_browser_t *browser);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
 int proton_engine_x11_window_is_focused(Display *display, Window browser_window);
@@ -169,6 +173,7 @@ struct proton_engine_client {
   proton_engine_ref_counted_t refs;
   proton_engine_window_t *window;
   proton_engine_view_t *view;
+  proton_browser_lifecycle_t *browser_lifecycle;
 };
 
 /* A web contents view: an extra child browser hosted inside a window's
@@ -181,6 +186,7 @@ struct proton_engine_view {
   proton_engine_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   cef_window_handle_t xwindow;
   Display *display;
   int32_t x;
@@ -197,8 +203,6 @@ struct proton_engine_view {
   proton_view_events_t *events;
   int has_background_color;
   uint32_t background_color;
-  int browser_close_requested;
-  int browser_before_close_seen;
   int finalize_after_browser_close;
   int finalized;
   int closed;
@@ -213,7 +217,12 @@ void proton_engine_bridge_pending_remove_browser(
     proton_engine_runtime_t *runtime,
     int browser_id);
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window);
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle);
+int CEF_CALLBACK proton_engine_client_release(
+    cef_base_ref_counted_t *base);
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle);
 void proton_engine_window_mark_closed(proton_engine_window_t *window);
 void proton_engine_overlay_update_input_shape(proton_engine_window_t *window);
 void proton_engine_overlay_update_maximize_button(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_menu.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_menu.c
@@ -350,15 +350,15 @@ static void proton_engine_menu_command_activated(const char *command_id,
 static void proton_engine_menu_apply_edit_role(
     proton_engine_window_t *window,
     const char *role) {
-  if (window == NULL || window->browser == NULL || role == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL || role == NULL) {
     return;
   }
   cef_frame_t *frame =
-      window->browser->get_focused_frame != NULL
-          ? window->browser->get_focused_frame(window->browser)
+      proton_engine_window_browser(window)->get_focused_frame != NULL
+          ? proton_engine_window_browser(window)->get_focused_frame(proton_engine_window_browser(window))
           : NULL;
   if (frame == NULL) {
-    frame = window->browser->get_main_frame(window->browser);
+    frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   }
   if (frame == NULL) {
     return;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
@@ -453,9 +453,6 @@ static void proton_engine_window_free_storage(proton_engine_window_t *window) {
     window->menu_accel_group = NULL;
   }
   proton_engine_window_free_views(window);
-  if (window->client != NULL) {
-    window->client->window = NULL;
-  }
   proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   proton_browser_session_destroy(window->browser_session);
@@ -479,77 +476,23 @@ static void proton_engine_free_closed_windows(void) {
 
 proton_engine_window_t *proton_engine_window_from_browser(
     cef_browser_t *browser) {
-  if (browser == NULL) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_MAIN) {
     return NULL;
   }
-  int browser_id = browser->get_identifier(browser);
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    if (window->browser_id == browser_id) {
-      return window;
-    }
-  }
-  return NULL;
+  return (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 proton_engine_view_t *proton_engine_view_from_browser(cef_browser_t *browser) {
-  if (browser == NULL) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_VIEW) {
     return NULL;
   }
-  int browser_id = proton_engine_browser_id(browser);
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    for (proton_engine_view_t *view = window->views; view != NULL;
-         view = view->next) {
-      if (view->browser_id == browser_id) {
-        return view;
-      }
-    }
-  }
-  return NULL;
-}
-
-proton_engine_window_t *proton_engine_window_from_browser_client(
-    cef_browser_t *browser) {
-  if (browser == NULL) {
-    return NULL;
-  }
-  cef_browser_host_t *host = browser->get_host(browser);
-  if (host == NULL) {
-    return NULL;
-  }
-  cef_client_t *cef_client = host->get_client(host);
-  proton_engine_window_t *window = NULL;
-  if (cef_client != NULL) {
-    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
-    window = client->window;
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  host->base.release((cef_base_ref_counted_t *)host);
-  return window;
-}
-
-// Resolves a view through the browser's client. Unlike the browser-id list
-// scan this also works while cef_browser_host_create_browser_sync is still
-// running, before the view records its browser id.
-proton_engine_view_t *proton_engine_view_from_browser_client(
-    cef_browser_t *browser) {
-  if (browser == NULL) {
-    return NULL;
-  }
-  cef_browser_host_t *host = browser->get_host(browser);
-  if (host == NULL) {
-    return NULL;
-  }
-  cef_client_t *cef_client = host->get_client(host);
-  proton_engine_view_t *view = NULL;
-  if (cef_client != NULL) {
-    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
-    view = client->view;
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  host->base.release((cef_base_ref_counted_t *)host);
-  return view;
+  return (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 static void proton_engine_runtime_dispose_menu(
@@ -575,7 +518,15 @@ proton_engine_window_t *proton_engine_window_lookup_browser(
 }
 
 cef_browser_t *proton_engine_window_browser(proton_engine_window_t *window) {
-  return window != NULL ? window->browser : NULL;
+  return window != NULL
+             ? proton_browser_lifecycle_browser(window->browser_lifecycle)
+             : NULL;
+}
+
+cef_browser_t *proton_engine_view_browser(proton_engine_view_t *view) {
+  return view != NULL
+             ? proton_browser_lifecycle_browser(view->browser_lifecycle)
+             : NULL;
 }
 
 proton_engine_view_t *proton_engine_window_lookup_view_browser(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
@@ -453,7 +453,10 @@ static void proton_engine_window_free_storage(proton_engine_window_t *window) {
     window->menu_accel_group = NULL;
   }
   proton_engine_window_free_views(window);
-  free(window->client);
+  if (window->client != NULL) {
+    window->client->window = NULL;
+  }
+  proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   proton_browser_session_destroy(window->browser_session);
   free(window->draggable_regions);
@@ -801,12 +804,22 @@ int32_t proton_engine_runtime_create(
   runtime->owns_cef_runtime = 1;
   runtime->headless = config.headless;
   runtime->next_bridge_request_id = 1;
+  runtime->browsers = proton_browser_registry_create(
+      proton_engine_browser_client_factory, runtime);
+  if (runtime->browsers == NULL) {
+    free(runtime);
+    proton_engine_remove_temporary_profile();
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser registry");
+    return PROTON_ERR_ENGINE;
+  }
   snprintf(runtime->dialog_ok_label, sizeof(runtime->dialog_ok_label), "%s",
            config.dialog_ok_label);
   snprintf(runtime->dialog_cancel_label,
            sizeof(runtime->dialog_cancel_label), "%s",
            config.dialog_cancel_label);
   if (!proton_engine_setup_wait_source(error, error_len)) {
+    proton_browser_registry_destroy(runtime->browsers);
     proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     proton_engine_remove_temporary_profile();
@@ -852,6 +865,7 @@ int32_t proton_engine_runtime_create(
   cef_string_clear(&settings.root_cache_path);
   proton_engine_free_main_args(&main_args);
   if (!cef_initialized) {
+    proton_browser_registry_destroy(runtime->browsers);
     proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
@@ -865,6 +879,7 @@ int32_t proton_engine_runtime_create(
    * process-global state and helper threads. */
   if (!proton_engine_ensure_gtk(error, error_len)) {
     proton_engine_cef_shutdown();
+    proton_browser_registry_destroy(runtime->browsers);
     proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
@@ -874,6 +889,7 @@ int32_t proton_engine_runtime_create(
   g_proton_cef_runtime_active = 1;
   if (!proton_engine_register_scheme_factory()) {
     proton_engine_cef_shutdown();
+    proton_browser_registry_destroy(runtime->browsers);
     proton_engine_runtime_dispose_menu(runtime);
     free(runtime);
     g_active_runtime = NULL;
@@ -898,7 +914,12 @@ static int proton_engine_runtime_has_windows(
 }
 
 int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
-  return runtime != NULL && !proton_engine_runtime_has_windows(runtime);
+  if (runtime == NULL) {
+    return 0;
+  }
+  proton_browser_registry_begin_shutdown(runtime->browsers);
+  return !proton_engine_runtime_has_windows(runtime) &&
+         proton_browser_registry_shutdown_ready(runtime->browsers);
 }
 
 int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
@@ -920,6 +941,7 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
     proton_engine_free_closed_windows();
     runtime->owns_cef_runtime = 0;
   }
+  proton_browser_registry_destroy(runtime->browsers);
   proton_engine_runtime_dispose_menu(runtime);
   if (g_active_runtime == runtime) {
     g_active_runtime = NULL;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -62,7 +62,10 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_engine_view_t *next = view->next;
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    free(view->client);
+    if (view->client != NULL) {
+      view->client->view = NULL;
+    }
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     view = next;
   }
@@ -73,12 +76,16 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
       !view->finalize_after_browser_close) {
     return;
   }
-  if (view->browser_id != 0 && !view->browser_before_close_seen) {
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(view->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   if (view->client != NULL) {
     view->client->view = NULL;
   }
+  proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   view->xwindow = 0;
   view->finalized = 1;
   // The window's own finalize is gated on every view being finalized; this
@@ -87,8 +94,13 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
 }
 
 void proton_engine_window_finalize_if_ready(proton_engine_window_t *window) {
-  if (window == NULL || !window->destroy_requested ||
-      window->browser != NULL) {
+  if (window == NULL || !window->destroy_requested) {
+    return;
+  }
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(window->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   for (proton_engine_view_t *view = window->views; view != NULL;
@@ -110,17 +122,7 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
       view->closed = 1;
       view->finalize_after_browser_close = 1;
       if (view->browser != NULL) {
-        cef_browser_host_t *host = view->browser->get_host(view->browser);
-        if (host != NULL) {
-          view->browser_close_requested = 1;
-          host->close_browser(host, 1);
-          host->base.release((cef_base_ref_counted_t *)host);
-        } else {
-          // A browser without a host can never deliver on_before_close.
-          view->browser_before_close_seen = 1;
-        }
-        proton_engine_browser_release(view->browser);
-        view->browser = NULL;
+        proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
       }
     } else if (!view->finalize_after_browser_close) {
       // Already closed by the page (JS window.close): allow its cleanup to
@@ -181,10 +183,16 @@ int CEF_CALLBACK proton_engine_do_close(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
   (void)self;
-  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_VIEW) {
+    // Main and DevTools browsers keep CEF's top-level close behavior.
+    return 0;
+  }
+  proton_engine_view_t *view =
+      (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
   if (view == NULL) {
-    // Frame windows keep CEF's default close behavior (delete event on the
-    // top-level window).
     return 0;
   }
   // A view browser owns no top-level window; CEF's default would deliver a
@@ -236,7 +244,8 @@ void proton_engine_view_handlers_init(void) {
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view) {
+    proton_engine_view_t *view,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -244,7 +253,9 @@ static proton_engine_client_t *proton_engine_view_client_create(
   }
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
   client->view = view;
+  client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Find results
@@ -297,16 +308,21 @@ static int32_t proton_engine_view_create_browser(
   }
   proton_engine_set_string(&window_info.window_name, "ProtonView");
   proton_engine_set_string(&url, "about:blank");
-  view->browser = cef_browser_host_create_browser_sync(
+  cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
       &window_info, &view->client->client, &url, &browser_settings, NULL,
       NULL);
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
-  if (view->browser == NULL) {
+  if (created_browser == NULL) {
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_engine_set_message(error, error_len, "view browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  view->browser_id = proton_engine_browser_id(view->browser);
+  proton_browser_lifecycle_adopt_created(view->browser_lifecycle,
+                                         created_browser);
+  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
+  view->browser_id =
+      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
@@ -386,7 +402,16 @@ int32_t proton_engine_view_create(
   view->background_color = config.background_color;
   snprintf(view->initial_url, sizeof(view->initial_url), "%s",
            config.initial_url);
-  view->client = proton_engine_view_client_create(view);
+  view->browser_lifecycle = proton_browser_lifecycle_create(
+      window->runtime->browsers, PROTON_BROWSER_ROLE_VIEW, view, NULL);
+  if (view->browser_lifecycle == NULL) {
+    free(view);
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser lifecycle");
+    return PROTON_ERR_ENGINE;
+  }
+  view->client = proton_engine_view_client_create(
+      view, view->browser_lifecycle);
   proton_browser_policy_t view_policy = {PROTON_BROWSER_POLICY_ALLOW,
                                          PROTON_BROWSER_POLICY_DENY,
                                          PROTON_BROWSER_POLICY_DENY,
@@ -400,12 +425,22 @@ int32_t proton_engine_view_create(
       view->events == NULL) {
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    free(view->client);
+    if (view->client != NULL) {
+      view->client->view = NULL;
+      proton_browser_lifecycle_set_client(view->browser_lifecycle,
+                                          &view->client->client);
+    }
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     proton_engine_set_message(error, error_len,
                               "failed to allocate view state");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(view->browser_lifecycle,
+                                      &view->client->client);
+  proton_browser_session_bind_lifecycle(view->browser_session,
+                                        view->browser_lifecycle);
   proton_view_events_bind(view->events, config.public_view,
                           config.public_window);
   proton_engine_view_list_add(window, view);
@@ -433,21 +468,10 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
   if (view->closed) {
     return PROTON_OK;
   }
-  cef_browser_host_t *host =
-      view->browser != NULL ? view->browser->get_host(view->browser) : NULL;
-  if (view->browser != NULL && host == NULL) {
-    proton_engine_set_message(error, error_len,
-                              "browser host is not available for close");
-    return PROTON_ERR_ENGINE;
-  }
   view->closed = 1;
   view->finalize_after_browser_close = 1;
   if (view->browser != NULL) {
-    view->browser_close_requested = 1;
-    host->close_browser(host, 1);
-    host->base.release((cef_base_ref_counted_t *)host);
-    proton_engine_browser_release(view->browser);
-    view->browser = NULL;
+    proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
   }
   proton_engine_view_finalize_if_ready(view);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -62,9 +62,6 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_engine_view_t *next = view->next;
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    if (view->client != NULL) {
-      view->client->view = NULL;
-    }
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     view = next;
@@ -81,9 +78,6 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
   if (browser_state != PROTON_BROWSER_CLOSED &&
       browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
-  }
-  if (view->client != NULL) {
-    view->client->view = NULL;
   }
   proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   view->xwindow = 0;
@@ -121,7 +115,7 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
     if (!view->closed) {
       view->closed = 1;
       view->finalize_after_browser_close = 1;
-      if (view->browser != NULL) {
+      if (proton_engine_view_browser(view) != NULL) {
         proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
       }
     } else if (!view->finalize_after_browser_close) {
@@ -244,7 +238,6 @@ void proton_engine_view_handlers_init(void) {
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
@@ -254,7 +247,6 @@ static proton_engine_client_t *proton_engine_view_client_create(
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
-  client->view = view;
   client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
@@ -265,8 +257,15 @@ static proton_engine_client_t *proton_engine_view_client_create(
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
-  client->client.get_find_handler =
-      view->window->client->client.get_find_handler;
+  proton_engine_view_t *view =
+      (proton_engine_view_t *)proton_browser_lifecycle_owner(browser_lifecycle);
+  cef_client_t *window_client = view != NULL && view->window != NULL
+                                    ? proton_browser_lifecycle_client(
+                                          view->window->browser_lifecycle)
+                                    : NULL;
+  client->client.get_find_handler = window_client != NULL
+                                        ? window_client->get_find_handler
+                                        : NULL;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -309,7 +308,7 @@ static int32_t proton_engine_view_create_browser(
   proton_engine_set_string(&window_info.window_name, "ProtonView");
   proton_engine_set_string(&url, "about:blank");
   cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
-      &window_info, &view->client->client, &url, &browser_settings, NULL,
+      &window_info, proton_browser_lifecycle_client(view->browser_lifecycle), &url, &browser_settings, NULL,
       NULL);
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
@@ -320,10 +319,7 @@ static int32_t proton_engine_view_create_browser(
   }
   proton_browser_lifecycle_adopt_created(view->browser_lifecycle,
                                          created_browser);
-  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
-  view->browser_id =
-      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
-  cef_browser_host_t *host = view->browser->get_host(view->browser);
+  cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
     host->set_zoom_level(host, log(factor) / log(1.2));
@@ -345,7 +341,7 @@ static int32_t proton_engine_view_create_browser(
   proton_engine_window_layout_views(window);
   if (view->initial_url[0] != '\0' &&
       strcmp(view->initial_url, "about:blank") != 0) {
-    cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+    cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
     if (frame != NULL) {
       cef_string_t initial = {0};
       proton_engine_set_string(&initial, view->initial_url);
@@ -410,8 +406,8 @@ int32_t proton_engine_view_create(
                               "failed to allocate browser lifecycle");
     return PROTON_ERR_ENGINE;
   }
-  view->client = proton_engine_view_client_create(
-      view, view->browser_lifecycle);
+  proton_engine_client_t *client = proton_engine_view_client_create(
+      view->browser_lifecycle);
   proton_browser_policy_t view_policy = {PROTON_BROWSER_POLICY_ALLOW,
                                          PROTON_BROWSER_POLICY_DENY,
                                          PROTON_BROWSER_POLICY_DENY,
@@ -421,14 +417,13 @@ int32_t proton_engine_view_create(
   view->browser_session = proton_browser_session_create(
       &view_policy, proton_engine_browser_signal, NULL);
   view->events = proton_view_events_create();
-  if (view->client == NULL || view->browser_session == NULL ||
+  if (client == NULL || view->browser_session == NULL ||
       view->events == NULL) {
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    if (view->client != NULL) {
-      view->client->view = NULL;
+    if (client != NULL) {
       proton_browser_lifecycle_set_client(view->browser_lifecycle,
-                                          &view->client->client);
+                                          &client->client);
     }
     proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
@@ -438,7 +433,7 @@ int32_t proton_engine_view_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(view->browser_lifecycle,
-                                      &view->client->client);
+                                      &client->client);
   proton_browser_session_bind_lifecycle(view->browser_session,
                                         view->browser_lifecycle);
   proton_view_events_bind(view->events, config.public_view,
@@ -470,7 +465,7 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
   }
   view->closed = 1;
   view->finalize_after_browser_close = 1;
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
   }
   proton_engine_view_finalize_if_ready(view);
@@ -498,8 +493,8 @@ int32_t proton_engine_view_set_bounds(proton_engine_view_t *view,
   view->width = width;
   view->height = height;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL) {
         host->was_resized(host);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -522,8 +517,8 @@ int32_t proton_engine_view_set_visible(proton_engine_view_t *view,
   }
   view->visible = visible ? 1 : 0;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL && host->was_hidden != NULL) {
         host->was_hidden(host, view->visible ? 0 : 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -563,7 +558,7 @@ int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   int32_t status = proton_browser_set_zoom_percent(
-      view->browser, zoom_percent, error, error_len);
+      proton_engine_view_browser(view), zoom_percent, error, error_len);
   if (status != PROTON_OK) {
     return status;
   }
@@ -579,9 +574,9 @@ int32_t proton_engine_view_set_audio_muted(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_set_audio_muted(
-        view->browser, muted, error, error_len);
+        proton_engine_view_browser(view), muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -598,9 +593,9 @@ int32_t proton_engine_view_is_audio_muted(proton_engine_view_t *view,
                               "view and muted output are required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_is_audio_muted(
-        view->browser, out_muted, error, error_len);
+        proton_engine_view_browser(view), out_muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -619,11 +614,11 @@ int32_t proton_engine_view_load_url(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser == NULL) {
+  if (proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -641,11 +636,11 @@ int32_t proton_engine_view_eval(proton_engine_view_t *view,
                                 const char *script,
                                 char *error,
                                 size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -667,12 +662,12 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 char *error,
                                                 size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(view->browser_session,
-                                             view->browser, command_json,
+                                             proton_engine_view_browser(view), command_json,
                                              error, error_len);
 }
 
@@ -680,7 +675,7 @@ int32_t proton_engine_view_get_browser_focus_state(
     proton_engine_view_t *view, int32_t *out_focused,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -691,7 +686,7 @@ int32_t proton_engine_view_get_browser_focus_state(
   }
   if (view->window != NULL && view->window->headless) {
     return proton_browser_headless_is_focused(
-        view->browser, out_focused, error, error_len);
+        proton_engine_view_browser(view), out_focused, error, error_len);
   }
   if (view->display == NULL || view->xwindow == None) {
     proton_engine_set_message(error, error_len,
@@ -706,24 +701,24 @@ int32_t proton_engine_view_get_browser_focus_state(
 int32_t proton_engine_view_get_devtools_state(
     proton_engine_view_t *view, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      view->browser, out_opened, error, error_len);
+      proton_engine_view_browser(view), out_opened, error, error_len);
 }
 
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_view_browser(view), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_view_find_in_page(
@@ -731,24 +726,24 @@ int32_t proton_engine_view_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      view->browser_session, view->browser, text, forward, match_case,
+      view->browser_session, proton_engine_view_browser(view), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_view_stop_find_in_page(
     proton_engine_view_t *view, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      view->browser, clear_selection, error, error_len);
+      proton_engine_view_browser(view), clear_selection, error, error_len);
 }
 
 #endif

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -441,6 +441,7 @@ int32_t proton_engine_view_create(
   proton_engine_view_list_add(window, view);
   status = proton_engine_view_create_browser(view, error, error_len);
   if (status != PROTON_OK) {
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     // The browser never started, so the view finalizes immediately; the
     // struct stays owned by the window list and is reclaimed with it.
     view->closed = 1;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -682,6 +682,7 @@ int32_t proton_engine_window_create(
   status = proton_engine_window_create_browser(window, config.initial_url, error,
                                                error_len);
   if (status != PROTON_OK) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     if (window->window != NULL) {
       gtk_widget_destroy(window->window);
     }

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -151,8 +151,8 @@ static gboolean proton_engine_on_window_delete(GtkWidget *widget,
     }
     return TRUE;
   }
-  if (window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (proton_engine_window_browser(window) != NULL) {
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host != NULL) {
       int allow_close = 0;
       if (host->is_ready_to_be_closed != NULL &&
@@ -193,18 +193,18 @@ static void proton_engine_on_window_destroy(GtkWidget *widget,
     proton_engine_overlay_release_input_windows(window);
   }
   if (window != NULL && !window->closed) {
-    if (window->browser == NULL) {
+    if (proton_engine_window_browser(window) == NULL) {
       proton_engine_window_mark_closed(window);
     }
   }
 }
 
 void proton_engine_sync_browser_bounds(proton_engine_window_t *window) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     return;
   }
   if (window->headless) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host != NULL) {
       if (host->was_resized != NULL) {
         host->was_resized(host);
@@ -228,7 +228,7 @@ void proton_engine_sync_browser_bounds(proton_engine_window_t *window) {
       attributes.width <= 0 || attributes.height <= 0) {
     return;
   }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
   if (host == NULL) {
     return;
   }
@@ -282,8 +282,8 @@ static gboolean proton_engine_window_configure(GtkWidget *widget,
   (void)event;
   proton_engine_window_t *window = (proton_engine_window_t *)user_data;
   proton_engine_sync_browser_bounds(window);
-  if (window != NULL && window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (window != NULL && proton_engine_window_browser(window) != NULL) {
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host != NULL) {
       if (host->notify_move_or_resize_started != NULL) {
         host->notify_move_or_resize_started(host);
@@ -396,7 +396,8 @@ static int32_t proton_engine_window_create_browser(
   memset(&browser_settings, 0, sizeof(browser_settings));
   window_info.size = sizeof(window_info);
   browser_settings.size = sizeof(browser_settings);
-  if (window == NULL || window->client == NULL ||
+  if (window == NULL ||
+      proton_browser_lifecycle_client(window->browser_lifecycle) == NULL ||
       (!window->headless &&
        (window->browser_host == NULL ||
         gtk_widget_get_window(window->browser_host) == NULL))) {
@@ -443,7 +444,7 @@ static int32_t proton_engine_window_create_browser(
           ? extra_info_value->get_dictionary(extra_info_value)
           : NULL;
   cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
-      &window_info, &window->client->client, &url, &browser_settings,
+      &window_info, proton_browser_lifecycle_client(window->browser_lifecycle), &url, &browser_settings,
       extra_info, NULL);
   if (extra_info_value != NULL) {
     extra_info_value->base.release((cef_base_ref_counted_t *)extra_info_value);
@@ -457,10 +458,6 @@ static int32_t proton_engine_window_create_browser(
   }
   proton_browser_lifecycle_adopt_created(window->browser_lifecycle,
                                          created_browser);
-  window->browser =
-      proton_browser_lifecycle_browser(window->browser_lifecycle);
-  window->browser_id =
-      proton_browser_lifecycle_browser_id(window->browser_lifecycle);
   proton_engine_window_list_add(window);
   proton_engine_sync_browser_bounds(window);
   return PROTON_OK;
@@ -544,9 +541,9 @@ int32_t proton_engine_window_create(
                                      config.public_window);
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
-  window->client = proton_engine_client_create(
-      window, window->browser_lifecycle);
-  if (window->client == NULL) {
+  proton_engine_client_t *client = proton_engine_client_create(
+      window->browser_lifecycle);
+  if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
@@ -556,12 +553,11 @@ int32_t proton_engine_window_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(window->browser_lifecycle,
-                                      &window->client->client);
+                                      &client->client);
 
   if (!window->headless) {
     window->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     if (window->window == NULL) {
-      window->client->window = NULL;
       proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
       proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
@@ -573,7 +569,6 @@ int32_t proton_engine_window_create(
     window->root_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     if (window->root_box == NULL) {
       gtk_widget_destroy(window->window);
-      window->client->window = NULL;
       proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
       proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
@@ -597,7 +592,6 @@ int32_t proton_engine_window_create(
       window->overlay = gtk_overlay_new();
       if (window->overlay == NULL) {
         gtk_widget_destroy(window->window);
-        window->client->window = NULL;
         proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
         proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
@@ -611,7 +605,6 @@ int32_t proton_engine_window_create(
     window->browser_host = gtk_drawing_area_new();
     if (window->browser_host == NULL) {
       gtk_widget_destroy(window->window);
-      window->client->window = NULL;
       proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
       proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
@@ -626,7 +619,6 @@ int32_t proton_engine_window_create(
       gtk_container_add(GTK_CONTAINER(window->overlay), window->browser_host);
       if (!proton_engine_overlay_create_controls(window)) {
         gtk_widget_destroy(window->window);
-        window->client->window = NULL;
         proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
         proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
@@ -648,7 +640,6 @@ int32_t proton_engine_window_create(
           window, runtime->menu_definition, error, error_len);
       if (status != PROTON_OK) {
         gtk_widget_destroy(window->window);
-        window->client->window = NULL;
         proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
         proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
@@ -694,7 +685,6 @@ int32_t proton_engine_window_create(
     if (window->window != NULL) {
       gtk_widget_destroy(window->window);
     }
-    window->client->window = NULL;
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
@@ -713,7 +703,7 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_dialog_cancel_window(window);
-  if (window->closed && window->browser == NULL) {
+  if (window->closed && proton_engine_window_browser(window) == NULL) {
     window->destroy_requested = 1;
     proton_engine_window_close_views(window);
     if (window->window != NULL) {
@@ -725,9 +715,10 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
     proton_engine_window_finalize_if_ready(window);
     return PROTON_OK;
   }
-  if (window->browser != NULL) {
-    proton_engine_bridge_pending_remove_browser(window->runtime,
-                                                window->browser_id);
+  if (proton_engine_window_browser(window) != NULL) {
+    proton_engine_bridge_pending_remove_browser(
+        window->runtime,
+        proton_browser_lifecycle_browser_id(window->browser_lifecycle));
     window->destroy_requested = 1;
     window->closing = 1;
     proton_engine_window_close_views(window);
@@ -756,8 +747,8 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 0;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 0);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -790,8 +781,8 @@ int32_t proton_engine_window_hide(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 1;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -828,8 +819,8 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
     gtk_window_close(GTK_WINDOW(window->window));
     return PROTON_OK;
   }
-  if (window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (proton_engine_window_browser(window) != NULL) {
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available for close");
@@ -857,8 +848,8 @@ int32_t proton_engine_window_focus(proton_engine_window_t *window,
   if (!window->headless) {
     gtk_window_present(GTK_WINDOW(window->window));
   }
-  if (window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+  if (proton_engine_window_browser(window) != NULL) {
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host != NULL) {
       host->set_focus(host, 1);
       host->base.release((cef_base_ref_counted_t *)host);
@@ -1442,12 +1433,12 @@ int32_t proton_engine_window_apply(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   if (action->kind == PROTON_ENGINE_WINDOW_SET_ZOOM_PERCENT) {
-    if (window->browser == NULL) {
+    if (proton_engine_window_browser(window) == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser is not initialized");
       return PROTON_ERR_NOT_INITIALIZED;
     }
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available");
@@ -1627,11 +1618,11 @@ int32_t proton_engine_window_load_url(proton_engine_window_t *window,
                                       const char *url,
                                       char *error,
                                       size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -1648,11 +1639,11 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
                                   const char *script,
                                   char *error,
                                   size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -1672,12 +1663,12 @@ int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(
-      window->browser_session, window->browser, command_json, error,
+      window->browser_session, proton_engine_window_browser(window), command_json, error,
       error_len);
 }
 
@@ -1685,7 +1676,7 @@ int32_t proton_engine_window_get_browser_focus_state(
     proton_engine_window_t *window, int32_t *out_focused,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -1696,9 +1687,9 @@ int32_t proton_engine_window_get_browser_focus_state(
   }
   if (window->headless) {
     return proton_browser_headless_is_focused(
-        window->browser, out_focused, error, error_len);
+        proton_engine_window_browser(window), out_focused, error, error_len);
   }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
   if (host == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser host is not available");
@@ -1724,43 +1715,43 @@ int32_t proton_engine_window_get_browser_focus_state(
 int32_t proton_engine_window_get_devtools_state(
     proton_engine_window_t *window, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      window->browser, out_opened, error, error_len);
+      proton_engine_window_browser(window), out_opened, error, error_len);
 }
 
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_window_browser(window), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_window_download_url(
     proton_engine_window_t *window, const char *url, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_download_url(window->browser, url, error, error_len);
+  return proton_browser_download_url(proton_engine_window_browser(window), url, error, error_len);
 }
 
 int32_t proton_engine_window_print(
     proton_engine_window_t *window, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_print(window->browser, error, error_len);
+  return proton_browser_print(proton_engine_window_browser(window), error, error_len);
 }
 
 int32_t proton_engine_window_print_to_pdf(
@@ -1773,12 +1764,12 @@ int32_t proton_engine_window_print_to_pdf(
     const char *footer_template, int32_t generate_tagged_pdf,
     int32_t generate_document_outline, int32_t *out_request_id,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_print_to_pdf(
-      window->browser_session, window->browser, path, landscape,
+      window->browser_session, proton_engine_window_browser(window), path, landscape,
       print_background, scale, paper_width, paper_height,
       prefer_css_page_size, margin_type, margin_top, margin_right,
       margin_bottom, margin_left, page_ranges, display_header_footer,
@@ -1791,46 +1782,46 @@ int32_t proton_engine_window_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      window->browser_session, window->browser, text, forward, match_case,
+      window->browser_session, proton_engine_window_browser(window), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_window_stop_find_in_page(
     proton_engine_window_t *window, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      window->browser, clear_selection, error, error_len);
+      proton_engine_window_browser(window), clear_selection, error, error_len);
 }
 
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_set_audio_muted(
-      window->browser, muted, error, error_len);
+      proton_engine_window_browser(window), muted, error, error_len);
 }
 
 int32_t proton_engine_window_is_audio_muted(
     proton_engine_window_t *window, int32_t *out_muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_audio_muted(
-      window->browser, out_muted, error, error_len);
+      proton_engine_window_browser(window), out_muted, error, error_len);
 }
 
 int32_t proton_engine_window_get_browser_url(
@@ -1897,12 +1888,12 @@ int32_t proton_engine_window_emit_bridge_event_json(
     const char *event_json,
     char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL ||
+  if (window == NULL || proton_engine_window_browser(window) == NULL ||
       window->bridge_config_json == NULL) {
     proton_engine_set_message(error, error_len, "bridge is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  if (!proton_engine_bridge_send_event(window->browser, event_json)) {
+  if (!proton_engine_bridge_send_event(proton_engine_window_browser(window), event_json)) {
     proton_engine_set_message(error, error_len,
                               "failed to send bridge event to renderer");
     return PROTON_ERR_ENGINE;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -442,7 +442,7 @@ static int32_t proton_engine_window_create_browser(
       extra_info_value != NULL
           ? extra_info_value->get_dictionary(extra_info_value)
           : NULL;
-  window->browser = cef_browser_host_create_browser_sync(
+  cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
       &window_info, &window->client->client, &url, &browser_settings,
       extra_info, NULL);
   if (extra_info_value != NULL) {
@@ -450,11 +450,17 @@ static int32_t proton_engine_window_create_browser(
   }
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
-  if (window->browser == NULL) {
+  if (created_browser == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_engine_set_message(error, error_len, "browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  window->browser_id = window->browser->get_identifier(window->browser);
+  proton_browser_lifecycle_adopt_created(window->browser_lifecycle,
+                                         created_browser);
+  window->browser =
+      proton_browser_lifecycle_browser(window->browser_lifecycle);
+  window->browser_id =
+      proton_browser_lifecycle_browser_id(window->browser_lifecycle);
   proton_engine_window_list_add(window);
   proton_engine_sync_browser_bounds(window);
   return PROTON_OK;
@@ -523,28 +529,41 @@ int32_t proton_engine_window_create(
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
       &config.browser_policy, proton_engine_browser_signal, NULL);
-  if (window->browser_session == NULL) {
+  window->browser_lifecycle = proton_browser_lifecycle_create(
+      runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
+  if (window->browser_session == NULL || window->browser_lifecycle == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     free(window->bridge_config_json);
+    proton_browser_session_destroy(window->browser_session);
     free(window);
     proton_engine_set_message(error, error_len,
-                              "failed to allocate browser session");
+                              "failed to allocate browser state");
     return PROTON_ERR_ENGINE;
   }
   proton_browser_session_bind_window(window->browser_session,
                                      config.public_window);
-  window->client = proton_engine_client_create(window);
+  proton_browser_session_bind_lifecycle(window->browser_session,
+                                        window->browser_lifecycle);
+  window->client = proton_engine_client_create(
+      window, window->browser_lifecycle);
   if (window->client == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
     free(window);
     proton_engine_set_message(error, error_len, "failed to allocate client");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(window->browser_lifecycle,
+                                      &window->client->client);
 
   if (!window->headless) {
     window->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     if (window->window == NULL) {
-      free(window->client);
+      window->client->window = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
       free(window->bridge_config_json);
       free(window);
@@ -554,7 +573,9 @@ int32_t proton_engine_window_create(
     window->root_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     if (window->root_box == NULL) {
       gtk_widget_destroy(window->window);
-      free(window->client);
+      window->client->window = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
       free(window->bridge_config_json);
       free(window);
@@ -576,7 +597,9 @@ int32_t proton_engine_window_create(
       window->overlay = gtk_overlay_new();
       if (window->overlay == NULL) {
         gtk_widget_destroy(window->window);
-        free(window->client);
+        window->client->window = NULL;
+        proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+        proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
         free(window->bridge_config_json);
         free(window);
@@ -588,7 +611,9 @@ int32_t proton_engine_window_create(
     window->browser_host = gtk_drawing_area_new();
     if (window->browser_host == NULL) {
       gtk_widget_destroy(window->window);
-      free(window->client);
+      window->client->window = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
       free(window->bridge_config_json);
       free(window);
@@ -601,7 +626,9 @@ int32_t proton_engine_window_create(
       gtk_container_add(GTK_CONTAINER(window->overlay), window->browser_host);
       if (!proton_engine_overlay_create_controls(window)) {
         gtk_widget_destroy(window->window);
-        free(window->client);
+        window->client->window = NULL;
+        proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+        proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
         free(window->bridge_config_json);
         free(window);
@@ -621,7 +648,9 @@ int32_t proton_engine_window_create(
           window, runtime->menu_definition, error, error_len);
       if (status != PROTON_OK) {
         gtk_widget_destroy(window->window);
-        free(window->client);
+        window->client->window = NULL;
+        proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+        proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
         free(window->bridge_config_json);
         free(window);
@@ -665,7 +694,8 @@ int32_t proton_engine_window_create(
     if (window->window != NULL) {
       gtk_widget_destroy(window->window);
     }
-    free(window->client);
+    window->client->window = NULL;
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
     free(window);
@@ -696,19 +726,12 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
     return PROTON_OK;
   }
   if (window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
-    if (host == NULL) {
-      proton_engine_set_message(error, error_len,
-                                "browser host is not available for close");
-      return PROTON_ERR_ENGINE;
-    }
     proton_engine_bridge_pending_remove_browser(window->runtime,
                                                 window->browser_id);
     window->destroy_requested = 1;
     window->closing = 1;
     proton_engine_window_close_views(window);
-    host->close_browser(host, 1);
-    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_lifecycle_request_close(window->browser_lifecycle, 1);
     return PROTON_OK;
   }
   window->closed = 1;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -634,7 +634,7 @@ static int CEF_CALLBACK proton_engine_client_on_process_message_received(
   free(message_name);
   int browser_id = proton_engine_browser_id(browser);
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(browser_id);
+      proton_engine_window_lookup_browser(browser);
   if (is_lifecycle) {
     cef_list_value_t *args = message->get_argument_list(message);
     if (window != NULL && frame->is_main(frame) && args != NULL &&
@@ -995,49 +995,6 @@ proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
   return lifecycle;
 }
 
-static proton_engine_window_t *proton_engine_window_from_browser_client(
-    cef_browser_t *browser) {
-  if (browser == NULL) {
-    return NULL;
-  }
-  cef_browser_host_t *host = browser->get_host(browser);
-  if (host == NULL) {
-    return NULL;
-  }
-  cef_client_t *cef_client = host->get_client(host);
-  proton_engine_window_t *window = NULL;
-  if (cef_client != NULL) {
-    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
-    window = client->window;
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  host->base.release((cef_base_ref_counted_t *)host);
-  return window;
-}
-
-// Resolves a view through the browser's client. Unlike the browser-id list
-// scan this also works while cef_browser_host_create_browser_sync is still
-// running, before the view records its browser id.
-static proton_engine_view_t *proton_engine_view_from_browser_client(
-    cef_browser_t *browser) {
-  if (browser == NULL) {
-    return NULL;
-  }
-  cef_browser_host_t *host = browser->get_host(browser);
-  if (host == NULL) {
-    return NULL;
-  }
-  cef_client_t *cef_client = host->get_client(host);
-  proton_engine_view_t *view = NULL;
-  if (cef_client != NULL) {
-    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
-    view = client->view;
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  host->base.release((cef_base_ref_counted_t *)host);
-  return view;
-}
-
 static void CEF_CALLBACK proton_engine_osr_get_view_rect(
     cef_render_handler_t *self,
     cef_browser_t *browser,
@@ -1049,11 +1006,11 @@ static void CEF_CALLBACK proton_engine_osr_get_view_rect(
   rect->x = 0;
   rect->y = 0;
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_view_browser(browser);
   if (view == NULL) {
     // CEF can query the viewport while create_browser_sync is still running,
     // before the view records its browser id; resolve via the client then.
-    view = proton_engine_view_from_browser_client(browser);
+    view = proton_engine_window_lookup_view_browser(browser);
   }
   if (view != NULL) {
     rect->width = view->width > 0 ? view->width : 1;
@@ -1061,7 +1018,7 @@ static void CEF_CALLBACK proton_engine_osr_get_view_rect(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_lookup_browser(browser);
   rect->width = window != NULL && window->width > 0 ? window->width : 1;
   rect->height = window != NULL && window->height > 0 ? window->height : 1;
 }
@@ -1091,7 +1048,7 @@ static void CEF_CALLBACK proton_engine_osr_on_popup_show(
     int show) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_lookup_browser(browser);
   if (window != NULL) {
     window->osr_popup_visible = show ? 1 : 0;
   }
@@ -1103,7 +1060,7 @@ static void CEF_CALLBACK proton_engine_osr_on_popup_size(
     const cef_rect_t *rect) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_lookup_browser(browser);
   if (window != NULL && rect != NULL) {
     window->osr_popup_rect = *rect;
   }
@@ -1141,14 +1098,12 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_new(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
     return NULL;
   }
-  client->window = window;
   client->browser_lifecycle = browser_lifecycle;
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
@@ -1218,9 +1173,6 @@ static void proton_engine_window_free_storage(
     DeleteObject(window->background_brush);
     window->background_brush = NULL;
   }
-  if (window->client != NULL) {
-    ((proton_engine_client_t *)window->client)->window = NULL;
-  }
   proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   proton_browser_session_destroy(window->browser_session);
@@ -1276,7 +1228,7 @@ static int CEF_CALLBACK proton_engine_on_before_popup(
   (void)extra_info;
   (void)no_javascript_access;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_before_popup(
       window != NULL ? window->browser_session : NULL, target_url,
       target_disposition, user_gesture);
@@ -1304,8 +1256,6 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     view->closed = 1;
     proton_view_events_closed(view->events);
     view->hwnd = NULL;
-    view->browser = NULL;
-    view->browser_id = 0;
     // A page-initiated close (JS window.close) reaches here without a prior
     // engine destroy; let the cleanup state machine finish so the struct can
     // be reclaimed with its owning window.
@@ -1323,14 +1273,14 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   }
   proton_engine_window_t *window =
       (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  if (window != NULL) {
+    proton_engine_bridge_pending_remove_browser(
+        window->runtime, proton_browser_lifecycle_browser_id(lifecycle));
+  }
   proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window == NULL) {
     return;
   }
-  proton_engine_bridge_pending_remove_browser(window->runtime,
-                                              window->browser_id);
-  window->browser = NULL;
-  window->browser_id = 0;
   window->closed = 1;
   if (window->hwnd != NULL) {
     // CEF keeps unwinding the browser teardown after this callback returns,
@@ -1381,7 +1331,7 @@ static void CEF_CALLBACK proton_engine_on_draggable_regions_changed(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   if (window == NULL || !window->titlebar_overlay) {
     return;
   }
@@ -1430,7 +1380,7 @@ static void CEF_CALLBACK proton_engine_on_loading_state_change(
   (void)canGoBack;
   (void)canGoForward;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_lookup_browser(browser);
   if (!isLoading && window != NULL && window->headless) {
     // The resize notification sent during synchronous browser creation can
     // precede compositor readiness. Invalidate after loading settles so a
@@ -1455,7 +1405,7 @@ static void CEF_CALLBACK proton_engine_on_load_start(
   char *url = frame != NULL ? proton_engine_userfree_to_utf8(frame->get_url(frame))
                             : NULL;
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_view_browser(browser);
   if (view != NULL) {
     if (frame != NULL && frame->is_main(frame) && url != NULL &&
         strcmp(url, "about:blank") != 0) {
@@ -1470,7 +1420,7 @@ static void CEF_CALLBACK proton_engine_on_load_start(
   if (frame != NULL && frame->is_main(frame) && url != NULL &&
       strcmp(url, "about:blank") != 0) {
     proton_engine_window_t *window =
-        proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+        proton_engine_window_lookup_browser(browser);
     proton_browser_session_navigated(
         window != NULL ? window->browser_session : NULL, url);
     proton_browser_session_loading_changed(
@@ -1489,7 +1439,7 @@ static void CEF_CALLBACK proton_engine_on_load_end(
   char *url = frame != NULL ? proton_engine_userfree_to_utf8(frame->get_url(frame))
                             : NULL;
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_view_browser(browser);
   if (view != NULL) {
     if (frame != NULL && frame->is_main(frame)) {
       proton_view_events_loading_changed(view->events, 0);
@@ -1500,7 +1450,7 @@ static void CEF_CALLBACK proton_engine_on_load_end(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   if (window != NULL && frame != NULL && frame->is_main(frame)) {
     proton_browser_session_loading_changed(window->browser_session, url, 0);
   }
@@ -1523,7 +1473,7 @@ static void CEF_CALLBACK proton_engine_on_load_error(
   char *text = proton_engine_cef_string_to_utf8(errorText);
   char *url = proton_engine_cef_string_to_utf8(failedUrl);
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_view_browser(browser);
   if (view != NULL) {
     if (frame != NULL && frame->is_main(frame)) {
       proton_view_events_load_failed(view->events, url, (int32_t)errorCode,
@@ -1536,7 +1486,7 @@ static void CEF_CALLBACK proton_engine_on_load_error(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   if (frame != NULL && frame->is_main(frame)) {
     proton_browser_session_load_failed(
         window != NULL ? window->browser_session : NULL, url,
@@ -1558,7 +1508,7 @@ static int CEF_CALLBACK proton_engine_on_before_browse(
     cef_request_t *request, int user_gesture, int is_redirect) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_before_browse(
       window != NULL ? window->browser_session : NULL, frame, request,
       user_gesture, is_redirect);
@@ -1571,7 +1521,7 @@ static int CEF_CALLBACK proton_engine_on_certificate_error(
   (void)self;
   (void)ssl_info;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_certificate_error(
       window != NULL ? window->browser_session : NULL, cert_error,
       request_url, callback);
@@ -1584,7 +1534,7 @@ static int CEF_CALLBACK proton_engine_can_download(
   (void)url;
   (void)request_method;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_can_download(
       window != NULL ? window->browser_session : NULL);
 }
@@ -1595,7 +1545,7 @@ static int CEF_CALLBACK proton_engine_on_before_download(
     cef_before_download_callback_t *callback) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_before_download(
       window != NULL ? window->browser_session : NULL, download_item,
       suggested_name, callback);
@@ -1607,7 +1557,7 @@ static void CEF_CALLBACK proton_engine_on_download_updated(
     cef_download_item_callback_t *callback) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   proton_browser_session_download_updated(
       window != NULL ? window->browser_session : NULL, download_item,
       callback);
@@ -1623,7 +1573,7 @@ static void CEF_CALLBACK proton_engine_on_find_result(
   int width = selection_rect != NULL ? selection_rect->width : 0;
   int height = selection_rect != NULL ? selection_rect->height : 0;
   int browser_id = proton_engine_browser_id(browser);
-  proton_engine_view_t *view = proton_engine_find_view_by_browser_id(browser_id);
+  proton_engine_view_t *view = proton_engine_window_lookup_view_browser(browser);
   if (view != NULL) {
     proton_view_events_find_result(
         view->events,
@@ -1633,7 +1583,7 @@ static void CEF_CALLBACK proton_engine_on_find_result(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(browser_id);
+      proton_engine_window_lookup_browser(browser);
   proton_browser_session_find_result(
       window != NULL ? window->browser_session : NULL, identifier, count,
       x, y, width, height, active_match_ordinal, final_update);
@@ -1646,7 +1596,7 @@ static int CEF_CALLBACK proton_engine_on_media_permission(
   (void)self;
   (void)frame;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   return proton_browser_session_media_permission(
       window != NULL ? window->browser_session : NULL, requesting_origin,
       requested_permissions, callback);
@@ -1658,7 +1608,7 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
     const cef_string_t *error_string) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   if (window == NULL || window->bridge_config_json == NULL || window->closed) {
     return;
   }
@@ -1732,12 +1682,23 @@ proton_engine_client_get_render_handler(cef_client_t *self) {
   if (client == NULL) {
     return NULL;
   }
-  if (client->view != NULL) {
-    if (client->view->window == NULL || !client->view->window->headless) {
+  proton_browser_lifecycle_t *lifecycle = client->browser_lifecycle;
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    return NULL;
+  }
+  if (proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view == NULL || view->window == NULL || !view->window->headless) {
       return NULL;
     }
-  } else if (client->window == NULL || !client->window->headless) {
-    return NULL;
+  } else {
+    proton_engine_window_t *window =
+        (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (window == NULL || !window->headless) {
+      return NULL;
+    }
   }
   g_proton_engine_render_handler.handler.base.add_ref(
       (cef_base_ref_counted_t *)&g_proton_engine_render_handler.handler);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -110,6 +110,8 @@ static int CEF_CALLBACK proton_engine_on_before_popup(
     cef_dictionary_value_t **extra_info, int *no_javascript_access);
 static void CEF_CALLBACK proton_engine_on_before_close(
     cef_life_span_handler_t *self, cef_browser_t *browser);
+static void CEF_CALLBACK proton_engine_on_after_created(
+    cef_life_span_handler_t *self, cef_browser_t *browser);
 static void CEF_CALLBACK proton_engine_on_draggable_regions_changed(
     cef_drag_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     size_t regions_count, const cef_draggable_region_t *regions);
@@ -887,6 +889,8 @@ void proton_engine_init_app(void) {
       proton_engine_on_load_error;
   g_proton_engine_life_span_handler.handler.on_before_popup =
       proton_engine_on_before_popup;
+  g_proton_engine_life_span_handler.handler.on_after_created =
+      proton_engine_on_after_created;
   g_proton_engine_life_span_handler.handler.on_before_close =
       proton_engine_on_before_close;
   g_proton_engine_life_span_handler.handler.do_close = proton_engine_do_close;
@@ -971,10 +975,24 @@ int proton_engine_utf8_to_wide(const char *value,
   return written;
 }
 
-void proton_engine_browser_release(cef_browser_t *browser) {
-  if (browser != NULL) {
-    browser->base.release((cef_base_ref_counted_t *)browser);
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
+    cef_browser_t *browser) {
+  if (browser == NULL) {
+    return NULL;
   }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    return NULL;
+  }
+  cef_client_t *cef_client = host->get_client(host);
+  proton_browser_lifecycle_t *lifecycle = NULL;
+  if (cef_client != NULL) {
+    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
+    lifecycle = client->browser_lifecycle;
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
+  }
+  host->base.release((cef_base_ref_counted_t *)host);
+  return lifecycle;
 }
 
 static proton_engine_window_t *proton_engine_window_from_browser_client(
@@ -1123,18 +1141,19 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_new(
-    proton_engine_window_t *window) {
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
     return NULL;
   }
   client->window = window;
+  client->browser_lifecycle = browser_lifecycle;
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
-  // The client must outlive the browser: CEF releases its own reference only
-  // after OnBeforeClose returns, so ownership is tracked by the refcount and
-  // the final release frees the allocation instead of an eager free().
+  // The registry keeps the initial client reference until CEF shutdown; CEF
+  // may hold additional references through and beyond OnBeforeClose.
   client->client.base.release = proton_engine_client_release;
   client->client.on_process_message_received =
       proton_engine_client_on_process_message_received;
@@ -1153,6 +1172,23 @@ proton_engine_client_t *proton_engine_client_new(
       proton_engine_client_get_permission_handler;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
+}
+
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle) {
+  (void)context;
+  proton_engine_client_t *client =
+      (proton_engine_client_t *)calloc(1, sizeof(*client));
+  if (client == NULL) {
+    return NULL;
+  }
+  proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
+                                 sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
+  client->browser_lifecycle = browser_lifecycle;
+  client->client.get_life_span_handler =
+      proton_engine_client_get_life_span_handler;
+  return &client->client;
 }
 
 void proton_engine_window_defer_free(proton_engine_window_t *window) {
@@ -1183,14 +1219,9 @@ static void proton_engine_window_free_storage(
     window->background_brush = NULL;
   }
   if (window->client != NULL) {
-    // Drop only the engine's reference. CEF releases its client reference
-    // after OnBeforeClose, and the last release frees the client.
-    cef_base_ref_counted_t *client_base =
-        (cef_base_ref_counted_t *)window->client;
     ((proton_engine_client_t *)window->client)->window = NULL;
-    window->client = NULL;
-    client_base->release(client_base);
   }
+  proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   proton_browser_session_destroy(window->browser_session);
   free(window->draggable_regions);
@@ -1255,18 +1286,26 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
   (void)self;
-  proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
-  if (view != NULL) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL) {
+    return;
+  }
+  proton_browser_role_t role = proton_browser_lifecycle_role(lifecycle);
+  if (role == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view == NULL) {
+      proton_browser_lifecycle_on_before_close(lifecycle, browser);
+      return;
+    }
     proton_engine_runtime_t *runtime = view->window->runtime;
-    view->browser_before_close_seen = 1;
+    proton_browser_lifecycle_on_before_close(lifecycle, browser);
     view->closed = 1;
     proton_view_events_closed(view->events);
     view->hwnd = NULL;
-    if (view->browser != NULL) {
-      proton_engine_browser_release(view->browser);
-      view->browser = NULL;
-    }
+    view->browser = NULL;
+    view->browser_id = 0;
     // A page-initiated close (JS window.close) reaches here without a prior
     // engine destroy; let the cleanup state machine finish so the struct can
     // be reclaimed with its owning window.
@@ -1275,19 +1314,24 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     proton_engine_signal_wait_source(runtime, PROTON_WAIT_PLATFORM);
     return;
   }
+  if (role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    proton_browser_lifecycle_on_before_close(lifecycle, browser);
+    proton_engine_runtime_t *runtime =
+        (proton_engine_runtime_t *)proton_browser_lifecycle_context(lifecycle);
+    proton_engine_signal_wait_source(runtime, PROTON_WAIT_PLATFORM);
+    return;
+  }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window == NULL) {
     return;
   }
   proton_engine_bridge_pending_remove_browser(window->runtime,
                                               window->browser_id);
-  if (window->browser != NULL) {
-    proton_engine_browser_release(window->browser);
-    window->browser = NULL;
-  }
+  window->browser = NULL;
+  window->browser_id = 0;
   window->closed = 1;
-  window->browser_close_requested = 1;
   if (window->hwnd != NULL) {
     // CEF keeps unwinding the browser teardown after this callback returns,
     // and on the external message pump route it can still touch frame-window
@@ -1297,6 +1341,27 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   }
   proton_engine_signal_wait_source(window->runtime, PROTON_WAIT_PLATFORM);
   proton_engine_window_finalize_if_ready(window);
+}
+
+static void CEF_CALLBACK proton_engine_on_after_created(
+    cef_life_span_handler_t *self,
+    cef_browser_t *browser) {
+  (void)self;
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL) {
+    cef_browser_host_t *host = browser != NULL ? browser->get_host(browser)
+                                                : NULL;
+    if (host != NULL) {
+      host->close_browser(host, 1);
+      host->base.release((cef_base_ref_counted_t *)host);
+    }
+    return;
+  }
+  proton_browser_lifecycle_on_after_created(lifecycle, browser);
+  proton_engine_runtime_t *runtime =
+      (proton_engine_runtime_t *)proton_browser_lifecycle_context(lifecycle);
+  proton_engine_signal_wait_source(runtime, PROTON_WAIT_PLATFORM);
 }
 
 cef_life_span_handler_t *CEF_CALLBACK

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -68,9 +68,6 @@ struct proton_engine_window {
   HWND hwnd;
   proton_engine_runtime_t *runtime;
   proton_window_id_t public_window_id;
-  cef_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   char *bridge_config_json;
   int32_t max_bridge_payload_bytes;
@@ -134,7 +131,6 @@ void proton_engine_browser_signal(void *user_data);
 int proton_engine_browser_id(cef_browser_t *browser);
 proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
     cef_browser_t *browser);
-proton_engine_view_t *proton_engine_find_view_by_browser_id(int browser_id);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
 int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd);
 void proton_win_menu_dispatch_command(proton_engine_window_t *window,
@@ -238,8 +234,6 @@ typedef struct {
 struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
-  proton_engine_window_t *window;
-  proton_engine_view_t *view;
   proton_browser_lifecycle_t *browser_lifecycle;
 };
 
@@ -250,9 +244,6 @@ struct proton_engine_client {
    was closed. */
 struct proton_engine_view {
   proton_engine_window_t *window;
-  proton_engine_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   HWND hwnd;
   int32_t x;
@@ -284,7 +275,6 @@ int proton_engine_runtime_enqueue_bridge_request(
 int proton_engine_runtime_enqueue_bridge_cancellation(
     proton_engine_runtime_t *runtime,
     int64_t request_id);
-proton_engine_window_t *proton_engine_find_window_by_browser_id(int browser_id);
 proton_engine_window_t *proton_engine_windows_head(void);
 void proton_engine_window_list_add(proton_engine_window_t *window);
 void proton_engine_window_list_remove(proton_engine_window_t *window);
@@ -309,7 +299,6 @@ void proton_engine_bridge_pending_remove_browser(
     proton_engine_runtime_t *runtime,
     int browser_id);
 proton_engine_client_t *proton_engine_client_new(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle);
 cef_client_t *proton_engine_browser_client_factory(
     void *context, proton_browser_lifecycle_t *browser_lifecycle);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -5,6 +5,7 @@
 #include "../../proton_engine.h"
 #include "../../proton_event.h"
 #include "../cef_common/bridge_lifecycle.h"
+#include "../cef_common/browser_lifecycle.h"
 #include "../cef_common/browser_session.h"
 #include "../cef_common/view_events.h"
 #include "../cef_common/window_state.h"
@@ -60,6 +61,7 @@ struct proton_engine_runtime {
   char dialog_ok_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   proton_menu_bar_t *menu_definition;
+  proton_browser_registry_t *browsers;
 };
 
 struct proton_engine_window {
@@ -69,6 +71,7 @@ struct proton_engine_window {
   cef_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   char *bridge_config_json;
   int32_t max_bridge_payload_bytes;
   proton_engine_bridge_lifecycle_t bridge_lifecycle;
@@ -107,7 +110,6 @@ struct proton_engine_window {
   proton_win_titlebar_region_t *draggable_regions;
   size_t draggable_region_count;
   int draggable_regions_reported;
-  int browser_close_requested;
   int close_interception_enabled;
   int close_authorized;
   int close_request_pending;
@@ -130,7 +132,8 @@ void proton_engine_signal_wait_source(proton_engine_runtime_t *runtime,
                                       uint32_t ready_mask);
 void proton_engine_browser_signal(void *user_data);
 int proton_engine_browser_id(cef_browser_t *browser);
-void proton_engine_browser_release(cef_browser_t *browser);
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
+    cef_browser_t *browser);
 proton_engine_view_t *proton_engine_find_view_by_browser_id(int browser_id);
 void proton_engine_window_defer_free(proton_engine_window_t *window);
 int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd);
@@ -237,6 +240,7 @@ struct proton_engine_client {
   proton_engine_ref_counted_t refs;
   proton_engine_window_t *window;
   proton_engine_view_t *view;
+  proton_browser_lifecycle_t *browser_lifecycle;
 };
 
 /* A web contents view: an extra child browser hosted inside a window's client
@@ -249,6 +253,7 @@ struct proton_engine_view {
   proton_engine_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   HWND hwnd;
   int32_t x;
   int32_t y;
@@ -264,8 +269,6 @@ struct proton_engine_view {
   proton_view_events_t *events;
   int has_background_color;
   uint32_t background_color;
-  int browser_close_requested;
-  int browser_before_close_seen;
   int finalize_after_browser_close;
   int finalized;
   int closed;
@@ -306,7 +309,10 @@ void proton_engine_bridge_pending_remove_browser(
     proton_engine_runtime_t *runtime,
     int browser_id);
 proton_engine_client_t *proton_engine_client_new(
-    proton_engine_window_t *window);
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle);
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle);
 int CEF_CALLBACK proton_engine_client_release(cef_base_ref_counted_t *base);
 int proton_engine_utf8_to_wide(const char *value,
                                wchar_t *buffer,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_menu.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_menu.c
@@ -337,15 +337,15 @@ static int32_t proton_win_menu_append_definition(
 
 static void proton_win_menu_apply_edit_role(proton_engine_window_t *window,
                                              const char *role) {
-  if (window == NULL || window->browser == NULL || role == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL || role == NULL) {
     return;
   }
   cef_frame_t *frame =
-      window->browser->get_focused_frame != NULL
-          ? window->browser->get_focused_frame(window->browser)
+      proton_engine_window_browser(window)->get_focused_frame != NULL
+          ? proton_engine_window_browser(window)->get_focused_frame(proton_engine_window_browser(window))
           : NULL;
   if (frame == NULL) {
-    frame = window->browser->get_main_frame(window->browser);
+    frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   }
   if (frame == NULL) {
     return;
@@ -465,7 +465,7 @@ int32_t proton_engine_window_popup_menu(
                               "popup menu requires at least one menu");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (window->hwnd == NULL || window->browser == NULL) {
+  if (window->hwnd == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "window is not ready for a popup menu");
     return PROTON_ERR_INVALID_ARGUMENT;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
@@ -348,27 +348,36 @@ void proton_engine_window_unlock(void) {
 
 proton_engine_window_t *proton_engine_window_lookup_browser(
     cef_browser_t *browser) {
-  int browser_id = proton_engine_browser_id(browser);
-  if (browser_id == 0) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_MAIN) {
     return NULL;
   }
-  for (proton_engine_window_t *window = g_proton_engine_windows;
-       window != NULL; window = window->next) {
-    if (window->browser_id == browser_id) {
-      return window;
-    }
-  }
-  return NULL;
+  return (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 cef_browser_t *proton_engine_window_browser(proton_engine_window_t *window) {
-  return window != NULL ? window->browser : NULL;
+  return window != NULL
+             ? proton_browser_lifecycle_browser(window->browser_lifecycle)
+             : NULL;
+}
+
+cef_browser_t *proton_engine_view_browser(proton_engine_view_t *view) {
+  return view != NULL
+             ? proton_browser_lifecycle_browser(view->browser_lifecycle)
+             : NULL;
 }
 
 proton_engine_view_t *proton_engine_window_lookup_view_browser(
     cef_browser_t *browser) {
-  return proton_engine_find_view_by_browser_id(
-      proton_engine_browser_id(browser));
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_VIEW) {
+    return NULL;
+  }
+  return (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 proton_window_id_t proton_engine_view_window_public_id(
@@ -391,45 +400,6 @@ proton_view_id_t proton_engine_view_public_id(proton_engine_view_t *view) {
   }
   return view_id;
 }
-
-proton_engine_view_t *proton_engine_find_view_by_browser_id(int browser_id) {
-  if (browser_id == 0 || !g_proton_engine_window_lock_initialized) {
-    return NULL;
-  }
-  proton_engine_view_t *found = NULL;
-  EnterCriticalSection(&g_proton_engine_window_lock);
-  for (proton_engine_window_t *window = g_proton_engine_windows;
-       window != NULL && found == NULL; window = window->next) {
-    for (proton_engine_view_t *view = window->views; view != NULL;
-         view = view->next) {
-      if (view->browser_id == browser_id) {
-        found = view;
-        break;
-      }
-    }
-  }
-  LeaveCriticalSection(&g_proton_engine_window_lock);
-  return found;
-}
-
-proton_engine_window_t *proton_engine_find_window_by_browser_id(int browser_id) {
-  if (browser_id == 0 || !g_proton_engine_window_lock_initialized) {
-    return NULL;
-  }
-  proton_engine_window_t *found = NULL;
-  EnterCriticalSection(&g_proton_engine_window_lock);
-  for (proton_engine_window_t *window = g_proton_engine_windows;
-       window != NULL; window = window->next) {
-    if (window->browser_id == browser_id) {
-      found = window;
-      break;
-    }
-  }
-  LeaveCriticalSection(&g_proton_engine_window_lock);
-  return found;
-}
-
-
 
 
 static void proton_engine_remove_temporary_profile(void) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
@@ -591,6 +591,17 @@ int32_t proton_engine_runtime_create(
   runtime->owns_cef_runtime = 1;
   runtime->headless = config.headless;
   runtime->next_bridge_request_id = 1;
+  runtime->browsers = proton_browser_registry_create(
+      proton_engine_browser_client_factory, runtime);
+  if (runtime->browsers == NULL) {
+    free(runtime);
+    proton_engine_cef_shutdown();
+    g_proton_cef_runtime_active = 0;
+    proton_engine_release_pump_event();
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser registry");
+    return PROTON_ERR_ENGINE;
+  }
   snprintf(runtime->dialog_ok_label, sizeof(runtime->dialog_ok_label), "%s",
            config.dialog_ok_label);
   snprintf(runtime->dialog_cancel_label,
@@ -613,6 +624,7 @@ static void proton_engine_dispose_runtime_state(
   }
   g_proton_cef_runtime_active = 0;
   proton_menu_bar_destroy(runtime->menu_definition);
+  proton_browser_registry_destroy(runtime->browsers);
   free(runtime);
 }
 
@@ -620,8 +632,10 @@ int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
   if (runtime == NULL) {
     return 0;
   }
+  proton_browser_registry_begin_shutdown(runtime->browsers);
   if (!g_proton_engine_window_lock_initialized) {
-    return g_proton_engine_windows == NULL;
+    return g_proton_engine_windows == NULL &&
+           proton_browser_registry_shutdown_ready(runtime->browsers);
   }
   int32_t ready = 1;
   EnterCriticalSection(&g_proton_engine_window_lock);
@@ -633,7 +647,8 @@ int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
     }
   }
   LeaveCriticalSection(&g_proton_engine_window_lock);
-  return ready && proton_engine_closed_windows_ready_for_shutdown();
+  return ready && proton_engine_closed_windows_ready_for_shutdown() &&
+         proton_browser_registry_shutdown_ready(runtime->browsers);
 }
 
 int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
@@ -644,6 +659,7 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_dialog_cancel_runtime(runtime);
+  proton_browser_registry_begin_shutdown(runtime->browsers);
   if (runtime->owns_cef_runtime) {
     if (!proton_engine_runtime_destroy_ready(runtime)) {
       proton_engine_set_message(error, error_len,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_titlebar.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_titlebar.c
@@ -333,10 +333,10 @@ void proton_engine_overlay_subclass_browser(
 void proton_engine_resize_browser(proton_engine_window_t *window,
                                   int width,
                                   int height) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     return;
   }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
   if (host == NULL) {
     return;
   }

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -62,9 +62,6 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_engine_view_t *next = view->next;
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    if (view->client != NULL) {
-      view->client->view = NULL;
-    }
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     view = next;
@@ -81,9 +78,6 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
   if (browser_state != PROTON_BROWSER_CLOSED &&
       browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
-  }
-  if (view->client != NULL) {
-    view->client->view = NULL;
   }
   proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   view->hwnd = NULL;
@@ -125,7 +119,7 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
     if (!view->closed) {
       view->closed = 1;
       view->finalize_after_browser_close = 1;
-      if (view->browser != NULL) {
+      if (proton_engine_view_browser(view) != NULL) {
         proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
       }
     } else if (!view->finalize_after_browser_close) {
@@ -221,7 +215,7 @@ void CEF_CALLBACK proton_engine_on_title_change(
     const cef_string_t *title) {
   (void)self;
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_view_browser(browser);
   char *title_utf8 = proton_engine_cef_string_to_utf8(title);
   if (view != NULL) {
     proton_view_events_title_updated(view->events, title_utf8);
@@ -230,7 +224,7 @@ void CEF_CALLBACK proton_engine_on_title_change(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_find_window_by_browser_id(proton_engine_browser_id(browser));
+      proton_engine_window_lookup_browser(browser);
   proton_browser_session_title_updated(
       window != NULL ? window->browser_session : NULL, title_utf8);
   free(title_utf8);
@@ -252,7 +246,6 @@ void proton_engine_view_handlers_init(void) {
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
@@ -262,7 +255,6 @@ static proton_engine_client_t *proton_engine_view_client_create(
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
-  client->view = view;
   client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
@@ -273,7 +265,15 @@ static proton_engine_client_t *proton_engine_view_client_create(
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
-  client->client.get_find_handler = view->window->client->get_find_handler;
+  proton_engine_view_t *view =
+      (proton_engine_view_t *)proton_browser_lifecycle_owner(browser_lifecycle);
+  cef_client_t *window_client = view != NULL && view->window != NULL
+                                    ? proton_browser_lifecycle_client(
+                                          view->window->browser_lifecycle)
+                                    : NULL;
+  client->client.get_find_handler = window_client != NULL
+                                        ? window_client->get_find_handler
+                                        : NULL;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -308,7 +308,7 @@ static int32_t proton_engine_view_create_browser(
   proton_engine_set_string(&window_info.window_name, "ProtonView");
   proton_engine_set_string(&url, "about:blank");
   cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
-      &window_info, &view->client->client, &url, &browser_settings, NULL,
+      &window_info, proton_browser_lifecycle_client(view->browser_lifecycle), &url, &browser_settings, NULL,
       NULL);
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
@@ -319,10 +319,7 @@ static int32_t proton_engine_view_create_browser(
   }
   proton_browser_lifecycle_adopt_created(view->browser_lifecycle,
                                          created_browser);
-  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
-  view->browser_id =
-      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
-  cef_browser_host_t *host = view->browser->get_host(view->browser);
+  cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
     host->set_zoom_level(host, log(factor) / log(1.2));
@@ -344,7 +341,7 @@ static int32_t proton_engine_view_create_browser(
   proton_engine_window_layout_views(window);
   if (view->initial_url[0] != '\0' &&
       strcmp(view->initial_url, "about:blank") != 0) {
-    cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+    cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
     if (frame != NULL) {
       cef_string_t initial = {0};
       proton_engine_set_string(&initial, view->initial_url);
@@ -409,8 +406,8 @@ int32_t proton_engine_view_create(
                               "failed to allocate browser lifecycle");
     return PROTON_ERR_ENGINE;
   }
-  view->client = proton_engine_view_client_create(
-      view, view->browser_lifecycle);
+  proton_engine_client_t *client = proton_engine_view_client_create(
+      view->browser_lifecycle);
   proton_browser_policy_t view_policy = {PROTON_BROWSER_POLICY_ALLOW,
                                          PROTON_BROWSER_POLICY_DENY,
                                          PROTON_BROWSER_POLICY_DENY,
@@ -420,14 +417,13 @@ int32_t proton_engine_view_create(
   view->browser_session = proton_browser_session_create(
       &view_policy, proton_engine_browser_signal, NULL);
   view->events = proton_view_events_create();
-  if (view->client == NULL || view->browser_session == NULL ||
+  if (client == NULL || view->browser_session == NULL ||
       view->events == NULL) {
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    if (view->client != NULL) {
-      view->client->view = NULL;
+    if (client != NULL) {
       proton_browser_lifecycle_set_client(view->browser_lifecycle,
-                                          &view->client->client);
+                                          &client->client);
     }
     proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
@@ -437,7 +433,7 @@ int32_t proton_engine_view_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(view->browser_lifecycle,
-                                      &view->client->client);
+                                      &client->client);
   proton_browser_session_bind_lifecycle(view->browser_session,
                                         view->browser_lifecycle);
   proton_view_events_bind(view->events, config.public_view,
@@ -469,7 +465,7 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
   }
   view->closed = 1;
   view->finalize_after_browser_close = 1;
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
   }
   proton_engine_view_finalize_if_ready(view);
@@ -497,8 +493,8 @@ int32_t proton_engine_view_set_bounds(proton_engine_view_t *view,
   view->width = width;
   view->height = height;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL) {
         host->was_resized(host);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -523,8 +519,8 @@ int32_t proton_engine_view_set_visible(proton_engine_view_t *view,
   }
   view->visible = visible ? 1 : 0;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL && host->was_hidden != NULL) {
         host->was_hidden(host, view->visible ? 0 : 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -562,7 +558,7 @@ int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   int32_t status = proton_browser_set_zoom_percent(
-      view->browser, zoom_percent, error, error_len);
+      proton_engine_view_browser(view), zoom_percent, error, error_len);
   if (status != PROTON_OK) {
     return status;
   }
@@ -579,9 +575,9 @@ int32_t proton_engine_view_set_audio_muted(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_set_audio_muted(
-        view->browser, muted, error, error_len);
+        proton_engine_view_browser(view), muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -598,9 +594,9 @@ int32_t proton_engine_view_is_audio_muted(proton_engine_view_t *view,
                               "view and muted output are required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_is_audio_muted(
-        view->browser, out_muted, error, error_len);
+        proton_engine_view_browser(view), out_muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -619,11 +615,11 @@ int32_t proton_engine_view_load_url(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser == NULL) {
+  if (proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -642,11 +638,11 @@ int32_t proton_engine_view_eval(proton_engine_view_t *view,
                                 const char *script,
                                 char *error,
                                 size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -669,12 +665,12 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 char *error,
                                                 size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(view->browser_session,
-                                             view->browser, command_json,
+                                             proton_engine_view_browser(view), command_json,
                                              error, error_len);
 }
 
@@ -682,7 +678,7 @@ int32_t proton_engine_view_get_browser_focus_state(
     proton_engine_view_t *view, int32_t *out_focused,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -693,7 +689,7 @@ int32_t proton_engine_view_get_browser_focus_state(
   }
   if (view->window != NULL && view->window->headless) {
     return proton_browser_headless_is_focused(
-        view->browser, out_focused, error, error_len);
+        proton_engine_view_browser(view), out_focused, error, error_len);
   }
   if (view->hwnd == NULL) {
     proton_engine_set_message(error, error_len,
@@ -707,24 +703,24 @@ int32_t proton_engine_view_get_browser_focus_state(
 int32_t proton_engine_view_get_devtools_state(
     proton_engine_view_t *view, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      view->browser, out_opened, error, error_len);
+      proton_engine_view_browser(view), out_opened, error, error_len);
 }
 
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_view_browser(view), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_view_find_in_page(
@@ -732,24 +728,24 @@ int32_t proton_engine_view_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      view->browser_session, view->browser, text, forward, match_case,
+      view->browser_session, proton_engine_view_browser(view), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_view_stop_find_in_page(
     proton_engine_view_t *view, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      view->browser, clear_selection, error, error_len);
+      proton_engine_view_browser(view), clear_selection, error, error_len);
 }
 
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -63,14 +63,9 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
     if (view->client != NULL) {
-      // Drop only the engine's reference; CEF's final release after
-      // OnBeforeClose frees the client (guaranteed by the finalize gate).
-      cef_base_ref_counted_t *client_base =
-          (cef_base_ref_counted_t *)view->client;
       view->client->view = NULL;
-      view->client = NULL;
-      client_base->release(client_base);
     }
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     view = next;
   }
@@ -81,12 +76,16 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
       !view->finalize_after_browser_close) {
     return;
   }
-  if (view->browser_id != 0 && !view->browser_before_close_seen) {
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(view->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   if (view->client != NULL) {
     view->client->view = NULL;
   }
+  proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   view->hwnd = NULL;
   view->finalized = 1;
   // The window's own finalize is gated on every view being finalized; this
@@ -96,7 +95,13 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
 
 void proton_engine_window_finalize_if_ready(proton_engine_window_t *window) {
   if (window == NULL || window->finalize_queued ||
-      !window->destroy_requested || window->browser != NULL) {
+      !window->destroy_requested) {
+    return;
+  }
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(window->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   for (proton_engine_view_t *view = window->views; view != NULL;
@@ -121,17 +126,7 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
       view->closed = 1;
       view->finalize_after_browser_close = 1;
       if (view->browser != NULL) {
-        cef_browser_host_t *host = view->browser->get_host(view->browser);
-        if (host != NULL) {
-          view->browser_close_requested = 1;
-          host->close_browser(host, 1);
-          host->base.release((cef_base_ref_counted_t *)host);
-        } else {
-          // A browser without a host can never deliver on_before_close.
-          view->browser_before_close_seen = 1;
-        }
-        proton_engine_browser_release(view->browser);
-        view->browser = NULL;
+        proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
       }
     } else if (!view->finalize_after_browser_close) {
       // Already closed by the page (JS window.close): allow its cleanup to
@@ -193,10 +188,16 @@ int CEF_CALLBACK proton_engine_do_close(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
   (void)self;
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_VIEW) {
+    // Main and DevTools browsers keep CEF's top-level close behavior.
+    return 0;
+  }
   proton_engine_view_t *view =
-      proton_engine_find_view_by_browser_id(proton_engine_browser_id(browser));
+      (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
   if (view == NULL) {
-    // Frame windows keep CEF's default close behavior (WM_CLOSE to the frame).
     return 0;
   }
   // A view browser owns no top-level window; CEF's default would post
@@ -251,7 +252,8 @@ void proton_engine_view_handlers_init(void) {
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view) {
+    proton_engine_view_t *view,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -261,6 +263,7 @@ static proton_engine_client_t *proton_engine_view_client_create(
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
   client->view = view;
+  client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Find results
@@ -304,16 +307,21 @@ static int32_t proton_engine_view_create_browser(
   }
   proton_engine_set_string(&window_info.window_name, "ProtonView");
   proton_engine_set_string(&url, "about:blank");
-  view->browser = cef_browser_host_create_browser_sync(
+  cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
       &window_info, &view->client->client, &url, &browser_settings, NULL,
       NULL);
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
-  if (view->browser == NULL) {
+  if (created_browser == NULL) {
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_engine_set_message(error, error_len, "view browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  view->browser_id = proton_engine_browser_id(view->browser);
+  proton_browser_lifecycle_adopt_created(view->browser_lifecycle,
+                                         created_browser);
+  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
+  view->browser_id =
+      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
   cef_browser_host_t *host = view->browser->get_host(view->browser);
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
@@ -393,7 +401,16 @@ int32_t proton_engine_view_create(
   view->background_color = config.background_color;
   snprintf(view->initial_url, sizeof(view->initial_url), "%s",
            config.initial_url);
-  view->client = proton_engine_view_client_create(view);
+  view->browser_lifecycle = proton_browser_lifecycle_create(
+      window->runtime->browsers, PROTON_BROWSER_ROLE_VIEW, view, NULL);
+  if (view->browser_lifecycle == NULL) {
+    free(view);
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser lifecycle");
+    return PROTON_ERR_ENGINE;
+  }
+  view->client = proton_engine_view_client_create(
+      view, view->browser_lifecycle);
   proton_browser_policy_t view_policy = {PROTON_BROWSER_POLICY_ALLOW,
                                          PROTON_BROWSER_POLICY_DENY,
                                          PROTON_BROWSER_POLICY_DENY,
@@ -407,12 +424,22 @@ int32_t proton_engine_view_create(
       view->events == NULL) {
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    free(view->client);
+    if (view->client != NULL) {
+      view->client->view = NULL;
+      proton_browser_lifecycle_set_client(view->browser_lifecycle,
+                                          &view->client->client);
+    }
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     proton_engine_set_message(error, error_len,
                               "failed to allocate view state");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(view->browser_lifecycle,
+                                      &view->client->client);
+  proton_browser_session_bind_lifecycle(view->browser_session,
+                                        view->browser_lifecycle);
   proton_view_events_bind(view->events, config.public_view,
                           config.public_window);
   proton_engine_view_list_add(window, view);
@@ -440,21 +467,10 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
   if (view->closed) {
     return PROTON_OK;
   }
-  cef_browser_host_t *host =
-      view->browser != NULL ? view->browser->get_host(view->browser) : NULL;
-  if (view->browser != NULL && host == NULL) {
-    proton_engine_set_message(error, error_len,
-                              "browser host is not available for close");
-    return PROTON_ERR_ENGINE;
-  }
   view->closed = 1;
   view->finalize_after_browser_close = 1;
   if (view->browser != NULL) {
-    view->browser_close_requested = 1;
-    host->close_browser(host, 1);
-    host->base.release((cef_base_ref_counted_t *)host);
-    proton_engine_browser_release(view->browser);
-    view->browser = NULL;
+    proton_browser_lifecycle_request_close(view->browser_lifecycle, 1);
   }
   proton_engine_view_finalize_if_ready(view);
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -625,6 +625,7 @@ int32_t proton_engine_window_create(
       proton_engine_window_create_browser(window, config.initial_url, error,
                                           error_len);
   if (status != PROTON_OK) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     if (window->hwnd != NULL) {
       DestroyWindow(window->hwnd);
     }

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -320,8 +320,8 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
         }
         return 0;
       }
-      if (window->browser != NULL) {
-        cef_browser_host_t *host = window->browser->get_host(window->browser);
+      if (proton_engine_window_browser(window) != NULL) {
+        cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
         if (host != NULL) {
           int allow_close = 0;
           if (host->is_ready_to_be_closed != NULL &&
@@ -416,7 +416,8 @@ static int32_t proton_engine_window_create_browser(
     const char *initial_url,
     char *error,
     size_t error_len) {
-  if (window == NULL || window->client == NULL ||
+  if (window == NULL ||
+      proton_browser_lifecycle_client(window->browser_lifecycle) == NULL ||
       (!window->headless && window->hwnd == NULL)) {
     proton_engine_set_message(error, error_len,
                               "window is not ready for browser creation");
@@ -463,7 +464,7 @@ static int32_t proton_engine_window_create_browser(
           ? extra_info_value->get_dictionary(extra_info_value)
           : NULL;
   cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
-      &window_info, window->client, &url, &browser_settings, extra_info, NULL);
+      &window_info, proton_browser_lifecycle_client(window->browser_lifecycle), &url, &browser_settings, extra_info, NULL);
   if (extra_info_value != NULL) {
     extra_info_value->base.release((cef_base_ref_counted_t *)extra_info_value);
   }
@@ -477,10 +478,6 @@ static int32_t proton_engine_window_create_browser(
   }
   proton_browser_lifecycle_adopt_created(window->browser_lifecycle,
                                          created_browser);
-  window->browser =
-      proton_browser_lifecycle_browser(window->browser_lifecycle);
-  window->browser_id =
-      proton_browser_lifecycle_browser_id(window->browser_lifecycle);
   proton_engine_resize_browser(window, browser_width, browser_height);
   return PROTON_OK;
 }
@@ -562,9 +559,9 @@ int32_t proton_engine_window_create(
                                      config.public_window);
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
-  window->client = (cef_client_t *)proton_engine_client_new(
-      window, window->browser_lifecycle);
-  if (window->client == NULL) {
+  proton_engine_client_t *client = proton_engine_client_new(
+      window->browser_lifecycle);
+  if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
@@ -574,7 +571,7 @@ int32_t proton_engine_window_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(window->browser_lifecycle,
-                                      window->client);
+                                      &client->client);
 
   if (!window->headless) {
     wchar_t wide_title[512];
@@ -593,7 +590,6 @@ int32_t proton_engine_window_create(
         CW_USEDEFAULT, config.width, config.height, NULL, NULL,
         GetModuleHandleW(NULL), window);
     if (window->hwnd == NULL) {
-      ((proton_engine_client_t *)window->client)->window = NULL;
       proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
       proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
@@ -615,7 +611,6 @@ int32_t proton_engine_window_create(
       if (menu_status != PROTON_OK) {
         DestroyWindow(window->hwnd);
         window->hwnd = NULL;
-        ((proton_engine_client_t *)window->client)->window = NULL;
         proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
         proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
@@ -633,7 +628,6 @@ int32_t proton_engine_window_create(
     if (window->hwnd != NULL) {
       DestroyWindow(window->hwnd);
     }
-    ((proton_engine_client_t *)window->client)->window = NULL;
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     free(window->bridge_config_json);
     proton_browser_session_destroy(window->browser_session);
@@ -654,11 +648,11 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
     return PROTON_OK;
   }
   proton_engine_dialog_cancel_window(window);
-  if (window->browser != NULL) {
+  if (proton_engine_window_browser(window) != NULL) {
     window->destroy_requested = 1;
     proton_engine_window_close_views(window);
     proton_engine_bridge_pending_remove_browser(window->runtime,
-                                                window->browser_id);
+        proton_browser_lifecycle_browser_id(window->browser_lifecycle));
     proton_browser_lifecycle_request_close(window->browser_lifecycle, 1);
     return PROTON_OK;
   }
@@ -681,8 +675,8 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 0;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 0);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1066,8 +1060,8 @@ int32_t proton_engine_window_hide(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 1;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1102,8 +1096,8 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
     return PROTON_OK;
   }
   if (window->headless) {
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host == NULL) {
         proton_engine_set_message(error, error_len,
                                   "browser host is not available for close");
@@ -1133,8 +1127,8 @@ int32_t proton_engine_window_focus(proton_engine_window_t *window,
     return PROTON_ERR_INVALID_HANDLE;
   }
   if (window->headless) {
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->set_focus(host, 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1369,12 +1363,12 @@ int32_t proton_engine_window_apply(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   if (action->kind == PROTON_ENGINE_WINDOW_SET_ZOOM_PERCENT) {
-    if (window->browser == NULL) {
+    if (proton_engine_window_browser(window) == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser is not initialized");
       return PROTON_ERR_NOT_INITIALIZED;
     }
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available");
@@ -1777,11 +1771,11 @@ int32_t proton_engine_window_load_url(proton_engine_window_t *window,
                                       const char *url,
                                       char *error,
                                       size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -1803,11 +1797,11 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
                                   const char *script,
                                   char *error,
                                   size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -1827,12 +1821,12 @@ int32_t proton_engine_window_browser_command_json(
     proton_engine_window_t *window, const char *command_json,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(
-      window->browser_session, window->browser, command_json, error,
+      window->browser_session, proton_engine_window_browser(window), command_json, error,
       error_len);
 }
 
@@ -1840,7 +1834,7 @@ int32_t proton_engine_window_get_browser_focus_state(
     proton_engine_window_t *window, int32_t *out_focused,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -1851,9 +1845,9 @@ int32_t proton_engine_window_get_browser_focus_state(
   }
   if (window->headless) {
     return proton_browser_headless_is_focused(
-        window->browser, out_focused, error, error_len);
+        proton_engine_window_browser(window), out_focused, error, error_len);
   }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
   if (host == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser host is not available");
@@ -1873,43 +1867,43 @@ int32_t proton_engine_window_get_browser_focus_state(
 int32_t proton_engine_window_get_devtools_state(
     proton_engine_window_t *window, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      window->browser, out_opened, error, error_len);
+      proton_engine_window_browser(window), out_opened, error, error_len);
 }
 
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_window_browser(window), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_window_download_url(
     proton_engine_window_t *window, const char *url, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_download_url(window->browser, url, error, error_len);
+  return proton_browser_download_url(proton_engine_window_browser(window), url, error, error_len);
 }
 
 int32_t proton_engine_window_print(
     proton_engine_window_t *window, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_print(window->browser, error, error_len);
+  return proton_browser_print(proton_engine_window_browser(window), error, error_len);
 }
 
 int32_t proton_engine_window_print_to_pdf(
@@ -1922,12 +1916,12 @@ int32_t proton_engine_window_print_to_pdf(
     const char *footer_template, int32_t generate_tagged_pdf,
     int32_t generate_document_outline, int32_t *out_request_id,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_print_to_pdf(
-      window->browser_session, window->browser, path, landscape,
+      window->browser_session, proton_engine_window_browser(window), path, landscape,
       print_background, scale, paper_width, paper_height,
       prefer_css_page_size, margin_type, margin_top, margin_right,
       margin_bottom, margin_left, page_ranges, display_header_footer,
@@ -1940,46 +1934,46 @@ int32_t proton_engine_window_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      window->browser_session, window->browser, text, forward, match_case,
+      window->browser_session, proton_engine_window_browser(window), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_window_stop_find_in_page(
     proton_engine_window_t *window, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      window->browser, clear_selection, error, error_len);
+      proton_engine_window_browser(window), clear_selection, error, error_len);
 }
 
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_set_audio_muted(
-      window->browser, muted, error, error_len);
+      proton_engine_window_browser(window), muted, error, error_len);
 }
 
 int32_t proton_engine_window_is_audio_muted(
     proton_engine_window_t *window, int32_t *out_muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_audio_muted(
-      window->browser, out_muted, error, error_len);
+      proton_engine_window_browser(window), out_muted, error, error_len);
 }
 
 int32_t proton_engine_window_get_browser_url(
@@ -2046,12 +2040,12 @@ int32_t proton_engine_window_emit_bridge_event_json(
     const char *event_json,
     char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL ||
+  if (window == NULL || proton_engine_window_browser(window) == NULL ||
       window->bridge_config_json == NULL) {
     proton_engine_set_message(error, error_len, "bridge is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  if (!proton_engine_bridge_send_event(window->browser, event_json)) {
+  if (!proton_engine_bridge_send_event(proton_engine_window_browser(window), event_json)) {
     proton_engine_set_message(error, error_len,
                               "failed to send bridge event to renderer");
     return PROTON_ERR_ENGINE;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -328,11 +328,15 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
               host->is_ready_to_be_closed(host)) {
             allow_close = 1;
           } else if (host->try_close_browser != NULL) {
+            proton_browser_lifecycle_note_close_requested(
+                window->browser_lifecycle, 0);
             allow_close = host->try_close_browser(host);
-          } else if (!window->browser_close_requested) {
-            host->close_browser(host, 0);
+          } else if (proton_browser_lifecycle_state(
+                         window->browser_lifecycle) !=
+                     PROTON_BROWSER_CLOSING) {
+            proton_browser_lifecycle_request_close(
+                window->browser_lifecycle, 0);
           }
-          window->browser_close_requested = 1;
           host->base.release((cef_base_ref_counted_t *)host);
           if (!allow_close) {
             return 0;
@@ -458,7 +462,7 @@ static int32_t proton_engine_window_create_browser(
       extra_info_value != NULL
           ? extra_info_value->get_dictionary(extra_info_value)
           : NULL;
-  window->browser = cef_browser_host_create_browser_sync(
+  cef_browser_t *created_browser = cef_browser_host_create_browser_sync(
       &window_info, window->client, &url, &browser_settings, extra_info, NULL);
   if (extra_info_value != NULL) {
     extra_info_value->base.release((cef_base_ref_counted_t *)extra_info_value);
@@ -466,11 +470,17 @@ static int32_t proton_engine_window_create_browser(
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
 
-  if (window->browser == NULL) {
+  if (created_browser == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_engine_set_message(error, error_len, "browser creation failed");
     return PROTON_ERR_ENGINE;
   }
-  window->browser_id = proton_engine_browser_id(window->browser);
+  proton_browser_lifecycle_adopt_created(window->browser_lifecycle,
+                                         created_browser);
+  window->browser =
+      proton_browser_lifecycle_browser(window->browser_lifecycle);
+  window->browser_id =
+      proton_browser_lifecycle_browser_id(window->browser_lifecycle);
   proton_engine_resize_browser(window, browser_width, browser_height);
   return PROTON_OK;
 }
@@ -537,23 +547,34 @@ int32_t proton_engine_window_create(
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
       &config.browser_policy, proton_engine_browser_signal, window);
-  if (window->browser_session == NULL) {
+  window->browser_lifecycle = proton_browser_lifecycle_create(
+      runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
+  if (window->browser_session == NULL || window->browser_lifecycle == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     free(window->bridge_config_json);
+    proton_browser_session_destroy(window->browser_session);
     free(window);
     proton_engine_set_message(error, error_len,
-                              "failed to allocate browser session");
+                              "failed to allocate browser state");
     return PROTON_ERR_ENGINE;
   }
   proton_browser_session_bind_window(window->browser_session,
                                      config.public_window);
-  window->client = (cef_client_t *)proton_engine_client_new(window);
+  proton_browser_session_bind_lifecycle(window->browser_session,
+                                        window->browser_lifecycle);
+  window->client = (cef_client_t *)proton_engine_client_new(
+      window, window->browser_lifecycle);
   if (window->client == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
     free(window);
     proton_engine_set_message(error, error_len, "failed to allocate client");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(window->browser_lifecycle,
+                                      window->client);
 
   if (!window->headless) {
     wchar_t wide_title[512];
@@ -572,8 +593,9 @@ int32_t proton_engine_window_create(
         CW_USEDEFAULT, config.width, config.height, NULL, NULL,
         GetModuleHandleW(NULL), window);
     if (window->hwnd == NULL) {
-      ((cef_base_ref_counted_t *)window->client)
-          ->release((cef_base_ref_counted_t *)window->client);
+      ((proton_engine_client_t *)window->client)->window = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
       free(window->bridge_config_json);
       free(window);
@@ -593,8 +615,9 @@ int32_t proton_engine_window_create(
       if (menu_status != PROTON_OK) {
         DestroyWindow(window->hwnd);
         window->hwnd = NULL;
-        ((cef_base_ref_counted_t *)window->client)
-            ->release((cef_base_ref_counted_t *)window->client);
+        ((proton_engine_client_t *)window->client)->window = NULL;
+        proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+        proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
         proton_browser_session_destroy(window->browser_session);
         free(window->bridge_config_json);
         free(window);
@@ -610,8 +633,8 @@ int32_t proton_engine_window_create(
     if (window->hwnd != NULL) {
       DestroyWindow(window->hwnd);
     }
-    ((cef_base_ref_counted_t *)window->client)
-        ->release((cef_base_ref_counted_t *)window->client);
+    ((proton_engine_client_t *)window->client)->window = NULL;
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     free(window->bridge_config_json);
     proton_browser_session_destroy(window->browser_session);
     free(window->draggable_regions);
@@ -632,19 +655,11 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
   }
   proton_engine_dialog_cancel_window(window);
   if (window->browser != NULL) {
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
-    if (host == NULL) {
-      proton_engine_set_message(error, error_len,
-                                "browser host is not available for close");
-      return PROTON_ERR_ENGINE;
-    }
     window->destroy_requested = 1;
     proton_engine_window_close_views(window);
     proton_engine_bridge_pending_remove_browser(window->runtime,
                                                 window->browser_id);
-    window->browser_close_requested = 1;
-    host->close_browser(host, 1);
-    host->base.release((cef_base_ref_counted_t *)host);
+    proton_browser_lifecycle_request_close(window->browser_lifecycle, 1);
     return PROTON_OK;
   }
   window->destroy_requested = 1;
@@ -1094,8 +1109,7 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
                                   "browser host is not available for close");
         return PROTON_ERR_ENGINE;
       }
-      window->browser_close_requested = 1;
-      host->close_browser(host, 0);
+      proton_browser_lifecycle_request_close(window->browser_lifecycle, 0);
       host->base.release((cef_base_ref_counted_t *)host);
     } else {
       window->closed = 1;

--- a/proton/internal/native/ffi_mac/mac_client.objc.c
+++ b/proton/internal/native/ffi_mac/mac_client.objc.c
@@ -207,6 +207,25 @@ static int CEF_CALLBACK proton_engine_on_before_popup(
       target_disposition, user_gesture);
 }
 
+static proton_engine_client_t *proton_engine_client_from_browser(
+    cef_browser_t *browser) {
+  if (browser == NULL) {
+    return NULL;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    return NULL;
+  }
+  cef_client_t *cef_client = host->get_client(host);
+  proton_engine_client_t *client =
+      cef_client != NULL ? proton_engine_client_from_base(cef_client) : NULL;
+  if (cef_client != NULL) {
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
+  }
+  host->base.release((cef_base_ref_counted_t *)host);
+  return client;
+}
+
 static void CEF_CALLBACK proton_engine_on_after_created(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
@@ -214,36 +233,47 @@ static void CEF_CALLBACK proton_engine_on_after_created(
   if (browser == NULL) {
     return;
   }
-  cef_browser_host_t *host = browser->get_host(browser);
-  cef_client_t *cef_client = host != NULL ? host->get_client(host) : NULL;
-  proton_engine_client_t *client =
-      cef_client != NULL ? proton_engine_client_from_base(cef_client) : NULL;
-  proton_engine_window_t *window = client != NULL ? client->window : NULL;
-  if (cef_client != NULL) {
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  if (client != NULL && client->view != NULL) {
-    proton_engine_view_on_after_created(client->view, browser);
-    if (host != NULL) {
-      host->base.release((cef_base_ref_counted_t *)host);
-    }
-    return;
-  }
-  if (window == NULL) {
+  proton_engine_client_t *client = proton_engine_client_from_browser(browser);
+  proton_browser_lifecycle_t *lifecycle =
+      client != NULL ? client->browser_lifecycle : NULL;
+  if (lifecycle == NULL) {
+    cef_browser_host_t *host = browser->get_host(browser);
     if (host != NULL) {
       host->close_browser(host, 1);
       host->base.release((cef_base_ref_counted_t *)host);
     }
     return;
   }
+  proton_browser_lifecycle_on_after_created(lifecycle, browser);
+  proton_browser_role_t role = proton_browser_lifecycle_role(lifecycle);
+  if (role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+    return;
+  }
+  if (role == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view != NULL) {
+      proton_engine_view_on_after_created(view, browser);
+    }
+    return;
+  }
+  proton_engine_window_t *window =
+      (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  if (window == NULL) {
+    proton_browser_lifecycle_request_close(lifecycle, 1);
+    return;
+  }
 
-  browser->base.add_ref((cef_base_ref_counted_t *)browser);
-  window->browser = browser;
+  cef_browser_host_t *host = browser->get_host(browser);
+  window->browser = proton_browser_lifecycle_browser(lifecycle);
   proton_engine_window_lock();
-  window->browser_id = browser->get_identifier(browser);
+  window->browser_id = proton_browser_lifecycle_browser_id(lifecycle);
   proton_engine_window_unlock();
   window->browser_create_scheduled = 0;
-  if (host != NULL) {
+  if (host == NULL) {
+    proton_browser_lifecycle_request_close(lifecycle, 1);
+  } else {
     if (window->headless) {
       if (window->headless_hidden && host->was_hidden != NULL) {
         host->was_hidden(host, 1);
@@ -288,14 +318,33 @@ static void CEF_CALLBACK proton_engine_on_before_close(
     cef_life_span_handler_t *self,
     cef_browser_t *browser) {
   (void)self;
-  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
-  if (view != NULL) {
+  proton_engine_client_t *client = proton_engine_client_from_browser(browser);
+  proton_browser_lifecycle_t *lifecycle =
+      client != NULL ? client->browser_lifecycle : NULL;
+  if (lifecycle == NULL) {
+    return;
+  }
+  proton_browser_role_t role = proton_browser_lifecycle_role(lifecycle);
+  if (role == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view == NULL) {
+      proton_browser_lifecycle_on_before_close(lifecycle, browser);
+      proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+      return;
+    }
     proton_engine_view_on_before_close(view, browser);
     return;
   }
-  proton_engine_window_t *window = proton_engine_window_from_browser(browser);
+  if (role == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    proton_browser_lifecycle_on_before_close(lifecycle, browser);
+    proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+    return;
+  }
+  proton_engine_window_t *window =
+      (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window != NULL) {
-    window->browser_before_close_seen = 1;
     proton_engine_window_close_views(window);
     proton_engine_window_mark_closed(window);
     proton_engine_window_release_browser(window);
@@ -309,7 +358,18 @@ static void CEF_CALLBACK proton_engine_on_before_close(
 static int CEF_CALLBACK proton_engine_do_close(cef_life_span_handler_t *self,
                                                cef_browser_t *browser) {
   (void)self;
-  proton_engine_view_t *view = proton_engine_view_from_browser(browser);
+  proton_engine_client_t *client = proton_engine_client_from_browser(browser);
+  proton_browser_lifecycle_t *lifecycle =
+      client != NULL ? client->browser_lifecycle : NULL;
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) ==
+          PROTON_BROWSER_ROLE_DEVTOOLS) {
+    return 0;
+  }
+  proton_engine_view_t *view =
+      proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_VIEW
+          ? (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle)
+          : NULL;
   if (view != NULL) {
     if (view->browser_view != nil) {
       // A view browser owns no top-level window, so the default behavior for
@@ -338,7 +398,8 @@ static int CEF_CALLBACK proton_engine_do_close(cef_life_span_handler_t *self,
     // the pending teardown still completes via WindowDestroyed.
     return 1;
   }
-  proton_engine_window_t *window = proton_engine_window_from_browser(browser);
+  proton_engine_window_t *window =
+      (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
   if (window != NULL) {
     window->cef_allows_appkit_close = 1;
   }
@@ -1231,8 +1292,22 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
   }
 }
 
+int CEF_CALLBACK proton_engine_client_release(
+    cef_base_ref_counted_t *base) {
+  proton_engine_ref_counted_t *refs =
+      (proton_engine_ref_counted_t *)((char *)base + base->size);
+  int value =
+      atomic_fetch_sub_explicit(&refs->refs, 1, memory_order_acq_rel) - 1;
+  if (value <= 0) {
+    free(base);
+    return 1;
+  }
+  return 0;
+}
+
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window) {
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -1240,7 +1315,9 @@ proton_engine_client_t *proton_engine_client_create(
   }
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
   client->window = window;
+  client->browser_lifecycle = browser_lifecycle;
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
@@ -1255,6 +1332,23 @@ proton_engine_client_t *proton_engine_client_create(
   client->client.on_process_message_received =
       proton_engine_client_on_process_message_received;
   return client;
+}
+
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle) {
+  (void)context;
+  proton_engine_client_t *client =
+      (proton_engine_client_t *)calloc(1, sizeof(*client));
+  if (client == NULL) {
+    return NULL;
+  }
+  proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
+                                 sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
+  client->browser_lifecycle = browser_lifecycle;
+  client->client.get_life_span_handler =
+      proton_engine_client_get_life_span_handler;
+  return &client->client;
 }
 
 

--- a/proton/internal/native/ffi_mac/mac_client.objc.c
+++ b/proton/internal/native/ffi_mac/mac_client.objc.c
@@ -117,7 +117,7 @@ static void proton_engine_bridge_pending_free(
 
 static void proton_engine_window_load_initial_url(
     proton_engine_window_t *window) {
-  if (window == NULL || window->closed || window->browser == NULL ||
+  if (window == NULL || window->closed || proton_engine_window_browser(window) == NULL ||
       window->initial_url == NULL || window->initial_url[0] == '\0' ||
       strcmp(window->initial_url, "about:blank") == 0) {
     return;
@@ -266,9 +266,7 @@ static void CEF_CALLBACK proton_engine_on_after_created(
   }
 
   cef_browser_host_t *host = browser->get_host(browser);
-  window->browser = proton_browser_lifecycle_browser(lifecycle);
   proton_engine_window_lock();
-  window->browser_id = proton_browser_lifecycle_browser_id(lifecycle);
   proton_engine_window_unlock();
   window->browser_create_scheduled = 0;
   if (host == NULL) {
@@ -343,11 +341,14 @@ static void CEF_CALLBACK proton_engine_on_before_close(
   }
   proton_engine_window_t *window =
       (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+  if (window != NULL) {
+    proton_engine_bridge_pending_remove_browser(
+        window->runtime, proton_browser_lifecycle_browser_id(lifecycle));
+  }
   proton_browser_lifecycle_on_before_close(lifecycle, browser);
   if (window != NULL) {
     proton_engine_window_close_views(window);
     proton_engine_window_mark_closed(window);
-    proton_engine_window_release_browser(window);
     if (window->window != nil && !window->appkit_closing) {
       [window->window close];
     }
@@ -460,12 +461,23 @@ proton_engine_client_get_render_handler(cef_client_t *self) {
   if (client == NULL) {
     return NULL;
   }
-  if (client->view != NULL) {
-    if (client->view->window == NULL || !client->view->window->headless) {
+  proton_browser_lifecycle_t *lifecycle = client->browser_lifecycle;
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_DEVTOOLS) {
+    return NULL;
+  }
+  if (proton_browser_lifecycle_role(lifecycle) == PROTON_BROWSER_ROLE_VIEW) {
+    proton_engine_view_t *view =
+        (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (view == NULL || view->window == NULL || !view->window->headless) {
       return NULL;
     }
-  } else if (client->window == NULL || !client->window->headless) {
-    return NULL;
+  } else {
+    proton_engine_window_t *window =
+        (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
+    if (window == NULL || !window->headless) {
+      return NULL;
+    }
   }
   g_render_handler.handler.base.add_ref(
       (cef_base_ref_counted_t *)&g_render_handler.handler);
@@ -1306,7 +1318,6 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
@@ -1316,7 +1327,6 @@ proton_engine_client_t *proton_engine_client_create(
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
-  client->window = window;
   client->browser_lifecycle = browser_lifecycle;
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -143,9 +143,6 @@ struct proton_engine_window {
   int programmatic_close_pending;
   uint64_t close_request_id;
   proton_browser_session_t *browser_session;
-  proton_engine_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   proton_window_id_t public_window_id;
   char *bridge_config_json;
@@ -186,16 +183,11 @@ struct proton_engine_window {
 struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
-  proton_engine_window_t *window;
-  proton_engine_view_t *view;
   proton_browser_lifecycle_t *browser_lifecycle;
 };
 
 struct proton_engine_view {
   proton_engine_window_t *window;
-  proton_engine_client_t *client;
-  cef_browser_t *browser;
-  int browser_id;
   proton_browser_lifecycle_t *browser_lifecycle;
   NSView *browser_view;
   int32_t x;
@@ -229,7 +221,6 @@ void proton_engine_init_handlers(void);
 cef_app_t *proton_engine_cef_app(void);
 int proton_engine_register_scheme_factory(void);
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window,
     proton_browser_lifecycle_t *browser_lifecycle);
 int CEF_CALLBACK proton_engine_client_release(
     cef_base_ref_counted_t *base);
@@ -249,7 +240,6 @@ void proton_engine_runtime_create_pending_browsers(
     proton_engine_runtime_t *runtime);
 int proton_engine_runtime_has_windows(proton_engine_runtime_t *runtime);
 proton_engine_client_t *proton_engine_client_from_base(cef_client_t *client);
-void proton_engine_window_release_browser(proton_engine_window_t *window);
 int proton_engine_send_bridge_response_to_frame(
     cef_frame_t *frame,
     int pending_id,
@@ -307,10 +297,8 @@ int proton_engine_browser_view_is_focused(NSView *browser_view);
 proton_engine_view_t *proton_engine_view_from_native_id(uint64_t native_id);
 proton_engine_window_t *proton_engine_window_from_browser(
     cef_browser_t *browser);
-proton_engine_window_t *proton_engine_window_from_browser_client(
-    cef_browser_t *browser);
 proton_engine_view_t *proton_engine_view_from_browser(cef_browser_t *browser);
-proton_engine_view_t *proton_engine_view_from_browser_client(
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
     cef_browser_t *browser);
 int proton_engine_runtime_initialized(void);
 uint64_t proton_engine_allocate_view_native_id(void);

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -6,6 +6,7 @@
 #include "../ffi/src/proton_event.h"
 
 #include "../ffi/src/engine/cef_common/bridge_lifecycle.h"
+#include "../ffi/src/engine/cef_common/browser_lifecycle.h"
 #include "../ffi/src/engine/cef_common/browser_session.h"
 #include "../ffi/src/engine/cef_common/view_events.h"
 
@@ -124,6 +125,7 @@ struct proton_engine_runtime {
   int64_t next_bridge_request_id;
   char dialog_ok_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
+  proton_browser_registry_t *browsers;
 };
 
 struct proton_engine_window {
@@ -133,7 +135,6 @@ struct proton_engine_window {
   NSView *browser_view;
   id delegate;
   int appkit_closing;
-  int browser_close_requested;
   int cef_allows_appkit_close;
   int close_interception_enabled;
   int close_authorized;
@@ -145,6 +146,7 @@ struct proton_engine_window {
   proton_engine_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   proton_window_id_t public_window_id;
   char *bridge_config_json;
   int32_t max_bridge_payload_bytes;
@@ -154,7 +156,6 @@ struct proton_engine_window {
   int browser_create_pending;
   int browser_create_scheduled;
   int window_listed;
-  int browser_before_close_seen;
   int finalize_after_browser_close;
   uint64_t native_id;
   int width;
@@ -187,6 +188,7 @@ struct proton_engine_client {
   proton_engine_ref_counted_t refs;
   proton_engine_window_t *window;
   proton_engine_view_t *view;
+  proton_browser_lifecycle_t *browser_lifecycle;
 };
 
 struct proton_engine_view {
@@ -194,6 +196,7 @@ struct proton_engine_view {
   proton_engine_client_t *client;
   cef_browser_t *browser;
   int browser_id;
+  proton_browser_lifecycle_t *browser_lifecycle;
   NSView *browser_view;
   int32_t x;
   int32_t y;
@@ -208,8 +211,6 @@ struct proton_engine_view {
   int initial_navigation_pending;
   int browser_create_pending;
   int browser_create_scheduled;
-  int browser_close_requested;
-  int browser_before_close_seen;
   int finalize_after_browser_close;
   int finalized;
   int closed;
@@ -228,7 +229,12 @@ void proton_engine_init_handlers(void);
 cef_app_t *proton_engine_cef_app(void);
 int proton_engine_register_scheme_factory(void);
 proton_engine_client_t *proton_engine_client_create(
-    proton_engine_window_t *window);
+    proton_engine_window_t *window,
+    proton_browser_lifecycle_t *browser_lifecycle);
+int CEF_CALLBACK proton_engine_client_release(
+    cef_base_ref_counted_t *base);
+cef_client_t *proton_engine_browser_client_factory(
+    void *context, proton_browser_lifecycle_t *browser_lifecycle);
 void proton_engine_bridge_pending_remove_browser(
     proton_engine_runtime_t *runtime,
     int browser_id);
@@ -296,7 +302,6 @@ void proton_engine_window_free_views(proton_engine_window_t *window);
 void proton_engine_view_finalize_if_ready(proton_engine_view_t *view);
 void proton_engine_signal_wait_source(uint32_t ready_mask);
 void proton_engine_browser_signal(void *user_data);
-void proton_engine_browser_release(cef_browser_t *browser);
 void proton_engine_window_finalize_if_ready(proton_engine_window_t *window);
 int proton_engine_browser_view_is_focused(NSView *browser_view);
 proton_engine_view_t *proton_engine_view_from_native_id(uint64_t native_id);

--- a/proton/internal/native/ffi_mac/mac_runtime.objc.c
+++ b/proton/internal/native/ffi_mac/mac_runtime.objc.c
@@ -829,6 +829,17 @@ int32_t proton_engine_runtime_create(
   runtime->owns_cef_runtime = 1;
   runtime->headless = config.headless;
   runtime->next_bridge_request_id = 1;
+  runtime->browsers = proton_browser_registry_create(
+      proton_engine_browser_client_factory, runtime);
+  if (runtime->browsers == NULL) {
+    free(runtime);
+    proton_engine_cef_shutdown();
+    proton_engine_reset_external_message_pump();
+    g_proton_cef_runtime_active = 0;
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser registry");
+    return PROTON_ERR_ENGINE;
+  }
   snprintf(runtime->dialog_ok_label, sizeof(runtime->dialog_ok_label), "%s",
            config.dialog_ok_label);
   snprintf(runtime->dialog_cancel_label,
@@ -839,6 +850,8 @@ int32_t proton_engine_runtime_create(
     proton_engine_cef_shutdown();
     proton_engine_reset_external_message_pump();
     g_proton_cef_runtime_active = 0;
+    proton_browser_registry_destroy(runtime->browsers);
+    free(runtime);
     proton_engine_set_message(error, error_len,
                               "failed to register proton scheme handler");
     return PROTON_ERR_ENGINE;
@@ -868,13 +881,19 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
     proton_engine_reset_external_message_pump();
     runtime->owns_cef_runtime = 0;
   }
+  proton_browser_registry_destroy(runtime->browsers);
   g_proton_cef_runtime_active = 0;
   free(runtime);
   return PROTON_OK;
 }
 
 int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {
-  return runtime != NULL && !proton_engine_runtime_has_windows(runtime);
+  if (runtime == NULL) {
+    return 0;
+  }
+  proton_browser_registry_begin_shutdown(runtime->browsers);
+  return !proton_engine_runtime_has_windows(runtime) &&
+         proton_browser_registry_shutdown_ready(runtime->browsers);
 }
 
 static void proton_engine_pump_appkit_cef_once(void) {

--- a/proton/internal/native/ffi_mac/mac_runtime.objc.c
+++ b/proton/internal/native/ffi_mac/mac_runtime.objc.c
@@ -517,7 +517,7 @@ void CEF_CALLBACK proton_engine_osr_get_view_rect(
   if (view == NULL) {
     // CEF can query the viewport while browser creation is still running,
     // before the view records its browser id; resolve via the client then.
-    view = proton_engine_view_from_browser_client(browser);
+    view = proton_engine_view_from_browser(browser);
   }
   if (view != NULL) {
     rect->width = view->width > 0 ? view->width : 1;
@@ -525,7 +525,7 @@ void CEF_CALLBACK proton_engine_osr_get_view_rect(
     return;
   }
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   rect->width = window != NULL && window->width > 0 ? window->width : 1;
   rect->height = window != NULL && window->height > 0 ? window->height : 1;
 }
@@ -554,7 +554,7 @@ void CEF_CALLBACK proton_engine_osr_on_popup_show(
     int show) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   if (window != NULL) {
     window->osr_popup_visible = show ? 1 : 0;
   }
@@ -566,7 +566,7 @@ void CEF_CALLBACK proton_engine_osr_on_popup_size(
     const cef_rect_t *rect) {
   (void)self;
   proton_engine_window_t *window =
-      proton_engine_window_from_browser_client(browser);
+      proton_engine_window_from_browser(browser);
   if (window != NULL && rect != NULL) {
     window->osr_popup_rect = *rect;
   }

--- a/proton/internal/native/ffi_mac/mac_view.objc.c
+++ b/proton/internal/native/ffi_mac/mac_view.objc.c
@@ -54,6 +54,12 @@ typedef struct {
   uint64_t native_id;
 } proton_engine_view_navigation_task_t;
 
+cef_browser_t *proton_engine_view_browser(proton_engine_view_t *view) {
+  return view != NULL
+             ? proton_browser_lifecycle_browser(view->browser_lifecycle)
+             : NULL;
+}
+
 static void proton_engine_view_list_add(proton_engine_window_t *window,
                                         proton_engine_view_t *view) {
   proton_engine_window_lock();
@@ -129,16 +135,9 @@ void proton_engine_window_layout_views(proton_engine_window_t *window) {
   free(order);
 }
 
-static void proton_engine_view_release_browser(proton_engine_view_t *view) {
-  if (view != NULL) {
-    view->browser = NULL;
-    view->browser_id = 0;
-  }
-}
-
 static int proton_engine_view_request_browser_close(proton_engine_view_t *view,
                                                     int force_close) {
-  if (view == NULL || view->browser == NULL) {
+  if (view == NULL || proton_engine_view_browser(view) == NULL) {
     return 0;
   }
   proton_browser_lifecycle_request_close(view->browser_lifecycle,
@@ -169,9 +168,6 @@ static void proton_engine_view_defer_finalize(proton_engine_view_t *view) {
   }
   view->finalize_after_browser_close = 1;
   view->browser_create_pending = 0;
-  if (view->client != NULL && !view->browser_create_scheduled) {
-    view->client->view = NULL;
-  }
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
 
@@ -182,9 +178,6 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_engine_view_t *next = view->next;
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    if (view->client != NULL) {
-      view->client->view = NULL;
-    }
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view->initial_url);
     free(view);
@@ -209,9 +202,6 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
   // Resource cleanup only. The struct stays in the window's view list and is
   // freed by proton_engine_window_free once every view has finalized, which
   // keeps native ABI view slots valid for the whole window lifetime.
-  if (view->client != NULL) {
-    view->client->view = NULL;
-  }
   proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   if (view->browser_view != nil) {
     [view->browser_view removeFromSuperview];
@@ -230,7 +220,7 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
   for (proton_engine_view_t *view = window->views; view != NULL;
        view = view->next) {
     if (!view->closed) {
-      if (view->browser != NULL) {
+      if (proton_engine_view_browser(view) != NULL) {
         proton_engine_view_request_browser_close(view, 1);
         proton_engine_view_mark_closed(view);
         proton_engine_view_defer_finalize(view);
@@ -279,7 +269,7 @@ static int32_t proton_engine_view_create_browser(proton_engine_view_t *view,
   proton_engine_set_string(&window_info.window_name, "ProtonView");
   proton_engine_set_string(&url, "about:blank");
   int accepted = cef_browser_host_create_browser(
-      &window_info, &view->client->client, &url, &browser_settings, NULL,
+      &window_info, proton_browser_lifecycle_client(view->browser_lifecycle), &url, &browser_settings, NULL,
       NULL);
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
@@ -384,9 +374,6 @@ void proton_engine_view_on_after_created(proton_engine_view_t *view,
   }
   proton_engine_window_t *window = view->window;
   cef_browser_host_t *host = browser->get_host(browser);
-  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
-  view->browser_id =
-      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
   view->browser_create_scheduled = 0;
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
@@ -434,7 +421,6 @@ void proton_engine_view_on_before_close(proton_engine_view_t *view,
   proton_browser_lifecycle_on_before_close(view->browser_lifecycle, browser);
   proton_engine_view_mark_closed(view);
   proton_view_events_closed(view->events);
-  proton_engine_view_release_browser(view);
   if (view->browser_view != nil) {
     [view->browser_view removeFromSuperview];
     view->browser_view = nil;
@@ -447,7 +433,6 @@ void proton_engine_view_on_before_close(proton_engine_view_t *view,
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view,
     proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
@@ -457,7 +442,6 @@ static proton_engine_client_t *proton_engine_view_client_create(
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
-  client->view = view;
   client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
@@ -470,8 +454,15 @@ static proton_engine_client_t *proton_engine_view_client_create(
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;
   client->client.get_display_handler = proton_engine_client_get_display_handler;
-  client->client.get_find_handler =
-      view->window->client->client.get_find_handler;
+  proton_engine_view_t *view =
+      (proton_engine_view_t *)proton_browser_lifecycle_owner(browser_lifecycle);
+  cef_client_t *window_client = view != NULL && view->window != NULL
+                                    ? proton_browser_lifecycle_client(
+                                          view->window->browser_lifecycle)
+                                    : NULL;
+  client->client.get_find_handler = window_client != NULL
+                                        ? window_client->get_find_handler
+                                        : NULL;
   client->client.get_render_handler = proton_engine_client_get_render_handler;
   return client;
 }
@@ -526,9 +517,9 @@ int32_t proton_engine_view_create(
                               "failed to allocate browser lifecycle");
     return PROTON_ERR_ENGINE;
   }
-  view->client = proton_engine_view_client_create(
-      view, view->browser_lifecycle);
-  if (view->client == NULL) {
+  proton_engine_client_t *client = proton_engine_view_client_create(
+      view->browser_lifecycle);
+  if (client == NULL) {
     proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
@@ -536,11 +527,10 @@ int32_t proton_engine_view_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(view->browser_lifecycle,
-                                      &view->client->client);
+                                      &client->client);
   view->initial_url = proton_engine_strdup(
       config.initial_url[0] != '\0' ? config.initial_url : "about:blank");
   if (view->initial_url == NULL) {
-    view->client->view = NULL;
     proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
@@ -564,7 +554,6 @@ int32_t proton_engine_view_create(
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
     free(view->initial_url);
-    view->client->view = NULL;
     proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
@@ -597,7 +586,7 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
   if (view->closed) {
     return PROTON_OK;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     if (!proton_engine_view_request_browser_close(view, 1)) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available for close");
@@ -636,8 +625,8 @@ int32_t proton_engine_view_set_bounds(proton_engine_view_t *view,
   view->width = width;
   view->height = height;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL) {
         host->was_resized(host);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -661,8 +650,8 @@ int32_t proton_engine_view_set_visible(proton_engine_view_t *view,
   }
   view->visible = visible ? 1 : 0;
   if (view->window != NULL && view->window->headless) {
-    if (view->browser != NULL) {
-      cef_browser_host_t *host = view->browser->get_host(view->browser);
+    if (proton_engine_view_browser(view) != NULL) {
+      cef_browser_host_t *host = proton_engine_view_browser(view)->get_host(proton_engine_view_browser(view));
       if (host != NULL && host->was_hidden != NULL) {
         host->was_hidden(host, view->visible ? 0 : 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -698,9 +687,9 @@ int32_t proton_engine_view_set_zoom_percent(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_set_zoom_percent(
-        view->browser, zoom_percent, error, error_len);
+        proton_engine_view_browser(view), zoom_percent, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -717,9 +706,9 @@ int32_t proton_engine_view_set_audio_muted(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_set_audio_muted(
-        view->browser, muted, error, error_len);
+        proton_engine_view_browser(view), muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -736,9 +725,9 @@ int32_t proton_engine_view_is_audio_muted(proton_engine_view_t *view,
                               "view and muted output are required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if (view->browser != NULL) {
+  if (proton_engine_view_browser(view) != NULL) {
     int32_t status = proton_browser_is_audio_muted(
-        view->browser, out_muted, error, error_len);
+        proton_engine_view_browser(view), out_muted, error, error_len);
     if (status != PROTON_OK) {
       return status;
     }
@@ -758,7 +747,7 @@ int32_t proton_engine_view_load_url(proton_engine_view_t *view,
     proton_engine_set_message(error, error_len, "view is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if ((view->browser == NULL &&
+  if ((proton_engine_view_browser(view) == NULL &&
        (view->browser_create_pending || view->browser_create_scheduled)) ||
       view->initial_navigation_pending) {
     char *url_copy =
@@ -773,11 +762,11 @@ int32_t proton_engine_view_load_url(proton_engine_view_t *view,
     proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     return PROTON_OK;
   }
-  if (view->browser == NULL) {
+  if (proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -796,11 +785,11 @@ int32_t proton_engine_view_eval(proton_engine_view_t *view,
                                 char *error,
                                 size_t error_len) {
 
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = view->browser->get_main_frame(view->browser);
+  cef_frame_t *frame = proton_engine_view_browser(view)->get_main_frame(proton_engine_view_browser(view));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -823,12 +812,12 @@ int32_t proton_engine_view_browser_command_json(proton_engine_view_t *view,
                                                 size_t error_len) {
 
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(view->browser_session,
-                                             view->browser, command_json,
+                                             proton_engine_view_browser(view), command_json,
                                              error, error_len);
 }
 
@@ -836,7 +825,7 @@ int32_t proton_engine_view_get_browser_focus_state(
     proton_engine_view_t *view, int32_t *out_focused,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -847,7 +836,7 @@ int32_t proton_engine_view_get_browser_focus_state(
   }
   if (view->window != NULL && view->window->headless) {
     return proton_browser_headless_is_focused(
-        view->browser, out_focused, error, error_len);
+        proton_engine_view_browser(view), out_focused, error, error_len);
   }
   *out_focused = proton_engine_browser_view_is_focused(view->browser_view);
   return PROTON_OK;
@@ -856,24 +845,24 @@ int32_t proton_engine_view_get_browser_focus_state(
 int32_t proton_engine_view_get_devtools_state(
     proton_engine_view_t *view, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      view->browser, out_opened, error, error_len);
+      proton_engine_view_browser(view), out_opened, error, error_len);
 }
 
 int32_t proton_engine_view_get_navigation_state(
     proton_engine_view_t *view, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      view->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_view_browser(view), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_view_find_in_page(
@@ -881,24 +870,24 @@ int32_t proton_engine_view_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (view == NULL || view->closed || view->browser_session == NULL ||
-      view->browser == NULL) {
+      proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      view->browser_session, view->browser, text, forward, match_case,
+      view->browser_session, proton_engine_view_browser(view), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_view_stop_find_in_page(
     proton_engine_view_t *view, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (view == NULL || view->closed || view->browser == NULL) {
+  if (view == NULL || view->closed || proton_engine_view_browser(view) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      view->browser, clear_selection, error, error_len);
+      proton_engine_view_browser(view), clear_selection, error, error_len);
 }
 
 #endif

--- a/proton/internal/native/ffi_mac/mac_view.objc.c
+++ b/proton/internal/native/ffi_mac/mac_view.objc.c
@@ -130,10 +130,9 @@ void proton_engine_window_layout_views(proton_engine_window_t *window) {
 }
 
 static void proton_engine_view_release_browser(proton_engine_view_t *view) {
-  if (view != NULL && view->browser != NULL) {
-    cef_browser_t *browser = view->browser;
+  if (view != NULL) {
     view->browser = NULL;
-    proton_engine_browser_release(browser);
+    view->browser_id = 0;
   }
 }
 
@@ -142,16 +141,8 @@ static int proton_engine_view_request_browser_close(proton_engine_view_t *view,
   if (view == NULL || view->browser == NULL) {
     return 0;
   }
-  if (view->browser_close_requested && !force_close) {
-    return 1;
-  }
-  view->browser_close_requested = 1;
-  cef_browser_host_t *host = view->browser->get_host(view->browser);
-  if (host == NULL) {
-    return 0;
-  }
-  host->close_browser(host, force_close);
-  host->base.release((cef_base_ref_counted_t *)host);
+  proton_browser_lifecycle_request_close(view->browser_lifecycle,
+                                         force_close);
   // For windowed rendering the browser only dies once its host view leaves
   // the view hierarchy (CefBrowserHostView dealloc -> WindowDestroyed). The
   // detach is owned by do_close, which runs inside the close handshake above
@@ -191,7 +182,10 @@ void proton_engine_window_free_views(proton_engine_window_t *window) {
     proton_engine_view_t *next = view->next;
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
-    free(view->client);
+    if (view->client != NULL) {
+      view->client->view = NULL;
+    }
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view->initial_url);
     free(view);
     view = next;
@@ -206,7 +200,10 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
   if (view->browser_create_scheduled || view->initial_navigation_pending) {
     return;
   }
-  if (view->browser_id != 0 && !view->browser_before_close_seen) {
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(view->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   // Resource cleanup only. The struct stays in the window's view list and is
@@ -215,6 +212,7 @@ void proton_engine_view_finalize_if_ready(proton_engine_view_t *view) {
   if (view->client != NULL) {
     view->client->view = NULL;
   }
+  proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
   if (view->browser_view != nil) {
     [view->browser_view removeFromSuperview];
     view->browser_view = nil;
@@ -236,7 +234,6 @@ void proton_engine_window_close_views(proton_engine_window_t *window) {
         proton_engine_view_request_browser_close(view, 1);
         proton_engine_view_mark_closed(view);
         proton_engine_view_defer_finalize(view);
-        proton_engine_view_release_browser(view);
       } else {
         proton_engine_view_mark_closed(view);
         proton_engine_view_defer_finalize(view);
@@ -287,6 +284,7 @@ static int32_t proton_engine_view_create_browser(proton_engine_view_t *view,
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
   if (!accepted) {
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
     proton_engine_set_message(error, error_len, "view browser creation failed");
     return PROTON_ERR_ENGINE;
   }
@@ -386,9 +384,9 @@ void proton_engine_view_on_after_created(proton_engine_view_t *view,
   }
   proton_engine_window_t *window = view->window;
   cef_browser_host_t *host = browser->get_host(browser);
-  browser->base.add_ref((cef_base_ref_counted_t *)browser);
-  view->browser = browser;
-  view->browser_id = browser->get_identifier(browser);
+  view->browser = proton_browser_lifecycle_browser(view->browser_lifecycle);
+  view->browser_id =
+      proton_browser_lifecycle_browser_id(view->browser_lifecycle);
   view->browser_create_scheduled = 0;
   if (host != NULL) {
     double factor = (double)view->zoom_percent / 100.0;
@@ -416,7 +414,6 @@ void proton_engine_view_on_after_created(proton_engine_view_t *view,
   if (view->closed || view->finalize_after_browser_close) {
     view->initial_navigation_pending = 0;
     proton_engine_view_request_browser_close(view, 1);
-    proton_engine_view_release_browser(view);
     proton_engine_view_finalize_if_ready(view);
     proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     return;
@@ -431,11 +428,10 @@ void proton_engine_view_on_after_created(proton_engine_view_t *view,
 
 void proton_engine_view_on_before_close(proton_engine_view_t *view,
                                         cef_browser_t *browser) {
-  (void)browser;
   if (view == NULL) {
     return;
   }
-  view->browser_before_close_seen = 1;
+  proton_browser_lifecycle_on_before_close(view->browser_lifecycle, browser);
   proton_engine_view_mark_closed(view);
   proton_view_events_closed(view->events);
   proton_engine_view_release_browser(view);
@@ -451,7 +447,8 @@ void proton_engine_view_on_before_close(proton_engine_view_t *view,
 }
 
 static proton_engine_client_t *proton_engine_view_client_create(
-    proton_engine_view_t *view) {
+    proton_engine_view_t *view,
+    proton_browser_lifecycle_t *browser_lifecycle) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -459,7 +456,9 @@ static proton_engine_client_t *proton_engine_view_client_create(
   }
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
+  client->client.base.release = proton_engine_client_release;
   client->view = view;
+  client->browser_lifecycle = browser_lifecycle;
   // Views wire the life span, load, display, and render handlers: life span
   // drives the close state machine, load/display feed the view event stream,
   // and the render handler gives headless (OSR) views a viewport. Find results
@@ -519,16 +518,31 @@ int32_t proton_engine_view_create(
   view->zoom_percent = 100;
   view->audio_muted = 0;
   view->visible = config.visible;
-  view->client = proton_engine_view_client_create(view);
+  view->browser_lifecycle = proton_browser_lifecycle_create(
+      window->runtime->browsers, PROTON_BROWSER_ROLE_VIEW, view, NULL);
+  if (view->browser_lifecycle == NULL) {
+    free(view);
+    proton_engine_set_message(error, error_len,
+                              "failed to allocate browser lifecycle");
+    return PROTON_ERR_ENGINE;
+  }
+  view->client = proton_engine_view_client_create(
+      view, view->browser_lifecycle);
   if (view->client == NULL) {
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     proton_engine_set_message(error, error_len, "failed to allocate client");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(view->browser_lifecycle,
+                                      &view->client->client);
   view->initial_url = proton_engine_strdup(
       config.initial_url[0] != '\0' ? config.initial_url : "about:blank");
   if (view->initial_url == NULL) {
-    free(view->client);
+    view->client->view = NULL;
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     proton_engine_set_message(error, error_len,
                               "failed to copy initial browser url");
@@ -550,12 +564,16 @@ int32_t proton_engine_view_create(
     proton_browser_session_destroy(view->browser_session);
     proton_view_events_destroy(view->events);
     free(view->initial_url);
-    free(view->client);
+    view->client->view = NULL;
+    proton_browser_lifecycle_creation_failed(view->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(view->browser_lifecycle);
     free(view);
     proton_engine_set_message(error, error_len,
                               "failed to allocate view state");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_session_bind_lifecycle(view->browser_session,
+                                        view->browser_lifecycle);
   proton_view_events_bind(view->events, config.public_view,
                           config.public_window);
   view->has_background_color = config.has_background_color;
@@ -587,7 +605,6 @@ int32_t proton_engine_view_destroy(proton_engine_view_t *view,
     }
     proton_engine_view_mark_closed(view);
     proton_engine_view_defer_finalize(view);
-    proton_engine_view_release_browser(view);
     proton_engine_view_finalize_if_ready(view);
     return PROTON_OK;
   }

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -180,37 +180,13 @@ int proton_engine_runtime_has_windows(proton_engine_runtime_t *runtime) {
 
 proton_engine_window_t *proton_engine_window_from_browser(
     cef_browser_t *browser) {
-  if (browser == NULL) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_MAIN) {
     return NULL;
   }
-  int browser_id = browser->get_identifier(browser);
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    if (window->browser_id == browser_id) {
-      return window;
-    }
-  }
-  return NULL;
-}
-
-proton_engine_window_t *proton_engine_window_from_browser_client(
-    cef_browser_t *browser) {
-  if (browser == NULL) {
-    return NULL;
-  }
-  cef_browser_host_t *host = browser->get_host(browser);
-  if (host == NULL) {
-    return NULL;
-  }
-  cef_client_t *cef_client = host->get_client(host);
-  proton_engine_window_t *window = NULL;
-  if (cef_client != NULL) {
-    proton_engine_client_t *client = proton_engine_client_from_base(cef_client);
-    window = client != NULL ? client->window : NULL;
-    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
-  }
-  host->base.release((cef_base_ref_counted_t *)host);
-  return window;
+  return (proton_engine_window_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 proton_engine_window_t *proton_engine_window_from_native_id(
@@ -229,20 +205,13 @@ proton_engine_window_t *proton_engine_window_from_native_id(
 
 proton_engine_view_t *proton_engine_view_from_browser(
     cef_browser_t *browser) {
-  if (browser == NULL) {
+  proton_browser_lifecycle_t *lifecycle =
+      proton_engine_browser_lifecycle(browser);
+  if (lifecycle == NULL ||
+      proton_browser_lifecycle_role(lifecycle) != PROTON_BROWSER_ROLE_VIEW) {
     return NULL;
   }
-  int browser_id = browser->get_identifier(browser);
-  for (proton_engine_window_t *window = g_windows; window != NULL;
-       window = window->next) {
-    for (proton_engine_view_t *view = window->views; view != NULL;
-         view = view->next) {
-      if (view->browser_id == browser_id) {
-        return view;
-      }
-    }
-  }
-  return NULL;
+  return (proton_engine_view_t *)proton_browser_lifecycle_owner(lifecycle);
 }
 
 proton_engine_view_t *proton_engine_view_from_native_id(
@@ -262,10 +231,7 @@ proton_engine_view_t *proton_engine_view_from_native_id(
   return NULL;
 }
 
-// Resolves a view through the browser's client. Unlike the browser-id list
-// scan this also works while browser creation is still running, before the
-// view records its browser id.
-proton_engine_view_t *proton_engine_view_from_browser_client(
+proton_browser_lifecycle_t *proton_engine_browser_lifecycle(
     cef_browser_t *browser) {
   if (browser == NULL) {
     return NULL;
@@ -275,14 +241,14 @@ proton_engine_view_t *proton_engine_view_from_browser_client(
     return NULL;
   }
   cef_client_t *cef_client = host->get_client(host);
-  proton_engine_view_t *view = NULL;
+  proton_browser_lifecycle_t *lifecycle = NULL;
   if (cef_client != NULL) {
     proton_engine_client_t *client = proton_engine_client_from_base(cef_client);
-    view = client != NULL ? client->view : NULL;
+    lifecycle = client != NULL ? client->browser_lifecycle : NULL;
     cef_client->base.release((cef_base_ref_counted_t *)cef_client);
   }
   host->base.release((cef_base_ref_counted_t *)host);
-  return view;
+  return lifecycle;
 }
 
 uint64_t proton_engine_window_native_id(proton_engine_window_t *window) {
@@ -338,7 +304,9 @@ proton_engine_window_t *proton_engine_window_lookup_browser(
 }
 
 cef_browser_t *proton_engine_window_browser(proton_engine_window_t *window) {
-  return window != NULL ? window->browser : NULL;
+  return window != NULL
+             ? proton_browser_lifecycle_browser(window->browser_lifecycle)
+             : NULL;
 }
 
 proton_engine_view_t *proton_engine_window_lookup_view_browser(
@@ -396,24 +364,17 @@ int proton_engine_runtime_has_pending_platform_work(
       continue;
     }
     if (window->browser_create_pending || window->browser_create_scheduled ||
-        (window->browser != NULL && window->appkit_closing && !window->closed)) {
+        (proton_engine_window_browser(window) != NULL && window->appkit_closing && !window->closed)) {
       return 1;
     }
   }
   return 0;
 }
 
-void proton_engine_window_release_browser(proton_engine_window_t *window) {
-  if (window != NULL) {
-    window->browser = NULL;
-    window->browser_id = 0;
-  }
-}
-
 int proton_engine_window_request_browser_close(
     proton_engine_window_t *window,
     int force_close) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     return 0;
   }
   proton_browser_lifecycle_request_close(window->browser_lifecycle,
@@ -428,7 +389,7 @@ void proton_engine_window_mark_closed(proton_engine_window_t *window) {
   }
   window->closed = 1;
   proton_engine_bridge_pending_remove_browser(window->runtime,
-                                              window->browser_id);
+      proton_browser_lifecycle_browser_id(window->browser_lifecycle));
   proton_engine_dialog_complete_window_closed(window->native_id);
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 }
@@ -446,9 +407,9 @@ static void proton_engine_window_commit_appkit_close(
        view = view->next) {
     view->browser_view = nil;
   }
-  if (window->browser != NULL) {
+  if (proton_engine_window_browser(window) != NULL) {
     proton_engine_bridge_pending_remove_browser(window->runtime,
-                                                window->browser_id);
+        proton_browser_lifecycle_browser_id(window->browser_lifecycle));
   }
   NSView *browser_view = window->browser_view;
   window->window = nil;
@@ -613,11 +574,11 @@ static void proton_engine_window_update_zoom_button(
     }
     return NO;
   }
-  if (window->browser == NULL) {
+  if (proton_engine_window_browser(window) == NULL) {
     proton_engine_window_commit_appkit_close(window, native_window);
     return YES;
   }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
+  cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
   if (host == NULL) {
     proton_engine_window_commit_appkit_close(window, native_window);
     return YES;
@@ -764,7 +725,7 @@ static int32_t proton_engine_window_create_browser(
           ? extra_info_value->get_dictionary(extra_info_value)
           : NULL;
   int accepted = cef_browser_host_create_browser(
-      &window_info, &window->client->client, &url, &browser_settings,
+      &window_info, proton_browser_lifecycle_client(window->browser_lifecycle), &url, &browser_settings,
       extra_info, NULL);
   if (extra_info_value != NULL) {
     extra_info_value->base.release((cef_base_ref_counted_t *)extra_info_value);
@@ -849,9 +810,9 @@ int32_t proton_engine_window_create(
                                      config.public_window);
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
-  window->client = proton_engine_client_create(
-      window, window->browser_lifecycle);
-  if (window->client == NULL) {
+  proton_engine_client_t *client = proton_engine_client_create(
+      window->browser_lifecycle);
+  if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
@@ -861,7 +822,7 @@ int32_t proton_engine_window_create(
     return PROTON_ERR_ENGINE;
   }
   proton_browser_lifecycle_set_client(window->browser_lifecycle,
-                                      &window->client->client);
+                                      &client->client);
 
   ProtonWindowDelegate *delegate = nil;
   if (!window->headless) {
@@ -880,7 +841,6 @@ int32_t proton_engine_window_create(
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
     if (window->window == nil) {
-      window->client->window = NULL;
       proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
       proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
@@ -932,7 +892,6 @@ int32_t proton_engine_window_create(
     if (delegate != nil) {
       [delegate release];
     }
-    window->client->window = NULL;
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
@@ -966,9 +925,6 @@ static void proton_engine_window_free(proton_engine_window_t *window) {
   }
   proton_engine_window_lock();
   proton_engine_window_free_views(window);
-  if (window->client != NULL) {
-    window->client->window = NULL;
-  }
   proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   free(window->initial_url);
@@ -1027,9 +983,6 @@ void proton_engine_window_finalize_if_ready(
     }
   }
   proton_engine_window_list_remove(window);
-  if (window->client != NULL) {
-    window->client->window = NULL;
-  }
   proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   proton_engine_window_detach_native_window(window);
   proton_engine_window_free(window);
@@ -1044,7 +997,7 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   proton_engine_window_close_views(window);
-  if (window->browser != NULL) {
+  if (proton_engine_window_browser(window) != NULL) {
     if (!proton_engine_window_request_browser_close(window, 1)) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available for close");
@@ -1071,8 +1024,8 @@ int32_t proton_engine_window_show(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 0;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 0);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1106,8 +1059,8 @@ int32_t proton_engine_window_hide(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_hidden = 1;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_hidden(host, 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1147,7 +1100,7 @@ int32_t proton_engine_window_close(proton_engine_window_t *window,
     [window->window performClose:nil];
     return PROTON_OK;
   }
-  if (window->browser != NULL) {
+  if (proton_engine_window_browser(window) != NULL) {
     if (!proton_engine_window_request_browser_close(window, 0)) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available for close");
@@ -1216,8 +1169,8 @@ int32_t proton_engine_window_focus(proton_engine_window_t *window,
   }
   if (window->headless) {
     window->headless_focused = 1;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->set_focus(host, 1);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1329,8 +1282,8 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
   window->width = width;
   window->height = height;
   if (window->headless) {
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_resized(host);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1360,8 +1313,8 @@ int32_t proton_engine_window_set_content_size(
   if (window->headless) {
     window->width = width;
     window->height = height;
-    if (window->browser != NULL) {
-      cef_browser_host_t *host = window->browser->get_host(window->browser);
+    if (proton_engine_window_browser(window) != NULL) {
+      cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
       if (host != NULL) {
         host->was_resized(host);
         host->base.release((cef_base_ref_counted_t *)host);
@@ -1764,12 +1717,12 @@ int32_t proton_engine_window_apply(
     return PROTON_ERR_INVALID_ARGUMENT;
   }
   if (action->kind == PROTON_ENGINE_WINDOW_SET_ZOOM_PERCENT) {
-    if (window->browser == NULL) {
+    if (proton_engine_window_browser(window) == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser is not initialized");
       return PROTON_ERR_NOT_INITIALIZED;
     }
-    cef_browser_host_t *host = window->browser->get_host(window->browser);
+    cef_browser_host_t *host = proton_engine_window_browser(window)->get_host(proton_engine_window_browser(window));
     if (host == NULL) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available");
@@ -2135,7 +2088,7 @@ int32_t proton_engine_window_load_url(proton_engine_window_t *window,
     proton_engine_set_message(error, error_len, "window is required");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  if ((window->browser == NULL &&
+  if ((proton_engine_window_browser(window) == NULL &&
        (window->browser_create_pending || window->browser_create_scheduled)) ||
       window->initial_navigation_pending) {
     char *url_copy =
@@ -2150,11 +2103,11 @@ int32_t proton_engine_window_load_url(proton_engine_window_t *window,
     proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
     return PROTON_OK;
   }
-  if (window->browser == NULL) {
+  if (proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -2173,11 +2126,11 @@ int32_t proton_engine_window_eval(proton_engine_window_t *window,
                                   char *error,
                                   size_t error_len) {
 
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  cef_frame_t *frame = window->browser->get_main_frame(window->browser);
+  cef_frame_t *frame = proton_engine_window_browser(window)->get_main_frame(proton_engine_window_browser(window));
   if (frame == NULL) {
     proton_engine_set_message(error, error_len, "main frame is not available");
     return PROTON_ERR_ENGINE;
@@ -2199,13 +2152,13 @@ int32_t proton_engine_window_browser_command_json(
     char *error, size_t error_len) {
 
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_session_command_json(
-      window->browser_session, window->browser, command_json, error,
+      window->browser_session, proton_engine_window_browser(window), command_json, error,
       error_len);
 }
 
@@ -2213,7 +2166,7 @@ int32_t proton_engine_window_get_browser_focus_state(
     proton_engine_window_t *window, int32_t *out_focused,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
@@ -2224,7 +2177,7 @@ int32_t proton_engine_window_get_browser_focus_state(
   }
   if (window->headless) {
     return proton_browser_headless_is_focused(
-        window->browser, out_focused, error, error_len);
+        proton_engine_window_browser(window), out_focused, error, error_len);
   }
   *out_focused = proton_engine_browser_view_is_focused(window->browser_view);
   return PROTON_OK;
@@ -2233,43 +2186,43 @@ int32_t proton_engine_window_get_browser_focus_state(
 int32_t proton_engine_window_get_devtools_state(
     proton_engine_window_t *window, int32_t *out_opened,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len,
                               "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_devtools_opened(
-      window->browser, out_opened, error, error_len);
+      proton_engine_window_browser(window), out_opened, error, error_len);
 }
 
 int32_t proton_engine_window_get_navigation_state(
     proton_engine_window_t *window, int32_t *out_can_go_back,
     int32_t *out_can_go_forward, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_navigation_state(
-      window->browser, out_can_go_back, out_can_go_forward, error, error_len);
+      proton_engine_window_browser(window), out_can_go_back, out_can_go_forward, error, error_len);
 }
 
 int32_t proton_engine_window_download_url(
     proton_engine_window_t *window, const char *url, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_download_url(window->browser, url, error, error_len);
+  return proton_browser_download_url(proton_engine_window_browser(window), url, error, error_len);
 }
 
 int32_t proton_engine_window_print(
     proton_engine_window_t *window, char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  return proton_browser_print(window->browser, error, error_len);
+  return proton_browser_print(proton_engine_window_browser(window), error, error_len);
 }
 
 int32_t proton_engine_window_print_to_pdf(
@@ -2282,12 +2235,12 @@ int32_t proton_engine_window_print_to_pdf(
     const char *footer_template, int32_t generate_tagged_pdf,
     int32_t generate_document_outline, int32_t *out_request_id,
     char *error, size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_print_to_pdf(
-      window->browser_session, window->browser, path, landscape,
+      window->browser_session, proton_engine_window_browser(window), path, landscape,
       print_background, scale, paper_width, paper_height,
       prefer_css_page_size, margin_type, margin_top, margin_right,
       margin_bottom, margin_left, page_ranges, display_header_footer,
@@ -2300,46 +2253,46 @@ int32_t proton_engine_window_find_in_page(
     int32_t match_case, int32_t find_next, int32_t *out_request_id,
     char *error, size_t error_len) {
   if (window == NULL || window->browser_session == NULL ||
-      window->browser == NULL) {
+      proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_find_in_page(
-      window->browser_session, window->browser, text, forward, match_case,
+      window->browser_session, proton_engine_window_browser(window), text, forward, match_case,
       find_next, out_request_id, error, error_len);
 }
 
 int32_t proton_engine_window_stop_find_in_page(
     proton_engine_window_t *window, int32_t clear_selection, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_stop_find_in_page(
-      window->browser, clear_selection, error, error_len);
+      proton_engine_window_browser(window), clear_selection, error, error_len);
 }
 
 int32_t proton_engine_window_set_audio_muted(
     proton_engine_window_t *window, int32_t muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_set_audio_muted(
-      window->browser, muted, error, error_len);
+      proton_engine_window_browser(window), muted, error, error_len);
 }
 
 int32_t proton_engine_window_is_audio_muted(
     proton_engine_window_t *window, int32_t *out_muted, char *error,
     size_t error_len) {
-  if (window == NULL || window->browser == NULL) {
+  if (window == NULL || proton_engine_window_browser(window) == NULL) {
     proton_engine_set_message(error, error_len, "browser is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
   return proton_browser_is_audio_muted(
-      window->browser, out_muted, error, error_len);
+      proton_engine_window_browser(window), out_muted, error, error_len);
 }
 
 int32_t proton_engine_window_get_browser_url(
@@ -2408,12 +2361,12 @@ int32_t proton_engine_window_emit_bridge_event_json(
     char *error,
     size_t error_len) {
 
-  if (window == NULL || window->browser == NULL ||
+  if (window == NULL || proton_engine_window_browser(window) == NULL ||
       window->bridge_config_json == NULL) {
     proton_engine_set_message(error, error_len, "bridge is not initialized");
     return PROTON_ERR_NOT_INITIALIZED;
   }
-  if (!proton_engine_bridge_send_event(window->browser, event_json)) {
+  if (!proton_engine_bridge_send_event(proton_engine_window_browser(window), event_json)) {
     proton_engine_set_message(error, error_len,
                               "failed to send bridge event to renderer");
     return PROTON_ERR_ENGINE;

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -403,17 +403,10 @@ int proton_engine_runtime_has_pending_platform_work(
   return 0;
 }
 
-void proton_engine_browser_release(cef_browser_t *browser) {
-  if (browser != NULL) {
-    browser->base.release((cef_base_ref_counted_t *)browser);
-  }
-}
-
 void proton_engine_window_release_browser(proton_engine_window_t *window) {
-  if (window != NULL && window->browser != NULL) {
-    cef_browser_t *browser = window->browser;
+  if (window != NULL) {
     window->browser = NULL;
-    proton_engine_browser_release(browser);
+    window->browser_id = 0;
   }
 }
 
@@ -423,16 +416,8 @@ int proton_engine_window_request_browser_close(
   if (window == NULL || window->browser == NULL) {
     return 0;
   }
-  if (window->browser_close_requested && !force_close) {
-    return 1;
-  }
-  cef_browser_host_t *host = window->browser->get_host(window->browser);
-  if (host == NULL) {
-    return 0;
-  }
-  window->browser_close_requested = 1;
-  host->close_browser(host, force_close);
-  host->base.release((cef_base_ref_counted_t *)host);
+  proton_browser_lifecycle_request_close(window->browser_lifecycle,
+                                         force_close);
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return 1;
 }
@@ -643,7 +628,8 @@ static void proton_engine_window_update_zoom_button(
     allow_close = 1;
     window->appkit_closing = 1;
   } else if (host->try_close_browser != NULL) {
-    window->browser_close_requested = 1;
+    proton_browser_lifecycle_note_close_requested(window->browser_lifecycle,
+                                                  0);
     allow_close = host->try_close_browser(host);
     if (allow_close) {
       window->appkit_closing = 1;
@@ -652,8 +638,7 @@ static void proton_engine_window_update_zoom_button(
     allow_close = 1;
     window->appkit_closing = 1;
   } else {
-    window->browser_close_requested = 1;
-    host->close_browser(host, 0);
+    proton_browser_lifecycle_request_close(window->browser_lifecycle, 0);
   }
   host->base.release((cef_base_ref_counted_t *)host);
   if (allow_close) {
@@ -787,6 +772,7 @@ static int32_t proton_engine_window_create_browser(
   cef_string_clear(&window_info.window_name);
   cef_string_clear(&url);
   if (!accepted) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_engine_set_message(error, error_len, "browser creation failed");
     return PROTON_ERR_ENGINE;
   }
@@ -848,23 +834,34 @@ int32_t proton_engine_window_create(
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
       &config.browser_policy, proton_engine_browser_signal, NULL);
-  if (window->browser_session == NULL) {
+  window->browser_lifecycle = proton_browser_lifecycle_create(
+      runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
+  if (window->browser_session == NULL || window->browser_lifecycle == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     free(window->bridge_config_json);
+    proton_browser_session_destroy(window->browser_session);
     free(window);
     proton_engine_set_message(error, error_len,
-                              "failed to allocate browser session");
+                              "failed to allocate browser state");
     return PROTON_ERR_ENGINE;
   }
   proton_browser_session_bind_window(window->browser_session,
                                      config.public_window);
-  window->client = proton_engine_client_create(window);
+  proton_browser_session_bind_lifecycle(window->browser_session,
+                                        window->browser_lifecycle);
+  window->client = proton_engine_client_create(
+      window, window->browser_lifecycle);
   if (window->client == NULL) {
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
     free(window);
     proton_engine_set_message(error, error_len, "failed to allocate client");
     return PROTON_ERR_ENGINE;
   }
+  proton_browser_lifecycle_set_client(window->browser_lifecycle,
+                                      &window->client->client);
 
   ProtonWindowDelegate *delegate = nil;
   if (!window->headless) {
@@ -883,7 +880,9 @@ int32_t proton_engine_window_create(
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
     if (window->window == nil) {
-      free(window->client);
+      window->client->window = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
       proton_browser_session_destroy(window->browser_session);
       free(window->bridge_config_json);
       free(window);
@@ -933,7 +932,9 @@ int32_t proton_engine_window_create(
     if (delegate != nil) {
       [delegate release];
     }
-    free(window->client);
+    window->client->window = NULL;
+    proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+    proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
     proton_browser_session_destroy(window->browser_session);
     free(window->bridge_config_json);
     free(window);
@@ -965,7 +966,10 @@ static void proton_engine_window_free(proton_engine_window_t *window) {
   }
   proton_engine_window_lock();
   proton_engine_window_free_views(window);
-  free(window->client);
+  if (window->client != NULL) {
+    window->client->window = NULL;
+  }
+  proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   free(window->bridge_config_json);
   free(window->initial_url);
   proton_browser_session_destroy(window->browser_session);
@@ -1010,7 +1014,10 @@ void proton_engine_window_finalize_if_ready(
       window->initial_navigation_pending) {
     return;
   }
-  if (window->browser_id != 0 && !window->browser_before_close_seen) {
+  proton_browser_lifecycle_state_t browser_state =
+      proton_browser_lifecycle_state(window->browser_lifecycle);
+  if (browser_state != PROTON_BROWSER_CLOSED &&
+      browser_state != PROTON_BROWSER_CREATION_FAILED) {
     return;
   }
   for (proton_engine_view_t *view = window->views; view != NULL;
@@ -1023,6 +1030,7 @@ void proton_engine_window_finalize_if_ready(
   if (window->client != NULL) {
     window->client->window = NULL;
   }
+  proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
   proton_engine_window_detach_native_window(window);
   proton_engine_window_free(window);
 }
@@ -1037,8 +1045,7 @@ int32_t proton_engine_window_destroy(proton_engine_window_t *window,
   }
   proton_engine_window_close_views(window);
   if (window->browser != NULL) {
-    if (!window->browser_close_requested &&
-        !proton_engine_window_request_browser_close(window, 1)) {
+    if (!proton_engine_window_request_browser_close(window, 1)) {
       proton_engine_set_message(error, error_len,
                                 "browser host is not available for close");
       return PROTON_ERR_ENGINE;


### PR DESCRIPTION
## Summary

CEF browser lifetime was previously split across window/view bookkeeping and unowned DevTools instances created with a null client. Runtime shutdown only waited for main windows and views, so a DevTools browser could still be unwinding when `cef_shutdown()` ran. This is a shutdown-order race and can surface as a macOS crash.

This refactor makes the runtime the explicit owner of every CEF browser session:

- add a shared lifecycle registry for main, WebContentsView, and DevTools browsers;
- model `Creating`, `Live`, `Closing`, `Closed`, and `CreationFailed` states, with `OnBeforeClose` as the only close-completion transition;
- create DevTools with a dedicated lifecycle-owned client instead of CEF's null-client default;
- begin DevTools shutdown before their inspected browser and block `cef_shutdown()` until every registry entry is terminal;
- remove the duplicated browser-close flags and eager browser/client releases from platform code;
- make heap-allocated CEF clients use releasing refcount callbacks consistently on macOS, Windows, and Linux.

The lifecycle registry is private native infrastructure. The public MoonBit API remains unchanged.

## Regression Coverage

`54_devtools` now opens DevTools, closes only the inspected host CDP target, and requires the application plus all CEF helper processes to exit. This exercises the shutdown path that previously relied on implicit CEF behavior.

## Validation

- `moon fmt`
- `moon info`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test internal/native --target native --diagnostic-limit 80` (36/36)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon -C e2e build --target native --diagnostic-limit 200`
- `moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`

The self-hosted macOS run passed all scenarios, including `52_web_contents_view` and the strengthened `54_devtools` shutdown test. Windows and Linux follow the same lifecycle implementation but still need platform-native CI validation.