### PR TITLE
feat(app): add protocol client and process controls

### DIFF
--- a/examples/75_app_protocol_process/README.md
+++ b/examples/75_app_protocol_process/README.md
@@ -1,0 +1,44 @@
+# Application Protocol And Process Control
+
+Manual review for Electron-style default protocol client registration,
+immediate process exit, and application relaunch.
+
+Build the development form from the repository root:
+
+```sh
+PROTON_NO_UPDATE_CHECK=1 moon -C cli run . -- dev -C .. \
+  --config examples/75_app_protocol_process/proton.project.json
+```
+
+The development form can review relaunch and exit. On macOS, protocol
+registration intentionally reports that a packaged application is required.
+
+Build and run the packaged macOS application:
+
+```sh
+moon -C cli run . -- package -C .. \
+  --config examples/75_app_protocol_process/proton.project.json \
+  --format app
+open "dist/Proton App Control.app"
+```
+
+1. Select **Refresh** and record the current default-handler state. macOS may
+   already report `yes` after LaunchServices discovers the packaged bundle.
+2. Select **Register**, refresh, and confirm the state is `yes`.
+3. Open `proton-control-review://manual-review` and confirm the packaged app is
+   activated.
+4. Select **Remove** and refresh. If another handler exists, confirm the state
+   becomes `no`; otherwise LaunchServices may rediscover this bundle as the
+   only available handler. This deliberately changes the system default, so
+   perform it only when protocol cleanup is part of the review.
+5. Select **Relaunch + quit**. A new instance must open with
+   `--proton-relaunch-review` in Startup argv after orderly shutdown.
+6. Select **Relaunch + exit**. A new instance must still open, while close
+   interception and lifecycle shutdown are skipped in the old process.
+7. Run the development executable from a terminal and select **Exit code 7**;
+   confirm the process exits with status 7 and no replacement instance opens.
+
+On Windows, also inspect
+`HKCU\\Software\\Classes\\proton-control-review` after register/remove. On
+Linux, install or integrate the generated `.desktop` entry before registration;
+Electron does not expose protocol removal on Linux, so **Remove** returns false.

--- a/examples/75_app_protocol_process/main.mbt
+++ b/examples/75_app_protocol_process/main.mbt
@@ -1,0 +1,152 @@
+///|
+struct ControlRequest {
+  action : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend ControlRequest with ToJson::{to_json}
+
+///|
+pub extend ControlRequest with FromJson::{from_json}
+
+///|
+struct ControlReply {
+  ok : Bool
+  is_default : Bool
+  message : String
+} derive(ToJson, FromJson)
+
+///|
+pub extend ControlReply with ToJson::{to_json}
+
+///|
+pub extend ControlReply with FromJson::{from_json}
+
+///|
+let scheme = "proton-control-review"
+
+///|
+let contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id="examples/app-protocol-process",
+  js_namespace="appControlReview",
+)
+
+///|
+let control_command : @proton_contract.Command[ControlRequest, ControlReply] = contract.command(
+  "control",
+)
+
+///|
+let application_slot : Ref[@proton.ApplicationContext?] = { val: None, }
+
+///|
+fn reply(
+  context : @proton.ApplicationContext,
+  message : String,
+  ok? : Bool = true,
+) -> ControlReply {
+  let is_default = context.is_default_protocol_client(scheme) catch {
+    _ => false
+  }
+  { ok, is_default, message, }
+}
+
+///|
+fn control(request : ControlRequest) -> ControlReply {
+  let context = match application_slot.val {
+    Some(context) => context
+    None =>
+      return {
+        ok: false,
+        is_default: false,
+        message: "Application context is not ready",
+      }
+  }
+  try {
+    match request.action {
+      "query" => reply(context, "Default protocol state refreshed")
+      "register" => {
+        let changed = context.set_as_default_protocol_client(scheme)
+        reply(
+          context,
+          if changed {
+            "Protocol handler registered"
+          } else {
+            "Protocol handler was not changed"
+          },
+          ok=changed,
+        )
+      }
+      "remove" => {
+        let removed = context.remove_default_protocol_client(scheme)
+        reply(
+          context,
+          if removed {
+            "Protocol handler removed"
+          } else {
+            "Removal is unavailable or this app is not the default"
+          },
+          ok=removed,
+        )
+      }
+      "relaunch-quit" => {
+        context.relaunch(
+          options=@proton.RelaunchOptions(arguments=["--proton-relaunch-review"]),
+        )
+        context.quit()
+        reply(context, "Relaunch scheduled; orderly quit requested")
+      }
+      "relaunch-exit" => {
+        context.relaunch(
+          options=@proton.RelaunchOptions(arguments=["--proton-relaunch-review"]),
+        )
+        context.exit(exit_code=0)
+        reply(context, "unreachable")
+      }
+      "exit-7" => {
+        context.exit(exit_code=7)
+        reply(context, "unreachable")
+      }
+      _ => reply(context, "Unknown action", ok=false)
+    }
+  } catch {
+    error => reply(context, error.message(), ok=false)
+  }
+}
+
+///|
+fn register_commands(registrar : @proton.CommandRegistrar) -> Unit raise {
+  registrar.bind(control_command, (_context, request) => control(request))
+}
+
+///|
+fn page(arguments : String) -> String {
+  (
+    $|<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Application protocol and process</title>
+    $|<style>*{box-sizing:border-box}:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#1f292d;background:#e9edef}body{margin:0;min-height:100vh}header{padding:28px 34px;background:#20272b;color:#fff;border-bottom:5px solid #c94f3d}.eyebrow{font:700 11px/1.4 ui-monospace,SFMono-Regular,monospace;color:#75d5b4}h1{margin:6px 0 8px;font-size:29px;letter-spacing:0}header p{margin:0;color:#c7d0d4}main{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:#aab3b7}.panel{min-width:0;padding:26px 30px;background:#fff}.panel h2{margin:0 0 8px;font-size:18px}.panel p{margin:0 0 18px;color:#5b676d;font-size:13px;line-height:1.55}.actions{display:grid;grid-template-columns:1fr 1fr;gap:8px}button{min-height:40px;border:1px solid #718087;background:#f8fafb;color:#20272b;font-weight:700;cursor:pointer}button.primary{background:#256b5a;border-color:#256b5a;color:#fff}button.danger{background:#a43c32;border-color:#a43c32;color:#fff}.state{margin-top:18px;padding:14px;border:1px solid #aab3b7;background:#f4f6f7;font:12px/1.5 ui-monospace,SFMono-Regular,monospace}.state strong{color:#256b5a}.argv{overflow-wrap:anywhere;color:#46545b}.status{grid-column:1/-1;padding:18px 30px;background:#20272b;color:#eaf0f2;font:13px/1.5 ui-monospace,SFMono-Regular,monospace}@media(max-width:720px){main{grid-template-columns:1fr}.panel{padding:22px}.status{grid-column:auto}}</style></head>
+    $|<body><header><span class="eyebrow">ELECTRON APP / REVIEW 75</span><h1>Protocol and process control</h1><p>Explicit system mutations and observable relaunch behavior.</p></header><main><section class="panel"><h2>Default protocol client</h2><p>Scheme: <code>\{scheme}</code>. Registration requires a packaged macOS app; Linux requires an installed desktop entry.</p><div class="actions"><button data-action="query">Refresh</button><button class="primary" data-action="register">Register</button><button data-action="remove">Remove</button></div><div class="state">Default handler: <strong id="default-state">unknown</strong></div></section><section class="panel"><h2>Exit and relaunch</h2><p>Relaunch uses <code>--proton-relaunch-review</code>. Immediate exit skips lifecycle shutdown and close interception.</p><div class="actions"><button class="primary" data-action="relaunch-quit">Relaunch + quit</button><button class="danger" data-action="relaunch-exit">Relaunch + exit</button><button class="danger" data-action="exit-7">Exit code 7</button></div><div class="state">Startup argv: <span class="argv">\{arguments}</span></div></section><div id="status" class="status" role="status">Ready. No system setting has been changed.</div></main>
+    $|<script>const status=document.querySelector('#status');const state=document.querySelector('#default-state');async function run(action){status.textContent=`${action}...`;try{const reply=await window.__MoonBit__.core.invokeOp('ext:appControlReview/control',{action});state.textContent=reply.is_default?'yes':'no';status.textContent=reply.message}catch(error){status.textContent=String(error)}}document.querySelectorAll('[data-action]').forEach(button=>button.onclick=()=>void run(button.dataset.action));void run('query')</script></body></html>
+  )
+}
+
+///|
+async fn main {
+  @proton.html(
+    "Application Protocol And Process",
+    page(@env.args().join(" ")),
+    width=960,
+    height=620,
+  )
+  .load_config()
+  .single_instance()
+  .url_scheme(scheme)
+  .commands(register_commands)
+  .app_lifecycle(
+    on_start=context => {
+      application_slot.val = Some(context)
+      context
+    },
+    on_shutdown=fn(_context) { application_slot.val = None },
+  )
+  .run_or_abort()
+}

--- a/examples/75_app_protocol_process/moon.pkg
+++ b/examples/75_app_protocol_process/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbit-community/proton_contract",
+  "moonbit-community/proton",
+}
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")
+
+options(
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/75_app_protocol_process/pkg.generated.mbti
+++ b/examples/75_app_protocol_process/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/examples/75_app_protocol_process"
+
+import {
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type ControlReply derive(ToJson, @json.FromJson)
+pub fn ControlReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ControlReply::to_json(Self) -> Json
+
+type ControlRequest derive(ToJson, @json.FromJson)
+pub fn ControlRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ControlRequest::to_json(Self) -> Json
+
+// Type aliases
+
+// Traits

--- a/examples/75_app_protocol_process/proton.project.json
+++ b/examples/75_app_protocol_process/proton.project.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "community.moonbit.proton.app-protocol-process",
+  "backend": {
+    "path": "../..",
+    "package": "examples/75_app_protocol_process"
+  },
+  "package": {
+    "product_name": "Proton App Control",
+    "version": "1.0.0",
+    "formats": [
+      "app"
+    ],
+    "output": "../../dist",
+    "url_schemes": [
+      "proton-control-review"
+    ]
+  }
+}

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -137,6 +137,9 @@ moon -C examples run 01_run --target native
   version, packaged-state, application-root, standard-path, and configured user
   directory review, including startup path overrides for user data, browser
   session data, downloads, and logs.
+- `75_app_protocol_process`: manual Electron-style default protocol client,
+  immediate exit-code, and scheduled relaunch review with explicit system
+  mutation controls.
 
 All runnable examples should import `moonbit-community/proton`. Runtime behavior
 is configured through the App builder; `proton.project.json` is present only

--- a/package/lib/error.mbt
+++ b/package/lib/error.mbt
@@ -2,6 +2,7 @@
 pub(all) suberror PackagePlanError {
   InvalidProductName(reason~ : String)
   InvalidIdentifier(identifier~ : String, reason~ : String)
+  InvalidUrlScheme(scheme~ : String, reason~ : String)
   InvalidVersion(version~ : String, reason~ : String)
   UnsupportedFormat(format~ : String)
   DuplicateFormat(format~ : String)
@@ -24,6 +25,8 @@ pub fn PackagePlanError::message(self : PackagePlanError) -> String {
     InvalidProductName(reason~) => "invalid product_name: " + reason
     InvalidIdentifier(identifier~, reason~) =>
       "invalid identifier " + identifier + ": " + reason
+    InvalidUrlScheme(scheme~, reason~) =>
+      "invalid URL scheme " + scheme + ": " + reason
     InvalidVersion(version~, reason~) =>
       "invalid version " + version + ": " + reason
     UnsupportedFormat(format~) => "unsupported package format: " + format

--- a/package/lib/linux.mbt
+++ b/package/lib/linux.mbt
@@ -35,27 +35,46 @@ fn linux_desktop_entry(spec : PackageSpec, name : String) -> String {
     #|Type=Application
     #|Terminal=false
     #|Categories=Utility;
+  let mime_types = if spec.url_schemes.length() == 0 {
+    ""
+  } else {
+    "\nMimeType=" +
+    spec.url_schemes.map(scheme => "x-scheme-handler/" + scheme).join(";") +
+    ";"
+  }
   prefix +
   "\nName=" +
   spec.product_name +
   "\n" +
   "Exec=" +
   name +
+  " %U" +
   "\n" +
   "Icon=" +
   name +
   "\n" +
   "X-AppImage-Version=" +
   spec.version +
+  mime_types +
   "\n"
 }
 
 ///|
-fn linux_apprun(name : String) -> String {
+fn linux_desktop_name(spec : PackageSpec) -> String {
+  spec.identifier + ".desktop"
+}
+
+///|
+fn linux_apprun(name : String, desktop_name : String) -> String {
   let prefix =
     #|#!/bin/sh
     #|HERE="$APPDIR"
-  prefix + "\nexec \"$HERE/usr/bin/" + name + "\" \"$@\"\n"
+  prefix +
+  "\nexport CHROME_DESKTOP=\"" +
+  desktop_name +
+  "\"\nexec \"$HERE/usr/bin/" +
+  name +
+  "\" \"$@\"\n"
 }
 
 ///|
@@ -97,11 +116,11 @@ async fn package_linux(
   copy_file(icon, path_join(appdir, name + ".png"))
   copy_file(icon, path_join(appdir, ".DirIcon"))
   write_text(
-    path_join(appdir, name + ".desktop"),
+    path_join(appdir, linux_desktop_name(spec)),
     linux_desktop_entry(spec, name),
   )
   let apprun = path_join(appdir, "AppRun")
-  write_text(apprun, linux_apprun(name))
+  write_text(apprun, linux_apprun(name, linux_desktop_name(spec)))
   @async_fs.chmod(apprun, 0o755)
   prepare(PackageLayout::{
     root: appdir,

--- a/package/lib/package.mbt
+++ b/package/lib/package.mbt
@@ -154,6 +154,7 @@ fn validate_spec(spec : PackageSpec) -> PackageSpec raise PackagePlanError {
   let product_name = validate_product_name(spec.product_name)
   let identifier = validate_identifier(spec.identifier)
   let version = validate_package_version(spec.version)
+  let url_schemes = validate_url_schemes(spec.url_schemes)
   for payload in spec.payloads {
     validate_relative_destination(payload.destination)
   }
@@ -162,8 +163,44 @@ fn validate_spec(spec : PackageSpec) -> PackageSpec raise PackagePlanError {
     product_name,
     identifier,
     version,
+    url_schemes,
     sign: spec.sign || spec.notarize,
   }
+}
+
+///|
+fn validate_url_schemes(
+  schemes : Array[String],
+) -> Array[String] raise PackagePlanError {
+  let normalized : Array[String] = []
+  for scheme in schemes {
+    let scheme = scheme.trim().to_owned().to_lower()
+    guard scheme.length() > 0 else {
+      raise InvalidUrlScheme(scheme~, reason="value is required")
+    }
+    for index, char in scheme {
+      let valid = if index == 0 {
+        char.is_ascii_alphabetic()
+      } else {
+        char.is_ascii_alphabetic() ||
+        char.is_ascii_digit() ||
+        char == '+' ||
+        char == '-' ||
+        char == '.'
+      }
+      guard valid else {
+        raise InvalidUrlScheme(
+          scheme~,
+          reason="contains an unsupported character",
+        )
+      }
+    }
+    guard !normalized.contains(scheme) else {
+      raise InvalidUrlScheme(scheme~, reason="is declared more than once")
+    }
+    normalized.push(scheme)
+  }
+  normalized
 }
 
 ///|

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -50,6 +50,19 @@ test "package metadata rejects path-unsafe values" {
 }
 
 ///|
+test "package URL schemes are normalized before entering native metadata" {
+  assert_eq(validate_url_schemes([" Demo+App "]), ["demo+app"])
+  for schemes in [["1bad"], ["bad/scheme"], ["demo", "DEMO"]] {
+    try ignore(validate_url_schemes(schemes)) catch {
+      InvalidUrlScheme(..) => ()
+      _ => abort("expected an invalid URL scheme")
+    } noraise {
+      _ => abort("expected an invalid URL scheme")
+    }
+  }
+}
+
+///|
 test "package versions cannot escape package paths" {
   for version in ["1.2", "v1", "2026.08", "1.2.3-beta.1+build.5"] {
     assert_eq(validate_package_version(version), version)
@@ -143,7 +156,13 @@ test "Windows icon embedding reports the native-only operation" {
 ///|
 fn package_test_spec(formats : Array[PackageFormat]) -> PackageSpec {
   PackageSpec(
-    "/tmp/demo", "Demo App", "dev.proton.demo", "1.2.3", formats, "/tmp/dist",
+    "/tmp/demo",
+    "Demo App",
+    "dev.proton.demo",
+    "1.2.3",
+    formats,
+    "/tmp/dist",
+    url_schemes=["devtoys"],
   )
 }
 
@@ -204,6 +223,14 @@ test "NSIS script carries package identity and update behavior" {
   assert_true(script.contains("Exec '\"$INSTDIR\\demo-app.exe\"'"))
   assert_true(
     script.contains(
+      "WriteRegStr HKCU \"Software\\Classes\\devtoys\" \"URL Protocol\" \"\"",
+    ),
+  )
+  assert_true(
+    script.contains("DeleteRegKey HKCU \"Software\\Classes\\devtoys\""),
+  )
+  assert_true(
+    script.contains(
       "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\dev.proton.demo",
     ),
   )
@@ -222,19 +249,23 @@ test "AppImage metadata points at the staged executable" {
       $|Terminal=false
       $|Categories=Utility;
       $|Name=Demo App
-      $|Exec=demo-app
+      $|Exec=demo-app %U
       $|Icon=demo-app
       $|X-AppImage-Version=1.2.3
+      $|MimeType=x-scheme-handler/devtoys;
       $|
     ),
   )
-  let apprun = linux_apprun("demo-app")
+  assert_eq(linux_desktop_name(spec), "dev.proton.demo.desktop")
+  let apprun = linux_apprun("demo-app", linux_desktop_name(spec))
   assert_true(apprun.contains("HERE=\"$APPDIR\""))
+  assert_true(apprun.contains("CHROME_DESKTOP=\"dev.proton.demo.desktop\""))
   inspect(
     apprun,
     content=(
       $|#!/bin/sh
       $|HERE="$APPDIR"
+      $|export CHROME_DESKTOP="dev.proton.demo.desktop"
       $|exec "$HERE/usr/bin/demo-app" "$@"
       $|
     ),

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -231,6 +231,11 @@ test "NSIS script carries package identity and update behavior" {
   )
   assert_true(
     script.contains(
+      "DeleteRegKey HKCU \"Software\\Classes\\devtoys\"\nSectionEnd",
+    ),
+  )
+  assert_true(
+    script.contains(
       "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\dev.proton.demo",
     ),
   )

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -210,6 +210,7 @@ test "NSIS versions and quoting follow installer syntax" {
 ///|
 test "NSIS script carries package identity and update behavior" {
   let spec = package_test_spec([App, Nsis])
+  spec.url_schemes.push("demo-app")
   let script = windows_installer_script(spec, "C:\\stage\\Demo App")
   assert_true(script.contains("Name \"Demo App\""))
   assert_true(script.contains("VIProductVersion \"1.2.3.0\""))
@@ -231,7 +232,8 @@ test "NSIS script carries package identity and update behavior" {
   )
   assert_true(
     script.contains(
-      "DeleteRegKey HKCU \"Software\\Classes\\devtoys\"\nSectionEnd",
+      "DeleteRegKey HKCU \"Software\\Classes\\devtoys\"\n" +
+      "  DeleteRegKey HKCU \"Software\\Classes\\demo-app\"\nSectionEnd",
     ),
   )
   assert_true(

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -154,7 +154,10 @@ test "Windows icon embedding reports the native-only operation" {
 }
 
 ///|
-fn package_test_spec(formats : Array[PackageFormat]) -> PackageSpec {
+fn package_test_spec(
+  formats : Array[PackageFormat],
+  url_schemes? : Array[String] = ["devtoys"],
+) -> PackageSpec {
   PackageSpec(
     "/tmp/demo",
     "Demo App",
@@ -162,7 +165,7 @@ fn package_test_spec(formats : Array[PackageFormat]) -> PackageSpec {
     "1.2.3",
     formats,
     "/tmp/dist",
-    url_schemes=["devtoys"],
+    url_schemes~,
   )
 }
 
@@ -209,8 +212,7 @@ test "NSIS versions and quoting follow installer syntax" {
 
 ///|
 test "NSIS script carries package identity and update behavior" {
-  let spec = package_test_spec([App, Nsis])
-  spec.url_schemes.push("demo-app")
+  let spec = package_test_spec([App, Nsis], url_schemes=["devtoys", "demo-app"])
   let script = windows_installer_script(spec, "C:\\stage\\Demo App")
   assert_true(script.contains("Name \"Demo App\""))
   assert_true(script.contains("VIProductVersion \"1.2.3.0\""))
@@ -233,7 +235,17 @@ test "NSIS script carries package identity and update behavior" {
   assert_true(
     script.contains(
       "DeleteRegKey HKCU \"Software\\Classes\\devtoys\"\n" +
-      "  DeleteRegKey HKCU \"Software\\Classes\\demo-app\"\nSectionEnd",
+      "  DeleteRegKey HKCU \"Software\\Classes\\demo-app\"\n" +
+      "SectionEnd",
+    ),
+  )
+  let empty_script = windows_installer_script(
+    package_test_spec([App, Nsis], url_schemes=[]),
+    "C:\\stage\\Demo App",
+  )
+  assert_true(
+    empty_script.contains(
+      "DeleteRegKey HKLM \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\dev.proton.demo\"\nSectionEnd",
     ),
   )
   assert_true(

--- a/package/lib/pkg.generated.mbti
+++ b/package/lib/pkg.generated.mbti
@@ -56,6 +56,7 @@ pub fn PackageFileSystemError::to_repr(Self) -> @debug.Repr
 pub(all) suberror PackagePlanError {
   InvalidProductName(reason~ : String)
   InvalidIdentifier(identifier~ : String, reason~ : String)
+  InvalidUrlScheme(scheme~ : String, reason~ : String)
   InvalidVersion(version~ : String, reason~ : String)
   UnsupportedFormat(format~ : String)
   DuplicateFormat(format~ : String)

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -262,7 +262,7 @@ async fn create_windows_installer(
         detail="\{script}: \{@debug.render(Repr(error))}",
       )
   }
-  let (code, _) = @process.collect_output_merged(windows_installer_tool, [
+  let (code, output) = @process.collect_output_merged(windows_installer_tool, [
     "/V2", script,
   ]) catch {
     _ =>
@@ -274,7 +274,10 @@ async fn create_windows_installer(
   guard code == 0 else {
     raise WindowsPackagingError::ToolFailure(
       stage="create Windows installer",
-      detail="exit code \{code}",
+      detail="exit code " +
+        code.to_string() +
+        ": " +
+        (output.text() catch { _ => "non-UTF-8 output" }),
     )
   }
   guard path_exists(staging) else {

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -54,7 +54,11 @@ fn windows_protocol_install_script(
     builder <+
       $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "$\\"$INSTDIR\\\{executable}$\\" $\\"%1$\\""
   }
-  builder.to_string()
+  if plan.url_schemes.length() == 0 {
+    ""
+  } else {
+    builder.to_string() + "\n"
+  }
 }
 
 ///|
@@ -64,7 +68,11 @@ fn windows_protocol_uninstall_script(plan : PackageSpec) -> String {
     builder <+
       $|  DeleteRegKey HKCU "Software\\Classes\\\{windows_installer_quote(scheme)}"
   }
-  builder.to_string()
+  if plan.url_schemes.length() == 0 {
+    ""
+  } else {
+    builder.to_string() + "\n"
+  }
 }
 
 ///|

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -217,9 +217,9 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoModify" 1
     $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoRepair" 1
     $|
+  builder.write_char('\n')
   builder.write_string(windows_protocol_install_script(plan, executable))
   builder <+
-    $|
     $|  CreateShortCut "$SMPROGRAMS\\\{product}.lnk" "$INSTDIR\\\{executable}"
     $|  ${If} $ProtonUpdate == "1"
     $|    Exec '"$INSTDIR\\\{executable}"'
@@ -237,6 +237,7 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  RMDir /r "$INSTDIR.proton-next"
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}"
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
+  builder.write_char('\n')
   builder.write_string(windows_protocol_uninstall_script(plan))
   builder <+
     $|SectionEnd

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -40,6 +40,34 @@ fn windows_uninstall_registry_key(plan : PackageSpec) -> String {
 }
 
 ///|
+fn windows_protocol_install_script(
+  plan : PackageSpec,
+  executable : String,
+) -> String {
+  let builder = StringBuilder()
+  for scheme in plan.url_schemes {
+    let scheme = windows_installer_quote(scheme)
+    builder <+
+      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "" "URL:\{scheme}"
+    builder <+
+      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "URL Protocol" ""
+    builder <+
+      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "$\\"$INSTDIR\\\{executable}$\\" $\\"%1$\\""
+  }
+  builder.to_string()
+}
+
+///|
+fn windows_protocol_uninstall_script(plan : PackageSpec) -> String {
+  let builder = StringBuilder()
+  for scheme in plan.url_schemes {
+    builder <+
+      $|  DeleteRegKey HKCU "Software\\Classes\\\{windows_installer_quote(scheme)}"
+  }
+  builder.to_string()
+}
+
+///|
 /// `VIProductVersion` rejects anything that is not exactly four numeric
 /// fields, so a semantic version has to be padded and any pre-release suffix
 /// dropped. The human-readable version still ships in `FileVersion`.
@@ -185,6 +213,9 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoModify" 1
     $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoRepair" 1
     $|
+  builder.write_string(windows_protocol_install_script(plan, executable))
+  builder <+
+    $|
     $|  CreateShortCut "$SMPROGRAMS\\\{product}.lnk" "$INSTDIR\\\{executable}"
     $|  ${If} $ProtonUpdate == "1"
     $|    Exec '"$INSTDIR\\\{executable}"'
@@ -202,6 +233,8 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  RMDir /r "$INSTDIR.proton-next"
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}"
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
+  builder.write_string(windows_protocol_uninstall_script(plan))
+  builder <+
     $|SectionEnd
     $|
   builder.to_string()

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -49,16 +49,15 @@ fn windows_protocol_install_script(
     let scheme = windows_installer_quote(scheme)
     builder <+
       $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "" "URL:\{scheme}"
+    builder.write_char('\n')
     builder <+
       $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "URL Protocol" ""
+    builder.write_char('\n')
     builder <+
       $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "$\\"$INSTDIR\\\{executable}$\\" $\\"%1$\\""
+    builder.write_char('\n')
   }
-  if plan.url_schemes.length() == 0 {
-    ""
-  } else {
-    builder.to_string() + "\n"
-  }
+  builder.to_string()
 }
 
 ///|
@@ -67,12 +66,9 @@ fn windows_protocol_uninstall_script(plan : PackageSpec) -> String {
   for scheme in plan.url_schemes {
     builder <+
       $|  DeleteRegKey HKCU "Software\\Classes\\\{windows_installer_quote(scheme)}"
+    builder.write_char('\n')
   }
-  if plan.url_schemes.length() == 0 {
-    ""
-  } else {
-    builder.to_string() + "\n"
-  }
+  builder.to_string()
 }
 
 ///|

--- a/proton/README.md
+++ b/proton/README.md
@@ -53,6 +53,24 @@ Electron's default logs location. `UserData` overrides feed the default
 `SessionData` path, while an explicit `SessionData` override becomes the CEF
 browser profile location for single-instance applications.
 
+## Protocol and process control
+
+Declare application URL schemes with `App::url_scheme`. A running
+`ApplicationContext` can then set, remove, or query the current application as
+the default handler with `set_as_default_protocol_client`,
+`remove_default_protocol_client`, and `is_default_protocol_client`. macOS
+requires the packaged `CFBundleURLTypes` declaration; Linux requires the
+generated desktop entry to be installed. Electron does not expose protocol
+removal on Linux, so Proton returns `false` there as well.
+
+`ApplicationContext::relaunch` schedules a replacement process without
+stopping the current one. With no options it preserves the current command
+line; `RelaunchOptions` can replace the executable or arguments. Call `quit`
+for orderly shutdown or `exit` for immediate Electron-style termination that
+skips close interception and lifecycle cleanup. Scheduled relaunches are
+started after orderly cleanup or immediately before `exit` terminates the
+process.
+
 ## Entry points
 
 - `@proton.html(title, html, ...)` — inline HTML document.

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -226,11 +226,12 @@ pub fn App::menu(self : App, menu : MenuBar) -> App {
 }
 
 ///|
-/// Registers an application URL scheme for single-instance launch forwarding.
-/// OS registration belongs to the package configuration.
+/// Declares an application URL scheme for launch forwarding and protocol-client
+/// controls. Package configuration must declare the same scheme so distributed
+/// applications contain the required platform metadata.
 pub fn App::url_scheme(self : App, scheme : String) -> App {
   let scheme = scheme.trim().to_owned().to_lower()
-  if scheme == "" || scheme.contains(":") || scheme.contains("/") {
+  if !app_url_scheme_is_valid(scheme) {
     self.validation_errors.push(
       InvalidSetting(name="url_scheme", message="must be a scheme name"),
     )
@@ -238,6 +239,24 @@ pub fn App::url_scheme(self : App, scheme : String) -> App {
     self.url_schemes.push(scheme)
   }
   self
+}
+
+///|
+fn app_url_scheme_is_valid(scheme : String) -> Bool {
+  guard scheme.length() > 0 else { return false }
+  for index, char in scheme {
+    let valid = if index == 0 {
+      char.is_ascii_alphabetic()
+    } else {
+      char.is_ascii_alphabetic() ||
+      char.is_ascii_digit() ||
+      char == '+' ||
+      char == '-' ||
+      char == '.'
+    }
+    guard valid else { return false }
+  }
+  true
 }
 
 ///|

--- a/proton/facade_context.mbt
+++ b/proton/facade_context.mbt
@@ -5,6 +5,10 @@ pub struct ApplicationContext {
   windows : WindowManager
   locale_preferences : @locale.LocalePreferences
   request_quit : () -> Unit
+  application_identifier : String
+  application_executable : String
+  application_arguments : Array[String]
+  url_schemes : Array[String]
 }
 
 ///|
@@ -50,8 +54,21 @@ fn ApplicationContext::ApplicationContext(
   windows : WindowManager,
   locale_preferences : @locale.LocalePreferences,
   request_quit? : () -> Unit = fn() {  },
+  application_identifier? : String = "",
+  application_executable? : String = "",
+  application_arguments? : Array[String] = [],
+  url_schemes? : Array[String] = [],
 ) -> ApplicationContext {
-  ApplicationContext::{ tasks, windows, locale_preferences, request_quit, }
+  ApplicationContext::{
+    tasks,
+    windows,
+    locale_preferences,
+    request_quit,
+    application_identifier,
+    application_executable,
+    application_arguments,
+    url_schemes,
+  }
 }
 
 ///|
@@ -130,6 +147,149 @@ pub fn ApplicationContext::windows(self : ApplicationContext) -> WindowManager {
 /// close cancels this quit request.
 pub fn ApplicationContext::quit(self : ApplicationContext) -> Unit {
   (self.request_quit)()
+}
+
+///|
+fn ApplicationContext::protocol_client_values(
+  self : ApplicationContext,
+  scheme : String,
+  executable : String?,
+) -> (String, String) raise AppControlError {
+  let scheme = scheme.trim().to_owned().to_lower()
+  guard app_url_scheme_is_valid(scheme) else {
+    raise InvalidProtocolScheme(scheme~)
+  }
+  guard self.url_schemes.contains(scheme) else {
+    raise UndeclaredProtocolScheme(scheme~)
+  }
+  let executable = executable.unwrap_or(self.application_executable)
+  guard executable.trim().to_owned() != "" else {
+    raise InvalidExecutable(path=executable)
+  }
+  (scheme, executable)
+}
+
+///|
+fn app_control_native_error(
+  action : String,
+  error : @native.NativeError,
+) -> AppControlError {
+  NativeControlFailure(action~, status=error.status(), detail=error.message())
+}
+
+///|
+/// Sets this application as the default handler for a declared URL scheme.
+///
+/// `executable` and `arguments` match Electron's Windows-only command
+/// override. Other platforms use the packaged application identity.
+pub fn ApplicationContext::set_as_default_protocol_client(
+  self : ApplicationContext,
+  scheme : String,
+  executable? : String,
+  arguments? : Array[String] = [],
+) -> Bool raise AppControlError {
+  let (scheme, executable) = self.protocol_client_values(scheme, executable)
+  @native.protocol_client_set(
+    scheme,
+    self.application_identifier,
+    executable,
+    arguments,
+  ) catch {
+    error =>
+      raise app_control_native_error("set default protocol client", error)
+  }
+}
+
+///|
+/// Removes this application as the default handler for a declared URL scheme.
+///
+/// Electron exposes removal on macOS and Windows. Linux returns `false`.
+pub fn ApplicationContext::remove_default_protocol_client(
+  self : ApplicationContext,
+  scheme : String,
+  executable? : String,
+  arguments? : Array[String] = [],
+) -> Bool raise AppControlError {
+  let (scheme, executable) = self.protocol_client_values(scheme, executable)
+  @native.protocol_client_remove(
+    scheme,
+    self.application_identifier,
+    executable,
+    arguments,
+  ) catch {
+    error =>
+      raise app_control_native_error("remove default protocol client", error)
+  }
+}
+
+///|
+/// Reports whether this application handles a declared URL scheme by default.
+pub fn ApplicationContext::is_default_protocol_client(
+  self : ApplicationContext,
+  scheme : String,
+  executable? : String,
+  arguments? : Array[String] = [],
+) -> Bool raise AppControlError {
+  let (scheme, executable) = self.protocol_client_values(scheme, executable)
+  @native.protocol_client_is_default(
+    scheme,
+    self.application_identifier,
+    executable,
+    arguments,
+  ) catch {
+    error =>
+      raise app_control_native_error("query default protocol client", error)
+  }
+}
+
+///|
+/// Schedules a new application instance after the current instance exits.
+///
+/// Calling this method multiple times schedules multiple instances. It does
+/// not quit the current application; call `quit` or `exit` separately.
+pub fn ApplicationContext::relaunch(
+  self : ApplicationContext,
+  options? : RelaunchOptions,
+) -> Unit raise AppControlError {
+  let (executable, arguments) = self.relaunch_command(options)
+  @native.process_schedule_relaunch(executable, arguments) catch {
+    error =>
+      raise app_control_native_error("schedule application relaunch", error)
+  }
+}
+
+///|
+fn ApplicationContext::relaunch_command(
+  self : ApplicationContext,
+  options : RelaunchOptions?,
+) -> (String, Array[String]) raise AppControlError {
+  let (executable, arguments) = match options {
+    None => (self.application_executable, self.application_arguments.copy())
+    Some({ executable: None, arguments: None, }) =>
+      (self.application_executable, self.application_arguments.copy())
+    Some(options) =>
+      (
+        options.executable.unwrap_or(self.application_executable),
+        options.arguments.unwrap_or([]),
+      )
+  }
+  guard executable.trim().to_owned() != "" else {
+    raise InvalidExecutable(path=executable)
+  }
+  (executable, arguments)
+}
+
+///|
+/// Immediately terminates the process with `exit_code`.
+///
+/// This skips window close interception and lifecycle shutdown hooks. Any
+/// relaunches already scheduled through `relaunch` are started first.
+pub fn ApplicationContext::exit(
+  self : ApplicationContext,
+  exit_code? : Int = 0,
+) -> Unit {
+  ignore(self)
+  @native.process_exit(exit_code)
 }
 
 ///|

--- a/proton/facade_error.mbt
+++ b/proton/facade_error.mbt
@@ -265,3 +265,30 @@ impl Show for AppRunError with fn output(self, logger) {
 
 ///|
 pub extend AppRunError with Show::{to_string, output}
+
+///|
+pub fn AppControlError::message(self : AppControlError) -> String {
+  match self {
+    InvalidProtocolScheme(scheme~) =>
+      "invalid application protocol scheme: " + scheme
+    UndeclaredProtocolScheme(scheme~) =>
+      "application protocol scheme is not declared with App::url_scheme: " +
+      scheme
+    InvalidExecutable(path~) => "invalid application executable path: " + path
+    NativeControlFailure(action~, status~, detail~) =>
+      "application failed to " +
+      action +
+      " (" +
+      status.to_string() +
+      "): " +
+      detail
+  }
+}
+
+///|
+impl Show for AppControlError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub extend AppControlError with Show::{to_string, output}

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -19,6 +19,20 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     error => raise ConfigurationError(error)
   }
   let locale_preferences = resolve_locale_preferences(self.explicit_locale)
+  let application_executable = executable_path() catch {
+    error =>
+      raise RuntimeOperationFailed(
+        action="resolve application executable",
+        status=-1,
+        detail=error.message(),
+      )
+  }
+  let process_arguments = @env.args()
+  let application_arguments = if process_arguments.length() > 1 {
+    process_arguments[1:].to_owned()
+  } else {
+    []
+  }
   let app_instance = match acquire_app_instance(resolved) {
     Some(@native.AppInstanceAcquire::Forwarded) => {
       @xlog.info(category="proton.runtime") <?
@@ -61,12 +75,19 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     download_event_handlers=self.download_event_handlers,
     update_channel=resolved.update_channel,
     update_handlers=self.update_handlers,
+    application_identifier=resolved.application_identifier,
+    application_executable~,
+    application_arguments~,
+    url_schemes=resolved.url_schemes,
   ) catch {
     error => raise logged_runtime_failure(error)
   }
   match app_instance {
     Some(instance) => destroy_app_instance(instance)
     None => ()
+  }
+  @native.process_run_relaunches() catch {
+    error => raise native_run_error("relaunch application", error)
   }
   @xlog.info(category="proton.runtime") <?
     { "message": "application runtime stopped" }
@@ -146,6 +167,10 @@ async fn run_manifest(
   ] = [],
   update_channel? : ResolvedUpdateChannel? = None,
   update_handlers? : Array[async (PendingUpdate) -> Unit noraise] = [],
+  application_identifier? : String = "",
+  application_executable? : String = "",
+  application_arguments? : Array[String] = [],
+  url_schemes? : Array[String] = [],
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -341,12 +366,36 @@ async fn run_manifest(
     @async.with_task_group(application_tasks => {
       @async.with_task_group(window_tasks => {
         let session = RuntimeSession(
-          runtime, event_pump, locale_preferences, definitions, windows, command_host,
-          wakeup, forward_menu_events, bridge_enabled, launch_input_handlers, window_event_handlers,
-          application_tasks, last_window_closed_policy, window_tasks, view_event_handlers,
-          browser_event_handlers, window_close_handler, window_lifecycle_hooks, lifecycle_failures,
-          bridge_startup_timeout_ms, navigation_handler, popup_handler, download_handler,
-          certificate_handler, media_handler, download_event_handlers,
+          runtime,
+          event_pump,
+          locale_preferences,
+          definitions,
+          windows,
+          command_host,
+          wakeup,
+          forward_menu_events,
+          bridge_enabled,
+          launch_input_handlers,
+          window_event_handlers,
+          application_tasks,
+          last_window_closed_policy,
+          window_tasks,
+          view_event_handlers,
+          browser_event_handlers,
+          window_close_handler,
+          window_lifecycle_hooks,
+          lifecycle_failures,
+          bridge_startup_timeout_ms,
+          navigation_handler,
+          popup_handler,
+          download_handler,
+          certificate_handler,
+          media_handler,
+          download_event_handlers,
+          application_identifier~,
+          application_executable~,
+          application_arguments~,
+          url_schemes~,
         )
         let application_context = session.application_context()
         let application_start = application_tasks.spawn(

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -34,6 +34,10 @@ fn RuntimeSession::RuntimeSession(
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ],
+  application_identifier? : String = "",
+  application_executable? : String = "",
+  application_arguments? : Array[String] = [],
+  url_schemes? : Array[String] = [],
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
@@ -69,6 +73,10 @@ fn RuntimeSession::RuntimeSession(
     media_handler,
     download_event_handlers,
     close_coordinator: CloseCoordinator(),
+    application_identifier,
+    application_executable,
+    application_arguments,
+    url_schemes,
   }
 }
 
@@ -148,6 +156,10 @@ fn RuntimeSession::application_context(
     self.window_manager(),
     self.locale_preferences,
     request_quit=() => self.request_quit(),
+    application_identifier=self.application_identifier,
+    application_executable=self.application_executable,
+    application_arguments=self.application_arguments,
+    url_schemes=self.url_schemes,
   )
 }
 

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -151,6 +151,32 @@ priv struct ResolvedUpdateChannel {
 }
 
 ///|
+/// Optional command override for `ApplicationContext::relaunch`.
+///
+/// With neither field set, Proton repeats the current executable and command
+/// line. Setting either field switches to Electron's override behavior: the
+/// executable still defaults to the current executable, while omitted
+/// arguments become an empty array.
+pub(all) struct RelaunchOptions {
+  executable : String?
+  arguments : Array[String]?
+} derive(Debug, Eq)
+
+///|
+pub extend RelaunchOptions with Eq::{not_equal, equal}
+
+///|
+pub extend RelaunchOptions with Debug::{to_repr}
+
+///|
+pub fn RelaunchOptions::RelaunchOptions(
+  executable? : String,
+  arguments? : Array[String],
+) -> RelaunchOptions {
+  RelaunchOptions::{ executable, arguments, }
+}
+
+///|
 priv struct BridgeDispatchTask {
   request_id : Int64
   window : Int64
@@ -355,6 +381,10 @@ priv struct RuntimeSession {
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
   close_coordinator : CloseCoordinator
+  application_identifier : String
+  application_executable : String
+  application_arguments : Array[String]
+  url_schemes : Array[String]
 }
 
 ///|
@@ -1001,6 +1031,21 @@ pub(all) suberror AppConfigurationError {
   InvalidEntryUrl(url~ : String, reason~ : String)
   InvalidRendererCapability(detail~ : String)
 } derive(Debug)
+
+///|
+/// Failures from application-level desktop and process controls.
+pub(all) suberror AppControlError {
+  InvalidProtocolScheme(scheme~ : String)
+  UndeclaredProtocolScheme(scheme~ : String)
+  InvalidExecutable(path~ : String)
+  NativeControlFailure(action~ : String, status~ : Int, detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend AppControlError with Eq::{not_equal, equal}
+
+///|
+pub extend AppControlError with Debug::{to_repr}
 
 ///|
 pub extend AppConfigurationError with Debug::{to_repr}

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -451,6 +451,55 @@ async test "application context forwards orderly quit requests" {
 }
 
 ///|
+async test "application context validates protocol declarations and relaunch options" {
+  @async.with_task_group(group => {
+    let context = ApplicationContext(
+      group,
+      test_window_manager(),
+      @locale.LocalePreferences::resolve(None, []),
+      application_identifier="dev.proton.control",
+      application_executable="/Applications/Control.app/Contents/MacOS/control",
+      application_arguments=["--profile", "default"],
+      url_schemes=["proton-control"],
+    )
+    assert_eq(
+      context.protocol_client_values(" PROTON-CONTROL ", None),
+      ("proton-control", "/Applications/Control.app/Contents/MacOS/control"),
+    )
+    try ignore(context.protocol_client_values("other", None)) catch {
+      UndeclaredProtocolScheme(scheme="other") => ()
+      error => fail("unexpected protocol error: " + error.message())
+    } noraise {
+      _ => fail("expected undeclared protocol rejection")
+    }
+    for invalid in ["", "1bad", "bad/scheme", "bad scheme"] {
+      try ignore(context.protocol_client_values(invalid, None)) catch {
+        InvalidProtocolScheme(..) => ()
+        error => fail("unexpected protocol error: " + error.message())
+      } noraise {
+        _ => fail("expected invalid protocol rejection")
+      }
+    }
+    assert_eq(
+      context.relaunch_command(None),
+      (
+        "/Applications/Control.app/Contents/MacOS/control",
+        ["--profile", "default"],
+      ),
+    )
+    assert_eq(
+      context.relaunch_command(Some(RelaunchOptions(arguments=["--fresh"]))),
+      ("/Applications/Control.app/Contents/MacOS/control", ["--fresh"]),
+    )
+    assert_eq(
+      context.relaunch_command(Some(RelaunchOptions(executable="/tmp/helper"))),
+      ("/tmp/helper", []),
+    )
+    group.return_immediately(())
+  })
+}
+
+///|
 fn test_extension_capability(
   spec : @proton_command.AppCommandExtensionSpec,
   scope? : Json = Json::empty_object(),

--- a/proton/internal/native/app_control.mbt
+++ b/proton/internal/native/app_control.mbt
@@ -1,0 +1,96 @@
+///|
+fn app_control_argument_blob(arguments : Array[String]) -> Bytes {
+  let output : Array[Byte] = []
+  for argument in arguments {
+    for byte in @ffi.to_cstr(argument) {
+      output.push(byte)
+    }
+  }
+  Bytes::from_array(output[:])
+}
+
+///|
+fn protocol_client_result(
+  operation : (Bytes, Bytes, Bytes, Bytes, Int, Ref[Int]) -> Int,
+  scheme : String,
+  identifier : String,
+  executable : String,
+  arguments : Array[String],
+) -> Bool raise NativeError {
+  let argument_blob = app_control_argument_blob(arguments)
+  let result = Ref(0)
+  check_status(
+    operation(
+      @ffi.to_cstr(scheme),
+      @ffi.to_cstr(identifier),
+      @ffi.to_cstr(executable),
+      argument_blob,
+      argument_blob.length(),
+      result,
+    ),
+  )
+  result.val != 0
+}
+
+///|
+pub fn protocol_client_set(
+  scheme : String,
+  identifier : String,
+  executable : String,
+  arguments : Array[String],
+) -> Bool raise NativeError {
+  protocol_client_result(
+    @native_ffi.proton_protocol_client_set_ffi, scheme, identifier, executable, arguments,
+  )
+}
+
+///|
+pub fn protocol_client_remove(
+  scheme : String,
+  identifier : String,
+  executable : String,
+  arguments : Array[String],
+) -> Bool raise NativeError {
+  protocol_client_result(
+    @native_ffi.proton_protocol_client_remove_ffi, scheme, identifier, executable,
+    arguments,
+  )
+}
+
+///|
+pub fn protocol_client_is_default(
+  scheme : String,
+  identifier : String,
+  executable : String,
+  arguments : Array[String],
+) -> Bool raise NativeError {
+  protocol_client_result(
+    @native_ffi.proton_protocol_client_is_default_ffi, scheme, identifier, executable,
+    arguments,
+  )
+}
+
+///|
+pub fn process_schedule_relaunch(
+  executable : String,
+  arguments : Array[String],
+) -> Unit raise NativeError {
+  let argument_blob = app_control_argument_blob(arguments)
+  check_status(
+    @native_ffi.proton_process_schedule_relaunch_ffi(
+      @ffi.to_cstr(executable),
+      argument_blob,
+      argument_blob.length(),
+    ),
+  )
+}
+
+///|
+pub fn process_run_relaunches() -> Unit raise NativeError {
+  check_status(@native_ffi.proton_process_run_relaunches_ffi())
+}
+
+///|
+pub fn process_exit(exit_code : Int) -> Unit {
+  @native_ffi.proton_process_exit_ffi(exit_code)
+}

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -88,6 +88,53 @@ pub extern "C" fn proton_system_path_ffi(
 ) -> Int = "proton_system_path"
 
 ///|
+#borrow(scheme, identifier, executable, arguments, out_changed)
+pub extern "C" fn proton_protocol_client_set_ffi(
+  scheme : Bytes,
+  identifier : Bytes,
+  executable : Bytes,
+  arguments : Bytes,
+  arguments_len : Int,
+  out_changed : Ref[Int],
+) -> Int = "proton_protocol_client_set"
+
+///|
+#borrow(scheme, identifier, executable, arguments, out_removed)
+pub extern "C" fn proton_protocol_client_remove_ffi(
+  scheme : Bytes,
+  identifier : Bytes,
+  executable : Bytes,
+  arguments : Bytes,
+  arguments_len : Int,
+  out_removed : Ref[Int],
+) -> Int = "proton_protocol_client_remove"
+
+///|
+#borrow(scheme, identifier, executable, arguments, out_is_default)
+pub extern "C" fn proton_protocol_client_is_default_ffi(
+  scheme : Bytes,
+  identifier : Bytes,
+  executable : Bytes,
+  arguments : Bytes,
+  arguments_len : Int,
+  out_is_default : Ref[Int],
+) -> Int = "proton_protocol_client_is_default"
+
+///|
+#borrow(executable, arguments)
+pub extern "C" fn proton_process_schedule_relaunch_ffi(
+  executable : Bytes,
+  arguments : Bytes,
+  arguments_len : Int,
+) -> Int = "proton_process_schedule_relaunch"
+
+///|
+pub extern "C" fn proton_process_run_relaunches_ffi() -> Int = "proton_process_run_relaunches"
+
+///|
+pub extern "C" fn proton_process_exit_ffi(exit_code : Int) -> Unit = "proton_process_exit"
+
+///|
 #borrow(identifier, activation_json, out_instance, out_primary)
 pub extern "C" fn proton_app_instance_acquire_ffi(
   identifier : Bytes,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -97,6 +97,29 @@ enum {
 };
 int32_t proton_system_path(int32_t kind, char *buffer, int32_t buffer_len,
                            int32_t *out_required_len);
+int32_t proton_protocol_client_set(const char *scheme,
+                                   const char *identifier,
+                                   const char *executable,
+                                   const char *arguments,
+                                   int32_t arguments_len,
+                                   int32_t *out_changed);
+int32_t proton_protocol_client_remove(const char *scheme,
+                                      const char *identifier,
+                                      const char *executable,
+                                      const char *arguments,
+                                      int32_t arguments_len,
+                                      int32_t *out_removed);
+int32_t proton_protocol_client_is_default(const char *scheme,
+                                          const char *identifier,
+                                          const char *executable,
+                                          const char *arguments,
+                                          int32_t arguments_len,
+                                          int32_t *out_is_default);
+int32_t proton_process_schedule_relaunch(const char *executable,
+                                         const char *arguments,
+                                         int32_t arguments_len);
+int32_t proton_process_run_relaunches(void);
+void proton_process_exit(int32_t exit_code);
 int32_t proton_app_instance_acquire(
     const char *identifier, const char *activation_json,
     proton_app_instance_id_t *out_instance, int32_t *out_primary);

--- a/proton/internal/native/ffi/moon.pkg
+++ b/proton/internal/native/ffi/moon.pkg
@@ -15,6 +15,7 @@ options(
     "src/proton_event.c",
     "src/proton_json.c",
     "src/proton_locale.c",
+    "src/proton_app_control.c",
     "src/proton_menu.c",
     "src/proton_state.c",
     "src/proton_system_path.c",

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -107,6 +107,18 @@ pub fn proton_notification_set_badge_count_ffi(Int) -> Int
 
 pub fn proton_notification_show_ffi(Bytes, Bytes, Bytes, Int) -> Int
 
+pub fn proton_process_exit_ffi(Int) -> Unit
+
+pub fn proton_process_run_relaunches_ffi() -> Int
+
+pub fn proton_process_schedule_relaunch_ffi(Bytes, Bytes, Int) -> Int
+
+pub fn proton_protocol_client_is_default_ffi(Bytes, Bytes, Bytes, Bytes, Int, @ref.Ref[Int]) -> Int
+
+pub fn proton_protocol_client_remove_ffi(Bytes, Bytes, Bytes, Bytes, Int, @ref.Ref[Int]) -> Int
+
+pub fn proton_protocol_client_set_ffi(Bytes, Bytes, Bytes, Bytes, Int, @ref.Ref[Int]) -> Int
+
 pub fn proton_runtime_begin_destroy_ffi(RuntimeHandle) -> Int
 
 pub fn proton_runtime_begin_message_dialog_ffi(RuntimeHandle, Bytes, Int, Bytes, Int, Int, @ref.Ref[Int64]) -> Int

--- a/proton/internal/native/ffi/src/proton_app_control.c
+++ b/proton/internal/native/ffi/src/proton_app_control.c
@@ -1,0 +1,618 @@
+#if !defined(__APPLE__)
+
+#include "proton_internal.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <gio/gdesktopappinfo.h>
+#include <gio/gio.h>
+#include <spawn.h>
+#include <unistd.h>
+extern char **environ;
+#endif
+
+typedef struct proton_relaunch_plan {
+  char *executable;
+  char *arguments;
+  int32_t arguments_len;
+  struct proton_relaunch_plan *next;
+} proton_relaunch_plan_t;
+
+static proton_relaunch_plan_t *g_relaunch_head = NULL;
+static proton_relaunch_plan_t *g_relaunch_tail = NULL;
+
+static char *proton_app_control_copy(const char *value, size_t length) {
+  char *copy = (char *)malloc(length + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  if (length > 0) {
+    memcpy(copy, value, length);
+  }
+  copy[length] = '\0';
+  return copy;
+}
+
+static int proton_app_control_arguments_valid(const char *arguments,
+                                              int32_t arguments_len) {
+  if (arguments_len < 0 || (arguments == NULL && arguments_len != 0)) {
+    return 0;
+  }
+  return arguments_len == 0 || arguments[arguments_len - 1] == '\0';
+}
+
+#if defined(_WIN32)
+
+static wchar_t *proton_app_control_wide(const char *value) {
+  if (value == NULL) {
+    return NULL;
+  }
+  int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value, -1,
+                                   NULL, 0);
+  if (length <= 0) {
+    return NULL;
+  }
+  wchar_t *wide = (wchar_t *)calloc((size_t)length, sizeof(wchar_t));
+  if (wide == NULL ||
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value, -1, wide,
+                          length) <= 0) {
+    free(wide);
+    return NULL;
+  }
+  return wide;
+}
+
+static int proton_app_control_append(wchar_t **buffer, size_t *length,
+                                     size_t *capacity, const wchar_t *value,
+                                     size_t value_len) {
+  if (*length + value_len + 1 > *capacity) {
+    size_t next = *capacity == 0 ? 64 : *capacity;
+    while (next < *length + value_len + 1) {
+      next *= 2;
+    }
+    wchar_t *resized =
+        (wchar_t *)realloc(*buffer, next * sizeof(wchar_t));
+    if (resized == NULL) {
+      return 0;
+    }
+    *buffer = resized;
+    *capacity = next;
+  }
+  memcpy(*buffer + *length, value, value_len * sizeof(wchar_t));
+  *length += value_len;
+  (*buffer)[*length] = L'\0';
+  return 1;
+}
+
+static int proton_app_control_append_quoted(wchar_t **buffer, size_t *length,
+                                            size_t *capacity,
+                                            const wchar_t *argument) {
+  if (!proton_app_control_append(buffer, length, capacity, L"\"", 1)) {
+    return 0;
+  }
+  size_t slashes = 0;
+  for (const wchar_t *cursor = argument;; cursor++) {
+    if (*cursor == L'\\') {
+      slashes++;
+      continue;
+    }
+    size_t copies = slashes;
+    if (*cursor == L'\"' || *cursor == L'\0') {
+      copies = slashes * 2;
+    }
+    for (size_t index = 0; index < copies; index++) {
+      if (!proton_app_control_append(buffer, length, capacity, L"\\", 1)) {
+        return 0;
+      }
+    }
+    slashes = 0;
+    if (*cursor == L'\0') {
+      break;
+    }
+    if (*cursor == L'\"' &&
+        !proton_app_control_append(buffer, length, capacity, L"\\", 1)) {
+      return 0;
+    }
+    if (!proton_app_control_append(buffer, length, capacity, cursor, 1)) {
+      return 0;
+    }
+  }
+  return proton_app_control_append(buffer, length, capacity, L"\"", 1);
+}
+
+static wchar_t *proton_app_control_command(const char *executable,
+                                           const char *arguments,
+                                           int32_t arguments_len,
+                                           int include_url) {
+  wchar_t *wide_executable = proton_app_control_wide(executable);
+  if (wide_executable == NULL) {
+    return NULL;
+  }
+  wchar_t *command = NULL;
+  size_t length = 0;
+  size_t capacity = 0;
+  int ok = proton_app_control_append_quoted(&command, &length, &capacity,
+                                            wide_executable);
+  free(wide_executable);
+  for (int32_t offset = 0; ok && offset < arguments_len;) {
+    const char *argument = arguments + offset;
+    size_t remaining = (size_t)(arguments_len - offset);
+    size_t argument_len = strnlen(argument, remaining);
+    if (argument_len == remaining) {
+      ok = 0;
+      break;
+    }
+    wchar_t *wide_argument = proton_app_control_wide(argument);
+    ok = wide_argument != NULL &&
+         proton_app_control_append(&command, &length, &capacity, L" ", 1) &&
+         proton_app_control_append_quoted(&command, &length, &capacity,
+                                          wide_argument);
+    free(wide_argument);
+    offset += (int32_t)argument_len + 1;
+  }
+  if (ok && include_url) {
+    ok = proton_app_control_append(&command, &length, &capacity, L" \"%1\"", 5);
+  }
+  if (!ok) {
+    free(command);
+    return NULL;
+  }
+  return command;
+}
+
+static int32_t proton_protocol_windows_command(
+    const char *scheme, const char *executable, const char *arguments,
+    int32_t arguments_len, wchar_t **out_scheme, wchar_t **out_command) {
+  *out_scheme = proton_app_control_wide(scheme);
+  *out_command = proton_app_control_command(executable, arguments, arguments_len,
+                                            1);
+  if (*out_scheme == NULL || *out_command == NULL) {
+    free(*out_scheme);
+    free(*out_command);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to encode protocol registration as UTF-16");
+  }
+  return PROTON_OK;
+}
+
+static wchar_t *proton_protocol_windows_key(const wchar_t *scheme,
+                                            const wchar_t *suffix) {
+  static const wchar_t prefix[] = L"Software\\Classes\\";
+  size_t length = wcslen(prefix) + wcslen(scheme) + wcslen(suffix) + 1;
+  wchar_t *key = (wchar_t *)calloc(length, sizeof(wchar_t));
+  if (key != NULL) {
+    _snwprintf(key, length, L"%ls%ls%ls", prefix, scheme, suffix);
+  }
+  return key;
+}
+
+static int32_t proton_protocol_windows_read(const wchar_t *command_key,
+                                            wchar_t **out_value) {
+  HKEY key = NULL;
+  LONG status = RegOpenKeyExW(HKEY_CURRENT_USER, command_key, 0, KEY_QUERY_VALUE,
+                              &key);
+  if (status == ERROR_FILE_NOT_FOUND) {
+    return PROTON_OK;
+  }
+  if (status != ERROR_SUCCESS) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to open protocol command registry key");
+  }
+  DWORD bytes = 0;
+  status = RegQueryValueExW(key, L"", NULL, NULL, NULL, &bytes);
+  if (status == ERROR_SUCCESS && bytes >= sizeof(wchar_t)) {
+    *out_value = (wchar_t *)calloc(1, bytes + sizeof(wchar_t));
+    if (*out_value == NULL) {
+      RegCloseKey(key);
+      return proton_set_error(PROTON_ERR_PLATFORM,
+                              "failed to allocate protocol command buffer");
+    }
+    status = RegQueryValueExW(key, L"", NULL, NULL, (BYTE *)*out_value, &bytes);
+  }
+  RegCloseKey(key);
+  if (status == ERROR_FILE_NOT_FOUND) {
+    return PROTON_OK;
+  }
+  if (status != ERROR_SUCCESS) {
+    free(*out_value);
+    *out_value = NULL;
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to read protocol command registry value");
+  }
+  return PROTON_OK;
+}
+
+#else
+
+static char **proton_app_control_argv(const char *executable,
+                                      const char *arguments,
+                                      int32_t arguments_len) {
+  size_t count = 1;
+  for (int32_t index = 0; index < arguments_len; index++) {
+    if (arguments[index] == '\0') {
+      count++;
+    }
+  }
+  char **argv = (char **)calloc(count + 1, sizeof(char *));
+  if (argv == NULL) {
+    return NULL;
+  }
+  argv[0] = (char *)executable;
+  size_t position = 1;
+  for (int32_t offset = 0; offset < arguments_len;) {
+    argv[position++] = (char *)(arguments + offset);
+    offset += (int32_t)strlen(arguments + offset) + 1;
+  }
+  return argv;
+}
+
+static char *proton_protocol_linux_desktop(const char *identifier) {
+  const char *configured = getenv("CHROME_DESKTOP");
+  if (configured != NULL && configured[0] != '\0') {
+    return proton_app_control_copy(configured, strlen(configured));
+  }
+  size_t length = strlen(identifier) + strlen(".desktop") + 1;
+  char *desktop = (char *)malloc(length);
+  if (desktop != NULL) {
+    snprintf(desktop, length, "%s.desktop", identifier);
+  }
+  return desktop;
+}
+
+#endif
+
+int32_t proton_protocol_client_set(const char *scheme, const char *identifier,
+                                   const char *executable,
+                                   const char *arguments,
+                                   int32_t arguments_len,
+                                   int32_t *out_changed) {
+  if (scheme == NULL || scheme[0] == '\0' || identifier == NULL ||
+      identifier[0] == '\0' || executable == NULL || executable[0] == '\0' ||
+      out_changed == NULL ||
+      !proton_app_control_arguments_valid(arguments, arguments_len)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid protocol client registration");
+  }
+  *out_changed = 0;
+#if defined(_WIN32)
+  wchar_t *wide_scheme = NULL;
+  wchar_t *command = NULL;
+  int32_t result = proton_protocol_windows_command(
+      scheme, executable, arguments, arguments_len, &wide_scheme, &command);
+  if (result != PROTON_OK) {
+    return result;
+  }
+  wchar_t *protocol_key = proton_protocol_windows_key(wide_scheme, L"");
+  wchar_t *command_key =
+      proton_protocol_windows_key(wide_scheme, L"\\shell\\open\\command");
+  wchar_t *description = NULL;
+  size_t description_len = wcslen(wide_scheme) + 5;
+  description = (wchar_t *)calloc(description_len, sizeof(wchar_t));
+  if (protocol_key == NULL || command_key == NULL || description == NULL) {
+    result = proton_set_error(PROTON_ERR_PLATFORM,
+                              "failed to allocate protocol registry paths");
+    goto cleanup;
+  }
+  _snwprintf(description, description_len, L"URL:%ls", wide_scheme);
+  HKEY protocol = NULL;
+  HKEY command_handle = NULL;
+  LONG status = RegCreateKeyExW(HKEY_CURRENT_USER, protocol_key, 0, NULL, 0,
+                                KEY_SET_VALUE, NULL, &protocol, NULL);
+  if (status == ERROR_SUCCESS) {
+    status = RegSetValueExW(protocol, L"", 0, REG_SZ, (BYTE *)description,
+                            (DWORD)((wcslen(description) + 1) * sizeof(wchar_t)));
+  }
+  if (status == ERROR_SUCCESS) {
+    status = RegSetValueExW(protocol, L"URL Protocol", 0, REG_SZ,
+                            (const BYTE *)L"", sizeof(wchar_t));
+  }
+  if (status == ERROR_SUCCESS) {
+    status = RegCreateKeyExW(HKEY_CURRENT_USER, command_key, 0, NULL, 0,
+                             KEY_SET_VALUE, NULL, &command_handle, NULL);
+  }
+  if (status == ERROR_SUCCESS) {
+    status = RegSetValueExW(command_handle, L"", 0, REG_SZ, (BYTE *)command,
+                            (DWORD)((wcslen(command) + 1) * sizeof(wchar_t)));
+  }
+  if (command_handle != NULL) {
+    RegCloseKey(command_handle);
+  }
+  if (protocol != NULL) {
+    RegCloseKey(protocol);
+  }
+  if (status == ERROR_SUCCESS) {
+    *out_changed = 1;
+    result = proton_set_error(PROTON_OK, NULL);
+  } else {
+    result = proton_set_error(PROTON_ERR_PLATFORM,
+                              "failed to write protocol registry values");
+  }
+cleanup:
+  free(description);
+  free(protocol_key);
+  free(command_key);
+  free(wide_scheme);
+  free(command);
+  return result;
+#else
+  char *desktop = proton_protocol_linux_desktop(identifier);
+  if (desktop == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to allocate Linux desktop entry name");
+  }
+  GDesktopAppInfo *app_info = g_desktop_app_info_new(desktop);
+  free(desktop);
+  if (app_info == NULL) {
+    return proton_set_error(
+        PROTON_ERR_PLATFORM,
+        "the packaged desktop entry is not installed for this application");
+  }
+  char *content_type = g_strdup_printf("x-scheme-handler/%s", scheme);
+  GError *error = NULL;
+  gboolean success = content_type != NULL &&
+                     g_app_info_set_as_default_for_type(
+                         G_APP_INFO(app_info), content_type, &error);
+  int had_error = error != NULL;
+  if (had_error) {
+    proton_set_error(PROTON_ERR_PLATFORM, error->message);
+    g_error_free(error);
+  }
+  g_free(content_type);
+  g_object_unref(app_info);
+  if (!success) {
+    return !had_error
+               ? proton_set_error(PROTON_ERR_PLATFORM,
+                                  "failed to set the Linux protocol handler")
+               : PROTON_ERR_PLATFORM;
+  }
+  *out_changed = 1;
+  return proton_set_error(PROTON_OK, NULL);
+#endif
+}
+
+int32_t proton_protocol_client_is_default(
+    const char *scheme, const char *identifier, const char *executable,
+    const char *arguments, int32_t arguments_len, int32_t *out_is_default) {
+  if (scheme == NULL || scheme[0] == '\0' || identifier == NULL ||
+      identifier[0] == '\0' || executable == NULL || executable[0] == '\0' ||
+      out_is_default == NULL ||
+      !proton_app_control_arguments_valid(arguments, arguments_len)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid protocol client query");
+  }
+  *out_is_default = 0;
+#if defined(_WIN32)
+  wchar_t *wide_scheme = NULL;
+  wchar_t *command = NULL;
+  int32_t result = proton_protocol_windows_command(
+      scheme, executable, arguments, arguments_len, &wide_scheme, &command);
+  if (result != PROTON_OK) {
+    return result;
+  }
+  wchar_t *command_key =
+      proton_protocol_windows_key(wide_scheme, L"\\shell\\open\\command");
+  wchar_t *registered = NULL;
+  if (command_key == NULL) {
+    result = proton_set_error(PROTON_ERR_PLATFORM,
+                              "failed to allocate protocol registry path");
+  } else {
+    result = proton_protocol_windows_read(command_key, &registered);
+    if (result == PROTON_OK && registered != NULL &&
+        wcscmp(registered, command) == 0) {
+      *out_is_default = 1;
+    }
+  }
+  free(registered);
+  free(command_key);
+  free(wide_scheme);
+  free(command);
+  return result;
+#else
+  GAppInfo *app_info = g_app_info_get_default_for_uri_scheme(scheme);
+  if (app_info != NULL) {
+    const char *app_id = g_app_info_get_id(app_info);
+    char *desktop = proton_protocol_linux_desktop(identifier);
+    *out_is_default = app_id != NULL && desktop != NULL &&
+                      strcmp(app_id, desktop) == 0;
+    free(desktop);
+    g_object_unref(app_info);
+  }
+  return proton_set_error(PROTON_OK, NULL);
+#endif
+}
+
+int32_t proton_protocol_client_remove(
+    const char *scheme, const char *identifier, const char *executable,
+    const char *arguments, int32_t arguments_len, int32_t *out_removed) {
+  if (out_removed == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "protocol removal result is required");
+  }
+  *out_removed = 0;
+#if defined(_WIN32)
+  int32_t is_default = 0;
+  int32_t result = proton_protocol_client_is_default(
+      scheme, identifier, executable, arguments, arguments_len, &is_default);
+  if (result != PROTON_OK || !is_default) {
+    return result;
+  }
+  wchar_t *wide_scheme = proton_app_control_wide(scheme);
+  if (wide_scheme == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to encode protocol scheme as UTF-16");
+  }
+  HKEY classes = NULL;
+  LONG status = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Classes", 0,
+                              KEY_ALL_ACCESS, &classes);
+  if (status == ERROR_FILE_NOT_FOUND) {
+    free(wide_scheme);
+    return proton_set_error(PROTON_OK, NULL);
+  }
+  if (status != ERROR_SUCCESS) {
+    free(wide_scheme);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to open the user protocol registry");
+  }
+  size_t shell_len = wcslen(wide_scheme) + wcslen(L"\\shell") + 1;
+  wchar_t *shell = (wchar_t *)calloc(shell_len, sizeof(wchar_t));
+  if (shell == NULL) {
+    RegCloseKey(classes);
+    free(wide_scheme);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to allocate protocol shell path");
+  }
+  _snwprintf(shell, shell_len, L"%ls\\shell", wide_scheme);
+  status = RegDeleteTreeW(classes, shell);
+  free(shell);
+  if (status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND) {
+    RegCloseKey(classes);
+    free(wide_scheme);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to remove protocol command registry key");
+  }
+  HKEY protocol = NULL;
+  status = RegOpenKeyExW(classes, wide_scheme, 0,
+                         KEY_QUERY_VALUE | KEY_SET_VALUE, &protocol);
+  if (status == ERROR_SUCCESS) {
+    (void)RegDeleteValueW(protocol, L"URL Protocol");
+    (void)RegDeleteValueW(protocol, L"");
+    DWORD subkeys = 0;
+    DWORD values = 0;
+    if (RegQueryInfoKeyW(protocol, NULL, NULL, NULL, &subkeys, NULL, NULL,
+                         &values, NULL, NULL, NULL, NULL) != ERROR_SUCCESS) {
+      subkeys = 1;
+      values = 1;
+    }
+    RegCloseKey(protocol);
+    if (subkeys == 0 && values == 0) {
+      (void)RegDeleteKeyW(classes, wide_scheme);
+    }
+  } else if (status != ERROR_FILE_NOT_FOUND) {
+    RegCloseKey(classes);
+    free(wide_scheme);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to open the protocol registry key");
+  }
+  RegCloseKey(classes);
+  free(wide_scheme);
+  *out_removed = 1;
+  return proton_set_error(PROTON_OK, NULL);
+#else
+  (void)scheme;
+  (void)identifier;
+  (void)executable;
+  (void)arguments;
+  (void)arguments_len;
+  return proton_set_error(PROTON_OK, NULL);
+#endif
+}
+
+int32_t proton_process_schedule_relaunch(const char *executable,
+                                         const char *arguments,
+                                         int32_t arguments_len) {
+  if (executable == NULL || executable[0] == '\0' ||
+      !proton_app_control_arguments_valid(arguments, arguments_len)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid relaunch command");
+  }
+  proton_relaunch_plan_t *plan =
+      (proton_relaunch_plan_t *)calloc(1, sizeof(*plan));
+  if (plan == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to allocate relaunch plan");
+  }
+  plan->executable = proton_app_control_copy(executable, strlen(executable));
+  plan->arguments =
+      proton_app_control_copy(arguments_len == 0 ? "" : arguments,
+                              (size_t)arguments_len);
+  plan->arguments_len = arguments_len;
+  if (plan->executable == NULL || plan->arguments == NULL) {
+    free(plan->executable);
+    free(plan->arguments);
+    free(plan);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to copy relaunch plan");
+  }
+  if (g_relaunch_tail == NULL) {
+    g_relaunch_head = plan;
+  } else {
+    g_relaunch_tail->next = plan;
+  }
+  g_relaunch_tail = plan;
+  return proton_set_error(PROTON_OK, NULL);
+}
+
+static int32_t proton_process_run_plan(const proton_relaunch_plan_t *plan) {
+#if defined(_WIN32)
+  wchar_t *command = proton_app_control_command(
+      plan->executable, plan->arguments, plan->arguments_len, 0);
+  if (command == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to encode relaunch command as UTF-16");
+  }
+  STARTUPINFOW startup = {0};
+  PROCESS_INFORMATION process = {0};
+  startup.cb = sizeof(startup);
+  BOOL started = CreateProcessW(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL,
+                                &startup, &process);
+  free(command);
+  if (!started) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to start the relaunched application");
+  }
+  CloseHandle(process.hThread);
+  CloseHandle(process.hProcess);
+  return PROTON_OK;
+#else
+  char **argv = proton_app_control_argv(plan->executable, plan->arguments,
+                                        plan->arguments_len);
+  if (argv == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to allocate relaunch arguments");
+  }
+  pid_t child = 0;
+  int status =
+      posix_spawn(&child, plan->executable, NULL, NULL, argv, environ);
+  free(argv);
+  if (status != 0) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to start the relaunched application");
+  }
+  return PROTON_OK;
+#endif
+}
+
+int32_t proton_process_run_relaunches(void) {
+  int32_t first_error = PROTON_OK;
+  while (g_relaunch_head != NULL) {
+    proton_relaunch_plan_t *plan = g_relaunch_head;
+    g_relaunch_head = plan->next;
+    int32_t status = proton_process_run_plan(plan);
+    if (first_error == PROTON_OK && status != PROTON_OK) {
+      first_error = status;
+    }
+    free(plan->executable);
+    free(plan->arguments);
+    free(plan);
+  }
+  g_relaunch_tail = NULL;
+  return first_error == PROTON_OK ? proton_set_error(PROTON_OK, NULL)
+                                  : first_error;
+}
+
+void proton_process_exit(int32_t exit_code) {
+  (void)proton_process_run_relaunches();
+#if defined(_WIN32)
+  ExitProcess((UINT)exit_code);
+#else
+  _exit(exit_code);
+#endif
+}
+
+#endif

--- a/proton/internal/native/ffi_mac/mac_app_control.objc.c
+++ b/proton/internal/native/ffi_mac/mac_app_control.objc.c
@@ -1,0 +1,289 @@
+#import <AppKit/AppKit.h>
+#import <CoreServices/CoreServices.h>
+
+#include "../ffi/src/proton_internal.h"
+
+#include <spawn.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+extern char **environ;
+
+typedef struct proton_relaunch_plan {
+  char *executable;
+  char *arguments;
+  int32_t arguments_len;
+  struct proton_relaunch_plan *next;
+} proton_relaunch_plan_t;
+
+static proton_relaunch_plan_t *g_relaunch_head = NULL;
+static proton_relaunch_plan_t *g_relaunch_tail = NULL;
+
+static int proton_app_control_arguments_valid(const char *arguments,
+                                              int32_t arguments_len) {
+  if (arguments_len < 0 || (arguments == NULL && arguments_len != 0)) {
+    return 0;
+  }
+  return arguments_len == 0 || arguments[arguments_len - 1] == '\0';
+}
+
+static char *proton_app_control_copy(const char *value, size_t length) {
+  char *copy = (char *)malloc(length + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  if (length > 0) {
+    memcpy(copy, value, length);
+  }
+  copy[length] = '\0';
+  return copy;
+}
+
+static NSString *proton_app_control_string(const char *value) {
+  return value == NULL ? nil : [NSString stringWithUTF8String:value];
+}
+
+static int32_t proton_protocol_client_validate(
+    const char *scheme, const char *identifier, const char *executable,
+    const char *arguments, int32_t arguments_len, int32_t *out_result,
+    NSString **out_scheme, NSString **out_identifier) {
+  (void)executable;
+  (void)arguments;
+  if (scheme == NULL || scheme[0] == '\0' || identifier == NULL ||
+      identifier[0] == '\0' || out_result == NULL ||
+      !proton_app_control_arguments_valid(arguments, arguments_len)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid protocol client operation");
+  }
+  *out_result = 0;
+  NSString *scheme_string = proton_app_control_string(scheme);
+  NSString *identifier_string = proton_app_control_string(identifier);
+  NSString *bundle_identifier = [[NSBundle mainBundle] bundleIdentifier];
+  if (scheme_string == nil || identifier_string == nil) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "protocol client values must be valid UTF-8");
+  }
+  if (bundle_identifier == nil ||
+      ![bundle_identifier isEqualToString:identifier_string]) {
+    return proton_set_error(
+        PROTON_ERR_PLATFORM,
+        "protocol registration requires a packaged macOS application");
+  }
+  BOOL declared = NO;
+  id url_types = [[[NSBundle mainBundle] infoDictionary]
+      objectForKey:@"CFBundleURLTypes"];
+  if ([url_types isKindOfClass:[NSArray class]]) {
+    for (id url_type in (NSArray *)url_types) {
+      if (![url_type isKindOfClass:[NSDictionary class]]) {
+        continue;
+      }
+      id schemes = [(NSDictionary *)url_type objectForKey:@"CFBundleURLSchemes"];
+      if ([schemes isKindOfClass:[NSArray class]] &&
+          [(NSArray *)schemes containsObject:scheme_string]) {
+        declared = YES;
+        break;
+      }
+    }
+  }
+  if (!declared) {
+    return proton_set_error(
+        PROTON_ERR_PLATFORM,
+        "protocol scheme is missing from the packaged CFBundleURLTypes");
+  }
+  *out_scheme = scheme_string;
+  *out_identifier = identifier_string;
+  return PROTON_OK;
+}
+
+int32_t proton_protocol_client_set(const char *scheme, const char *identifier,
+                                   const char *executable,
+                                   const char *arguments,
+                                   int32_t arguments_len,
+                                   int32_t *out_changed) {
+  @autoreleasepool {
+    NSString *scheme_string = nil;
+    NSString *identifier_string = nil;
+    int32_t status = proton_protocol_client_validate(
+        scheme, identifier, executable, arguments, arguments_len, out_changed,
+        &scheme_string, &identifier_string);
+    if (status != PROTON_OK) {
+      return status;
+    }
+    OSStatus result = LSSetDefaultHandlerForURLScheme(
+        (__bridge CFStringRef)scheme_string,
+        (__bridge CFStringRef)identifier_string);
+    if (result != noErr) {
+      return proton_set_error(PROTON_ERR_PLATFORM,
+                              "Launch Services rejected the protocol handler");
+    }
+    *out_changed = 1;
+    return proton_set_error(PROTON_OK, NULL);
+  }
+}
+
+int32_t proton_protocol_client_is_default(
+    const char *scheme, const char *identifier, const char *executable,
+    const char *arguments, int32_t arguments_len, int32_t *out_is_default) {
+  @autoreleasepool {
+    NSString *scheme_string = nil;
+    NSString *identifier_string = nil;
+    int32_t status = proton_protocol_client_validate(
+        scheme, identifier, executable, arguments, arguments_len,
+        out_is_default, &scheme_string, &identifier_string);
+    if (status != PROTON_OK) {
+      return status;
+    }
+    NSURL *protocol_url =
+        [NSURL URLWithString:[scheme_string stringByAppendingString:@":"]];
+    NSURL *application_url = protocol_url == nil
+                                 ? nil
+                                 : [[NSWorkspace sharedWorkspace]
+                                       URLForApplicationToOpenURL:protocol_url];
+    NSString *handler = application_url == nil
+                            ? nil
+                            : [[NSBundle bundleWithURL:application_url]
+                                  bundleIdentifier];
+    if (handler != nil) {
+      *out_is_default = [handler isEqualToString:identifier_string];
+    }
+    return proton_set_error(PROTON_OK, NULL);
+  }
+}
+
+int32_t proton_protocol_client_remove(
+    const char *scheme, const char *identifier, const char *executable,
+    const char *arguments, int32_t arguments_len, int32_t *out_removed) {
+  @autoreleasepool {
+    NSString *scheme_string = nil;
+    NSString *identifier_string = nil;
+    int32_t status = proton_protocol_client_validate(
+        scheme, identifier, executable, arguments, arguments_len, out_removed,
+        &scheme_string, &identifier_string);
+    if (status != PROTON_OK) {
+      return status;
+    }
+    int32_t is_default = 0;
+    status = proton_protocol_client_is_default(
+        scheme, identifier, executable, arguments, arguments_len, &is_default);
+    if (status != PROTON_OK || !is_default) {
+      return status;
+    }
+    NSURL *protocol_url =
+        [NSURL URLWithString:[scheme_string stringByAppendingString:@":"]];
+    if (protocol_url == nil) {
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "cannot construct the protocol URL");
+    }
+    NSString *replacement = nil;
+    for (NSURL *application_url in
+         [[NSWorkspace sharedWorkspace]
+             URLsForApplicationsToOpenURL:protocol_url]) {
+      NSString *candidate =
+          [[NSBundle bundleWithURL:application_url] bundleIdentifier];
+      if (candidate != nil &&
+          ![candidate isEqualToString:identifier_string]) {
+        replacement = candidate;
+        break;
+      }
+    }
+    if (replacement == nil) {
+      replacement = @"None";
+    }
+    OSStatus result = LSSetDefaultHandlerForURLScheme(
+        (__bridge CFStringRef)scheme_string,
+        (__bridge CFStringRef)replacement);
+    if (result != noErr) {
+      return proton_set_error(PROTON_ERR_PLATFORM,
+                              "Launch Services rejected protocol removal");
+    }
+    *out_removed = 1;
+    return proton_set_error(PROTON_OK, NULL);
+  }
+}
+
+int32_t proton_process_schedule_relaunch(const char *executable,
+                                         const char *arguments,
+                                         int32_t arguments_len) {
+  if (executable == NULL || executable[0] == '\0' ||
+      !proton_app_control_arguments_valid(arguments, arguments_len)) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid relaunch command");
+  }
+  proton_relaunch_plan_t *plan =
+      (proton_relaunch_plan_t *)calloc(1, sizeof(*plan));
+  if (plan == NULL) {
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to allocate relaunch plan");
+  }
+  plan->executable = proton_app_control_copy(executable, strlen(executable));
+  plan->arguments =
+      proton_app_control_copy(arguments_len == 0 ? "" : arguments,
+                              (size_t)arguments_len);
+  plan->arguments_len = arguments_len;
+  if (plan->executable == NULL || plan->arguments == NULL) {
+    free(plan->executable);
+    free(plan->arguments);
+    free(plan);
+    return proton_set_error(PROTON_ERR_PLATFORM,
+                            "failed to copy relaunch plan");
+  }
+  if (g_relaunch_tail == NULL) {
+    g_relaunch_head = plan;
+  } else {
+    g_relaunch_tail->next = plan;
+  }
+  g_relaunch_tail = plan;
+  return proton_set_error(PROTON_OK, NULL);
+}
+
+static char **proton_process_argv(const proton_relaunch_plan_t *plan) {
+  size_t count = 1;
+  for (int32_t index = 0; index < plan->arguments_len; index++) {
+    if (plan->arguments[index] == '\0') {
+      count++;
+    }
+  }
+  char **argv = (char **)calloc(count + 1, sizeof(char *));
+  if (argv == NULL) {
+    return NULL;
+  }
+  argv[0] = plan->executable;
+  size_t position = 1;
+  for (int32_t offset = 0; offset < plan->arguments_len;) {
+    argv[position++] = plan->arguments + offset;
+    offset += (int32_t)strlen(plan->arguments + offset) + 1;
+  }
+  return argv;
+}
+
+int32_t proton_process_run_relaunches(void) {
+  int32_t first_error = PROTON_OK;
+  while (g_relaunch_head != NULL) {
+    proton_relaunch_plan_t *plan = g_relaunch_head;
+    g_relaunch_head = plan->next;
+    char **argv = proton_process_argv(plan);
+    pid_t child = 0;
+    if (argv == NULL ||
+        posix_spawn(&child, plan->executable, NULL, NULL, argv, environ) != 0) {
+      if (first_error == PROTON_OK) {
+        first_error = proton_set_error(
+            PROTON_ERR_PLATFORM,
+            "failed to start the relaunched application");
+      }
+    }
+    free(argv);
+    free(plan->executable);
+    free(plan->arguments);
+    free(plan);
+  }
+  g_relaunch_tail = NULL;
+  return first_error == PROTON_OK ? proton_set_error(PROTON_OK, NULL)
+                                  : first_error;
+}
+
+void proton_process_exit(int32_t exit_code) {
+  (void)proton_process_run_relaunches();
+  _exit(exit_code);
+}

--- a/proton/internal/native/ffi_mac/mac_app_control.objc.c
+++ b/proton/internal/native/ffi_mac/mac_app_control.objc.c
@@ -1,3 +1,5 @@
+#if defined(__APPLE__)
+
 #import <AppKit/AppKit.h>
 #import <CoreServices/CoreServices.h>
 
@@ -287,3 +289,5 @@ void proton_process_exit(int32_t exit_code) {
   (void)proton_process_run_relaunches();
   _exit(exit_code);
 }
+
+#endif

--- a/proton/internal/native/ffi_mac/moon.pkg
+++ b/proton/internal/native/ffi_mac/moon.pkg
@@ -4,6 +4,7 @@ options(
   "is-main": false,
   "native-stub": [
     "mac_client.objc.c",
+    "mac_app_control.objc.c",
     "mac_dialog.objc.c",
     "mac_launch_input.objc.c",
     "mac_menu.objc.c",

--- a/proton/internal/native/moon.pkg
+++ b/proton/internal/native/moon.pkg
@@ -21,6 +21,7 @@ options(
     "ffi_constants.mbt": [ "native" ],
     "types.mbt": [ "native" ],
     "native.mbt": [ "native" ],
+    "app_control.mbt": [ "native" ],
     "native_text.mbt": [ "native" ],
     "update.mbt": [ "native" ],
     "update_wbtest.mbt": [ "native" ],

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -39,6 +39,15 @@ fn native_text_test_copy(
 }
 
 ///|
+test "application control argument blobs preserve utf8 boundaries" {
+  assert_eq(app_control_argument_blob([]), b"")
+  assert_eq(
+    app_control_argument_blob(["--mode", "窗口", ""]),
+    b"--mode\x00\xe7\xaa\x97\xe5\x8f\xa3\x00\x00",
+  )
+}
+
+///|
 test "native text reader retries when the payload grows" {
   let calls = Ref(0)
   let final_text = "{\"url\":\"proton://app/a/much/longer/path\"}"

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -34,6 +34,18 @@ pub fn notification_show(String, String, payload? : String) -> Unit raise Native
 
 pub fn notification_supported() -> Bool raise NativeError
 
+pub fn process_exit(Int) -> Unit
+
+pub fn process_run_relaunches() -> Unit raise NativeError
+
+pub fn process_schedule_relaunch(String, Array[String]) -> Unit raise NativeError
+
+pub fn protocol_client_is_default(String, String, String, Array[String]) -> Bool raise NativeError
+
+pub fn protocol_client_remove(String, String, String, Array[String]) -> Bool raise NativeError
+
+pub fn protocol_client_set(String, String, String, Array[String]) -> Bool raise NativeError
+
 pub fn runtime_info() -> RuntimeInfo raise NativeError
 
 pub let runtime_wait_all : Int

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -63,6 +63,19 @@ pub fn AppConfigurationError::output(Self, &Logger) -> Unit
 pub fn AppConfigurationError::to_repr(Self) -> @debug.Repr
 pub fn AppConfigurationError::to_string(Self) -> String
 
+pub(all) suberror AppControlError {
+  InvalidProtocolScheme(scheme~ : String)
+  UndeclaredProtocolScheme(scheme~ : String)
+  InvalidExecutable(path~ : String)
+  NativeControlFailure(action~ : String, status~ : Int, detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn AppControlError::equal(Self, Self) -> Bool
+pub fn AppControlError::message(Self) -> String
+pub fn AppControlError::not_equal(Self, Self) -> Bool
+pub fn AppControlError::output(Self, &Logger) -> Unit
+pub fn AppControlError::to_repr(Self) -> @debug.Repr
+pub fn AppControlError::to_string(Self) -> String
+
 pub(all) suberror AppEntryError {
   ReadFailed(path~ : String, detail~ : String)
   PlatformLoad(action~ : String, status~ : Int, detail~ : String)
@@ -261,10 +274,19 @@ pub struct ApplicationContext {
   windows : WindowManager
   locale_preferences : @locale.LocalePreferences
   request_quit : () -> Unit
+  application_identifier : String
+  application_executable : String
+  application_arguments : Array[String]
+  url_schemes : Array[String]
 }
+pub fn ApplicationContext::exit(Self, exit_code? : Int) -> Unit
+pub fn ApplicationContext::is_default_protocol_client(Self, String, executable? : String, arguments? : Array[String]) -> Bool raise AppControlError
 pub fn ApplicationContext::locale(Self) -> @locale.Locale
 pub fn ApplicationContext::preferred_languages(Self) -> Array[@locale.Locale]
 pub fn ApplicationContext::quit(Self) -> Unit
+pub fn ApplicationContext::relaunch(Self, options? : RelaunchOptions) -> Unit raise AppControlError
+pub fn ApplicationContext::remove_default_protocol_client(Self, String, executable? : String, arguments? : Array[String]) -> Bool raise AppControlError
+pub fn ApplicationContext::set_as_default_protocol_client(Self, String, executable? : String, arguments? : Array[String]) -> Bool raise AppControlError
 pub fn ApplicationContext::task_group(Self) -> @async.TaskGroup[Unit]
 pub fn ApplicationContext::windows(Self) -> WindowManager
 
@@ -618,6 +640,15 @@ pub(all) struct PopupRequest {
 pub fn PopupRequest::equal(Self, Self) -> Bool
 pub fn PopupRequest::not_equal(Self, Self) -> Bool
 pub fn PopupRequest::to_repr(Self) -> @debug.Repr
+
+pub(all) struct RelaunchOptions {
+  executable : String?
+  arguments : Array[String]?
+} derive(Eq, @debug.Debug)
+pub fn RelaunchOptions::RelaunchOptions(executable? : String, arguments? : Array[String]) -> Self
+pub fn RelaunchOptions::equal(Self, Self) -> Bool
+pub fn RelaunchOptions::not_equal(Self, Self) -> Bool
+pub fn RelaunchOptions::to_repr(Self) -> @debug.Repr
 
 pub struct RendererTarget {
   window : String


### PR DESCRIPTION
## Summary

- add Electron-aligned default protocol client set/remove/query APIs to `ApplicationContext`
- add `ApplicationContext::relaunch` and immediate `ApplicationContext::exit`
- register declared URL schemes in macOS, Windows, and Linux package metadata
- add `75_app_protocol_process` for manual protocol, relaunch, and exit review

## Platform behavior

- macOS uses LaunchServices and requires the packaged bundle identity plus `CFBundleURLTypes`
- Windows uses per-user UTF-16 registry entries and supports Electron-style executable/argument overrides
- Linux uses GIO and the packaged desktop id; removal returns `false`, matching Electron availability
- normal shutdown launches queued replacements after runtime and single-instance cleanup; immediate exit launches them before terminating

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 100` (38/38)
- `moon -C proton test -p moonbit-community/proton --target native --diagnostic-limit 100` (152/152)
- `moon -C package test lib --target native --diagnostic-limit 100` (14/14)
- `moon -C examples build 75_app_protocol_process --target native --diagnostic-limit 100`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon check --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- packaged macOS app built successfully and its `Info.plist` contains `CFBundleURLTypes` for `proton-control-review`
- manually reviewed the macOS UI, protocol query, orderly relaunch, and immediate-exit relaunch
- GitHub Actions passed on macOS, Ubuntu, and Windows, including Windows native compilation and NSIS package creation

## Remaining manual review

- use `examples/75_app_protocol_process/README.md` to review intentional register/remove mutations
- verify Windows registry ownership/removal and relaunch runtime behavior on Windows
- verify installed desktop entry registration/query and relaunch runtime behavior on Linux
