### PR TITLE
fix(package): preserve reassigned Windows URL schemes

### DIFF
--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -224,21 +224,6 @@ test "NSIS script carries package identity and update behavior" {
   assert_true(script.contains("Rename \"$INSTDIR.proton-next\" \"$INSTDIR\""))
   assert_true(script.contains("File /r \"C:\\stage\\Demo App\\*.*\""))
   assert_true(script.contains("Exec '\"$INSTDIR\\demo-app.exe\"'"))
-  assert_true(
-    script.contains(
-      "WriteRegStr HKCU \"Software\\Classes\\devtoys\" \"URL Protocol\" \"\"",
-    ),
-  )
-  assert_true(
-    script.contains("DeleteRegKey HKCU \"Software\\Classes\\devtoys\""),
-  )
-  assert_true(
-    script.contains(
-      "DeleteRegKey HKCU \"Software\\Classes\\devtoys\"\n" +
-      "  DeleteRegKey HKCU \"Software\\Classes\\demo-app\"\n" +
-      "SectionEnd",
-    ),
-  )
   let empty_script = windows_installer_script(
     package_test_spec([App, Nsis], url_schemes=[]),
     "C:\\stage\\Demo App",
@@ -254,6 +239,30 @@ test "NSIS script carries package identity and update behavior" {
     ),
   )
   assert_true(windows_installer_path(spec).has_suffix("demo-app-setup.exe"))
+}
+
+///|
+test "NSIS URL scheme scripts share an owned command" {
+  let spec = package_test_spec([App, Nsis], url_schemes=["devtoys"])
+  inspect(
+    windows_protocol_install_script(spec, "demo-app.exe"),
+    content=(
+      #|  WriteRegStr HKCU "Software\Classes\devtoys" "" "URL:devtoys"
+      #|  WriteRegStr HKCU "Software\Classes\devtoys" "URL Protocol" ""
+      #|  WriteRegStr HKCU "Software\Classes\devtoys\shell\open\command" "" "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
+      #|
+    ),
+  )
+  inspect(
+    windows_protocol_uninstall_script(spec, "demo-app.exe"),
+    content=(
+      #|  ReadRegStr $0 HKCU "Software\Classes\devtoys\shell\open\command" ""
+      #|  ${If} $0 == "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
+      #|    DeleteRegKey HKCU "Software\Classes\devtoys"
+      #|  ${EndIf}
+      #|
+    ),
+  )
 }
 
 ///|

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -40,11 +40,17 @@ fn windows_uninstall_registry_key(plan : PackageSpec) -> String {
 }
 
 ///|
+fn windows_protocol_command(executable : String) -> String {
+  "$\\\"$INSTDIR\\\{executable}$\\\" $\\\"%1$\\\""
+}
+
+///|
 fn windows_protocol_install_script(
   plan : PackageSpec,
   executable : String,
 ) -> String {
   let builder = StringBuilder()
+  let command = windows_protocol_command(executable)
   for scheme in plan.url_schemes {
     let scheme = windows_installer_quote(scheme)
     builder <+
@@ -54,18 +60,32 @@ fn windows_protocol_install_script(
       $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "URL Protocol" ""
     builder.write_char('\n')
     builder <+
-      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "$\\"$INSTDIR\\\{executable}$\\" $\\"%1$\\""
+      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "\{command}"
     builder.write_char('\n')
   }
   builder.to_string()
 }
 
 ///|
-fn windows_protocol_uninstall_script(plan : PackageSpec) -> String {
+fn windows_protocol_uninstall_script(
+  plan : PackageSpec,
+  executable : String,
+) -> String {
   let builder = StringBuilder()
+  let command = windows_protocol_command(executable)
   for scheme in plan.url_schemes {
+    let scheme = windows_installer_quote(scheme)
     builder <+
-      $|  DeleteRegKey HKCU "Software\\Classes\\\{windows_installer_quote(scheme)}"
+      $|  ReadRegStr $0 HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" ""
+    builder.write_char('\n')
+    builder <+
+      $|  ${If} $0 == "\{command}"
+    builder.write_char('\n')
+    builder <+
+      $|    DeleteRegKey HKCU "Software\\Classes\\\{scheme}"
+    builder.write_char('\n')
+    builder <+
+      #|  ${EndIf}
     builder.write_char('\n')
   }
   builder.to_string()
@@ -238,7 +258,7 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}"
     $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
   builder.write_char('\n')
-  builder.write_string(windows_protocol_uninstall_script(plan))
+  builder.write_string(windows_protocol_uninstall_script(plan, executable))
   builder <+
     $|SectionEnd
     $|


### PR DESCRIPTION
## Summary

- render the Windows URL protocol command once for install and uninstall scripts
- remove a protocol key only when its current open command still points to the uninstalling application
- cover the complete generated install and guarded-uninstall snippets with exact inspections

## Validation

- moon -C package test lib --target native --diagnostic-limit 80
- moon -C package check --target native --diagnostic-limit 80
- moon fmt --check