### PR TITLE
fix(window): honor native theme policy

### DIFF
--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -160,6 +160,7 @@ pub fn App::title(self : App, title : String) -> App {
     self.window.height,
     size_hint=self.window.size_hint,
     titlebar_style=self.window.titlebar_style,
+    theme=self.window.theme,
   )
   self
 }
@@ -173,6 +174,7 @@ pub fn App::size(self : App, width~ : Int, height~ : Int) -> App {
     height,
     size_hint=self.window.size_hint,
     titlebar_style=self.window.titlebar_style,
+    theme=self.window.theme,
   )
   self
 }
@@ -190,6 +192,24 @@ pub fn App::titlebar_style(self : App, style : TitlebarStyle) -> App {
       Default => @manifest.TitlebarStyle::Default
       Overlay => @manifest.TitlebarStyle::Overlay
     },
+    theme=self.window.theme,
+  )
+  self
+}
+
+///|
+/// Sets the primary window's native chrome theme.
+///
+/// Explicit `Light` and `Dark` themes require platform support. `System` is
+/// portable and follows the platform's effective application appearance.
+pub fn App::theme(self : App, theme : WindowTheme) -> App {
+  self.window = @manifest.WindowManifest(
+    self.window.title,
+    self.window.width,
+    self.window.height,
+    size_hint=self.window.size_hint,
+    titlebar_style=self.window.titlebar_style,
+    theme=manifest_window_theme(theme),
   )
   self
 }
@@ -507,6 +527,7 @@ pub fn App::add_window(
   height? : Int = 700,
   size_hint? : WindowSizeHint = WindowSizeHint::Unconstrained,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
+  theme? : WindowTheme = WindowTheme::System,
   open_on_start? : Bool = true,
 ) -> App {
   let normalized_id = id.trim().to_owned()
@@ -541,6 +562,7 @@ pub fn App::add_window(
         height,
         size_hint=manifest_window_size_hint(size_hint),
         titlebar_style=manifest_titlebar_style(titlebar_style),
+        theme=manifest_window_theme(theme),
       ),
       entry,
       open_on_start~,
@@ -564,6 +586,15 @@ fn manifest_titlebar_style(style : TitlebarStyle) -> @manifest.TitlebarStyle {
   match style {
     TitlebarStyle::Default => @manifest.TitlebarStyle::Default
     TitlebarStyle::Overlay => @manifest.TitlebarStyle::Overlay
+  }
+}
+
+///|
+fn manifest_window_theme(theme : WindowTheme) -> @manifest.WindowTheme {
+  match theme {
+    WindowTheme::System => @manifest.WindowTheme::System
+    WindowTheme::Light => @manifest.WindowTheme::Light
+    WindowTheme::Dark => @manifest.WindowTheme::Dark
   }
 }
 

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -160,7 +160,7 @@ pub fn App::title(self : App, title : String) -> App {
     self.window.height,
     size_hint=self.window.size_hint,
     titlebar_style=self.window.titlebar_style,
-    theme=self.window.theme,
+    theme=self.window.theme_preference,
   )
   self
 }
@@ -174,7 +174,7 @@ pub fn App::size(self : App, width~ : Int, height~ : Int) -> App {
     height,
     size_hint=self.window.size_hint,
     titlebar_style=self.window.titlebar_style,
-    theme=self.window.theme,
+    theme=self.window.theme_preference,
   )
   self
 }
@@ -192,7 +192,7 @@ pub fn App::titlebar_style(self : App, style : TitlebarStyle) -> App {
       Default => @manifest.TitlebarStyle::Default
       Overlay => @manifest.TitlebarStyle::Overlay
     },
-    theme=self.window.theme,
+    theme=self.window.theme_preference,
   )
   self
 }
@@ -202,7 +202,7 @@ pub fn App::titlebar_style(self : App, style : TitlebarStyle) -> App {
 ///
 /// Explicit `Light` and `Dark` themes require platform support. `System` is
 /// portable and follows the platform's effective application appearance.
-pub fn App::theme(self : App, theme : WindowTheme) -> App {
+pub fn App::theme(self : App, theme : WindowThemePreference) -> App {
   self.window = @manifest.WindowManifest(
     self.window.title,
     self.window.width,
@@ -527,7 +527,7 @@ pub fn App::add_window(
   height? : Int = 700,
   size_hint? : WindowSizeHint = WindowSizeHint::Unconstrained,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
-  theme? : WindowTheme = WindowTheme::System,
+  theme? : WindowThemePreference = WindowThemePreference::System,
   open_on_start? : Bool = true,
 ) -> App {
   let normalized_id = id.trim().to_owned()
@@ -590,11 +590,13 @@ fn manifest_titlebar_style(style : TitlebarStyle) -> @manifest.TitlebarStyle {
 }
 
 ///|
-fn manifest_window_theme(theme : WindowTheme) -> @manifest.WindowTheme {
+fn manifest_window_theme(
+  theme : WindowThemePreference,
+) -> @manifest.WindowThemePreference {
   match theme {
-    WindowTheme::System => @manifest.WindowTheme::System
-    WindowTheme::Light => @manifest.WindowTheme::Light
-    WindowTheme::Dark => @manifest.WindowTheme::Dark
+    WindowThemePreference::System => @manifest.WindowThemePreference::System
+    WindowThemePreference::Light => @manifest.WindowThemePreference::Light
+    WindowThemePreference::Dark => @manifest.WindowThemePreference::Dark
   }
 }
 

--- a/proton/facade_native_types.mbt
+++ b/proton/facade_native_types.mbt
@@ -12,6 +12,20 @@ pub extend TitlebarStyle with Eq::{not_equal, equal}
 pub extend TitlebarStyle with Debug::{to_repr}
 
 ///|
+/// Controls the native window chrome theme.
+pub(all) enum WindowTheme {
+  System
+  Light
+  Dark
+} derive(Debug, Eq)
+
+///|
+pub extend WindowTheme with Eq::{not_equal, equal}
+
+///|
+pub extend WindowTheme with Debug::{to_repr}
+
+///|
 /// Controls how configured window dimensions constrain native resizing.
 pub(all) enum WindowSizeHint {
   Unconstrained
@@ -76,7 +90,7 @@ pub(all) struct WindowState {
   maximized : Bool
   fullscreen : Bool
   always_on_top : Bool
-  theme : String
+  theme : WindowTheme
 } derive(Debug, Eq)
 
 ///|
@@ -100,7 +114,11 @@ fn WindowState::from_native(state : @native.WindowState) -> WindowState {
     maximized: state.maximized,
     fullscreen: state.fullscreen,
     always_on_top: state.always_on_top,
-    theme: state.theme,
+    theme: match state.theme {
+      @native.WindowTheme::System => WindowTheme::System
+      @native.WindowTheme::Light => WindowTheme::Light
+      @native.WindowTheme::Dark => WindowTheme::Dark
+    },
   }
 }
 

--- a/proton/facade_native_types.mbt
+++ b/proton/facade_native_types.mbt
@@ -12,9 +12,8 @@ pub extend TitlebarStyle with Eq::{not_equal, equal}
 pub extend TitlebarStyle with Debug::{to_repr}
 
 ///|
-/// Controls the native window chrome theme.
+/// Describes the effective native window chrome theme.
 pub(all) enum WindowTheme {
-  System
   Light
   Dark
 } derive(Debug, Eq)
@@ -24,6 +23,20 @@ pub extend WindowTheme with Eq::{not_equal, equal}
 
 ///|
 pub extend WindowTheme with Debug::{to_repr}
+
+///|
+/// Controls how Proton chooses the native window chrome theme.
+pub(all) enum WindowThemePreference {
+  System
+  Light
+  Dark
+} derive(Debug, Eq)
+
+///|
+pub extend WindowThemePreference with Eq::{not_equal, equal}
+
+///|
+pub extend WindowThemePreference with Debug::{to_repr}
 
 ///|
 /// Controls how configured window dimensions constrain native resizing.
@@ -77,6 +90,9 @@ fn WindowMonitor::from_native(monitor : @native.WindowMonitor) -> WindowMonitor 
 
 ///|
 /// A point-in-time snapshot of a native window.
+///
+/// `theme` is the effective `Light` or `Dark` theme after resolving the
+/// window's configured `WindowThemePreference`.
 pub(all) struct WindowState {
   x : Int
   y : Int
@@ -115,7 +131,6 @@ fn WindowState::from_native(state : @native.WindowState) -> WindowState {
     fullscreen: state.fullscreen,
     always_on_top: state.always_on_top,
     theme: match state.theme {
-      @native.WindowTheme::System => WindowTheme::System
       @native.WindowTheme::Light => WindowTheme::Light
       @native.WindowTheme::Dark => WindowTheme::Dark
     },

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -601,10 +601,13 @@ fn native_window_config(
       @manifest.TitlebarStyle::Default => @native.TitlebarStyle::Default
       @manifest.TitlebarStyle::Overlay => @native.TitlebarStyle::Overlay
     },
-    theme=match window.theme {
-      @manifest.WindowTheme::System => @native.WindowTheme::System
-      @manifest.WindowTheme::Light => @native.WindowTheme::Light
-      @manifest.WindowTheme::Dark => @native.WindowTheme::Dark
+    theme=match window.theme_preference {
+      @manifest.WindowThemePreference::System =>
+        @native.WindowThemePreference::System
+      @manifest.WindowThemePreference::Light =>
+        @native.WindowThemePreference::Light
+      @manifest.WindowThemePreference::Dark =>
+        @native.WindowThemePreference::Dark
     },
     browser~,
     bridge?,

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -601,6 +601,11 @@ fn native_window_config(
       @manifest.TitlebarStyle::Default => @native.TitlebarStyle::Default
       @manifest.TitlebarStyle::Overlay => @native.TitlebarStyle::Overlay
     },
+    theme=match window.theme {
+      @manifest.WindowTheme::System => @native.WindowTheme::System
+      @manifest.WindowTheme::Light => @native.WindowTheme::Light
+      @manifest.WindowTheme::Dark => @native.WindowTheme::Dark
+    },
     browser~,
     bridge?,
   ).with_framework_titlebar_labels(

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -331,9 +331,10 @@ fn RuntimeSession::window_handle(
       self.control_window(id, native_id, "set theme", window => {
         window.set_theme(
           match theme {
-            WindowTheme::System => @native.WindowTheme::System
-            WindowTheme::Light => @native.WindowTheme::Light
-            WindowTheme::Dark => @native.WindowTheme::Dark
+            WindowThemePreference::System =>
+              @native.WindowThemePreference::System
+            WindowThemePreference::Light => @native.WindowThemePreference::Light
+            WindowThemePreference::Dark => @native.WindowThemePreference::Dark
           },
         )
       })
@@ -2029,7 +2030,7 @@ pub fn WindowHandle::set_background_color(
 /// platforms without per-window native theme support.
 pub fn WindowHandle::set_theme(
   self : WindowHandle,
-  theme : WindowTheme,
+  theme : WindowThemePreference,
 ) -> Unit raise WindowSessionError {
   (self.set_window_theme)(theme)
 }

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -327,6 +327,17 @@ fn RuntimeSession::window_handle(
         window.set_background_color(color)
       })
     },
+    set_window_theme: theme => {
+      self.control_window(id, native_id, "set theme", window => {
+        window.set_theme(
+          match theme {
+            WindowTheme::System => @native.WindowTheme::System
+            WindowTheme::Light => @native.WindowTheme::Light
+            WindowTheme::Dark => @native.WindowTheme::Dark
+          },
+        )
+      })
+    },
     set_window_visible_on_all_workspaces: visible => {
       self.control_window(id, native_id, "set workspace visibility", window => {
         window.set_visible_on_all_workspaces(visible)
@@ -2008,6 +2019,19 @@ pub fn WindowHandle::set_background_color(
   color : String,
 ) -> Unit raise WindowSessionError {
   (self.set_window_background_color)(color)
+}
+
+///|
+/// Sets the native window chrome theme.
+///
+/// `System` follows platform appearance changes. Explicit `Light` and `Dark`
+/// remain stable until changed again and raise `WindowSessionError` on
+/// platforms without per-window native theme support.
+pub fn WindowHandle::set_theme(
+  self : WindowHandle,
+  theme : WindowTheme,
+) -> Unit raise WindowSessionError {
+  (self.set_window_theme)(theme)
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -599,7 +599,7 @@ pub struct WindowHandle {
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_ignore_mouse_events : (Bool, Bool) -> Unit raise WindowSessionError
   set_window_background_color : (String) -> Unit raise WindowSessionError
-  set_window_theme : (WindowTheme) -> Unit raise WindowSessionError
+  set_window_theme : (WindowThemePreference) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
   set_window_menu : (MenuBar?) -> Unit raise WindowSessionError

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -599,6 +599,7 @@ pub struct WindowHandle {
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_ignore_mouse_events : (Bool, Bool) -> Unit raise WindowSessionError
   set_window_background_color : (String) -> Unit raise WindowSessionError
+  set_window_theme : (WindowTheme) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
   set_window_menu : (MenuBar?) -> Unit raise WindowSessionError

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -76,7 +76,7 @@ fn test_window_handle(
   has_shadow_calls? : Array[Bool],
   ignore_mouse_events_calls? : Array[(Bool, Bool)],
   background_color_calls? : Array[String],
-  theme_calls? : Array[WindowTheme],
+  theme_calls? : Array[WindowThemePreference],
   visible_on_all_workspaces_calls? : Array[Bool],
   enabled_calls? : Array[Bool],
   kiosk_calls? : Array[Bool],
@@ -1054,7 +1054,7 @@ fn test_activation_window_state(
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: @native.WindowTheme::System,
+    theme: @native.WindowTheme::Light,
   }
 }
 
@@ -2140,7 +2140,7 @@ test "direct launches use the working directory as their resource directory" {
 ///|
 test "typed facade appends validated secondary windows" {
   let configured = html("Main", "<main>Main</main>")
-    .theme(WindowTheme::Light)
+    .theme(WindowThemePreference::Light)
     .title("Themed Main")
     .size(width=800, height=600)
     .titlebar_style(TitlebarStyle::Overlay)
@@ -2151,18 +2151,24 @@ test "typed facade appends validated secondary windows" {
       width=480,
       height=360,
       size_hint=WindowSizeHint::Fixed,
-      theme=WindowTheme::Dark,
+      theme=WindowThemePreference::Dark,
       open_on_start=false,
     )
   let manifest = configured.inline_manifest()
-  assert_eq(manifest.window.theme, @manifest.WindowTheme::Light)
+  assert_eq(
+    manifest.window.theme_preference,
+    @manifest.WindowThemePreference::Light,
+  )
   assert_eq(manifest.windows.length(), 1)
   assert_eq(manifest.windows[0].id, "settings")
   assert_eq(
     manifest.windows[0].window.size_hint,
     @manifest.WindowSizeHint::Fixed,
   )
-  assert_eq(manifest.windows[0].window.theme, @manifest.WindowTheme::Dark)
+  assert_eq(
+    manifest.windows[0].window.theme_preference,
+    @manifest.WindowThemePreference::Dark,
+  )
   assert_false(manifest.windows[0].open_on_start)
   let plans = planned_windows(manifest)
   assert_eq(plans.map(fn(plan) { plan.id }), ["main", "settings"])
@@ -2915,10 +2921,10 @@ test "window background color routes values through the handle" {
 
 ///|
 test "window theme routes typed values through the handle" {
-  let calls : Array[WindowTheme] = []
+  let calls : Array[WindowThemePreference] = []
   let window = test_window_handle("main", 17L, theme_calls=calls)
-  window.set_theme(WindowTheme::Light)
-  window.set_theme(WindowTheme::System)
+  window.set_theme(WindowThemePreference::Light)
+  window.set_theme(WindowThemePreference::System)
   debug_inspect(calls, content="[Light, System]")
 }
 
@@ -2988,7 +2994,7 @@ test "window center uses the current monitor work area and frame size" {
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: WindowTheme::System,
+    theme: WindowTheme::Light,
   })
   window.center()
   debug_inspect(position_calls, content="[(560, 240)]")
@@ -3021,7 +3027,7 @@ test "window bounds read and write use Electron coordinate order" {
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: WindowTheme::System,
+    theme: WindowTheme::Light,
   })
   assert_eq(window.bounds(), (120, 80, 800, 600))
   window.set_bounds(x=40, y=50, width=640, height=480)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -76,6 +76,7 @@ fn test_window_handle(
   has_shadow_calls? : Array[Bool],
   ignore_mouse_events_calls? : Array[(Bool, Bool)],
   background_color_calls? : Array[String],
+  theme_calls? : Array[WindowTheme],
   visible_on_all_workspaces_calls? : Array[Bool],
   enabled_calls? : Array[Bool],
   kiosk_calls? : Array[Bool],
@@ -308,6 +309,12 @@ fn test_window_handle(
     set_window_background_color: color => {
       match background_color_calls {
         Some(calls) => calls.push(color)
+        None => ()
+      }
+    },
+    set_window_theme: theme => {
+      match theme_calls {
+        Some(calls) => calls.push(theme)
         None => ()
       }
     },
@@ -1047,7 +1054,7 @@ fn test_activation_window_state(
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: "system",
+    theme: @native.WindowTheme::System,
   }
 }
 
@@ -2132,22 +2139,30 @@ test "direct launches use the working directory as their resource directory" {
 
 ///|
 test "typed facade appends validated secondary windows" {
-  let configured = html("Main", "<main>Main</main>").add_window(
-    "settings",
-    "Settings",
-    AppEntry::Html("<main>Settings</main>"),
-    width=480,
-    height=360,
-    size_hint=WindowSizeHint::Fixed,
-    open_on_start=false,
-  )
+  let configured = html("Main", "<main>Main</main>")
+    .theme(WindowTheme::Light)
+    .title("Themed Main")
+    .size(width=800, height=600)
+    .titlebar_style(TitlebarStyle::Overlay)
+    .add_window(
+      "settings",
+      "Settings",
+      AppEntry::Html("<main>Settings</main>"),
+      width=480,
+      height=360,
+      size_hint=WindowSizeHint::Fixed,
+      theme=WindowTheme::Dark,
+      open_on_start=false,
+    )
   let manifest = configured.inline_manifest()
+  assert_eq(manifest.window.theme, @manifest.WindowTheme::Light)
   assert_eq(manifest.windows.length(), 1)
   assert_eq(manifest.windows[0].id, "settings")
   assert_eq(
     manifest.windows[0].window.size_hint,
     @manifest.WindowSizeHint::Fixed,
   )
+  assert_eq(manifest.windows[0].window.theme, @manifest.WindowTheme::Dark)
   assert_false(manifest.windows[0].open_on_start)
   let plans = planned_windows(manifest)
   assert_eq(plans.map(fn(plan) { plan.id }), ["main", "settings"])
@@ -2899,6 +2914,15 @@ test "window background color routes values through the handle" {
 }
 
 ///|
+test "window theme routes typed values through the handle" {
+  let calls : Array[WindowTheme] = []
+  let window = test_window_handle("main", 17L, theme_calls=calls)
+  window.set_theme(WindowTheme::Light)
+  window.set_theme(WindowTheme::System)
+  debug_inspect(calls, content="[Light, System]")
+}
+
+///|
 test "window kiosk routes live flags through the handle" {
   let calls : Array[Bool] = []
   let window = test_window_handle("main", 17L, kiosk_calls=calls)
@@ -2964,7 +2988,7 @@ test "window center uses the current monitor work area and frame size" {
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: "system",
+    theme: WindowTheme::System,
   })
   window.center()
   debug_inspect(position_calls, content="[(560, 240)]")
@@ -2997,7 +3021,7 @@ test "window bounds read and write use Electron coordinate order" {
     maximized: false,
     fullscreen: false,
     always_on_top: false,
-    theme: "system",
+    theme: WindowTheme::System,
   })
   assert_eq(window.bounds(), (120, 80, 800, 600))
   window.set_bounds(x=40, y=50, width=640, height=480)

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -454,6 +454,7 @@ pub extern "C" fn window_create(
   initial_url : Bytes,
   size_hint : Int,
   titlebar_overlay : Int,
+  theme : Int,
   navigation_policy : Int,
   titlebar_minimize_label : Bytes,
   titlebar_maximize_label : Bytes,
@@ -722,6 +723,12 @@ pub extern "C" fn proton_window_set_background_color_ffi(
   window : WindowHandle,
   color : Bytes,
 ) -> Int = "proton_window_set_background_color"
+
+///|
+pub extern "C" fn proton_window_set_theme_ffi(
+  window : WindowHandle,
+  theme : Int,
+) -> Int = "proton_window_set_theme"
 
 ///|
 pub extern "C" fn proton_window_set_visible_on_all_workspaces_ffi(

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -454,7 +454,7 @@ pub extern "C" fn window_create(
   initial_url : Bytes,
   size_hint : Int,
   titlebar_overlay : Int,
-  theme : Int,
+  theme_preference : Int,
   navigation_policy : Int,
   titlebar_minimize_label : Bytes,
   titlebar_maximize_label : Bytes,
@@ -727,7 +727,7 @@ pub extern "C" fn proton_window_set_background_color_ffi(
 ///|
 pub extern "C" fn proton_window_set_theme_ffi(
   window : WindowHandle,
-  theme : Int,
+  theme_preference : Int,
 ) -> Int = "proton_window_set_theme"
 
 ///|

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -244,6 +244,8 @@ int32_t proton_window_set_ignore_mouse_events(proton_window_handle_t window,
                                               int32_t forward);
 int32_t proton_window_set_background_color(proton_window_handle_t window,
                                            const char *color);
+int32_t proton_window_set_theme(proton_window_handle_t window,
+                                int32_t theme);
 int32_t proton_window_set_visible_on_all_workspaces(
     proton_window_handle_t window, int32_t visible);
 int32_t proton_window_set_enabled(proton_window_handle_t window,

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -245,7 +245,7 @@ int32_t proton_window_set_ignore_mouse_events(proton_window_handle_t window,
 int32_t proton_window_set_background_color(proton_window_handle_t window,
                                            const char *color);
 int32_t proton_window_set_theme(proton_window_handle_t window,
-                                int32_t theme);
+                                int32_t theme_preference);
 int32_t proton_window_set_visible_on_all_workspaces(
     proton_window_handle_t window, int32_t visible);
 int32_t proton_window_set_enabled(proton_window_handle_t window,

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -351,6 +351,8 @@ pub fn proton_window_set_size_ffi(WindowHandle, Int, Int) -> Int
 
 pub fn proton_window_set_skip_taskbar_ffi(WindowHandle, Int) -> Int
 
+pub fn proton_window_set_theme_ffi(WindowHandle, Int) -> Int
+
 pub fn proton_window_set_title_ffi(WindowHandle, Bytes) -> Int
 
 pub fn proton_window_set_visible_on_all_workspaces_ffi(WindowHandle, Int) -> Int
@@ -379,7 +381,7 @@ pub fn view_logical_id(ViewHandle) -> Int64
 
 pub fn view_null() -> ViewHandle
 
-pub fn window_create(RuntimeHandle, Bytes, Int, Int, Bytes, Int, Int, Int, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, Int, Int, BridgeConfigHandle, @ref.Ref[WindowHandle]) -> Int
+pub fn window_create(RuntimeHandle, Bytes, Int, Int, Bytes, Int, Int, Int, Int, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, Int, Int, BridgeConfigHandle, @ref.Ref[WindowHandle]) -> Int
 
 pub fn window_logical_id(WindowHandle) -> Int64
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -102,6 +102,7 @@ struct proton_engine_window {
   cef_rect_t osr_popup_rect;
   int size_hint;
   int titlebar_overlay;
+  proton_window_theme_t theme;
   int always_on_top;
   int fullscreenable;
   int enabled;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -102,7 +102,7 @@ struct proton_engine_window {
   cef_rect_t osr_popup_rect;
   int size_hint;
   int titlebar_overlay;
-  proton_window_theme_t theme;
+  proton_window_theme_preference_t theme_preference;
   int always_on_top;
   int fullscreenable;
   int enabled;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -477,6 +477,12 @@ int32_t proton_engine_window_create(
         "titlebar overlay is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
+  if (!runtime->headless && config.theme != PROTON_WINDOW_THEME_SYSTEM) {
+    proton_engine_set_message(
+        error, error_len,
+        "explicit window themes are not supported on Linux");
+    return PROTON_ERR_UNSUPPORTED;
+  }
 
   proton_engine_window_t *window =
       (proton_engine_window_t *)calloc(1, sizeof(*window));
@@ -496,6 +502,7 @@ int32_t proton_engine_window_create(
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
   window->titlebar_overlay = config.titlebar_overlay;
+  window->theme = config.theme;
   snprintf(window->titlebar_minimize_label,
            sizeof(window->titlebar_minimize_label), "%s",
            config.titlebar_minimize_label);
@@ -1331,6 +1338,33 @@ int32_t proton_engine_window_set_background_color(
                                        &native_color);
   gtk_widget_override_background_color(window->root_box, GTK_STATE_FLAG_NORMAL,
                                        &native_color);
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_theme(
+    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+    proton_engine_set_message(error, error_len, "window theme is invalid");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window theme is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  if (theme != PROTON_WINDOW_THEME_SYSTEM) {
+    proton_engine_set_message(
+        error, error_len,
+        "explicit window themes are not supported on Linux");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  window->theme = theme;
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -98,6 +98,26 @@ int proton_engine_x11_window_is_focused(Display *display,
   return is_focused;
 }
 
+static proton_window_theme_t proton_engine_window_effective_theme(
+    const proton_engine_window_t *window) {
+  if (window != NULL) {
+    switch (window->theme_preference) {
+    case PROTON_WINDOW_THEME_PREFERENCE_LIGHT:
+      return PROTON_WINDOW_THEME_LIGHT;
+    case PROTON_WINDOW_THEME_PREFERENCE_DARK:
+      return PROTON_WINDOW_THEME_DARK;
+    case PROTON_WINDOW_THEME_PREFERENCE_SYSTEM:
+      break;
+    }
+  }
+  gboolean dark = FALSE;
+  GtkSettings *settings = gtk_settings_get_default();
+  if (settings != NULL) {
+    g_object_get(settings, "gtk-application-prefer-dark-theme", &dark, NULL);
+  }
+  return dark ? PROTON_WINDOW_THEME_DARK : PROTON_WINDOW_THEME_LIGHT;
+}
+
 static void proton_engine_apply_size_constraints(
     proton_engine_window_t *window) {
   if (window == NULL || window->window == NULL || window->headless) {
@@ -477,7 +497,8 @@ int32_t proton_engine_window_create(
         "titlebar overlay is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  if (!runtime->headless && config.theme != PROTON_WINDOW_THEME_SYSTEM) {
+  if (!runtime->headless && config.theme_preference !=
+                                PROTON_WINDOW_THEME_PREFERENCE_SYSTEM) {
     proton_engine_set_message(
         error, error_len,
         "explicit window themes are not supported on Linux");
@@ -502,7 +523,7 @@ int32_t proton_engine_window_create(
   window->headless = runtime->headless;
   window->size_hint = config.size_hint;
   window->titlebar_overlay = config.titlebar_overlay;
-  window->theme = config.theme;
+  window->theme_preference = config.theme_preference;
   snprintf(window->titlebar_minimize_label,
            sizeof(window->titlebar_minimize_label), "%s",
            config.titlebar_minimize_label);
@@ -1342,13 +1363,15 @@ int32_t proton_engine_window_set_background_color(
 }
 
 int32_t proton_engine_window_set_theme(
-    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    proton_engine_window_t *window,
+    proton_window_theme_preference_t theme_preference, char *error,
     size_t error_len) {
   if (window == NULL || (!window->headless && window->window == NULL)) {
     proton_engine_set_message(error, error_len, "window is not initialized");
     return PROTON_ERR_INVALID_HANDLE;
   }
-  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+  if (theme_preference < PROTON_WINDOW_THEME_PREFERENCE_SYSTEM ||
+      theme_preference > PROTON_WINDOW_THEME_PREFERENCE_DARK) {
     proton_engine_set_message(error, error_len, "window theme is invalid");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
@@ -1357,13 +1380,13 @@ int32_t proton_engine_window_set_theme(
                               "window theme is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  if (theme != PROTON_WINDOW_THEME_SYSTEM) {
+  if (theme_preference != PROTON_WINDOW_THEME_PREFERENCE_SYSTEM) {
     proton_engine_set_message(
         error, error_len,
         "explicit window themes are not supported on Linux");
     return PROTON_ERR_UNSUPPORTED;
   }
-  window->theme = theme;
+  window->theme_preference = theme_preference;
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
@@ -1537,6 +1560,7 @@ int32_t proton_engine_window_get_state(
   out_state->zoom_percent =
       window->zoom_percent > 0 ? window->zoom_percent : 100;
   out_state->scale_factor_percent = 100;
+  out_state->theme = proton_engine_window_effective_theme(window);
   if (window->headless) {
     out_state->width = window->width;
     out_state->height = window->height;
@@ -1584,12 +1608,6 @@ int32_t proton_engine_window_get_state(
   out_state->focused =
       gtk_window_has_toplevel_focus(GTK_WINDOW(window->window)) ? 1 : 0;
   out_state->always_on_top = window->always_on_top;
-  gboolean dark = FALSE;
-  GtkSettings *settings = gtk_settings_get_default();
-  if (settings != NULL) {
-    g_object_get(settings, "gtk-application-prefer-dark-theme", &dark, NULL);
-    out_state->theme = dark ? 2 : 1;
-  }
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -89,6 +89,7 @@ struct proton_engine_window {
   int max_height;
   double aspect_ratio;
   int titlebar_overlay;
+  proton_window_theme_t theme;
   int fullscreen;
   int always_on_top;
   int zoom_percent;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -89,7 +89,8 @@ struct proton_engine_window {
   int max_height;
   double aspect_ratio;
   int titlebar_overlay;
-  proton_window_theme_t theme;
+  proton_window_theme_preference_t theme_preference;
+  proton_window_theme_t current_theme;
   int fullscreen;
   int always_on_top;
   int zoom_percent;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_titlebar.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_titlebar.c
@@ -7,8 +7,6 @@
 #include <string.h>
 #include <windowsx.h>
 
-#define PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE 20
-
 static int proton_win_is_caption_button_hit(LRESULT hit_test) {
   return hit_test == HTMINBUTTON || hit_test == HTMAXBUTTON ||
          hit_test == HTCLOSE;
@@ -194,10 +192,6 @@ static int proton_engine_overlay_caption_buttons_rect(HWND hwnd, RECT *out) {
 }
 
 void proton_engine_overlay_apply_frame(HWND hwnd) {
-  const BOOL use_dark_caption = TRUE;
-  (void)DwmSetWindowAttribute(hwnd, PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE,
-                              &use_dark_caption,
-                              sizeof(use_dark_caption));
   MARGINS margins = {
       .cxLeftWidth = 0,
       .cxRightWidth = 0,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -47,6 +47,9 @@
 #define WDA_EXCLUDEFROMCAPTURE 0x00000011
 #endif
 
+#define PROTON_WINDOWS_DARK_MODE_MIN_BUILD 17763
+#define PROTON_WINDOWS_DARK_MODE_ATTRIBUTE_TRANSITION_BUILD 18985
+#define PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 19
 #define PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE 20
 
 #include <math.h>
@@ -62,6 +65,36 @@ int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd) {
          (focused == browser_hwnd || IsChild(browser_hwnd, focused));
 }
 
+static DWORD proton_engine_windows_build_number(void) {
+  static int initialized = 0;
+  static DWORD build_number = 0;
+  if (!initialized) {
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (ntdll != NULL) {
+      typedef LONG(WINAPI * proton_rtl_get_version_proc)(OSVERSIONINFOW *);
+      proton_rtl_get_version_proc get_version =
+          (proton_rtl_get_version_proc)GetProcAddress(ntdll, "RtlGetVersion");
+      if (get_version != NULL) {
+        OSVERSIONINFOW version = {0};
+        version.dwOSVersionInfoSize = sizeof(version);
+        if (get_version(&version) == 0) {
+          build_number = version.dwBuildNumber;
+        }
+      }
+    }
+    initialized = 1;
+  }
+  return build_number;
+}
+
+static int proton_engine_windows_high_contrast(void) {
+  HIGHCONTRASTW high_contrast = {0};
+  high_contrast.cbSize = sizeof(high_contrast);
+  return SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(high_contrast),
+                               &high_contrast, 0) &&
+         (high_contrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
+}
+
 static proton_window_theme_t proton_engine_windows_system_theme(void) {
   DWORD light = 1;
   DWORD size = sizeof(light);
@@ -69,38 +102,54 @@ static proton_window_theme_t proton_engine_windows_system_theme(void) {
       HKEY_CURRENT_USER,
       L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
       L"AppsUseLightTheme", RRF_RT_REG_DWORD, NULL, &light, &size);
-  return status == ERROR_SUCCESS && light == 0 ? PROTON_WINDOW_THEME_DARK
-                                               : PROTON_WINDOW_THEME_LIGHT;
+  return status == ERROR_SUCCESS && light == 0 &&
+                 !proton_engine_windows_high_contrast()
+             ? PROTON_WINDOW_THEME_DARK
+             : PROTON_WINDOW_THEME_LIGHT;
 }
 
 static proton_window_theme_t
 proton_engine_window_effective_theme(const proton_engine_window_t *window) {
-  if (window != NULL && window->theme != PROTON_WINDOW_THEME_SYSTEM) {
-    return window->theme;
+  if (window != NULL) {
+    switch (window->theme_preference) {
+    case PROTON_WINDOW_THEME_PREFERENCE_LIGHT:
+      return PROTON_WINDOW_THEME_LIGHT;
+    case PROTON_WINDOW_THEME_PREFERENCE_DARK:
+      return PROTON_WINDOW_THEME_DARK;
+    case PROTON_WINDOW_THEME_PREFERENCE_SYSTEM:
+      break;
+    }
   }
   return proton_engine_windows_system_theme();
 }
 
-static int32_t proton_engine_window_apply_theme(
-    proton_engine_window_t *window, char *error, size_t error_len) {
-  if (window == NULL || window->hwnd == NULL) {
-    proton_engine_set_message(error, error_len, "window is not initialized");
-    return PROTON_ERR_INVALID_HANDLE;
+static void proton_engine_window_refresh_non_client_theme(
+    proton_engine_window_t *window, int redraw) {
+  if (window == NULL) {
+    return;
   }
+  window->current_theme = proton_engine_window_effective_theme(window);
+  DWORD build_number = proton_engine_windows_build_number();
+  if (build_number < PROTON_WINDOWS_DARK_MODE_MIN_BUILD) {
+    window->current_theme = PROTON_WINDOW_THEME_LIGHT;
+    return;
+  }
+  if (window->hwnd == NULL) {
+    return;
+  }
+  DWORD attribute =
+      build_number <= PROTON_WINDOWS_DARK_MODE_ATTRIBUTE_TRANSITION_BUILD
+          ? PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1
+          : PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE;
   const BOOL use_dark_caption =
-      proton_engine_window_effective_theme(window) == PROTON_WINDOW_THEME_DARK;
-  HRESULT result = DwmSetWindowAttribute(
-      window->hwnd, PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE, &use_dark_caption,
-      sizeof(use_dark_caption));
-  if (FAILED(result)) {
-    if (window->theme == PROTON_WINDOW_THEME_SYSTEM) {
-      return PROTON_OK;
-    }
-    proton_engine_set_message(error, error_len,
-                              "failed to update native window theme");
-    return PROTON_ERR_PLATFORM;
+      window->current_theme == PROTON_WINDOW_THEME_DARK;
+  (void)DwmSetWindowAttribute(window->hwnd, attribute, &use_dark_caption,
+                              sizeof(use_dark_caption));
+  if (redraw) {
+    BOOL active = GetActiveWindow() == window->hwnd;
+    DefWindowProcW(window->hwnd, WM_NCACTIVATE, active ? FALSE : TRUE, 0);
+    DefWindowProcW(window->hwnd, WM_NCACTIVATE, active ? TRUE : FALSE, 0);
   }
-  return PROTON_OK;
 }
 
 static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
@@ -318,8 +367,9 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
   case WM_THEMECHANGED:
   case WM_SETTINGCHANGE:
     if (window != NULL) {
-      if (window->theme == PROTON_WINDOW_THEME_SYSTEM) {
-        (void)proton_engine_window_apply_theme(window, NULL, 0);
+      if (window->theme_preference ==
+          PROTON_WINDOW_THEME_PREFERENCE_SYSTEM) {
+        proton_engine_window_refresh_non_client_theme(window, 0);
       }
       proton_engine_signal_wait_source(window->runtime,
                                        PROTON_WAIT_PLATFORM);
@@ -571,7 +621,8 @@ int32_t proton_engine_window_create(
   window->max_width = config.size_hint == 3 ? config.width : 0;
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->titlebar_overlay = config.titlebar_overlay;
-  window->theme = config.theme;
+  window->theme_preference = config.theme_preference;
+  proton_engine_window_refresh_non_client_theme(window, 0);
   window->zoom_percent = 100;
   window->windowed_placement.length = sizeof(WINDOWPLACEMENT);
   window->runtime = runtime;
@@ -635,18 +686,7 @@ int32_t proton_engine_window_create(
       proton_engine_set_message(error, error_len, "window creation failed");
       return PROTON_ERR_PLATFORM;
     }
-    int32_t theme_status =
-        proton_engine_window_apply_theme(window, error, error_len);
-    if (theme_status != PROTON_OK) {
-      DestroyWindow(window->hwnd);
-      window->hwnd = NULL;
-      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
-      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
-      proton_browser_session_destroy(window->browser_session);
-      proton_internal_bridge_config_destroy(window->bridge_config);
-      free(window);
-      return theme_status;
-    }
+    proton_engine_window_refresh_non_client_theme(window, 0);
     if (window->titlebar_overlay) {
       proton_engine_overlay_apply_frame(window->hwnd);
       SetWindowPos(window->hwnd, NULL, 0, 0, 0, 0,
@@ -1664,13 +1704,15 @@ int32_t proton_engine_window_set_background_color(
 }
 
 int32_t proton_engine_window_set_theme(
-    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    proton_engine_window_t *window,
+    proton_window_theme_preference_t theme_preference, char *error,
     size_t error_len) {
   if (window == NULL || (!window->headless && window->hwnd == NULL)) {
     proton_engine_set_message(error, error_len, "window is not initialized");
     return PROTON_ERR_INVALID_HANDLE;
   }
-  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+  if (theme_preference < PROTON_WINDOW_THEME_PREFERENCE_SYSTEM ||
+      theme_preference > PROTON_WINDOW_THEME_PREFERENCE_DARK) {
     proton_engine_set_message(error, error_len, "window theme is invalid");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
@@ -1679,15 +1721,11 @@ int32_t proton_engine_window_set_theme(
                               "window theme is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  proton_window_theme_t previous = window->theme;
-  window->theme = theme;
-  int32_t status = proton_engine_window_apply_theme(window, error, error_len);
-  if (status != PROTON_OK) {
-    window->theme = previous;
-    return status;
+  if (window->theme_preference == theme_preference) {
+    return PROTON_OK;
   }
-  RedrawWindow(window->hwnd, NULL, NULL,
-               RDW_INVALIDATE | RDW_FRAME | RDW_UPDATENOW);
+  window->theme_preference = theme_preference;
+  proton_engine_window_refresh_non_client_theme(window, 1);
   proton_engine_signal_wait_source(window->runtime, PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
@@ -1783,7 +1821,7 @@ int32_t proton_engine_window_get_state(
   out_state->maximized = IsZoomed(window->hwnd) ? 1 : 0;
   out_state->fullscreen = window->fullscreen;
   out_state->always_on_top = window->always_on_top;
-  out_state->theme = proton_engine_window_effective_theme(window);
+  out_state->theme = window->current_theme;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -47,6 +47,8 @@
 #define WDA_EXCLUDEFROMCAPTURE 0x00000011
 #endif
 
+#define PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE 20
+
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -58,6 +60,47 @@ int proton_engine_browser_hwnd_is_focused(HWND browser_hwnd) {
   const HWND focused = GetFocus();
   return browser_hwnd != NULL && focused != NULL &&
          (focused == browser_hwnd || IsChild(browser_hwnd, focused));
+}
+
+static proton_window_theme_t proton_engine_windows_system_theme(void) {
+  DWORD light = 1;
+  DWORD size = sizeof(light);
+  LSTATUS status = RegGetValueW(
+      HKEY_CURRENT_USER,
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+      L"AppsUseLightTheme", RRF_RT_REG_DWORD, NULL, &light, &size);
+  return status == ERROR_SUCCESS && light == 0 ? PROTON_WINDOW_THEME_DARK
+                                               : PROTON_WINDOW_THEME_LIGHT;
+}
+
+static proton_window_theme_t
+proton_engine_window_effective_theme(const proton_engine_window_t *window) {
+  if (window != NULL && window->theme != PROTON_WINDOW_THEME_SYSTEM) {
+    return window->theme;
+  }
+  return proton_engine_windows_system_theme();
+}
+
+static int32_t proton_engine_window_apply_theme(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL || window->hwnd == NULL) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  const BOOL use_dark_caption =
+      proton_engine_window_effective_theme(window) == PROTON_WINDOW_THEME_DARK;
+  HRESULT result = DwmSetWindowAttribute(
+      window->hwnd, PROTON_DWMWA_USE_IMMERSIVE_DARK_MODE, &use_dark_caption,
+      sizeof(use_dark_caption));
+  if (FAILED(result)) {
+    if (window->theme == PROTON_WINDOW_THEME_SYSTEM) {
+      return PROTON_OK;
+    }
+    proton_engine_set_message(error, error_len,
+                              "failed to update native window theme");
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
 }
 
 static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
@@ -275,6 +318,9 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
   case WM_THEMECHANGED:
   case WM_SETTINGCHANGE:
     if (window != NULL) {
+      if (window->theme == PROTON_WINDOW_THEME_SYSTEM) {
+        (void)proton_engine_window_apply_theme(window, NULL, 0);
+      }
       proton_engine_signal_wait_source(window->runtime,
                                        PROTON_WAIT_PLATFORM);
     }
@@ -525,6 +571,7 @@ int32_t proton_engine_window_create(
   window->max_width = config.size_hint == 3 ? config.width : 0;
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->titlebar_overlay = config.titlebar_overlay;
+  window->theme = config.theme;
   window->zoom_percent = 100;
   window->windowed_placement.length = sizeof(WINDOWPLACEMENT);
   window->runtime = runtime;
@@ -587,6 +634,18 @@ int32_t proton_engine_window_create(
       free(window);
       proton_engine_set_message(error, error_len, "window creation failed");
       return PROTON_ERR_PLATFORM;
+    }
+    int32_t theme_status =
+        proton_engine_window_apply_theme(window, error, error_len);
+    if (theme_status != PROTON_OK) {
+      DestroyWindow(window->hwnd);
+      window->hwnd = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
+      proton_browser_session_destroy(window->browser_session);
+      proton_internal_bridge_config_destroy(window->bridge_config);
+      free(window);
+      return theme_status;
     }
     if (window->titlebar_overlay) {
       proton_engine_overlay_apply_frame(window->hwnd);
@@ -1604,6 +1663,35 @@ int32_t proton_engine_window_set_background_color(
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_set_theme(
+    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->hwnd == NULL)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+    proton_engine_set_message(error, error_len, "window theme is invalid");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window theme is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  proton_window_theme_t previous = window->theme;
+  window->theme = theme;
+  int32_t status = proton_engine_window_apply_theme(window, error, error_len);
+  if (status != PROTON_OK) {
+    window->theme = previous;
+    return status;
+  }
+  RedrawWindow(window->hwnd, NULL, NULL,
+               RDW_INVALIDATE | RDW_FRAME | RDW_UPDATENOW);
+  proton_engine_signal_wait_source(window->runtime, PROTON_WAIT_PLATFORM);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_set_visible_on_all_workspaces(
     proton_engine_window_t *window, int32_t visible, char *error,
     size_t error_len) {
@@ -1640,19 +1728,6 @@ int32_t proton_engine_window_set_enabled(proton_engine_window_t *window,
   EnableWindow(window->hwnd, enabled != 0);
   window->enabled = enabled;
   return PROTON_OK;
-}
-
-static int proton_engine_windows_theme(void) {
-  DWORD light = 1;
-  DWORD size = sizeof(light);
-  LSTATUS status = RegGetValueW(
-      HKEY_CURRENT_USER,
-      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-      L"AppsUseLightTheme", RRF_RT_REG_DWORD, NULL, &light, &size);
-  if (status != ERROR_SUCCESS) {
-    return 0;
-  }
-  return light != 0 ? 1 : 2;
 }
 
 int32_t proton_engine_window_get_state(
@@ -1708,7 +1783,7 @@ int32_t proton_engine_window_get_state(
   out_state->maximized = IsZoomed(window->hwnd) ? 1 : 0;
   out_state->fullscreen = window->fullscreen;
   out_state->always_on_top = window->always_on_top;
-  out_state->theme = proton_engine_windows_theme();
+  out_state->theme = proton_engine_window_effective_theme(window);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -700,7 +700,7 @@ int32_t proton_runtime_respond_bridge_request(
 int32_t proton_internal_window_create(
     proton_runtime_handle_t runtime, const char *title, int32_t width,
     int32_t height, const char *initial_url, int32_t size_hint,
-    int32_t titlebar_overlay, int32_t navigation_policy,
+    int32_t titlebar_overlay, int32_t theme, int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,
     int32_t popup_policy, int32_t download_policy,
@@ -718,7 +718,7 @@ int32_t proton_internal_window_create(
   proton_engine_window_config_t config;
   status = proton_config_prepare_window(
       title, width, height, initial_url, size_hint, titlebar_overlay,
-      navigation_policy, titlebar_minimize_label, titlebar_maximize_label,
+      theme, navigation_policy, titlebar_minimize_label, titlebar_maximize_label,
       titlebar_restore_label, titlebar_close_label, popup_policy,
       download_policy, certificate_policy, media_policy, devtools,
       bridge_config, &config);
@@ -1554,6 +1554,28 @@ int32_t proton_window_set_background_color(proton_window_handle_t window,
   char engine_error[512] = {0};
   status = proton_engine_window_set_background_color(
       slot->engine_window, parsed_color, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
+int32_t proton_window_set_theme(proton_window_handle_t window, int32_t theme) {
+  if (theme < PROTON_WINDOW_THEME_SYSTEM ||
+      theme > PROTON_WINDOW_THEME_DARK) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "window theme is invalid");
+  }
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "window theme requires native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_set_theme(
+      slot->engine_window, (proton_window_theme_t)theme, engine_error,
+      sizeof(engine_error));
   if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
   g_last_error[0] = '\0';
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -700,7 +700,8 @@ int32_t proton_runtime_respond_bridge_request(
 int32_t proton_internal_window_create(
     proton_runtime_handle_t runtime, const char *title, int32_t width,
     int32_t height, const char *initial_url, int32_t size_hint,
-    int32_t titlebar_overlay, int32_t theme, int32_t navigation_policy,
+    int32_t titlebar_overlay, int32_t theme_preference,
+    int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,
     int32_t popup_policy, int32_t download_policy,
@@ -718,10 +719,10 @@ int32_t proton_internal_window_create(
   proton_engine_window_config_t config;
   status = proton_config_prepare_window(
       title, width, height, initial_url, size_hint, titlebar_overlay,
-      theme, navigation_policy, titlebar_minimize_label, titlebar_maximize_label,
-      titlebar_restore_label, titlebar_close_label, popup_policy,
-      download_policy, certificate_policy, media_policy, devtools,
-      bridge_config, &config);
+      theme_preference, navigation_policy, titlebar_minimize_label,
+      titlebar_maximize_label, titlebar_restore_label, titlebar_close_label,
+      popup_policy, download_policy, certificate_policy, media_policy,
+      devtools, bridge_config, &config);
   if (status != PROTON_OK) {
     return status;
   }
@@ -1559,9 +1560,10 @@ int32_t proton_window_set_background_color(proton_window_handle_t window,
   return PROTON_OK;
 }
 
-int32_t proton_window_set_theme(proton_window_handle_t window, int32_t theme) {
-  if (theme < PROTON_WINDOW_THEME_SYSTEM ||
-      theme > PROTON_WINDOW_THEME_DARK) {
+int32_t proton_window_set_theme(proton_window_handle_t window,
+                                int32_t theme_preference) {
+  if (theme_preference < PROTON_WINDOW_THEME_PREFERENCE_SYSTEM ||
+      theme_preference > PROTON_WINDOW_THEME_PREFERENCE_DARK) {
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                             "window theme is invalid");
   }
@@ -1574,8 +1576,9 @@ int32_t proton_window_set_theme(proton_window_handle_t window, int32_t theme) {
   }
   char engine_error[512] = {0};
   status = proton_engine_window_set_theme(
-      slot->engine_window, (proton_window_theme_t)theme, engine_error,
-      sizeof(engine_error));
+      slot->engine_window,
+      (proton_window_theme_preference_t)theme_preference,
+      engine_error, sizeof(engine_error));
   if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
   g_last_error[0] = '\0';
   return PROTON_OK;

--- a/proton/internal/native/ffi/src/proton_config.c
+++ b/proton/internal/native/ffi/src/proton_config.c
@@ -664,7 +664,7 @@ static bool proton_browser_policy_mode_valid(int32_t mode) {
 
 int32_t proton_config_prepare_window(
     const char *title, int32_t width, int32_t height, const char *initial_url,
-    int32_t size_hint, int32_t titlebar_overlay, int32_t theme,
+    int32_t size_hint, int32_t titlebar_overlay, int32_t theme_preference,
     int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,
@@ -684,8 +684,8 @@ int32_t proton_config_prepare_window(
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                             "window size hint is invalid");
   }
-  if (theme < PROTON_WINDOW_THEME_SYSTEM ||
-      theme > PROTON_WINDOW_THEME_DARK) {
+  if (theme_preference < PROTON_WINDOW_THEME_PREFERENCE_SYSTEM ||
+      theme_preference > PROTON_WINDOW_THEME_PREFERENCE_DARK) {
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                             "window theme is invalid");
   }
@@ -712,7 +712,8 @@ int32_t proton_config_prepare_window(
   config.height = height;
   config.size_hint = size_hint;
   config.titlebar_overlay = titlebar_overlay != 0;
-  config.theme = (proton_window_theme_t)theme;
+  config.theme_preference =
+      (proton_window_theme_preference_t)theme_preference;
   if ((titlebar_minimize_label != NULL && titlebar_minimize_label[0] != '\0' &&
        !proton_copy_config_text(config.titlebar_minimize_label,
                                 sizeof(config.titlebar_minimize_label),

--- a/proton/internal/native/ffi/src/proton_config.c
+++ b/proton/internal/native/ffi/src/proton_config.c
@@ -664,7 +664,8 @@ static bool proton_browser_policy_mode_valid(int32_t mode) {
 
 int32_t proton_config_prepare_window(
     const char *title, int32_t width, int32_t height, const char *initial_url,
-    int32_t size_hint, int32_t titlebar_overlay, int32_t navigation_policy,
+    int32_t size_hint, int32_t titlebar_overlay, int32_t theme,
+    int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,
     int32_t popup_policy, int32_t download_policy,
@@ -682,6 +683,11 @@ int32_t proton_config_prepare_window(
   if (size_hint < 0 || size_hint > 3) {
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                             "window size hint is invalid");
+  }
+  if (theme < PROTON_WINDOW_THEME_SYSTEM ||
+      theme > PROTON_WINDOW_THEME_DARK) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "window theme is invalid");
   }
   if (!proton_browser_policy_mode_valid(navigation_policy) ||
       !proton_browser_policy_mode_valid(popup_policy) ||
@@ -706,6 +712,7 @@ int32_t proton_config_prepare_window(
   config.height = height;
   config.size_hint = size_hint;
   config.titlebar_overlay = titlebar_overlay != 0;
+  config.theme = (proton_window_theme_t)theme;
   if ((titlebar_minimize_label != NULL && titlebar_minimize_label[0] != '\0' &&
        !proton_copy_config_text(config.titlebar_minimize_label,
                                 sizeof(config.titlebar_minimize_label),

--- a/proton/internal/native/ffi/src/proton_config.h
+++ b/proton/internal/native/ffi/src/proton_config.h
@@ -20,7 +20,8 @@ PROTON_INTERNAL int32_t proton_config_probe_runtime(
     const proton_engine_runtime_config_t *config);
 PROTON_INTERNAL int32_t proton_config_prepare_window(
     const char *title, int32_t width, int32_t height, const char *initial_url,
-    int32_t size_hint, int32_t titlebar_overlay, int32_t navigation_policy,
+    int32_t size_hint, int32_t titlebar_overlay, int32_t theme,
+    int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,
     int32_t popup_policy, int32_t download_policy,

--- a/proton/internal/native/ffi/src/proton_config.h
+++ b/proton/internal/native/ffi/src/proton_config.h
@@ -20,7 +20,7 @@ PROTON_INTERNAL int32_t proton_config_probe_runtime(
     const proton_engine_runtime_config_t *config);
 PROTON_INTERNAL int32_t proton_config_prepare_window(
     const char *title, int32_t width, int32_t height, const char *initial_url,
-    int32_t size_hint, int32_t titlebar_overlay, int32_t theme,
+    int32_t size_hint, int32_t titlebar_overlay, int32_t theme_preference,
     int32_t navigation_policy,
     const char *titlebar_minimize_label, const char *titlebar_maximize_label,
     const char *titlebar_restore_label, const char *titlebar_close_label,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -38,6 +38,12 @@ typedef struct {
   int32_t persist_session_cookies;
 } proton_engine_runtime_config_t;
 
+typedef enum {
+  PROTON_WINDOW_THEME_SYSTEM = 0,
+  PROTON_WINDOW_THEME_LIGHT = 1,
+  PROTON_WINDOW_THEME_DARK = 2,
+} proton_window_theme_t;
+
 typedef struct {
   proton_window_id_t public_window;
   char title[512];
@@ -46,6 +52,7 @@ typedef struct {
   int32_t height;
   int32_t size_hint;
   int32_t titlebar_overlay;
+  proton_window_theme_t theme;
   char titlebar_minimize_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_maximize_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_restore_label[PROTON_ENGINE_MAX_LABEL_BYTES];
@@ -278,6 +285,9 @@ int32_t proton_engine_window_set_ignore_mouse_events(
     char *error, size_t error_len);
 int32_t proton_engine_window_set_background_color(
     proton_engine_window_t *window, uint32_t color, char *error,
+    size_t error_len);
+int32_t proton_engine_window_set_theme(
+    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
     size_t error_len);
 int32_t proton_engine_window_set_visible_on_all_workspaces(
     proton_engine_window_t *window, int32_t visible, char *error,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -39,10 +39,15 @@ typedef struct {
 } proton_engine_runtime_config_t;
 
 typedef enum {
-  PROTON_WINDOW_THEME_SYSTEM = 0,
   PROTON_WINDOW_THEME_LIGHT = 1,
   PROTON_WINDOW_THEME_DARK = 2,
 } proton_window_theme_t;
+
+typedef enum {
+  PROTON_WINDOW_THEME_PREFERENCE_SYSTEM = 0,
+  PROTON_WINDOW_THEME_PREFERENCE_LIGHT = 1,
+  PROTON_WINDOW_THEME_PREFERENCE_DARK = 2,
+} proton_window_theme_preference_t;
 
 typedef struct {
   proton_window_id_t public_window;
@@ -52,7 +57,7 @@ typedef struct {
   int32_t height;
   int32_t size_hint;
   int32_t titlebar_overlay;
-  proton_window_theme_t theme;
+  proton_window_theme_preference_t theme_preference;
   char titlebar_minimize_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_maximize_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_restore_label[PROTON_ENGINE_MAX_LABEL_BYTES];
@@ -287,7 +292,8 @@ int32_t proton_engine_window_set_background_color(
     proton_engine_window_t *window, uint32_t color, char *error,
     size_t error_len);
 int32_t proton_engine_window_set_theme(
-    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    proton_engine_window_t *window,
+    proton_window_theme_preference_t theme_preference, char *error,
     size_t error_len);
 int32_t proton_engine_window_set_visible_on_all_workspaces(
     proton_engine_window_t *window, int32_t visible, char *error,

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -160,7 +160,7 @@ struct proton_engine_window {
   int max_height;
   double aspect_ratio;
   int zoom_percent;
-  proton_window_theme_t theme;
+  proton_window_theme_preference_t theme_preference;
   NSInteger attention_request_id;
   int headless;
   int maximizable;

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -160,6 +160,7 @@ struct proton_engine_window {
   int max_height;
   double aspect_ratio;
   int zoom_percent;
+  proton_window_theme_t theme;
   NSInteger attention_request_id;
   int headless;
   int maximizable;

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -776,6 +776,7 @@ int32_t proton_engine_window_create(
   window->max_width = config.size_hint == 3 ? config.width : 0;
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->zoom_percent = 100;
+  window->theme = config.theme;
   window->maximizable = 1;
   window->closable = 1;
   window->fullscreenable = 1;
@@ -852,6 +853,20 @@ int32_t proton_engine_window_create(
     [window->window setRestorable:NO];
     [window->window disableSnapshotRestoration];
     [window->window setTitle:title != nil ? title : @"Proton"];
+    switch (window->theme) {
+    case PROTON_WINDOW_THEME_LIGHT:
+      [window->window
+          setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+      break;
+    case PROTON_WINDOW_THEME_DARK:
+      [window->window setAppearance:
+                          [NSAppearance
+                              appearanceNamed:NSAppearanceNameDarkAqua]];
+      break;
+    case PROTON_WINDOW_THEME_SYSTEM:
+      [window->window setAppearance:nil];
+      break;
+    }
     proton_engine_apply_size_constraints(window);
     if (config.titlebar_overlay) {
       [window->window setTitleVisibility:NSWindowTitleHidden];
@@ -1908,6 +1923,40 @@ int32_t proton_engine_window_set_background_color(
   window->content_view.wantsLayer = YES;
   window->content_view.layer.backgroundColor =
       [NSColor colorWithRed:red green:green blue:blue alpha:alpha].CGColor;
+  return PROTON_OK;
+}
+
+int32_t proton_engine_window_set_theme(
+    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    size_t error_len) {
+  if (window == NULL || (!window->headless && window->window == nil)) {
+    proton_engine_set_message(error, error_len, "window is not initialized");
+    return PROTON_ERR_INVALID_HANDLE;
+  }
+  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+    proton_engine_set_message(error, error_len, "window theme is invalid");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (window->headless) {
+    proton_engine_set_message(error, error_len,
+                              "window theme is not supported in headless mode");
+    return PROTON_ERR_UNSUPPORTED;
+  }
+  switch (theme) {
+  case PROTON_WINDOW_THEME_LIGHT:
+    [window->window
+        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+    break;
+  case PROTON_WINDOW_THEME_DARK:
+    [window->window
+        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
+    break;
+  case PROTON_WINDOW_THEME_SYSTEM:
+    [window->window setAppearance:nil];
+    break;
+  }
+  window->theme = theme;
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
 

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -69,6 +69,41 @@ static void proton_engine_apply_size_constraints(
                      : NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX)];
 }
 
+static void proton_engine_window_apply_theme_preference(
+    proton_engine_window_t *window) {
+  if (window == NULL || window->window == nil) {
+    return;
+  }
+  switch (window->theme_preference) {
+  case PROTON_WINDOW_THEME_PREFERENCE_LIGHT:
+    [window->window
+        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+    break;
+  case PROTON_WINDOW_THEME_PREFERENCE_DARK:
+    [window->window
+        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
+    break;
+  case PROTON_WINDOW_THEME_PREFERENCE_SYSTEM:
+    [window->window setAppearance:nil];
+    break;
+  }
+}
+
+static proton_window_theme_t proton_engine_window_effective_theme(
+    const proton_engine_window_t *window) {
+  NSAppearance *appearance =
+      window != NULL && window->window != nil
+          ? window->window.effectiveAppearance
+          : NSApp.effectiveAppearance;
+  NSAppearanceName match = [appearance
+      bestMatchFromAppearancesWithNames:@[
+        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
+      ]];
+  return [match isEqualToString:NSAppearanceNameDarkAqua]
+             ? PROTON_WINDOW_THEME_DARK
+             : PROTON_WINDOW_THEME_LIGHT;
+}
+
 static void proton_engine_dock_progress_clear(void) {
   if (g_dock_progress_indicator != nil) {
     [g_dock_progress_indicator stopAnimation:nil];
@@ -776,7 +811,7 @@ int32_t proton_engine_window_create(
   window->max_width = config.size_hint == 3 ? config.width : 0;
   window->max_height = config.size_hint == 3 ? config.height : 0;
   window->zoom_percent = 100;
-  window->theme = config.theme;
+  window->theme_preference = config.theme_preference;
   window->maximizable = 1;
   window->closable = 1;
   window->fullscreenable = 1;
@@ -853,20 +888,7 @@ int32_t proton_engine_window_create(
     [window->window setRestorable:NO];
     [window->window disableSnapshotRestoration];
     [window->window setTitle:title != nil ? title : @"Proton"];
-    switch (window->theme) {
-    case PROTON_WINDOW_THEME_LIGHT:
-      [window->window
-          setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
-      break;
-    case PROTON_WINDOW_THEME_DARK:
-      [window->window setAppearance:
-                          [NSAppearance
-                              appearanceNamed:NSAppearanceNameDarkAqua]];
-      break;
-    case PROTON_WINDOW_THEME_SYSTEM:
-      [window->window setAppearance:nil];
-      break;
-    }
+    proton_engine_window_apply_theme_preference(window);
     proton_engine_apply_size_constraints(window);
     if (config.titlebar_overlay) {
       [window->window setTitleVisibility:NSWindowTitleHidden];
@@ -1927,13 +1949,15 @@ int32_t proton_engine_window_set_background_color(
 }
 
 int32_t proton_engine_window_set_theme(
-    proton_engine_window_t *window, proton_window_theme_t theme, char *error,
+    proton_engine_window_t *window,
+    proton_window_theme_preference_t theme_preference, char *error,
     size_t error_len) {
   if (window == NULL || (!window->headless && window->window == nil)) {
     proton_engine_set_message(error, error_len, "window is not initialized");
     return PROTON_ERR_INVALID_HANDLE;
   }
-  if (theme < PROTON_WINDOW_THEME_SYSTEM || theme > PROTON_WINDOW_THEME_DARK) {
+  if (theme_preference < PROTON_WINDOW_THEME_PREFERENCE_SYSTEM ||
+      theme_preference > PROTON_WINDOW_THEME_PREFERENCE_DARK) {
     proton_engine_set_message(error, error_len, "window theme is invalid");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
@@ -1942,20 +1966,11 @@ int32_t proton_engine_window_set_theme(
                               "window theme is not supported in headless mode");
     return PROTON_ERR_UNSUPPORTED;
   }
-  switch (theme) {
-  case PROTON_WINDOW_THEME_LIGHT:
-    [window->window
-        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
-    break;
-  case PROTON_WINDOW_THEME_DARK:
-    [window->window
-        setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
-    break;
-  case PROTON_WINDOW_THEME_SYSTEM:
-    [window->window setAppearance:nil];
-    break;
+  if (window->theme_preference == theme_preference) {
+    return PROTON_OK;
   }
-  window->theme = theme;
+  window->theme_preference = theme_preference;
+  proton_engine_window_apply_theme_preference(window);
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return PROTON_OK;
 }
@@ -2020,6 +2035,7 @@ int32_t proton_engine_window_get_state(
   out_state->zoom_percent =
       window->zoom_percent > 0 ? window->zoom_percent : 100;
   out_state->scale_factor_percent = 100;
+  out_state->theme = proton_engine_window_effective_theme(window);
   if (window->headless) {
     out_state->width = window->width;
     out_state->height = window->height;
@@ -2060,12 +2076,6 @@ int32_t proton_engine_window_get_state(
       (window->window.styleMask & NSWindowStyleMaskFullScreen) != 0 ? 1 : 0;
   out_state->always_on_top =
       window->window.level > NSNormalWindowLevel ? 1 : 0;
-  NSAppearance *appearance = window->window.effectiveAppearance;
-  NSAppearanceName match = [appearance
-      bestMatchFromAppearancesWithNames:@[
-        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
-      ]];
-  out_state->theme = [match isEqualToString:NSAppearanceNameDarkAqua] ? 2 : 1;
   return PROTON_OK;
 }
 

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -916,9 +916,9 @@ fn decode_native_cookie_snapshot(
 ///|
 fn window_state_from_fields(field : (Int) -> Int) -> WindowState {
   let theme = match field(20) {
-    1 => "light"
-    2 => "dark"
-    _ => "system"
+    1 => WindowTheme::Light
+    2 => WindowTheme::Dark
+    _ => WindowTheme::System
   }
   {
     x: field(0),
@@ -1375,6 +1375,7 @@ pub fn Window::Window(
     @ffi.to_cstr(config.initial_url),
     window_size_hint_code(config.size_hint),
     runtime_config_bool(config.titlebar_style is TitlebarStyle::Overlay),
+    config.theme.native_value(),
     browser_policy_code(config.browser.navigation),
     runtime_config_string(config.framework_titlebar_minimize_label),
     runtime_config_string(config.framework_titlebar_maximize_label),
@@ -1959,6 +1960,19 @@ pub fn Window::set_background_color(
     @native_ffi.proton_window_set_background_color_ffi(
       self.live_handle(),
       @utf8.encode(color),
+    ),
+  )
+}
+
+///|
+pub fn Window::set_theme(
+  self : Window,
+  theme : WindowTheme,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_set_theme_ffi(
+      self.live_handle(),
+      theme.native_value(),
     ),
   )
 }

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -916,9 +916,8 @@ fn decode_native_cookie_snapshot(
 ///|
 fn window_state_from_fields(field : (Int) -> Int) -> WindowState {
   let theme = match field(20) {
-    1 => WindowTheme::Light
     2 => WindowTheme::Dark
-    _ => WindowTheme::System
+    _ => WindowTheme::Light
   }
   {
     x: field(0),
@@ -1375,7 +1374,7 @@ pub fn Window::Window(
     @ffi.to_cstr(config.initial_url),
     window_size_hint_code(config.size_hint),
     runtime_config_bool(config.titlebar_style is TitlebarStyle::Overlay),
-    config.theme.native_value(),
+    config.theme_preference.native_value(),
     browser_policy_code(config.browser.navigation),
     runtime_config_string(config.framework_titlebar_minimize_label),
     runtime_config_string(config.framework_titlebar_maximize_label),
@@ -1967,7 +1966,7 @@ pub fn Window::set_background_color(
 ///|
 pub fn Window::set_theme(
   self : Window,
-  theme : WindowTheme,
+  theme : WindowThemePreference,
 ) -> Unit raise NativeError {
   check_status(
     @native_ffi.proton_window_set_theme_ffi(

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -353,7 +353,7 @@ test "typed window state fields map to a snapshot" {
   inspect(state.zoom_percent, content="125")
   inspect(state.focused, content="true")
   inspect(state.always_on_top, content="true")
-  inspect(state.theme, content="dark")
+  assert_eq(state.theme, WindowTheme::Dark)
 }
 
 ///|
@@ -442,6 +442,7 @@ test "window config preserves typed native ABI values" {
     title="Typed",
     width=320,
     height=240,
+    theme=WindowTheme::Dark,
     browser=BrowserPolicy(
       navigation=BrowserPolicyMode::Ask,
       popup=BrowserPolicyMode::Ask,
@@ -455,6 +456,7 @@ test "window config preserves typed native ABI values" {
   assert_eq(window_config.title, "Typed")
   assert_eq(window_config.width, 320)
   assert_eq(window_config.height, 240)
+  assert_eq(window_config.theme, WindowTheme::Dark)
   assert_eq(window_config.browser.navigation, BrowserPolicyMode::Ask)
   assert_eq(window_config.browser.popup, BrowserPolicyMode::Ask)
   assert_true(window_config.browser.devtools)

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -442,7 +442,7 @@ test "window config preserves typed native ABI values" {
     title="Typed",
     width=320,
     height=240,
-    theme=WindowTheme::Dark,
+    theme=WindowThemePreference::Dark,
     browser=BrowserPolicy(
       navigation=BrowserPolicyMode::Ask,
       popup=BrowserPolicyMode::Ask,
@@ -456,7 +456,7 @@ test "window config preserves typed native ABI values" {
   assert_eq(window_config.title, "Typed")
   assert_eq(window_config.width, 320)
   assert_eq(window_config.height, 240)
-  assert_eq(window_config.theme, WindowTheme::Dark)
+  assert_eq(window_config.theme_preference, WindowThemePreference::Dark)
   assert_eq(window_config.browser.navigation, BrowserPolicyMode::Ask)
   assert_eq(window_config.browser.popup, BrowserPolicyMode::Ask)
   assert_true(window_config.browser.devtools)

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -727,7 +727,7 @@ pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_skip_taskbar(Self, Bool) -> Unit raise NativeError
-pub fn Window::set_theme(Self, WindowTheme) -> Unit raise NativeError
+pub fn Window::set_theme(Self, WindowThemePreference) -> Unit raise NativeError
 pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_visible_on_all_workspaces(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError
@@ -738,7 +738,7 @@ pub fn Window::stop_find_in_page(Self, Bool) -> Unit raise NativeError
 pub fn Window::take_bridge_failure(Self) -> BridgeDiagnostic? raise NativeError
 
 type WindowConfig derive(Eq, @debug.Debug)
-pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme, browser? : BrowserPolicy, bridge? : BridgeConfig) -> Self
+pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference, browser? : BrowserPolicy, bridge? : BridgeConfig) -> Self
 pub fn WindowConfig::equal(Self, Self) -> Bool
 pub fn WindowConfig::not_equal(Self, Self) -> Bool
 pub fn WindowConfig::to_repr(Self) -> @debug.Repr
@@ -802,13 +802,21 @@ pub fn WindowState::not_equal(Self, Self) -> Bool
 pub fn WindowState::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WindowTheme {
-  System
   Light
   Dark
 } derive(Eq, @debug.Debug)
 pub fn WindowTheme::equal(Self, Self) -> Bool
 pub fn WindowTheme::not_equal(Self, Self) -> Bool
 pub fn WindowTheme::to_repr(Self) -> @debug.Repr
+
+pub(all) enum WindowThemePreference {
+  System
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+pub fn WindowThemePreference::equal(Self, Self) -> Bool
+pub fn WindowThemePreference::not_equal(Self, Self) -> Bool
+pub fn WindowThemePreference::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -727,6 +727,7 @@ pub fn Window::set_progress_bar(Self, Double) -> Unit raise NativeError
 pub fn Window::set_resizable(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_size(Self, Int, Int) -> Unit raise NativeError
 pub fn Window::set_skip_taskbar(Self, Bool) -> Unit raise NativeError
+pub fn Window::set_theme(Self, WindowTheme) -> Unit raise NativeError
 pub fn Window::set_title(Self, String) -> Unit raise NativeError
 pub fn Window::set_visible_on_all_workspaces(Self, Bool) -> Unit raise NativeError
 pub fn Window::set_zoom_percent(Self, Int) -> Unit raise NativeError
@@ -737,7 +738,7 @@ pub fn Window::stop_find_in_page(Self, Bool) -> Unit raise NativeError
 pub fn Window::take_bridge_failure(Self) -> BridgeDiagnostic? raise NativeError
 
 type WindowConfig derive(Eq, @debug.Debug)
-pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, browser? : BrowserPolicy, bridge? : BridgeConfig) -> Self
+pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme, browser? : BrowserPolicy, bridge? : BridgeConfig) -> Self
 pub fn WindowConfig::equal(Self, Self) -> Bool
 pub fn WindowConfig::not_equal(Self, Self) -> Bool
 pub fn WindowConfig::to_repr(Self) -> @debug.Repr
@@ -794,11 +795,20 @@ pub(all) struct WindowState {
   maximized : Bool
   fullscreen : Bool
   always_on_top : Bool
-  theme : String
+  theme : WindowTheme
 } derive(Eq, @debug.Debug)
 pub fn WindowState::equal(Self, Self) -> Bool
 pub fn WindowState::not_equal(Self, Self) -> Bool
 pub fn WindowState::to_repr(Self) -> @debug.Repr
+
+pub(all) enum WindowTheme {
+  System
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+pub fn WindowTheme::equal(Self, Self) -> Bool
+pub fn WindowTheme::not_equal(Self, Self) -> Bool
+pub fn WindowTheme::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -554,6 +554,8 @@ pub extend WindowMonitor with Debug::{to_repr}
 
 ///|
 /// A point-in-time native window state snapshot.
+///
+/// `theme` is the effective theme after resolving `theme_preference`.
 pub(all) struct WindowState {
   x : Int
   y : Int
@@ -1279,7 +1281,6 @@ pub extend TitlebarStyle with Debug::{to_repr}
 
 ///|
 pub(all) enum WindowTheme {
-  System = 0
   Light = 1
   Dark = 2
 } derive(Debug, Eq)
@@ -1291,7 +1292,20 @@ pub extend WindowTheme with Eq::{not_equal, equal}
 pub extend WindowTheme with Debug::{to_repr}
 
 ///|
-fn WindowTheme::native_value(self : WindowTheme) -> Int {
+pub(all) enum WindowThemePreference {
+  System = 0
+  Light = 1
+  Dark = 2
+} derive(Debug, Eq)
+
+///|
+pub extend WindowThemePreference with Eq::{not_equal, equal}
+
+///|
+pub extend WindowThemePreference with Debug::{to_repr}
+
+///|
+fn WindowThemePreference::native_value(self : WindowThemePreference) -> Int {
   match self {
     System => 0
     Light => 1
@@ -1427,7 +1441,7 @@ struct WindowConfig {
   initial_url : String
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
-  theme : WindowTheme
+  theme_preference : WindowThemePreference
   browser : BrowserPolicy
   bridge : BridgeConfig?
   framework_titlebar_minimize_label : String?
@@ -1518,7 +1532,7 @@ pub fn WindowConfig::WindowConfig(
   initial_url? : String = "about:blank",
   size_hint? : WindowSizeHint = WindowSizeHint::Unconstrained,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
-  theme? : WindowTheme = WindowTheme::System,
+  theme? : WindowThemePreference = WindowThemePreference::System,
   browser? : BrowserPolicy = BrowserPolicy(),
   bridge? : BridgeConfig,
 ) -> WindowConfig {
@@ -1529,7 +1543,7 @@ pub fn WindowConfig::WindowConfig(
     initial_url,
     size_hint,
     titlebar_style,
-    theme,
+    theme_preference: theme,
     browser,
     bridge,
     framework_titlebar_minimize_label: Some("Minimize"),
@@ -1579,7 +1593,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     initial_url: self.initial_url,
     size_hint: self.size_hint,
     titlebar_style: self.titlebar_style,
-    theme: self.theme,
+    theme_preference: self.theme_preference,
     browser: self.browser,
     bridge: self.bridge,
     framework_titlebar_minimize_label: Some(minimize),

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -567,7 +567,7 @@ pub(all) struct WindowState {
   maximized : Bool
   fullscreen : Bool
   always_on_top : Bool
-  theme : String
+  theme : WindowTheme
 } derive(Debug, Eq)
 
 ///|
@@ -1278,6 +1278,28 @@ pub extend TitlebarStyle with Eq::{not_equal, equal}
 pub extend TitlebarStyle with Debug::{to_repr}
 
 ///|
+pub(all) enum WindowTheme {
+  System = 0
+  Light = 1
+  Dark = 2
+} derive(Debug, Eq)
+
+///|
+pub extend WindowTheme with Eq::{not_equal, equal}
+
+///|
+pub extend WindowTheme with Debug::{to_repr}
+
+///|
+fn WindowTheme::native_value(self : WindowTheme) -> Int {
+  match self {
+    System => 0
+    Light => 1
+    Dark => 2
+  }
+}
+
+///|
 /// Process-wide cache for `runtime_info`: the loaded runtime's identity and
 /// feature set cannot change within a process, so feature probes reuse the
 /// first successful result. Failures are not cached — callers keep the
@@ -1405,6 +1427,7 @@ struct WindowConfig {
   initial_url : String
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
+  theme : WindowTheme
   browser : BrowserPolicy
   bridge : BridgeConfig?
   framework_titlebar_minimize_label : String?
@@ -1495,6 +1518,7 @@ pub fn WindowConfig::WindowConfig(
   initial_url? : String = "about:blank",
   size_hint? : WindowSizeHint = WindowSizeHint::Unconstrained,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
+  theme? : WindowTheme = WindowTheme::System,
   browser? : BrowserPolicy = BrowserPolicy(),
   bridge? : BridgeConfig,
 ) -> WindowConfig {
@@ -1505,6 +1529,7 @@ pub fn WindowConfig::WindowConfig(
     initial_url,
     size_hint,
     titlebar_style,
+    theme,
     browser,
     bridge,
     framework_titlebar_minimize_label: Some("Minimize"),
@@ -1554,6 +1579,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     initial_url: self.initial_url,
     size_hint: self.size_hint,
     titlebar_style: self.titlebar_style,
+    theme: self.theme,
     browser: self.browser,
     bridge: self.bridge,
     framework_titlebar_minimize_label: Some(minimize),

--- a/proton/manifest/manifest_window.mbt
+++ b/proton/manifest/manifest_window.mbt
@@ -42,6 +42,32 @@ pub impl Show for TitlebarStyle with fn output(self, logger) {
 }
 
 ///|
+/// Controls the native window chrome theme.
+pub(all) enum WindowTheme {
+  System
+  Light
+  Dark
+} derive(Debug, Eq)
+
+///|
+pub extend WindowTheme with Eq::{not_equal, equal}
+
+///|
+pub extend WindowTheme with Debug::{to_repr}
+
+///|
+pub extend WindowTheme with Show::{to_string, output}
+
+///|
+pub impl Show for WindowTheme with fn output(self, logger) {
+  match self {
+    System => logger.write_string("System")
+    Light => logger.write_string("Light")
+    Dark => logger.write_string("Dark")
+  }
+}
+
+///|
 pub impl Show for WindowSizeHint with fn output(self, logger) {
   match self {
     None => logger.write_string("None")
@@ -59,6 +85,7 @@ pub struct WindowManifest {
   height : Int
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
+  theme : WindowTheme
 } derive(Debug, Eq)
 
 ///|
@@ -82,6 +109,8 @@ pub impl Show for WindowManifest with fn output(self, logger) {
   logger.write_object(self.size_hint)
   logger.write_string(", titlebar_style: ")
   logger.write_object(self.titlebar_style)
+  logger.write_string(", theme: ")
+  logger.write_object(self.theme)
   logger.write_string(" }")
 }
 
@@ -126,8 +155,9 @@ pub fn WindowManifest::WindowManifest(
   height : Int,
   size_hint? : WindowSizeHint = WindowSizeHint::None,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
+  theme? : WindowTheme = WindowTheme::System,
 ) -> WindowManifest {
-  WindowManifest::{ title, width, height, size_hint, titlebar_style, }
+  WindowManifest::{ title, width, height, size_hint, titlebar_style, theme, }
 }
 
 ///|

--- a/proton/manifest/manifest_window.mbt
+++ b/proton/manifest/manifest_window.mbt
@@ -42,24 +42,24 @@ pub impl Show for TitlebarStyle with fn output(self, logger) {
 }
 
 ///|
-/// Controls the native window chrome theme.
-pub(all) enum WindowTheme {
+/// Controls how Proton chooses the native window chrome theme.
+pub(all) enum WindowThemePreference {
   System
   Light
   Dark
 } derive(Debug, Eq)
 
 ///|
-pub extend WindowTheme with Eq::{not_equal, equal}
+pub extend WindowThemePreference with Eq::{not_equal, equal}
 
 ///|
-pub extend WindowTheme with Debug::{to_repr}
+pub extend WindowThemePreference with Debug::{to_repr}
 
 ///|
-pub extend WindowTheme with Show::{to_string, output}
+pub extend WindowThemePreference with Show::{to_string, output}
 
 ///|
-pub impl Show for WindowTheme with fn output(self, logger) {
+pub impl Show for WindowThemePreference with fn output(self, logger) {
   match self {
     System => logger.write_string("System")
     Light => logger.write_string("Light")
@@ -85,7 +85,7 @@ pub struct WindowManifest {
   height : Int
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
-  theme : WindowTheme
+  theme_preference : WindowThemePreference
 } derive(Debug, Eq)
 
 ///|
@@ -109,8 +109,8 @@ pub impl Show for WindowManifest with fn output(self, logger) {
   logger.write_object(self.size_hint)
   logger.write_string(", titlebar_style: ")
   logger.write_object(self.titlebar_style)
-  logger.write_string(", theme: ")
-  logger.write_object(self.theme)
+  logger.write_string(", theme_preference: ")
+  logger.write_object(self.theme_preference)
   logger.write_string(" }")
 }
 
@@ -155,9 +155,16 @@ pub fn WindowManifest::WindowManifest(
   height : Int,
   size_hint? : WindowSizeHint = WindowSizeHint::None,
   titlebar_style? : TitlebarStyle = TitlebarStyle::Default,
-  theme? : WindowTheme = WindowTheme::System,
+  theme? : WindowThemePreference = WindowThemePreference::System,
 ) -> WindowManifest {
-  WindowManifest::{ title, width, height, size_hint, titlebar_style, theme, }
+  WindowManifest::{
+    title,
+    width,
+    height,
+    size_hint,
+    titlebar_style,
+    theme_preference: theme,
+  }
 }
 
 ///|

--- a/proton/manifest/pkg.generated.mbti
+++ b/proton/manifest/pkg.generated.mbti
@@ -62,8 +62,9 @@ pub struct WindowManifest {
   height : Int
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
+  theme : WindowTheme
 } derive(Eq, @debug.Debug)
-pub fn WindowManifest::WindowManifest(String, Int, Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle) -> Self
+pub fn WindowManifest::WindowManifest(String, Int, Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme) -> Self
 pub fn WindowManifest::equal(Self, Self) -> Bool
 pub fn WindowManifest::not_equal(Self, Self) -> Bool
 pub fn WindowManifest::output(Self, &Logger) -> Unit
@@ -83,6 +84,18 @@ pub fn WindowSizeHint::output(Self, &Logger) -> Unit
 pub fn WindowSizeHint::to_repr(Self) -> @debug.Repr
 pub fn WindowSizeHint::to_string(Self) -> String
 pub impl Show for WindowSizeHint
+
+pub(all) enum WindowTheme {
+  System
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+pub fn WindowTheme::equal(Self, Self) -> Bool
+pub fn WindowTheme::not_equal(Self, Self) -> Bool
+pub fn WindowTheme::output(Self, &Logger) -> Unit
+pub fn WindowTheme::to_repr(Self) -> @debug.Repr
+pub fn WindowTheme::to_string(Self) -> String
+pub impl Show for WindowTheme
 
 // Type aliases
 

--- a/proton/manifest/pkg.generated.mbti
+++ b/proton/manifest/pkg.generated.mbti
@@ -62,9 +62,9 @@ pub struct WindowManifest {
   height : Int
   size_hint : WindowSizeHint
   titlebar_style : TitlebarStyle
-  theme : WindowTheme
+  theme_preference : WindowThemePreference
 } derive(Eq, @debug.Debug)
-pub fn WindowManifest::WindowManifest(String, Int, Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme) -> Self
+pub fn WindowManifest::WindowManifest(String, Int, Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference) -> Self
 pub fn WindowManifest::equal(Self, Self) -> Bool
 pub fn WindowManifest::not_equal(Self, Self) -> Bool
 pub fn WindowManifest::output(Self, &Logger) -> Unit
@@ -85,17 +85,17 @@ pub fn WindowSizeHint::to_repr(Self) -> @debug.Repr
 pub fn WindowSizeHint::to_string(Self) -> String
 pub impl Show for WindowSizeHint
 
-pub(all) enum WindowTheme {
+pub(all) enum WindowThemePreference {
   System
   Light
   Dark
 } derive(Eq, @debug.Debug)
-pub fn WindowTheme::equal(Self, Self) -> Bool
-pub fn WindowTheme::not_equal(Self, Self) -> Bool
-pub fn WindowTheme::output(Self, &Logger) -> Unit
-pub fn WindowTheme::to_repr(Self) -> @debug.Repr
-pub fn WindowTheme::to_string(Self) -> String
-pub impl Show for WindowTheme
+pub fn WindowThemePreference::equal(Self, Self) -> Bool
+pub fn WindowThemePreference::not_equal(Self, Self) -> Bool
+pub fn WindowThemePreference::output(Self, &Logger) -> Unit
+pub fn WindowThemePreference::to_repr(Self) -> @debug.Repr
+pub fn WindowThemePreference::to_string(Self) -> String
+pub impl Show for WindowThemePreference
 
 // Type aliases
 

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -200,7 +200,7 @@ pub fn WindowSessionError::to_string(Self) -> String
 
 // Types and methods
 type App
-pub fn App::add_window(Self, String, String, @manifest.AppEntry, width? : Int, height? : Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme, open_on_start? : Bool) -> Self
+pub fn App::add_window(Self, String, String, @manifest.AppEntry, width? : Int, height? : Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference, open_on_start? : Bool) -> Self
 pub fn[State] App::app_lifecycle(Self, on_start~ : async (ApplicationContext) -> State, on_shutdown~ : async (State) -> Unit) -> Self
 pub fn App::bridge_startup_timeout_ms(Self, Int) -> Self
 pub fn App::capability(Self, @extension.RendererCapability, targets? : Array[RendererTarget]) -> Self
@@ -239,7 +239,7 @@ pub fn App::set_app_logs_path(Self, path? : String) -> Self raise AppPathError
 pub fn App::set_path(Self, AppPathKind, String) -> Self raise AppPathError
 pub fn App::single_instance(Self, enabled? : Bool) -> Self
 pub fn App::size(Self, width~ : Int, height~ : Int) -> Self
-pub fn App::theme(Self, WindowTheme) -> Self
+pub fn App::theme(Self, WindowThemePreference) -> Self
 pub fn App::title(Self, String) -> Self
 pub fn App::titlebar_style(Self, TitlebarStyle) -> Self
 pub fn App::update_channel(Self, String, Array[String], check_on_launch? : Bool, freshness_days? : Int) -> Self
@@ -891,7 +891,7 @@ pub struct WindowHandle {
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_ignore_mouse_events : (Bool, Bool) -> Unit raise WindowSessionError
   set_window_background_color : (String) -> Unit raise WindowSessionError
-  set_window_theme : (WindowTheme) -> Unit raise WindowSessionError
+  set_window_theme : (WindowThemePreference) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
   set_window_menu : (MenuBar?) -> Unit raise WindowSessionError
@@ -950,7 +950,7 @@ pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionE
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_skip_taskbar(Self, Bool) -> Unit raise WindowSessionError
-pub fn WindowHandle::set_theme(Self, WindowTheme) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_theme(Self, WindowThemePreference) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_visible_on_all_workspaces(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_window_button_visibility(Self, Bool) -> Unit raise WindowSessionError
@@ -1014,13 +1014,21 @@ pub fn WindowState::not_equal(Self, Self) -> Bool
 pub fn WindowState::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WindowTheme {
-  System
   Light
   Dark
 } derive(Eq, @debug.Debug)
 pub fn WindowTheme::equal(Self, Self) -> Bool
 pub fn WindowTheme::not_equal(Self, Self) -> Bool
 pub fn WindowTheme::to_repr(Self) -> @debug.Repr
+
+pub(all) enum WindowThemePreference {
+  System
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+pub fn WindowThemePreference::equal(Self, Self) -> Bool
+pub fn WindowThemePreference::not_equal(Self, Self) -> Bool
+pub fn WindowThemePreference::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 pub using @manifest {type AppEntry}

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -200,7 +200,7 @@ pub fn WindowSessionError::to_string(Self) -> String
 
 // Types and methods
 type App
-pub fn App::add_window(Self, String, String, @manifest.AppEntry, width? : Int, height? : Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, open_on_start? : Bool) -> Self
+pub fn App::add_window(Self, String, String, @manifest.AppEntry, width? : Int, height? : Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowTheme, open_on_start? : Bool) -> Self
 pub fn[State] App::app_lifecycle(Self, on_start~ : async (ApplicationContext) -> State, on_shutdown~ : async (State) -> Unit) -> Self
 pub fn App::bridge_startup_timeout_ms(Self, Int) -> Self
 pub fn App::capability(Self, @extension.RendererCapability, targets? : Array[RendererTarget]) -> Self
@@ -239,6 +239,7 @@ pub fn App::set_app_logs_path(Self, path? : String) -> Self raise AppPathError
 pub fn App::set_path(Self, AppPathKind, String) -> Self raise AppPathError
 pub fn App::single_instance(Self, enabled? : Bool) -> Self
 pub fn App::size(Self, width~ : Int, height~ : Int) -> Self
+pub fn App::theme(Self, WindowTheme) -> Self
 pub fn App::title(Self, String) -> Self
 pub fn App::titlebar_style(Self, TitlebarStyle) -> Self
 pub fn App::update_channel(Self, String, Array[String], check_on_launch? : Bool, freshness_days? : Int) -> Self
@@ -890,6 +891,7 @@ pub struct WindowHandle {
   set_window_has_shadow : (Bool) -> Unit raise WindowSessionError
   set_window_ignore_mouse_events : (Bool, Bool) -> Unit raise WindowSessionError
   set_window_background_color : (String) -> Unit raise WindowSessionError
+  set_window_theme : (WindowTheme) -> Unit raise WindowSessionError
   set_window_visible_on_all_workspaces : (Bool) -> Unit raise WindowSessionError
   set_window_enabled : (Bool) -> Unit raise WindowSessionError
   set_window_menu : (MenuBar?) -> Unit raise WindowSessionError
@@ -948,6 +950,7 @@ pub fn WindowHandle::set_progress_bar(Self, Double) -> Unit raise WindowSessionE
 pub fn WindowHandle::set_resizable(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_size(Self, Int, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_skip_taskbar(Self, Bool) -> Unit raise WindowSessionError
+pub fn WindowHandle::set_theme(Self, WindowTheme) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_title(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_visible_on_all_workspaces(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_window_button_visibility(Self, Bool) -> Unit raise WindowSessionError
@@ -1004,11 +1007,20 @@ pub(all) struct WindowState {
   maximized : Bool
   fullscreen : Bool
   always_on_top : Bool
-  theme : String
+  theme : WindowTheme
 } derive(Eq, @debug.Debug)
 pub fn WindowState::equal(Self, Self) -> Bool
 pub fn WindowState::not_equal(Self, Self) -> Bool
 pub fn WindowState::to_repr(Self) -> @debug.Repr
+
+pub(all) enum WindowTheme {
+  System
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+pub fn WindowTheme::equal(Self, Self) -> Bool
+pub fn WindowTheme::not_equal(Self, Self) -> Bool
+pub fn WindowTheme::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 pub using @manifest {type AppEntry}


### PR DESCRIPTION
## Summary

Fixes #214.

Windows titlebar overlays previously forced immersive dark caption controls every time the native frame was applied. Activation and DPI changes therefore overwrote an application's light-caption workaround.

This PR makes native window appearance an explicit window policy instead of an overlay side effect.

## Changes

- add `WindowThemePreference::{System, Light, Dark}` for configured policy
- keep `WindowTheme::{Light, Dark}` as the resolved effective state
- expose theme policy through `App::theme`, secondary-window configuration, and `WindowHandle::set_theme`
- remove the hard-coded dark-caption update from the Windows overlay frame path
- resolve Windows system appearance with high-contrast awareness
- use DWM attribute 19 on older supported Windows 10 builds and attribute 20 after build 18985
- refresh system-managed Windows themes on native appearance-setting changes
- apply per-window `NSAppearance` policy on macOS
- keep Linux explicit Light/Dark policies unsupported instead of pretending they were applied
- update typed native configuration, generated interfaces, and facade tests

## Design

The implementation follows the model used by TAO/Tauri: configured preference and current effective theme are separate state.

`System` may change as the operating system appearance changes. Explicit `Light` and `Dark` remain stable when the window is activated or its DPI changes. Titlebar overlay layout no longer decides appearance.

## Platform impact

- **Windows:** full policy implementation, including Windows 10 DWM compatibility and high contrast handling
- **macOS:** per-window native appearance implementation
- **Linux:** `System` remains supported; explicit per-window Light/Dark returns `Unsupported`

A real Windows GUI run is still required to visually verify Windows 10, Windows 11, high contrast, system theme changes, and overlay activation/DPI behavior.

## Validation

- `moon fmt --check`
- `moon info`
- `moon -C proton test --target native --diagnostic-limit 100` (642 tests)
- `moon -C examples build --target native --diagnostic-limit 100`
- `moon check --target native --diagnostic-limit 100`
- `node scripts/verify_generated.mjs`
- `git diff --check`
