### PR TITLE
fix(build): target macOS 12

### DIFF
--- a/cefsetup/store/cef_helper.mbt
+++ b/cefsetup/store/cef_helper.mbt
@@ -42,14 +42,32 @@ async fn default_helper_paths() -> (String, String, String) {
 }
 
 ///|
-fn helper_moon_environment() -> Map[String, String] {
-  let environment = @env.get_env_vars()
+async fn helper_moon_environment() -> Map[String, String] noraise {
+  let macos = is_macos_host() catch { _ => false }
+  helper_moon_environment_for(
+    @env.get_env_vars(),
+    windows=@path.sep == '\\',
+    macos~,
+    configured_cc=@env.get_env_var("MOON_CC"),
+  )
+}
+
+///|
+fn helper_moon_environment_for(
+  environment : Map[String, String],
+  windows~ : Bool,
+  macos~ : Bool,
+  configured_cc~ : String?,
+) -> Map[String, String] {
   environment["PROTON_CEF_SETUP_BOOTSTRAP"] = "0"
-  if @path.sep != '\\' {
-    environment["MOON_CC"] = match @env.get_env_var("MOON_CC") {
+  if !windows {
+    environment["MOON_CC"] = match configured_cc {
       Some(value) if value.trim() != "" => value
       _ => "cc"
     }
+  }
+  if macos {
+    environment["MACOSX_DEPLOYMENT_TARGET"] = "12.0"
   }
   environment
 }
@@ -137,7 +155,16 @@ test "helper cache identity includes platform and Proton version" {
 ///|
 test "helper build uses the normal Proton native link configuration" {
   assert_eq(
-    helper_moon_environment().get("PROTON_CEF_SETUP_BOOTSTRAP"),
-    Some("0"),
+    helper_moon_environment_for(
+      {},
+      windows=false,
+      macos=true,
+      configured_cc=None,
+    ),
+    {
+      "MACOSX_DEPLOYMENT_TARGET": "12.0",
+      "MOON_CC": "cc",
+      "PROTON_CEF_SETUP_BOOTSTRAP": "0",
+    },
   )
 }

--- a/cli/build_cmd/build.mbt
+++ b/cli/build_cmd/build.mbt
@@ -274,6 +274,7 @@ async fn project_build_invocation(
 ///|
 fn native_moon_process_env_for(
   windows : Bool,
+  macos : Bool,
   configured_cc : String?,
 ) -> Map[String, String] {
   let env : Map[String, String] = Map([])
@@ -286,13 +287,25 @@ fn native_moon_process_env_for(
       _ => "cc"
     }
   }
+  if macos {
+    env["MACOSX_DEPLOYMENT_TARGET"] = "12.0"
+  }
   env
 }
 
 ///|
 /// Returns the environment required for a Proton native Moon command.
-pub fn native_moon_process_env() -> Map[String, String] {
-  native_moon_process_env_for(@path.sep == '\\', @env.get_env_var("MOON_CC"))
+pub async fn native_moon_process_env() -> Map[String, String] noraise {
+  let macos = @fsutil.path_exists(
+    "/System/Library/CoreServices/SystemVersion.plist",
+  ) catch {
+    _ => false
+  }
+  native_moon_process_env_for(
+    @path.sep == '\\',
+    macos,
+    @env.get_env_var("MOON_CC"),
+  )
 }
 
 ///|

--- a/cli/build_cmd/build_wbtest.mbt
+++ b/cli/build_cmd/build_wbtest.mbt
@@ -134,14 +134,24 @@ test "moon build-only output rejects missing or ambiguous artifacts" {
 
 ///|
 test "native Moon commands select a source-built runtime on Unix" {
-  @debug.assert_eq(native_moon_process_env_for(false, None), { "MOON_CC": "cc" })
-  @debug.assert_eq(native_moon_process_env_for(false, Some("gcc")), {
+  @debug.assert_eq(native_moon_process_env_for(false, false, None), {
+    "MOON_CC": "cc",
+  })
+  @debug.assert_eq(native_moon_process_env_for(false, false, Some("gcc")), {
     "MOON_CC": "gcc",
   })
-  @debug.assert_eq(native_moon_process_env_for(false, Some("clang")), {
+  @debug.assert_eq(native_moon_process_env_for(false, false, Some("clang")), {
     "MOON_CC": "clang",
   })
-  @debug.assert_eq(native_moon_process_env_for(true, None), Map([]))
+  @debug.assert_eq(native_moon_process_env_for(true, false, None), Map([]))
+}
+
+///|
+test "native Moon commands target macOS 12" {
+  @debug.assert_eq(native_moon_process_env_for(false, true, None), {
+    "MACOSX_DEPLOYMENT_TARGET": "12.0",
+    "MOON_CC": "cc",
+  })
 }
 
 ///|

--- a/cli/build_cmd/pkg.generated.mbti
+++ b/cli/build_cmd/pkg.generated.mbti
@@ -12,7 +12,7 @@ pub async fn build_executable(String, String, String, Bool) -> String
 
 pub fn command() -> @argparse.Command
 
-pub fn native_moon_process_env() -> Map[String, String]
+pub async fn native_moon_process_env() -> Map[String, String] noraise
 
 pub async fn run(String, @argparse.Matches) -> Unit
 

--- a/proton/build.mjs
+++ b/proton/build.mjs
@@ -12,6 +12,7 @@ import {
 
 const moduleRoot = path.dirname(fileURLToPath(import.meta.url));
 const ffiRoot = path.join(moduleRoot, "internal", "native", "ffi");
+const macosDeploymentTarget = "12.0";
 
 function readPayloadEnv() {
   const raw = fs.readFileSync(0, "utf8").trim();
@@ -75,14 +76,21 @@ function platformConfig(cefRoot) {
     `-I${quote(cefRoot)}`,
   );
   if (process.platform === "darwin") {
+    const deploymentFlag = `-mmacosx-version-min=${macosDeploymentTarget}`;
     return {
-      stubFlags: commonStubFlags,
-      macObjcFlags: appendFlags("-ObjC -fblocks", commonStubFlags),
+      stubFlags: appendFlags(deploymentFlag, commonStubFlags),
+      macObjcFlags: appendFlags(
+        deploymentFlag,
+        "-ObjC -fblocks",
+        commonStubFlags,
+      ),
       loaderFlags: appendFlags(
+        deploymentFlag,
         "-ObjC++ -std=c++17 -DWRAPPING_CEF_SHARED=1",
         `-I${quote(cefRoot)}`,
       ),
       linkFlags: [
+        deploymentFlag,
         "-framework Cocoa",
         "-framework AppKit",
         "-framework Foundation",


### PR DESCRIPTION
## Summary

- compile and link Proton native stubs with a macOS 12 deployment target
- propagate `MACOSX_DEPLOYMENT_TARGET=12.0` through CLI build/dev/package commands
- apply the same target when cefsetup builds the versioned CEF subprocess helper
- detect the macOS host at runtime so the WASM-based CLI configures native child builds correctly

## Validation

- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80` (92 passed)
- `moon -C cefsetup test store --target native --diagnostic-limit 80` (20 passed)
- `moon -C proton check --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- `moon fmt --check`
- rebuilt a Proton application in a fresh target directory and verified every Mach-O object and executable reports `minos 12.0`
- rebuilt `cef_process` independently and verified it reports `minos 12.0`