### PR TITLE
fix(native): complete denied download callbacks

### DIFF
--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -34,16 +34,29 @@ typedef struct proton_browser_pending {
   cef_frame_t *frame;
   cef_request_t *request;
   cef_before_download_callback_t *download;
+  uint32_t download_id;
   cef_callback_t *certificate;
   cef_media_access_callback_t *media;
   struct proton_browser_pending *next;
 } proton_browser_pending_t;
 
+typedef enum {
+  PROTON_BROWSER_DOWNLOAD_ACTIVE = 0,
+  PROTON_BROWSER_DOWNLOAD_CANCEL_REQUESTED = 1,
+  PROTON_BROWSER_DOWNLOAD_CANCEL_SENT = 2,
+} proton_browser_download_state_t;
+
 typedef struct proton_browser_download {
   uint32_t id;
   cef_download_item_callback_t *callback;
+  proton_browser_download_state_t state;
   struct proton_browser_download *next;
 } proton_browser_download_t;
+
+static void proton_browser_download_request_cancel(
+    proton_browser_download_t *download);
+static void proton_browser_pending_reject(
+    proton_browser_session_t *session, proton_browser_pending_t *pending);
 
 typedef struct proton_pdf_print_callback {
   cef_pdf_print_callback_t callback;
@@ -259,21 +272,18 @@ void proton_browser_session_destroy(proton_browser_session_t *session) {
   proton_browser_pending_t *pending = session->pending;
   while (pending != NULL) {
     proton_browser_pending_t *next = pending->next;
-    if (pending->certificate != NULL) {
-      pending->certificate->cancel(pending->certificate);
-    }
-    if (pending->media != NULL) {
-      pending->media->cancel(pending->media);
-    }
+    proton_browser_pending_reject(session, pending);
     proton_browser_pending_release(pending);
     pending = next;
   }
   proton_browser_download_t *download = session->downloads;
   while (download != NULL) {
     proton_browser_download_t *next = download->next;
-    download->callback->cancel(download->callback);
-    download->callback->base.release(
-        (cef_base_ref_counted_t *)download->callback);
+    proton_browser_download_request_cancel(download);
+    if (download->callback != NULL) {
+      download->callback->base.release(
+          (cef_base_ref_counted_t *)download->callback);
+    }
     free(download);
     download = next;
   }
@@ -471,6 +481,20 @@ static proton_browser_pending_t *proton_browser_pending_take(
   return pending;
 }
 
+static proton_browser_pending_t *proton_browser_pending_take_download(
+    proton_browser_session_t *session, uint32_t download_id) {
+  proton_browser_pending_t *pending = session->pending;
+  while (pending != NULL &&
+         (pending->kind != PROTON_BROWSER_REQUEST_DOWNLOAD ||
+          pending->download_id != download_id)) {
+    pending = pending->next;
+  }
+  if (pending != NULL) {
+    proton_browser_pending_remove(session, pending);
+  }
+  return pending;
+}
+
 static proton_event_t *proton_browser_request_event(
     proton_browser_session_t *session, proton_browser_pending_t *pending,
     proton_event_kind_t kind) {
@@ -650,8 +674,12 @@ int proton_browser_session_before_download(
     return 1;
   }
   if (session->policy.download != PROTON_BROWSER_POLICY_ASK) {
-    return 1;
+    return 0;
   }
+  uint32_t download_id =
+      download_item != NULL && download_item->get_id != NULL
+          ? download_item->get_id(download_item)
+          : 0;
   char *url =
       download_item != NULL && download_item->get_url != NULL
           ? proton_browser_userfree_to_utf8(download_item->get_url(download_item))
@@ -660,21 +688,18 @@ int proton_browser_session_before_download(
   if (url == NULL || name == NULL) {
     free(url);
     free(name);
-    return 1;
+    return 0;
   }
   proton_browser_pending_t *pending =
       proton_browser_pending_new(session, PROTON_BROWSER_REQUEST_DOWNLOAD, url);
   free(url);
   if (pending == NULL) {
     free(name);
-    return 1;
+    return 0;
   }
   pending->download = callback;
+  pending->download_id = download_id;
   callback->base.add_ref((cef_base_ref_counted_t *)callback);
-  uint32_t download_id =
-      download_item != NULL && download_item->get_id != NULL
-          ? download_item->get_id(download_item)
-          : 0;
   proton_event_t *event = proton_browser_request_event(
       session, pending, PROTON_EVENT_BROWSER_DOWNLOAD_REQUESTED);
   int valid = event != NULL && proton_event_set_text(&event->text_b, name);
@@ -688,6 +713,7 @@ int proton_browser_session_before_download(
     }
     proton_browser_pending_remove(session, pending);
     proton_browser_pending_release(pending);
+    return 0;
   }
   return 1;
 }
@@ -701,6 +727,48 @@ static proton_browser_download_t *proton_browser_download_find(
   return download;
 }
 
+static proton_browser_download_t *proton_browser_download_get_or_create(
+    proton_browser_session_t *session, uint32_t id) {
+  proton_browser_download_t *download =
+      proton_browser_download_find(session, id);
+  if (download != NULL) {
+    return download;
+  }
+  download = (proton_browser_download_t *)calloc(1, sizeof(*download));
+  if (download != NULL) {
+    download->id = id;
+    download->next = session->downloads;
+    session->downloads = download;
+  }
+  return download;
+}
+
+static void proton_browser_download_request_cancel(
+    proton_browser_download_t *download) {
+  if (download == NULL ||
+      download->state == PROTON_BROWSER_DOWNLOAD_CANCEL_SENT) {
+    return;
+  }
+  download->state = PROTON_BROWSER_DOWNLOAD_CANCEL_REQUESTED;
+  if (download->callback != NULL) {
+    download->callback->cancel(download->callback);
+    download->state = PROTON_BROWSER_DOWNLOAD_CANCEL_SENT;
+  }
+}
+
+static void proton_browser_pending_reject(
+    proton_browser_session_t *session, proton_browser_pending_t *pending) {
+  if (pending->kind == PROTON_BROWSER_REQUEST_DOWNLOAD) {
+    proton_browser_download_request_cancel(
+        proton_browser_download_get_or_create(
+            session, pending->download_id));
+  } else if (pending->certificate != NULL) {
+    pending->certificate->cancel(pending->certificate);
+  } else if (pending->media != NULL) {
+    pending->media->cancel(pending->media);
+  }
+}
+
 void proton_browser_session_download_updated(
     proton_browser_session_t *session, cef_download_item_t *download_item,
     cef_download_item_callback_t *callback) {
@@ -711,14 +779,14 @@ void proton_browser_session_download_updated(
   proton_browser_download_t *download =
       proton_browser_download_find(session, id);
   if (download == NULL && download_item->is_in_progress(download_item)) {
-    download =
-        (proton_browser_download_t *)calloc(1, sizeof(*download));
-    if (download != NULL) {
-      download->id = id;
-      download->callback = callback;
-      callback->base.add_ref((cef_base_ref_counted_t *)callback);
-      download->next = session->downloads;
-      session->downloads = download;
+    download = proton_browser_download_get_or_create(session, id);
+  }
+  if (download != NULL && download->callback == NULL &&
+      download_item->is_in_progress(download_item)) {
+    download->callback = callback;
+    callback->base.add_ref((cef_base_ref_counted_t *)callback);
+    if (download->state == PROTON_BROWSER_DOWNLOAD_CANCEL_REQUESTED) {
+      proton_browser_download_request_cancel(download);
     }
   }
   const char *state = download_item->is_complete(download_item)
@@ -748,8 +816,10 @@ void proton_browser_session_download_updated(
     if (*cursor != NULL) {
       *cursor = download->next;
     }
-    download->callback->base.release(
-        (cef_base_ref_counted_t *)download->callback);
+    if (download->callback != NULL) {
+      download->callback->base.release(
+          (cef_base_ref_counted_t *)download->callback);
+    }
     free(download);
   }
 }
@@ -824,8 +894,7 @@ int proton_browser_session_media_permission(
 int32_t proton_browser_session_respond(
     proton_browser_session_t *session, uint64_t request_id,
     const char *action, const char *path, char *error, size_t error_len) {
-  if (session == NULL || request_id == 0 || action == NULL ||
-      action[0] == '\0') {
+  if (session == NULL || request_id == 0) {
     proton_browser_set_message(error, error_len,
                                "browser session and response fields are required");
     return PROTON_ERR_INVALID_ARGUMENT;
@@ -836,6 +905,13 @@ int32_t proton_browser_session_respond(
     proton_browser_set_message(error, error_len,
                                "browser request is no longer pending");
     return PROTON_ERR_STALE_BROWSER_REQUEST;
+  }
+  if (action == NULL || action[0] == '\0') {
+    proton_browser_pending_reject(session, pending);
+    proton_browser_pending_release(pending);
+    proton_browser_set_message(error, error_len,
+                               "browser response action is invalid");
+    return PROTON_ERR_INVALID_ARGUMENT;
   }
   int32_t status = PROTON_OK;
   switch (pending->kind) {
@@ -872,7 +948,11 @@ int32_t proton_browser_session_respond(
       pending->download->cont(pending->download, &destination,
                               path == NULL || path[0] == '\0');
       cef_string_clear(&destination);
-    } else if (strcmp(action, "deny") != 0) {
+    } else if (strcmp(action, "deny") == 0) {
+      proton_browser_download_request_cancel(
+          proton_browser_download_get_or_create(
+              session, pending->download_id));
+    } else {
       status = PROTON_ERR_INVALID_ARGUMENT;
     }
     break;
@@ -897,6 +977,7 @@ int32_t proton_browser_session_respond(
     break;
   }
   if (status != PROTON_OK) {
+    proton_browser_pending_reject(session, pending);
     proton_browser_set_message(error, error_len,
                                "browser response action is invalid");
   }
@@ -971,7 +1052,11 @@ int32_t proton_browser_session_command(
                                  "download is no longer active");
       return PROTON_ERR_STALE_BROWSER_REQUEST;
     }
-    download->callback->cancel(download->callback);
+    proton_browser_download_request_cancel(download);
+    proton_browser_pending_t *pending =
+        proton_browser_pending_take_download(
+            session, (uint32_t)download_id);
+    proton_browser_pending_release(pending);
   } else if (strcmp(command, "focus") == 0) {
     cef_browser_host_t *host = browser->get_host(browser);
     if (host == NULL) {

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
@@ -1,0 +1,71 @@
+///|
+extern "C" fn download_deny_after_update_trace_ffi() -> Bytes = "proton_test_download_deny_after_update_trace"
+
+///|
+extern "C" fn download_deny_before_update_trace_ffi() -> Bytes = "proton_test_download_deny_before_update_trace"
+
+///|
+extern "C" fn download_invalid_response_trace_ffi() -> Bytes = "proton_test_download_invalid_response_trace"
+
+///|
+extern "C" fn download_empty_response_trace_ffi() -> Bytes = "proton_test_download_empty_response_trace"
+
+///|
+extern "C" fn denied_download_policy_trace_ffi() -> Bytes = "proton_test_denied_download_policy_trace"
+
+///|
+extern "C" fn unpublished_download_request_trace_ffi() -> Bytes = "proton_test_unpublished_download_request_trace"
+
+///|
+extern "C" fn download_single_completion_trace_ffi() -> Bytes = "proton_test_download_single_completion_trace"
+
+///|
+extern "C" fn download_command_beats_allow_trace_ffi() -> Bytes = "proton_test_download_command_beats_allow_trace"
+
+///|
+pub fn download_deny_after_update_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_deny_after_update_trace_ffi())
+}
+
+///|
+pub fn download_deny_before_update_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_deny_before_update_trace_ffi())
+}
+
+///|
+pub fn download_invalid_response_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_invalid_response_trace_ffi())
+}
+
+///|
+pub fn download_empty_response_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_empty_response_trace_ffi())
+}
+
+///|
+pub fn denied_download_policy_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(denied_download_policy_trace_ffi())
+}
+
+///|
+pub fn unpublished_download_request_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(unpublished_download_request_trace_ffi())
+}
+
+///|
+pub fn download_single_completion_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_single_completion_trace_ffi())
+}
+
+///|
+pub fn download_command_beats_allow_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(download_command_beats_allow_trace_ffi())
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
@@ -1,0 +1,348 @@
+#include "../../src/engine/cef_common/browser_session.h"
+#include "../../src/proton_event.h"
+
+#include "moonbit.h"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+  cef_before_download_callback_t callback;
+  int refs;
+  int continue_calls;
+  int release_calls;
+} proton_test_before_download_callback_t;
+
+typedef struct {
+  cef_download_item_callback_t callback;
+  int refs;
+  int cancel_calls;
+  int release_calls;
+} proton_test_download_item_callback_t;
+
+typedef struct {
+  cef_download_item_t item;
+  uint32_t id;
+  int in_progress;
+} proton_test_download_item_t;
+
+static proton_test_before_download_callback_t *proton_test_before_from_base(
+    cef_base_ref_counted_t *base) {
+  return (proton_test_before_download_callback_t *)base;
+}
+
+static void CEF_CALLBACK proton_test_before_add_ref(
+    cef_base_ref_counted_t *base) {
+  proton_test_before_from_base(base)->refs++;
+}
+
+static int CEF_CALLBACK proton_test_before_release(
+    cef_base_ref_counted_t *base) {
+  proton_test_before_download_callback_t *callback =
+      proton_test_before_from_base(base);
+  callback->release_calls++;
+  callback->refs--;
+  return callback->refs == 0;
+}
+
+static void CEF_CALLBACK proton_test_before_continue(
+    cef_before_download_callback_t *self, const cef_string_t *path,
+    int show_dialog) {
+  proton_test_before_download_callback_t *callback =
+      (proton_test_before_download_callback_t *)self;
+  (void)path;
+  (void)show_dialog;
+  callback->continue_calls++;
+}
+
+static proton_test_download_item_callback_t *proton_test_item_from_base(
+    cef_base_ref_counted_t *base) {
+  return (proton_test_download_item_callback_t *)base;
+}
+
+static void CEF_CALLBACK proton_test_item_add_ref(
+    cef_base_ref_counted_t *base) {
+  proton_test_item_from_base(base)->refs++;
+}
+
+static int CEF_CALLBACK proton_test_item_release(
+    cef_base_ref_counted_t *base) {
+  proton_test_download_item_callback_t *callback =
+      proton_test_item_from_base(base);
+  callback->release_calls++;
+  callback->refs--;
+  return callback->refs == 0;
+}
+
+static void CEF_CALLBACK proton_test_item_cancel(
+    cef_download_item_callback_t *self) {
+  proton_test_download_item_callback_t *callback =
+      (proton_test_download_item_callback_t *)self;
+  callback->cancel_calls++;
+}
+
+static uint32_t CEF_CALLBACK proton_test_download_id(
+    cef_download_item_t *self) {
+  return ((proton_test_download_item_t *)self)->id;
+}
+
+static int CEF_CALLBACK proton_test_download_is_in_progress(
+    cef_download_item_t *self) {
+  return ((proton_test_download_item_t *)self)->in_progress;
+}
+
+static int CEF_CALLBACK proton_test_download_is_false(
+    cef_download_item_t *self) {
+  (void)self;
+  return 0;
+}
+
+static int64_t CEF_CALLBACK proton_test_download_bytes(
+    cef_download_item_t *self) {
+  (void)self;
+  return 0;
+}
+
+static int CEF_CALLBACK proton_test_download_percent(
+    cef_download_item_t *self) {
+  (void)self;
+  return -1;
+}
+
+static void proton_test_before_init(
+    proton_test_before_download_callback_t *callback) {
+  memset(callback, 0, sizeof(*callback));
+  callback->callback.base.size = sizeof(callback->callback);
+  callback->callback.base.add_ref = proton_test_before_add_ref;
+  callback->callback.base.release = proton_test_before_release;
+  callback->callback.cont = proton_test_before_continue;
+  callback->refs = 1;
+}
+
+static void proton_test_item_callback_init(
+    proton_test_download_item_callback_t *callback) {
+  memset(callback, 0, sizeof(*callback));
+  callback->callback.base.size = sizeof(callback->callback);
+  callback->callback.base.add_ref = proton_test_item_add_ref;
+  callback->callback.base.release = proton_test_item_release;
+  callback->callback.cancel = proton_test_item_cancel;
+  callback->refs = 1;
+}
+
+static void proton_test_download_init(proton_test_download_item_t *download,
+                                      uint32_t id) {
+  memset(download, 0, sizeof(*download));
+  download->item.base.size = sizeof(download->item);
+  download->item.is_in_progress = proton_test_download_is_in_progress;
+  download->item.is_complete = proton_test_download_is_false;
+  download->item.is_canceled = proton_test_download_is_false;
+  download->item.is_interrupted = proton_test_download_is_false;
+  download->item.get_percent_complete = proton_test_download_percent;
+  download->item.get_total_bytes = proton_test_download_bytes;
+  download->item.get_received_bytes = proton_test_download_bytes;
+  download->item.get_id = proton_test_download_id;
+  download->id = id;
+  download->in_progress = 1;
+}
+
+static moonbit_bytes_t proton_test_copy_trace(const char *trace) {
+  size_t length = strlen(trace);
+  moonbit_bytes_t result = moonbit_make_bytes((int32_t)length, 0);
+  memcpy(result, trace, length);
+  return result;
+}
+
+static moonbit_bytes_t proton_test_download_deny_trace(
+    int update_before_response, const char *action) {
+  proton_browser_policy_t policy = {0};
+  proton_test_before_download_callback_t before;
+  proton_test_download_item_callback_t item_callback;
+  proton_test_download_item_t download;
+  char error[128] = {0};
+  char trace[192];
+
+  policy.download = PROTON_BROWSER_POLICY_ASK;
+  proton_test_before_init(&before);
+  proton_test_item_callback_init(&item_callback);
+  proton_test_download_init(&download, 41);
+
+  proton_event_dispatch_begin();
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, NULL, NULL);
+  cef_string_t suggested_name = {0};
+  (void)proton_browser_session_before_download(
+      session, &download.item, &suggested_name, &before.callback);
+  if (update_before_response) {
+    proton_browser_session_download_updated(
+        session, &download.item, &item_callback.callback);
+  }
+  int32_t status = proton_browser_session_respond(
+      session, 1, action, NULL, error, sizeof(error));
+  if (!update_before_response) {
+    proton_browser_session_download_updated(
+        session, &download.item, &item_callback.callback);
+  }
+
+  int written = snprintf(
+      trace, sizeof(trace),
+      "before_continue=%d,before_release=%d,item_cancel=%d,item_release=%d,respond=%d",
+      before.continue_calls, before.release_calls, item_callback.cancel_calls,
+      item_callback.release_calls, status);
+  proton_browser_session_destroy(session);
+  proton_event_dispatch_end();
+  if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_deny_after_update_trace(void) {
+  return proton_test_download_deny_trace(1, "deny");
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_deny_before_update_trace(void) {
+  return proton_test_download_deny_trace(0, "deny");
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_invalid_response_trace(void) {
+  return proton_test_download_deny_trace(1, "invalid");
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_empty_response_trace(void) {
+  return proton_test_download_deny_trace(1, "");
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_denied_download_policy_trace(void) {
+  proton_browser_policy_t policy = {0};
+  proton_test_before_download_callback_t before;
+  proton_test_download_item_t download;
+  char trace[128];
+
+  policy.download = PROTON_BROWSER_POLICY_DENY;
+  proton_test_before_init(&before);
+  proton_test_download_init(&download, 42);
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, NULL, NULL);
+  cef_string_t suggested_name = {0};
+  int handled = proton_browser_session_before_download(
+      session, &download.item, &suggested_name, &before.callback);
+  int written = snprintf(
+      trace, sizeof(trace),
+      "handled=%d,before_continue=%d,before_release=%d", handled,
+      before.continue_calls, before.release_calls);
+  proton_browser_session_destroy(session);
+  if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_unpublished_download_request_trace(void) {
+  proton_browser_policy_t policy = {0};
+  proton_test_before_download_callback_t before;
+  proton_test_download_item_t download;
+  char trace[128];
+
+  policy.download = PROTON_BROWSER_POLICY_ASK;
+  proton_test_before_init(&before);
+  proton_test_download_init(&download, 43);
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, NULL, NULL);
+  cef_string_t suggested_name = {0};
+  int handled = proton_browser_session_before_download(
+      session, &download.item, &suggested_name, &before.callback);
+  int written = snprintf(
+      trace, sizeof(trace),
+      "handled=%d,before_continue=%d,before_release=%d", handled,
+      before.continue_calls, before.release_calls);
+  proton_browser_session_destroy(session);
+  if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_single_completion_trace(void) {
+  proton_browser_policy_t policy = {0};
+  proton_test_before_download_callback_t before;
+  proton_test_download_item_callback_t item_callback;
+  proton_test_download_item_t download;
+  char error[128] = {0};
+  char trace[224];
+
+  policy.download = PROTON_BROWSER_POLICY_ASK;
+  proton_test_before_init(&before);
+  proton_test_item_callback_init(&item_callback);
+  proton_test_download_init(&download, 44);
+  proton_event_dispatch_begin();
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, NULL, NULL);
+  cef_string_t suggested_name = {0};
+  (void)proton_browser_session_before_download(
+      session, &download.item, &suggested_name, &before.callback);
+  proton_browser_session_download_updated(
+      session, &download.item, &item_callback.callback);
+  int32_t status = proton_browser_session_respond(
+      session, 1, "deny", NULL, error, sizeof(error));
+  int32_t repeat = proton_browser_session_respond(
+      session, 1, "deny", NULL, error, sizeof(error));
+  proton_browser_session_destroy(session);
+  proton_event_dispatch_end();
+
+  int written = snprintf(
+      trace, sizeof(trace),
+      "before_continue=%d,before_release=%d,item_cancel=%d,item_release=%d,respond=%d,repeat=%d",
+      before.continue_calls, before.release_calls, item_callback.cancel_calls,
+      item_callback.release_calls, status, repeat);
+  if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_download_command_beats_allow_trace(void) {
+  proton_browser_policy_t policy = {0};
+  proton_test_before_download_callback_t before;
+  proton_test_download_item_callback_t item_callback;
+  proton_test_download_item_t download;
+  cef_browser_t browser = {0};
+  char error[128] = {0};
+  char trace[224];
+
+  policy.download = PROTON_BROWSER_POLICY_ASK;
+  proton_test_before_init(&before);
+  proton_test_item_callback_init(&item_callback);
+  proton_test_download_init(&download, 45);
+  proton_event_dispatch_begin();
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, NULL, NULL);
+  cef_string_t suggested_name = {0};
+  (void)proton_browser_session_before_download(
+      session, &download.item, &suggested_name, &before.callback);
+  proton_browser_session_download_updated(
+      session, &download.item, &item_callback.callback);
+  int32_t command = proton_browser_session_command(
+      session, &browser, "cancel_download", 45, error, sizeof(error));
+  int32_t status = proton_browser_session_respond(
+      session, 1, "allow", NULL, error, sizeof(error));
+  proton_browser_session_destroy(session);
+  proton_event_dispatch_end();
+
+  int written = snprintf(
+      trace, sizeof(trace),
+      "before_continue=%d,before_release=%d,item_cancel=%d,item_release=%d,command=%d,respond=%d",
+      before.continue_calls, before.release_calls, item_callback.cancel_calls,
+      item_callback.release_calls, command, status);
+  if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
@@ -1,0 +1,75 @@
+///|
+test "download deny cancels an item updated before the decision" {
+  inspect(
+    download_deny_after_update_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=0,respond=0
+    ),
+  )
+}
+
+///|
+test "invalid download response fails closed" {
+  inspect(
+    download_invalid_response_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=0,respond=-1
+    ),
+  )
+}
+
+///|
+test "empty download response fails closed" {
+  inspect(
+    download_empty_response_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=0,respond=-1
+    ),
+  )
+}
+
+///|
+test "denied download policy leaves cancellation to CEF" {
+  inspect(
+    denied_download_policy_trace(),
+    content="handled=0,before_continue=0,before_release=0",
+  )
+}
+
+///|
+test "unpublished download request leaves cancellation to CEF" {
+  inspect(
+    unpublished_download_request_trace(),
+    content="handled=0,before_continue=0,before_release=1",
+  )
+}
+
+///|
+test "download cancellation completes once across response and destroy" {
+  inspect(
+    download_single_completion_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=1,respond=0,repeat=-14
+    ),
+  )
+}
+
+///|
+test "download command wins over a later allow decision" {
+  inspect(
+    download_command_beats_allow_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=1,command=0,respond=-14
+    ),
+  )
+}
+
+///|
+test "download deny is remembered until its item callback arrives" {
+  inspect(
+    download_deny_before_update_trace(),
+    content=(
+      #|before_continue=0,before_release=1,item_cancel=1,item_release=0,respond=0
+    ),
+  )
+}

--- a/proton/internal/native/ffi/tests/browser_session/moon.pkg
+++ b/proton/internal/native/ffi/tests/browser_session/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "moonbit-community/proton/internal/native/ffi",
+  "moonbitlang/core/encoding/utf8",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "browser_session_test.c" ],
+  link: {
+    "native": { "stub-cc-flags": "${build.PROTON_NATIVE_STUB_CC_FLAGS}" },
+  },
+)


### PR DESCRIPTION
## Summary

- correlate pending download decisions with CEF download item callbacks by download ID
- deliver cancellation exactly once whether OnDownloadUpdated arrives before or after the policy decision
- fail closed for denied, invalid, empty, unpublished, and session-destroyed requests
- make cancel_download end a pending decision so a later allow response is stale
- add exact native callback traces for both callback orderings and lifecycle races

This change intentionally does not introduce a browser-policy timeout; timeout duration and configuration remain a separate API decision.

## Validation

- moon -C proton test internal/native --target native --diagnostic-limit 80
- moon -C proton check --target native --diagnostic-limit 80
- moon -C examples build --target native --diagnostic-limit 80
- moon -C e2e test -p moonbit-community/proton/e2e/test --target native --no-parallelize --diagnostic-limit 200
- moon fmt --check
- node scripts/verify_generated.mjs