### PR TITLE
feat(package): support platform-specific project settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install MoonBit
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s pre-release
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: moon version
@@ -64,13 +64,13 @@ jobs:
       - name: Install MoonBit
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s pre-release
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Install MoonBit on Windows
         if: ${{ matrix.os == 'windows-latest' }}
         env:
-          MOONBIT_INSTALL_VERSION: nightly
+          MOONBIT_INSTALL_VERSION: pre-release
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ controls. See [examples/Readme.md](examples/Readme.md).
   "package": {
     "product_name": "My App",
     "version": "1.0.0",
-    "formats": ["app", "zip"],
+    "platforms": {
+      "macos": { "formats": ["app", "dmg"] },
+      "windows": { "formats": ["app", "zip", "nsis"] },
+      "linux": { "formats": ["appimage"] }
+    },
     "output": "dist"
   }
 }
@@ -214,13 +218,20 @@ Supported host-native formats are:
 - Windows: `app`, `zip`, and `nsis`
 - Linux: `appimage`
 
-Use repeated `--format` options or `package.formats` in
-`proton.project.json`. Output is written to `dist` by default.
+Use repeated `--format` options, the shared `package.formats` field, or
+`package.platforms.<platform>.formats` in `proton.project.json`. A platform
+format list replaces the shared list; omitting both selects the current host's
+defaults. Output is written to `dist` by default.
 
 `package.resources` copies sidecar files into the application resources
 directory. Backend code resolves the same files before and after packaging with
-`@proton.resource_dir()`. `package.sign.binaries` names copied executables that
-must be included in platform signing.
+`@proton.resource_dir()`. Platform resources are appended from
+`package.platforms.<platform>.resources`. `package.sign.binaries` names copied
+executables that must be included in platform signing, and platform-specific
+signing targets can be appended under the matching platform block. Supported
+platform keys are `macos`, `windows`, and `linux`; platform blocks accept only
+`formats`, `resources`, and `sign`. Explicit command-line options retain the
+highest priority.
 
 On macOS, `--sign` signs the application and `--notarize` submits, staples, and
 validates distributable artifacts. URL schemes and document types are written

--- a/cli/new/new_project_wbtest.mbt
+++ b/cli/new/new_project_wbtest.mbt
@@ -218,6 +218,64 @@ test "project config uses host-native package format defaults" {
 }
 
 ///|
+test "isomorphic README documents host-native package defaults" {
+  let context = template_context(
+    "Demo App", "moonbit-community", "demo", "com.justjavac.demo", 1000, 700,
+  )
+  let mut readme : String? = None
+  for spec in generated_isomorphic_template_specs() {
+    if spec.output_path == "README.md" {
+      readme = Some(render_template(spec, context).content)
+    }
+  }
+  guard readme is Some(readme) else {
+    abort("isomorphic template did not include README.md")
+  }
+  let package_and_rest = match readme.split_once("## Package\n\n") {
+    Some((_, package_and_rest)) => package_and_rest
+    None => abort("isomorphic README did not include the Package section")
+  }
+  let package_section = match package_and_rest.split_once("\n## Layout\n") {
+    Some((package_section, _)) => package_section
+    None => abort("isomorphic README did not terminate the Package section")
+  }
+  inspect(
+    package_section.to_owned(),
+    content=(
+      #|The top-level `identifier` is the application's canonical identity. The
+      #|`package` block contains the remaining static packaging metadata:
+      #|
+      #|```json
+      #|{
+      #|  "identifier": "com.example.my-app",
+      #|  "package": {
+      #|    "product_name": "My App",
+      #|    "version": "0.1.0",
+      #|    "output": "dist"
+      #|  }
+      #|}
+      #|```
+      #|
+      #|When `formats` is omitted, Proton selects the current host's default package
+      #|formats. Use `package.platforms` for platform-specific formats, resources, or
+      #|signing targets.
+      #|
+      #|Window behavior, the asset entry, single-instance handling, and renderer
+      #|permissions are declared by the Proton `App` builder in `backend/app/main.mbt`.
+      #|
+      #|Inspect the resolved package plan, then create the current host's native
+      #|artifacts:
+      #|
+      #|```sh
+      #|proton_cli package --dry-run
+      #|proton_cli package --release
+      #|```
+      #|
+    ),
+  )
+}
+
+///|
 test "isomorphic project config pins Warren browser entry" {
   let context = template_context(
     "Demo App", "moonbit-community", "demo", "com.justjavac.demo", 1000, 700,

--- a/cli/new/new_project_wbtest.mbt
+++ b/cli/new/new_project_wbtest.mbt
@@ -205,6 +205,19 @@ test "project config preserves application identity" {
 }
 
 ///|
+test "project config uses host-native package format defaults" {
+  let context = template_context(
+    "Demo App", "moonbit-community", "demo", "com.justjavac.demo", 1000, 700,
+  )
+  let config = @json.parse(project_config_file(context, "isomorphic").content) catch {
+    error => abort(error.to_string())
+  }
+  guard config is { "package": { "formats"? : None, .. }, .. } else {
+    abort("generated project config fixed package formats to one platform")
+  }
+}
+
+///|
 test "isomorphic project config pins Warren browser entry" {
   let context = template_context(
     "Demo App", "moonbit-community", "demo", "com.justjavac.demo", 1000, 700,

--- a/cli/new/templates.generated.mbt
+++ b/cli/new/templates.generated.mbt
@@ -867,16 +867,20 @@ fn generated_isomorphic_template_specs() -> Array[TemplateSpec] {
           #|  "package": {
           #|    "product_name": "My App",
           #|    "version": "0.1.0",
-          #|    "formats": ["app", "zip"],
           #|    "output": "dist"
           #|  }
           #|}
           #|```
           #|
+          #|When `formats` is omitted, Proton selects the current host's default package
+          #|formats. Use `package.platforms` for platform-specific formats, resources, or
+          #|signing targets.
+          #|
           #|Window behavior, the asset entry, single-instance handling, and renderer
           #|permissions are declared by the Proton `App` builder in `backend/app/main.mbt`.
           #|
-          #|Inspect the resolved package plan, then create the application and zip archive:
+          #|Inspect the resolved package plan, then create the current host's native
+          #|artifacts:
           #|
           #|```sh
           #|proton_cli package --dry-run

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -234,7 +234,6 @@ fn project_config_file(
   let package_config : Json = {
     "product_name": context.title,
     "version": "0.1.0",
-    "formats": ["app", "zip"],
     "output": "dist",
   }
   let config : Json = match template {

--- a/cli/new/templates/isomorphic/files/README.md.mtpl
+++ b/cli/new/templates/isomorphic/files/README.md.mtpl
@@ -52,16 +52,20 @@ The top-level `identifier` is the application's canonical identity. The
   "package": {
     "product_name": "My App",
     "version": "0.1.0",
-    "formats": ["app", "zip"],
     "output": "dist"
   }
 }
 ```
 
+When `formats` is omitted, Proton selects the current host's default package
+formats. Use `package.platforms` for platform-specific formats, resources, or
+signing targets.
+
 Window behavior, the asset entry, single-instance handling, and renderer
 permissions are declared by the Proton `App` builder in `backend/app/main.mbt`.
 
-Inspect the resolved package plan, then create the application and zip archive:
+Inspect the resolved package plan, then create the current host's native
+artifacts:
 
 ```sh
 proton_cli package --dry-run

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -51,6 +51,19 @@ struct PackagePlan {
 } derive(Debug, Eq)
 
 ///|
+struct ResolvedPlatformPackageConfig {
+  formats : Array[String]
+  resources : Array[String]
+  sign_binaries : Array[String]
+} derive(Debug, Eq)
+
+///|
+pub extend ResolvedPlatformPackageConfig with Eq::{not_equal, equal}
+
+///|
+pub extend ResolvedPlatformPackageConfig with Debug::{to_repr}
+
+///|
 pub extend PackagePlan with Eq::{not_equal, equal}
 
 ///|
@@ -208,14 +221,18 @@ async fn build_package_plan(
     Some(package_config) => package_config
     None => raise PackageConfigError::PackageMissing
   }
+  let platform_config = resolve_platform_package_config(
+    package_config,
+    @packager.current_package_host(),
+  )
   let product_name = @packager.validate_product_name(
     raw.package_args.product_name.unwrap_or(package_config.product_name),
   )
   let identifier = @packager.validate_identifier(project.identifier())
   let configured_formats = if raw.package_args.formats.length() > 0 {
     raw.package_args.formats.copy()
-  } else if package_config.formats.length() > 0 {
-    package_config.formats.map(value => @packager.PackageFormat::parse(value))
+  } else if platform_config.formats.length() > 0 {
+    platform_config.formats.map(value => @packager.PackageFormat::parse(value))
   } else {
     []
   }
@@ -258,11 +275,8 @@ async fn build_package_plan(
     release: raw.release,
     base_dir,
     frontend_dist,
-    resources: package_config.resources(),
-    sign_binaries: match package_config.sign() {
-      Some(sign) => sign.binaries()
-      None => []
-    },
+    resources: platform_config.resources,
+    sign_binaries: platform_config.sign_binaries,
     icons: if raw.package_args.icons.length() > 0 {
       raw.package_args.icons.map(icon => @fsutil.resolve_path(base_dir, icon))
     } else {
@@ -276,6 +290,48 @@ async fn build_package_plan(
     document_types: package_config.document_types(),
     sign: raw.package_args.sign,
     notarize: raw.package_args.notarize,
+  }
+}
+
+///|
+fn resolve_platform_package_config(
+  package_config : @proton_config.ProjectPackageConfig,
+  platform : @packager.PackageHost,
+) -> ResolvedPlatformPackageConfig {
+  let platforms = package_config.platforms()
+  let platform_config = match platform {
+    @packager.PackageHost::Macos => platforms.macos()
+    @packager.PackageHost::Windows => platforms.windows()
+    @packager.PackageHost::Linux => platforms.linux()
+  }
+  let formats = match platform_config {
+    Some(config) => config.formats().unwrap_or(package_config.formats())
+    None => package_config.formats()
+  }
+  let resources = package_config.resources()
+  let sign_binaries = match package_config.sign() {
+    Some(sign) => sign.binaries()
+    None => []
+  }
+  match platform_config {
+    Some(config) => {
+      append_unique(resources, config.resources())
+      match config.sign() {
+        Some(sign) => append_unique(sign_binaries, sign.binaries())
+        None => ()
+      }
+    }
+    None => ()
+  }
+  ResolvedPlatformPackageConfig::{ formats, resources, sign_binaries, }
+}
+
+///|
+fn append_unique(values : Array[String], additions : Array[String]) -> Unit {
+  for value in additions {
+    if !values.contains(value) {
+      values.push(value)
+    }
   }
 }
 

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -27,6 +27,61 @@ test "parse package args accepts repeated formats and overrides" {
 }
 
 ///|
+test "project package resolves platform overrides exactly" {
+  let package_config = @proton_config.ProjectPackageConfig(
+    "Demo",
+    "1.2.3",
+    formats=["app"],
+    resources=["assets/common"],
+    sign=Some(@proton_config.ProjectSignConfig(binaries=["helpers/common"])),
+    platforms=@proton_config.ProjectPackagePlatforms(
+      macos=@proton_config.ProjectPlatformPackageConfig(
+        formats=["app", "dmg"],
+        resources=["assets/macos"],
+        sign=@proton_config.ProjectSignConfig(binaries=["helpers/macos"]),
+      ),
+      windows=@proton_config.ProjectPlatformPackageConfig(resources=[
+        "assets/windows",
+      ]),
+      linux=@proton_config.ProjectPlatformPackageConfig(formats=[]),
+    ),
+  )
+  assert_eq(
+    resolve_platform_package_config(
+      package_config,
+      @packager.PackageHost::Macos,
+    ),
+    ResolvedPlatformPackageConfig::{
+      formats: ["app", "dmg"],
+      resources: ["assets/common", "assets/macos"],
+      sign_binaries: ["helpers/common", "helpers/macos"],
+    },
+  )
+  assert_eq(
+    resolve_platform_package_config(
+      package_config,
+      @packager.PackageHost::Windows,
+    ),
+    ResolvedPlatformPackageConfig::{
+      formats: ["app"],
+      resources: ["assets/common", "assets/windows"],
+      sign_binaries: ["helpers/common"],
+    },
+  )
+  assert_eq(
+    resolve_platform_package_config(
+      package_config,
+      @packager.PackageHost::Linux,
+    ),
+    ResolvedPlatformPackageConfig::{
+      formats: [],
+      resources: ["assets/common"],
+      sign_binaries: ["helpers/common"],
+    },
+  )
+}
+
+///|
 test "project packaging rejects an identifier override" {
   try parse_package_args(["--identifier", "com.example.demo"]) catch {
     error =>

--- a/cli/package/pkg.generated.mbti
+++ b/cli/package/pkg.generated.mbti
@@ -52,6 +52,11 @@ pub fn RawPackageOptions::equal(Self, Self) -> Bool
 pub fn RawPackageOptions::not_equal(Self, Self) -> Bool
 pub fn RawPackageOptions::to_repr(Self) -> @debug.Repr
 
+type ResolvedPlatformPackageConfig derive(Eq, @debug.Debug)
+pub fn ResolvedPlatformPackageConfig::equal(Self, Self) -> Bool
+pub fn ResolvedPlatformPackageConfig::not_equal(Self, Self) -> Bool
+pub fn ResolvedPlatformPackageConfig::to_repr(Self) -> @debug.Repr
+
 // Type aliases
 
 // Traits

--- a/config/config_test.mbt
+++ b/config/config_test.mbt
@@ -49,6 +49,65 @@ test "project config contains only CLI build and package settings" {
 }
 
 ///|
+test "project package decodes platform-specific inputs" {
+  let source =
+    #|{
+    #|  "identifier": "com.example.todo",
+    #|  "package": {
+    #|    "product_name": "Todo",
+    #|    "version": "1.2.3",
+    #|    "formats": ["app"],
+    #|    "resources": ["assets/common"],
+    #|    "sign": { "binaries": ["helpers/common"] },
+    #|    "platforms": {
+    #|      "macos": {
+    #|        "formats": ["app", "dmg"],
+    #|        "resources": ["assets/macos"],
+    #|        "sign": { "binaries": ["helpers/macos"] }
+    #|      },
+    #|      "windows": {
+    #|        "formats": ["app", "zip", "nsis"],
+    #|        "resources": ["assets/windows"]
+    #|      },
+    #|      "linux": { "formats": [] }
+    #|    }
+    #|  }
+    #|}
+  let config = load_project_config_from_text(source, "/workspace/todo")
+  let platforms = config.package_config().unwrap().platforms()
+  let macos = platforms.macos().unwrap()
+  assert_eq(macos.formats(), Some(["app", "dmg"]))
+  assert_eq(macos.resources(), [
+    @mbpath.Path("/workspace/todo/assets/macos").resolve().to_string(),
+  ])
+  assert_eq(macos.sign().unwrap().binaries(), [
+    @mbpath.Path("/workspace/todo/helpers/macos").resolve().to_string(),
+  ])
+  assert_eq(
+    platforms.windows().unwrap().formats(),
+    Some(["app", "zip", "nsis"]),
+  )
+  assert_eq(platforms.linux().unwrap().formats(), Some([]))
+}
+
+///|
+test "project package rejects unknown platform overrides" {
+  let source =
+    #|{
+    #|  "identifier": "com.example.todo",
+    #|  "package": {
+    #|    "product_name": "Todo",
+    #|    "version": "1.2.3",
+    #|    "platforms": { "android": { "formats": ["app"] } }
+    #|  }
+    #|}
+  let error = expect_config_error(() => {
+    ignore(load_project_config_from_text(source, "/workspace/todo"))
+  })
+  assert_eq(error, UnknownField(path="package.platforms.android"))
+}
+
+///|
 test "project config rejects unknown top-level fields" {
   let source =
     #|{ "identifier": "com.example.todo", "window": { "title": "Todo" } }

--- a/config/pkg.generated.mbti
+++ b/config/pkg.generated.mbti
@@ -100,19 +100,47 @@ pub(all) struct ProjectPackageConfig {
   url_schemes : Array[String]
   document_types : Array[ProjectDocumentType]
   output : String
+  platforms : ProjectPackagePlatforms
 } derive(Eq, @debug.Debug)
-pub fn ProjectPackageConfig::ProjectPackageConfig(String, String, formats? : Array[String], icons? : Array[String], resources? : Array[String], sign? : ProjectSignConfig?, url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String) -> Self
+pub fn ProjectPackageConfig::ProjectPackageConfig(String, String, formats? : Array[String], icons? : Array[String], resources? : Array[String], sign? : ProjectSignConfig?, url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String, platforms? : ProjectPackagePlatforms) -> Self
 pub fn ProjectPackageConfig::document_types(Self) -> Array[ProjectDocumentType]
 pub fn ProjectPackageConfig::equal(Self, Self) -> Bool
 pub fn ProjectPackageConfig::formats(Self) -> Array[String]
 pub fn ProjectPackageConfig::icons(Self) -> Array[String]
 pub fn ProjectPackageConfig::not_equal(Self, Self) -> Bool
 pub fn ProjectPackageConfig::output(Self) -> String
+pub fn ProjectPackageConfig::platforms(Self) -> ProjectPackagePlatforms
 pub fn ProjectPackageConfig::resources(Self) -> Array[String]
 pub fn ProjectPackageConfig::sign(Self) -> ProjectSignConfig?
 pub fn ProjectPackageConfig::to_repr(Self) -> @debug.Repr
 pub fn ProjectPackageConfig::url_schemes(Self) -> Array[String]
 pub fn ProjectPackageConfig::version(Self) -> String
+
+pub(all) struct ProjectPackagePlatforms {
+  macos : ProjectPlatformPackageConfig?
+  windows : ProjectPlatformPackageConfig?
+  linux : ProjectPlatformPackageConfig?
+} derive(Eq, @debug.Debug)
+pub fn ProjectPackagePlatforms::ProjectPackagePlatforms(macos? : ProjectPlatformPackageConfig, windows? : ProjectPlatformPackageConfig, linux? : ProjectPlatformPackageConfig) -> Self
+pub fn ProjectPackagePlatforms::equal(Self, Self) -> Bool
+pub fn ProjectPackagePlatforms::linux(Self) -> ProjectPlatformPackageConfig?
+pub fn ProjectPackagePlatforms::macos(Self) -> ProjectPlatformPackageConfig?
+pub fn ProjectPackagePlatforms::not_equal(Self, Self) -> Bool
+pub fn ProjectPackagePlatforms::to_repr(Self) -> @debug.Repr
+pub fn ProjectPackagePlatforms::windows(Self) -> ProjectPlatformPackageConfig?
+
+pub(all) struct ProjectPlatformPackageConfig {
+  formats : Array[String]?
+  resources : Array[String]
+  sign : ProjectSignConfig?
+} derive(Eq, @debug.Debug)
+pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(formats? : Array[String], resources? : Array[String], sign? : ProjectSignConfig) -> Self
+pub fn ProjectPlatformPackageConfig::equal(Self, Self) -> Bool
+pub fn ProjectPlatformPackageConfig::formats(Self) -> Array[String]?
+pub fn ProjectPlatformPackageConfig::not_equal(Self, Self) -> Bool
+pub fn ProjectPlatformPackageConfig::resources(Self) -> Array[String]
+pub fn ProjectPlatformPackageConfig::sign(Self) -> ProjectSignConfig?
+pub fn ProjectPlatformPackageConfig::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ProjectSignConfig {
   binaries : Array[String]

--- a/config/project_config.mbt
+++ b/config/project_config.mbt
@@ -109,6 +109,104 @@ pub fn ProjectSignConfig::binaries(self : ProjectSignConfig) -> Array[String] {
 }
 
 ///|
+/// Package inputs that apply only to one desktop platform.
+pub(all) struct ProjectPlatformPackageConfig {
+  formats : Array[String]?
+  resources : Array[String]
+  sign : ProjectSignConfig?
+} derive(Eq, Debug)
+
+///|
+pub extend ProjectPlatformPackageConfig with Eq::{not_equal, equal}
+
+///|
+pub extend ProjectPlatformPackageConfig with Debug::{to_repr}
+
+///|
+pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(
+  formats? : Array[String],
+  resources? : Array[String] = [],
+  sign? : ProjectSignConfig,
+) -> ProjectPlatformPackageConfig {
+  ProjectPlatformPackageConfig::{
+    formats: match formats {
+      Some(formats) => Some(formats.copy())
+      None => None
+    },
+    resources: resources.copy(),
+    sign,
+  }
+}
+
+///|
+pub fn ProjectPlatformPackageConfig::formats(
+  self : ProjectPlatformPackageConfig,
+) -> Array[String]? {
+  match self.formats {
+    Some(formats) => Some(formats.copy())
+    None => None
+  }
+}
+
+///|
+pub fn ProjectPlatformPackageConfig::resources(
+  self : ProjectPlatformPackageConfig,
+) -> Array[String] {
+  self.resources.copy()
+}
+
+///|
+pub fn ProjectPlatformPackageConfig::sign(
+  self : ProjectPlatformPackageConfig,
+) -> ProjectSignConfig? {
+  self.sign
+}
+
+///|
+/// Optional package overrides for each supported desktop platform.
+pub(all) struct ProjectPackagePlatforms {
+  macos : ProjectPlatformPackageConfig?
+  windows : ProjectPlatformPackageConfig?
+  linux : ProjectPlatformPackageConfig?
+} derive(Eq, Debug)
+
+///|
+pub extend ProjectPackagePlatforms with Eq::{not_equal, equal}
+
+///|
+pub extend ProjectPackagePlatforms with Debug::{to_repr}
+
+///|
+pub fn ProjectPackagePlatforms::ProjectPackagePlatforms(
+  macos? : ProjectPlatformPackageConfig,
+  windows? : ProjectPlatformPackageConfig,
+  linux? : ProjectPlatformPackageConfig,
+) -> ProjectPackagePlatforms {
+  ProjectPackagePlatforms::{ macos, windows, linux, }
+}
+
+///|
+pub fn ProjectPackagePlatforms::macos(
+  self : ProjectPackagePlatforms,
+) -> ProjectPlatformPackageConfig? {
+  self.macos
+}
+
+///|
+pub fn ProjectPackagePlatforms::windows(
+  self : ProjectPackagePlatforms,
+) -> ProjectPlatformPackageConfig? {
+  self.windows
+}
+
+///|
+pub fn ProjectPackagePlatforms::linux(
+  self : ProjectPackagePlatforms,
+) -> ProjectPlatformPackageConfig? {
+  self.linux
+}
+
+///|
 pub(all) struct ProjectDocumentType {
   name : String
   extensions : Array[String]
@@ -149,6 +247,7 @@ pub(all) struct ProjectPackageConfig {
   url_schemes : Array[String]
   document_types : Array[ProjectDocumentType]
   output : String
+  platforms : ProjectPackagePlatforms
 } derive(Eq, Debug)
 
 ///|
@@ -168,6 +267,7 @@ pub fn ProjectPackageConfig::ProjectPackageConfig(
   url_schemes? : Array[String] = [],
   document_types? : Array[ProjectDocumentType] = [],
   output? : String = "dist",
+  platforms? : ProjectPackagePlatforms = ProjectPackagePlatforms(),
 ) -> ProjectPackageConfig {
   ProjectPackageConfig::{
     product_name,
@@ -179,6 +279,7 @@ pub fn ProjectPackageConfig::ProjectPackageConfig(
     url_schemes: url_schemes.copy(),
     document_types: document_types.copy(),
     output,
+    platforms,
   }
 }
 
@@ -232,6 +333,13 @@ pub fn ProjectPackageConfig::document_types(
 ///|
 pub fn ProjectPackageConfig::output(self : ProjectPackageConfig) -> String {
   self.output
+}
+
+///|
+pub fn ProjectPackageConfig::platforms(
+  self : ProjectPackageConfig,
+) -> ProjectPackagePlatforms {
+  self.platforms
 }
 
 ///|

--- a/config/project_decode.mbt
+++ b/config/project_decode.mbt
@@ -131,7 +131,7 @@ fn decode_package(
     Some(Object(values)) => {
       validate_object_fields(values, "package", [
         "product_name", "version", "formats", "icons", "resources", "sign", "url_schemes",
-        "document_types", "output",
+        "document_types", "output", "platforms",
       ])
       let formats = optional_string_array(values, "formats", "package.formats")
       let icons = rebased_paths(
@@ -156,7 +156,7 @@ fn decode_package(
           icons~,
           resources~,
           url_schemes~,
-          sign=decode_sign(values, base_dir),
+          sign=decode_sign(values, base_dir, "package.sign"),
           document_types=decode_document_types(values),
           output=rebase_project_path(
             optional_string(values, "output", "package.output").unwrap_or(
@@ -165,12 +165,74 @@ fn decode_package(
             base_dir,
             "package.output",
           ),
+          platforms=decode_package_platforms(values, base_dir),
         ),
       )
     }
     Some(_) =>
       raise InvalidField(
         path="proton.project.json.package",
+        expectation="must be an object",
+      )
+  }
+}
+
+///|
+fn decode_package_platforms(
+  fields : Map[String, Json],
+  base_dir : String,
+) -> ProjectPackagePlatforms raise ProjectConfigError {
+  match fields.get("platforms") {
+    None => ProjectPackagePlatforms()
+    Some(Object(values)) => {
+      validate_object_fields(values, "package.platforms", [
+        "macos", "windows", "linux",
+      ])
+      let macos = decode_platform_package(values, "macos", base_dir)
+      let windows = decode_platform_package(values, "windows", base_dir)
+      let linux = decode_platform_package(values, "linux", base_dir)
+      ProjectPackagePlatforms(macos?, windows?, linux?)
+    }
+    Some(_) =>
+      raise InvalidField(
+        path="package.platforms",
+        expectation="must be an object",
+      )
+  }
+}
+
+///|
+fn decode_platform_package(
+  fields : Map[String, Json],
+  platform : String,
+  base_dir : String,
+) -> ProjectPlatformPackageConfig? raise ProjectConfigError {
+  match fields.get(platform) {
+    None => None
+    Some(Object(values)) => {
+      let label = "package.platforms." + platform
+      validate_object_fields(values, label, ["formats", "resources", "sign"])
+      let formats = if values.contains("formats") {
+        Some(optional_string_array(values, "formats", label + ".formats"))
+      } else {
+        None
+      }
+      let sign = decode_sign(values, base_dir, label + ".sign")
+      Some(
+        ProjectPlatformPackageConfig(
+          formats?,
+          resources=rebased_paths(
+            optional_string_array(values, "resources", label + ".resources"),
+            base_dir,
+            label + ".resources",
+          ),
+          sign?,
+        ),
+      )
+    }
+    Some(_) =>
+      raise InvalidField(
+        path="package.platforms." + platform,
         expectation="must be an object",
       )
   }
@@ -222,30 +284,32 @@ pub fn validate_application_identifier(
 fn decode_sign(
   fields : Map[String, Json],
   base_dir : String,
+  label : String,
 ) -> ProjectSignConfig? raise ProjectConfigError {
   match fields.get("sign") {
     None => None
     Some(Object(values)) => {
-      validate_object_fields(values, "package.sign", ["binaries"])
+      validate_object_fields(values, label, ["binaries"])
       let binaries = optional_string_array(
-        values, "binaries", "package.sign.binaries",
+        values,
+        "binaries",
+        label + ".binaries",
       )
       for path in binaries {
         if path.contains("*") {
           raise InvalidField(
-            path="package.sign.binaries",
+            path=label + ".binaries",
             expectation="must not contain glob patterns",
           )
         }
       }
       Some(
         ProjectSignConfig(
-          binaries=rebased_paths(binaries, base_dir, "package.sign.binaries"),
+          binaries=rebased_paths(binaries, base_dir, label + ".binaries"),
         ),
       )
     }
-    Some(_) =>
-      raise InvalidField(path="package.sign", expectation="must be an object")
+    Some(_) => raise InvalidField(path=label, expectation="must be an object")
   }
 }
 

--- a/package/lib/package.mbt
+++ b/package/lib/package.mbt
@@ -1,12 +1,17 @@
 ///|
-priv enum PackageHost {
+/// The desktop platform supported by the current host-native packager.
+pub(all) enum PackageHost {
   Macos
   Windows
   Linux
 } derive(Eq)
 
 ///|
-async fn current_package_host() -> PackageHost {
+pub extend PackageHost with Eq::{not_equal, equal}
+
+///|
+/// Returns the desktop platform of the current packaging host.
+pub async fn current_package_host() -> PackageHost {
   if @path.sep == '\\' {
     Windows
   } else if path_exists("/System/Library/CoreServices/SystemVersion.plist") {

--- a/package/lib/pkg.generated.mbti
+++ b/package/lib/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub async fn build(PackageSpec) -> Array[String]
 
 pub async fn build_with(PackageSpec, PackageCustomization, async (PackageLayout) -> Unit) -> Array[String]
 
+pub async fn current_package_host() -> PackageHost
+
 pub fn macos_versions(String) -> (String, String) raise PackagePlanError
 
 pub async fn resolve_package_formats(Array[PackageFormat]) -> Array[PackageFormat]
@@ -140,6 +142,14 @@ pub fn PackageFormat::not_equal(Self, Self) -> Bool
 pub fn PackageFormat::parse(String) -> Self raise PackagePlanError
 pub fn PackageFormat::to_repr(Self) -> @debug.Repr
 pub fn PackageFormat::to_string(Self) -> String
+
+pub(all) enum PackageHost {
+  Macos
+  Windows
+  Linux
+} derive(Eq)
+pub fn PackageHost::equal(Self, Self) -> Bool
+pub fn PackageHost::not_equal(Self, Self) -> Bool
 
 pub struct PackageLayout {
   root : String


### PR DESCRIPTION
## Summary

- add per-platform package overrides for formats, resources, and signing targets
- resolve package settings for the current host while preserving command-line precedence
- let generated projects use host-native format defaults and update scaffold guidance

## Platform impact

Projects can configure `macos`, `windows`, and `linux` package blocks independently. Existing shared package settings remain supported, and explicit CLI options keep the highest priority.

## Validation

- `moon -C config test --target native --diagnostic-limit 80`
- `moon -C cli test package --target native --no-parallelize --diagnostic-limit 80`
- `moon -C cli test new --target native --diagnostic-limit 80`
- `moon -C package test lib --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- `moon -C cli info`
- `moon fmt --check`
- `git diff --check`