### PR TITLE
fix(scripts): update wasm runner syntax

### DIFF
--- a/scripts/e2e_scaffold_registry_smoke.mjs
+++ b/scripts/e2e_scaffold_registry_smoke.mjs
@@ -106,7 +106,7 @@ function useLocalCodegenPackage() {
   const backendModPath = path.join(projectDir, "backend", "moon.mod");
   const source = fs.readFileSync(backendModPath, "utf8");
   const coordinate = `moonx moonbit-community/proton_codegen@${moduleVersion("codegen/moon.mod")}`;
-  const localCommand = `moon runwasm '${path.join(repoRoot, "codegen")}'`;
+  const localCommand = `moon run '${path.join(repoRoot, "codegen")}' --target wasm --`;
   const updated = source.replace(coordinate, localCommand);
   if (updated === source || updated.includes(coordinate)) {
     throw new Error("could not select the local codegen package");

--- a/scripts/e2e_scaffold_source_smoke.mjs
+++ b/scripts/e2e_scaffold_source_smoke.mjs
@@ -152,7 +152,7 @@ function verifyGeneratedTree() {
 function useLocalCodegenPackage() {
   const backendModPath = path.join(projectDir, "backend", "moon.mod");
   const source = fs.readFileSync(backendModPath, "utf8");
-  const localCommand = `moon runwasm '${path.join(repoRoot, "codegen")}'`;
+  const localCommand = `moon run '${path.join(repoRoot, "codegen")}' --target wasm --`;
   const updated = source.replace(`moonx ${codegenCoordinate}`, localCommand);
   assert(updated !== source, "generated backend is missing the codegen command");
   assert(
@@ -171,8 +171,11 @@ function verifySourceSmokeCodegen() {
   );
   const fresh = path.join(tempRoot, "commands.fresh.mbt");
   run("moon", [
-    "runwasm",
+    "run",
     path.join(repoRoot, "codegen"),
+    "--target",
+    "wasm",
+    "--",
     path.join(projectDir, "backend", "todo", "commands.mbt"),
     "-o",
     fresh,


### PR DESCRIPTION
## Summary

- replace deprecated `moon runwasm` invocations with `moon run <package> --target wasm`
- preserve the argument boundary with `--` so codegen options are forwarded to the executable
- update both source and registry scaffold smoke paths

## Validation

- `moon fmt`
- `moon info`
- direct Proton codegen execution with the new syntax
- registry scaffold smoke
- full source scaffold E2E, including generation, build, signed macOS packaging, and application lifecycle