### PR TITLE
fix(cookie): honor HttpOnly filter for all queries

### DIFF
--- a/proton/facade_cookie.mbt
+++ b/proton/facade_cookie.mbt
@@ -124,6 +124,7 @@ pub fn SessionHandle::window_id(self : SessionHandle) -> String {
 
 ///|
 /// Returns cookies visible to the session, optionally restricted to one URL.
+/// HTTP-only cookies are excluded unless `include_http_only` is `true`.
 pub async fn SessionHandle::get_cookies(
   self : SessionHandle,
   url? : String,

--- a/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
@@ -121,6 +121,7 @@ typedef struct proton_cookie_get_state {
   proton_cookie_state_detached_t detached; /* no longer visible to callers */
   int64_t request_id;
   int64_t event_window;
+  int include_http_only;
   int accepted;
   int completion_emitted;
   int32_t status;
@@ -159,7 +160,7 @@ proton_cookie_get_state_find(proton_engine_window_t *window) {
 }
 
 static proton_cookie_get_state_t *proton_cookie_get_state_create(
-    proton_engine_window_t *window) {
+    proton_engine_window_t *window, int include_http_only) {
   if (proton_cookie_get_state_find(window) != NULL) {
     return NULL;
   }
@@ -176,6 +177,7 @@ static proton_cookie_get_state_t *proton_cookie_get_state_create(
   }
   proton_cookie_state_lifetime_init(&state->refs, &state->detached);
   state->window = window;
+  state->include_http_only = include_http_only;
   state->request_id = g_next_cookie_request_id++;
   if (g_next_cookie_request_id <= 0) {
     g_next_cookie_request_id = 1;
@@ -295,6 +297,9 @@ static int CEF_CALLBACK proton_cookie_visitor_visit(
   }
   if (state->status != PROTON_OK) {
     return 0;
+  }
+  if (!state->include_http_only && cookie->httponly != 0) {
+    return 1;
   }
 
   char *name = proton_cookie_cef_string_to_utf8(&cookie->name);
@@ -512,7 +517,7 @@ int32_t proton_engine_window_cookie_begin_get(
   }
 
   proton_cookie_get_state_t *state =
-      proton_cookie_get_state_create(window);
+      proton_cookie_get_state_create(window, include_http_only != 0);
   if (state == NULL) {
     manager->base.release((cef_base_ref_counted_t *)manager);
     proton_engine_set_message(error, error_len,


### PR DESCRIPTION
## Summary

Fix the no-URL cookie query path so `include_http_only=false` has the same meaning for full-store and URL-scoped queries.

## Problem

`SessionHandle::get_cookies` defaults `include_http_only` to `false`. URL-scoped reads passed that policy to CEF's `visit_url_cookies`, but full-store reads used `visit_all_cookies`, which has no equivalent argument. The shared visitor then copied every returned cookie into the native snapshot, including HttpOnly cookies.

As a result, `session.get_cookies()` could expose HttpOnly cookies despite the public API default.

## Fix

- store `include_http_only` in the native cookie request state
- apply the policy in the shared CEF visitor before copying a cookie into the result snapshot
- document that HttpOnly cookies are excluded unless explicitly requested

Filtering at the visitor boundary keeps both CEF query paths consistent and prevents excluded cookie values from crossing the native snapshot/FFI boundary.

## Validation

- `moon fmt`
- `moon info`
- `moon -C proton test --target native --diagnostic-limit 80` (643 tests)
- `moon -C proton check --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- `git diff --check`
