### PR TITLE
fix(native): suppress Windows CEF helper consoles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,19 @@ jobs:
           $helperBin = Join-Path $env:RUNNER_TEMP "proton-helper"
           $helperBuild = Join-Path $env:RUNNER_TEMP "proton-helper-build"
           moon --target-dir $helperBuild install --path proton/internal/cef_process --bin $helperBin
+          $helper = Join-Path $helperBin "cef_process.exe"
+          $image = [System.IO.File]::ReadAllBytes($helper)
+          $peOffset = [System.BitConverter]::ToInt32($image, 0x3c)
+          $subsystem = [System.BitConverter]::ToUInt16($image, $peOffset + 92)
+          if ($subsystem -ne 2) {
+            throw "cef_process.exe must use the Windows GUI subsystem; found $subsystem"
+          }
           # windows-latest runners have no usable D3D device; force ANGLE's
           # SwiftShader path so the engine's GPU process can start at all.
           $env:ANGLE_DEFAULT_PLATFORM = "swiftshader"
           "ANGLE_DEFAULT_PLATFORM=swiftshader" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "PROTON_RUNTIME_ROOT=$runtime" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "PROTON_HELPER_PATH=$(Join-Path $helperBin 'cef_process.exe')" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "PROTON_HELPER_PATH=$helper" | Out-File -FilePath $env:GITHUB_ENV -Append
           Join-Path $runtime "bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Test Windows NSIS packaging

--- a/proton/internal/cef_process/main.mbt
+++ b/proton/internal/cef_process/main.mbt
@@ -1,5 +1,9 @@
 ///|
+extern "C" fn link_anchor() = "proton_cef_process_link_anchor"
+
+///|
 fn main raise {
+  link_anchor()
   match @native.execute_process(config=@native.RuntimeConfig::bundled()) {
     @native.ProcessResult::SubprocessHandled(exit_code) => @sys.exit(exit_code)
     @native.ProcessResult::MainProcess =>

--- a/proton/internal/cef_process/moon.pkg
+++ b/proton/internal/cef_process/moon.pkg
@@ -8,5 +8,6 @@ supported_targets = "native"
 pkgtype(kind: "executable")
 
 options(
+  "native-stub": [ "windows_subsystem.c" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/proton/internal/cef_process/windows_subsystem.c
+++ b/proton/internal/cef_process/windows_subsystem.c
@@ -1,0 +1,10 @@
+#include <moonbit.h>
+
+#if defined(_WIN32)
+/* CEF launches this executable once per subprocess. Keep MoonBit's regular
+   main entry point without allocating a console for every child process. */
+#pragma comment(linker, "/SUBSYSTEM:WINDOWS")
+#pragma comment(linker, "/ENTRY:mainCRTStartup")
+#endif
+
+MOONBIT_FFI_EXPORT void proton_cef_process_link_anchor(void) {}


### PR DESCRIPTION
## Summary

- link the Windows `cef_process.exe` helper as a GUI-subsystem executable
- preserve MoonBit's generated `main` entry through `mainCRTStartup`
- verify the installed helper's PE subsystem in Windows CI

## Background

CEF launches the configured subprocess helper separately for renderer, GPU, and utility processes. The helper was installed as a normal MoonBit executable with the default console subsystem, so Windows could allocate a visible console window for every CEF child process.

The linker directives are owned by the `cef_process` package itself. They do not enter Proton's shared native link configuration and therefore do not change application executables built by downstream users.

## Validation

- `moon fmt`
- `moon info`
- `moon check proton/internal/cef_process --target native --diagnostic-limit 80`
- `moon build proton/internal/cef_process --target native --release --diagnostic-limit 80`
- Windows CI reads the installed PE optional header and requires subsystem `2` (`Windows GUI`)
