### PR TITLE
chore(release): prepare 0.2.6

### DIFF
--- a/cdp/moon.mod
+++ b/cdp/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cdp"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.mbt.md"
 

--- a/cefsetup/moon.mod
+++ b/cefsetup/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_cefsetup"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/async@0.21.2",

--- a/cefsetup/store/requirements.generated.mbt
+++ b/cefsetup/store/requirements.generated.mbt
@@ -3,7 +3,7 @@
 
 ///|
 pub fn release_version() -> String {
-  "0.2.5"
+  "0.2.6"
 }
 
 ///|

--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let cli_current_version : String = "0.2.5"
+let cli_current_version : String = "0.2.6"
 
 ///|
 let cli_manifest_url : String = "https://mooncakes.io/api/v0/manifest/moonbit-community/proton_cli"

--- a/cli/moon.mod
+++ b/cli/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton_cli"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_config@0.2.5",
-  "moonbit-community/proton_package@0.2.5",
-  "moonbit-community/proton_cefsetup@0.2.5",
-  "moonbit-community/proton_rsa@0.2.5",
-  "moonbit-community/proton_updater@0.2.5",
+  "moonbit-community/proton_config@0.2.6",
+  "moonbit-community/proton_package@0.2.6",
+  "moonbit-community/proton_cefsetup@0.2.6",
+  "moonbit-community/proton_rsa@0.2.6",
+  "moonbit-community/proton_updater@0.2.6",
   "moonbitlang/x@0.5.1",
   "moonbitlang/moon_config@0.3.14",
   "moonbitlang/async@0.21.2",

--- a/cli/new/templates.mbt
+++ b/cli/new/templates.mbt
@@ -1,20 +1,20 @@
 ///|
-let default_proton_version = "0.2.5"
+let default_proton_version = "0.2.6"
 
 ///|
-let default_proton_codegen_version = "0.2.5"
+let default_proton_codegen_version = "0.2.6"
 
 ///|
-let default_proton_cli_version = "0.2.5"
+let default_proton_cli_version = "0.2.6"
 
 ///|
-let default_proton_contract_version = "0.2.5"
+let default_proton_contract_version = "0.2.6"
 
 ///|
-let default_proton_client_version = "0.2.5"
+let default_proton_client_version = "0.2.6"
 
 ///|
-let default_proton_rabbita_version = "0.2.5"
+let default_proton_rabbita_version = "0.2.6"
 
 ///|
 let default_rabbita_version = "0.15.4"

--- a/client/moon.mod
+++ b/client/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_client"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/async@0.21.2",
-  "moonbit-community/proton_contract@0.2.5",
+  "moonbit-community/proton_contract@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/codegen/moon.mod
+++ b/codegen/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_codegen"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/async@0.21.2",

--- a/config/moon.mod
+++ b/config/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_config"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/contract/moon.mod
+++ b/contract/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_contract"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.mbt.md"
 

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -1,15 +1,15 @@
 name = "moonbit-community/proton/e2e"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/async@0.21.2",
   "moonbitlang/x@0.5.1",
-  "moonbit-community/proton_cdp@0.2.5",
-  "moonbit-community/proton@0.2.5",
-  "moonbit-community/proton_cefsetup@0.2.5",
-  "moonbit-community/proton_updater@0.2.5",
-  "moonbit-community/proton/examples@0.2.5",
+  "moonbit-community/proton_cdp@0.2.6",
+  "moonbit-community/proton@0.2.6",
+  "moonbit-community/proton_cefsetup@0.2.6",
+  "moonbit-community/proton_updater@0.2.6",
+  "moonbit-community/proton/examples@0.2.6",
 }
 
 readme = "README.md"

--- a/examples/moon.mod
+++ b/examples/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton/examples"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.2",
-  "moonbit-community/proton_ext@0.2.5",
-  "moonbit-community/proton_contract@0.2.5",
-  "moonbit-community/proton@0.2.5",
+  "moonbit-community/proton_ext@0.2.6",
+  "moonbit-community/proton_contract@0.2.6",
+  "moonbit-community/proton@0.2.6",
 }
 
 readme = "README.md"

--- a/extensions/moon.mod
+++ b/extensions/moon.mod
@@ -1,23 +1,23 @@
 name = "moonbit-community/proton_ext"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
   "moonbitlang/x@0.5.1",
   "moonbitlang/async@0.21.2",
-  "moonbit-community/proton_clipboard@0.2.5",
-  "moonbit-community/proton_tray@0.2.5",
-  "moonbit-community/proton_global_hotkey@0.2.5",
-  "moonbit-community/proton@0.2.5",
-  "moonbit-community/proton_contract@0.2.5",
-  "moonbit-community/proton_microphone@0.2.5",
-  "moonbit-community/proton_auto_launch@0.2.5",
-  "moonbit-community/proton_keepawake@0.2.5",
-  "moonbit-community/proton_power_monitor@0.2.5",
-  "moonbit-community/proton_screen_monitor@0.2.5",
-  "moonbit-community/proton_process@0.2.5",
-  "moonbit-community/proton_shell@0.2.5",
+  "moonbit-community/proton_clipboard@0.2.6",
+  "moonbit-community/proton_tray@0.2.6",
+  "moonbit-community/proton_global_hotkey@0.2.6",
+  "moonbit-community/proton@0.2.6",
+  "moonbit-community/proton_contract@0.2.6",
+  "moonbit-community/proton_microphone@0.2.6",
+  "moonbit-community/proton_auto_launch@0.2.6",
+  "moonbit-community/proton_keepawake@0.2.6",
+  "moonbit-community/proton_power_monitor@0.2.6",
+  "moonbit-community/proton_screen_monitor@0.2.6",
+  "moonbit-community/proton_process@0.2.6",
+  "moonbit-community/proton_shell@0.2.6",
 }
 
 readme = "README.md"

--- a/package/moon.mod
+++ b/package/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_package"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/async@0.21.2",

--- a/proton/README.md
+++ b/proton/README.md
@@ -153,7 +153,7 @@ independent `set_zoom_percent` and `zoom_percent` controls for their own browser
 
 ## Logging
 
-Use `tonyfettes/xlog@0.4.1` directly for application logs. Proton configures the
+Use `tonyfettes/xlog@0.4.2` directly for application logs. Proton configures the
 global logger before native runtime creation. Packaged applications write to
 their platform log directory; direct launches and `proton_cli dev` use stderr.
 `MOON_XLOG` controls filtering and `PROTON_LOG_OUTPUT` selects `file` or

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -11,7 +11,7 @@ import {
   "moonbitlang/async@0.21.2",
   "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.15",
-  "tonyfettes/xlog@0.4.1",
+  "tonyfettes/xlog@0.4.2",
 }
 
 readme = "README.md"

--- a/proton/moon.mod
+++ b/proton/moon.mod
@@ -1,13 +1,13 @@
 name = "moonbit-community/proton"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
-  "moonbit-community/proton_config@0.2.5",
-  "moonbit-community/proton_contract@0.2.5",
-  "moonbit-community/proton_updater@0.2.5",
-  "moonbit-community/proton_rsa@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
+  "moonbit-community/proton_config@0.2.6",
+  "moonbit-community/proton_contract@0.2.6",
+  "moonbit-community/proton_updater@0.2.6",
+  "moonbit-community/proton_rsa@0.2.6",
   "moonbitlang/async@0.21.2",
   "moonbitlang/x@0.5.1",
   "moonbitlang/lexer@0.3.15",

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,10 +1,10 @@
 name = "moonbit-community/proton_rabbita"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_client@0.2.5",
-  "moonbit-community/proton_contract@0.2.5",
+  "moonbit-community/proton_client@0.2.6",
+  "moonbit-community/proton_contract@0.2.6",
   "moonbit-community/rabbita@0.15.4",
 }
 

--- a/rsa/moon.mod
+++ b/rsa/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_rsa"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.mbt.md"
 

--- a/sys/auto_launch/moon.mod
+++ b/sys/auto_launch/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_auto_launch"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.md"
 

--- a/sys/clipboard/moon.mod
+++ b/sys/clipboard/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_clipboard"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.mbt.md"
 

--- a/sys/ffi/moon.mod
+++ b/sys/ffi/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_ffi"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
   "moonbitlang/x@0.5.1",

--- a/sys/global_hotkey/moon.mod
+++ b/sys/global_hotkey/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_global_hotkey"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/keepawake/moon.mod
+++ b/sys/keepawake/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_keepawake"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/microphone/moon.mod
+++ b/sys/microphone/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_microphone"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/power_monitor/moon.mod
+++ b/sys/power_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_power_monitor"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/process/moon.mod
+++ b/sys/process/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_process"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/screen_monitor/moon.mod
+++ b/sys/screen_monitor/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_screen_monitor"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/sys/shell/moon.mod
+++ b/sys/shell/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_shell"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 repository = "https://github.com/moonbit-community/proton/tree/main/sys/shell"

--- a/sys/tray/moon.mod
+++ b/sys/tray/moon.mod
@@ -1,9 +1,9 @@
 name = "moonbit-community/proton_tray"
 
-version = "0.2.5"
+version = "0.2.6"
 
 import {
-  "moonbit-community/proton_ffi@0.2.5",
+  "moonbit-community/proton_ffi@0.2.6",
 }
 
 readme = "README.mbt.md"

--- a/updater/moon.mod
+++ b/updater/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/proton_updater"
 
-version = "0.2.5"
+version = "0.2.6"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
## Summary

- bump all 26 workspace modules from 0.2.5 to 0.2.6 with lockstep
- update the CLI reported version and scaffolded Proton dependency defaults
- regenerate the CEF runtime release metadata
- refresh external dependencies and update `tonyfettes/xlog` from 0.4.1 to 0.4.2

## Platform impact

This updates release metadata and the shared native logging dependency for all supported platforms. It does not change Proton runtime behavior.

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80`
- `moon -C proton test internal/native --target native --diagnostic-limit 80`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon check --target native --diagnostic-limit 80`
- `moon -C proton info --target native`