### PR TITLE
feat(cli): add package prepare command

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ platform keys are `macos`, `windows`, and `linux`; platform blocks accept only
 `formats`, `resources`, and `sign`. Explicit command-line options retain the
 highest priority.
 
+Use `package.prepare` when the application must generate package-only resources
+or additional binaries. Proton runs this command once from the project root
+after building the frontend and application executable, then validates and
+packages the declared inputs. The command is not run by `proton_cli build` or
+`proton_cli package --dry-run`; the generic `proton_package` tool never runs
+project commands.
+
 On macOS, `--sign` signs the application and `--notarize` submits, staples, and
 validates distributable artifacts. URL schemes and document types are written
 to the macOS application metadata. Current Windows and Linux packages do not

--- a/cli/package/moon.pkg
+++ b/cli/package/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbit-community/proton_updater" @updater,
   "moonbit-community/proton_cli/build_cmd" @build,
   "moonbit-community/proton_cli/fsutil",
+  "moonbit-community/proton_cli/output",
   "moonbitlang/async/fs" @async_fs,
   "moonbitlang/async/process",
   "moonbitlang/core/argparse",

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -41,6 +41,7 @@ struct PackagePlan {
   release : Bool
   base_dir : String
   frontend_dist : String?
+  prepare : String?
   resources : Array[String]
   sign_binaries : Array[String]
   icons : Array[String]
@@ -275,6 +276,7 @@ async fn build_package_plan(
     release: raw.release,
     base_dir,
     frontend_dist,
+    prepare: package_config.prepare(),
     resources: platform_config.resources,
     sign_binaries: platform_config.sign_binaries,
     icons: if raw.package_args.icons.length() > 0 {
@@ -352,6 +354,7 @@ fn print_package_plan(plan : PackagePlan, dry_run : Bool) -> Unit {
     "  formats: " + plan.formats.map(format => format.to_string()).join(", "),
   )
   println("  output: " + plan.output)
+  println("  prepare: " + plan.prepare.unwrap_or("none"))
   let sign_binaries = if plan.sign_binaries.length() == 0 {
     "none"
   } else {
@@ -379,6 +382,7 @@ async fn execute_package_plan(plan : PackagePlan) -> (Array[String], String) {
   if !@fsutil.path_exists(executable) || !@fsutil.path_is_file(executable) {
     raise @packager.PackagePlanError::MissingExecutable(path=executable)
   }
+  run_package_prepare(plan)
   let document_types = plan.document_types.map(document_type => {
     @packager.DocumentType(
       document_type.name,
@@ -422,6 +426,40 @@ async fn run_package_build(plan : PackagePlan) -> String {
     plan.config_path,
     plan.release,
   )
+}
+
+///|
+async fn run_package_prepare(plan : PackagePlan) -> Unit {
+  match plan.prepare {
+    None => ()
+    Some(command) => {
+      @output.info("Preparing package: " + command)
+      @output.info("Package prepare cwd: " + plan.base_dir)
+      let (program, args) = package_shell_command(command)
+      let code = @process.run(program, args, cwd=plan.base_dir) catch {
+        error =>
+          raise @build.BuildProcessError::Start(
+            command="package.prepare '" + command + "'",
+            detail=@debug.render(Repr(error)),
+          )
+      }
+      if code != 0 {
+        raise @build.BuildProcessError::Exit(
+          command="package.prepare '" + command + "'",
+          code~,
+        )
+      }
+    }
+  }
+}
+
+///|
+fn package_shell_command(command : String) -> (String, Array[String]) {
+  if @path.sep == '\\' {
+    ("cmd", ["/c", command])
+  } else {
+    ("sh", ["-c", command])
+  }
 }
 
 ///|

--- a/config/config_test.mbt
+++ b/config/config_test.mbt
@@ -27,6 +27,7 @@ test "project config contains only CLI build and package settings" {
     #|    "version": "1.2.3",
     #|    "formats": ["app", "zip"],
     #|    "icons": ["icons/app.icns"],
+    #|    "prepare": "moon run package/prepare --target native",
     #|    "resources": ["assets"],
     #|    "output": "dist"
     #|  }
@@ -46,6 +47,10 @@ test "project config contains only CLI build and package settings" {
   assert_eq(package_config.version(), "1.2.3")
   assert_eq(package_config.formats(), ["app", "zip"])
   assert_true(package_config.icons()[0].has_suffix("icons/app.icns"))
+  assert_eq(
+    package_config.prepare(),
+    Some("moon run package/prepare --target native"),
+  )
 }
 
 ///|

--- a/config/pkg.generated.mbti
+++ b/config/pkg.generated.mbti
@@ -95,6 +95,7 @@ pub(all) struct ProjectPackageConfig {
   version : String
   formats : Array[String]
   icons : Array[String]
+  prepare : String?
   resources : Array[String]
   sign : ProjectSignConfig?
   url_schemes : Array[String]
@@ -102,7 +103,7 @@ pub(all) struct ProjectPackageConfig {
   output : String
   platforms : ProjectPackagePlatforms
 } derive(Eq, @debug.Debug)
-pub fn ProjectPackageConfig::ProjectPackageConfig(String, String, formats? : Array[String], icons? : Array[String], resources? : Array[String], sign? : ProjectSignConfig?, url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String, platforms? : ProjectPackagePlatforms) -> Self
+pub fn ProjectPackageConfig::ProjectPackageConfig(String, String, formats? : Array[String], icons? : Array[String], prepare? : String?, resources? : Array[String], sign? : ProjectSignConfig?, url_schemes? : Array[String], document_types? : Array[ProjectDocumentType], output? : String, platforms? : ProjectPackagePlatforms) -> Self
 pub fn ProjectPackageConfig::document_types(Self) -> Array[ProjectDocumentType]
 pub fn ProjectPackageConfig::equal(Self, Self) -> Bool
 pub fn ProjectPackageConfig::formats(Self) -> Array[String]
@@ -110,6 +111,7 @@ pub fn ProjectPackageConfig::icons(Self) -> Array[String]
 pub fn ProjectPackageConfig::not_equal(Self, Self) -> Bool
 pub fn ProjectPackageConfig::output(Self) -> String
 pub fn ProjectPackageConfig::platforms(Self) -> ProjectPackagePlatforms
+pub fn ProjectPackageConfig::prepare(Self) -> String?
 pub fn ProjectPackageConfig::resources(Self) -> Array[String]
 pub fn ProjectPackageConfig::sign(Self) -> ProjectSignConfig?
 pub fn ProjectPackageConfig::to_repr(Self) -> @debug.Repr

--- a/config/project_config.mbt
+++ b/config/project_config.mbt
@@ -236,12 +236,14 @@ pub fn ProjectDocumentType::extensions(
 }
 
 ///|
-/// Static metadata and payload inputs consumed by `proton_cli package`.
+/// Package metadata, input preparation, and payloads consumed by
+/// `proton_cli package`.
 pub(all) struct ProjectPackageConfig {
   product_name : String
   version : String
   formats : Array[String]
   icons : Array[String]
+  prepare : String?
   resources : Array[String]
   sign : ProjectSignConfig?
   url_schemes : Array[String]
@@ -262,6 +264,7 @@ pub fn ProjectPackageConfig::ProjectPackageConfig(
   version : String,
   formats? : Array[String] = [],
   icons? : Array[String] = [],
+  prepare? : String? = None,
   resources? : Array[String] = [],
   sign? : ProjectSignConfig? = None,
   url_schemes? : Array[String] = [],
@@ -274,6 +277,7 @@ pub fn ProjectPackageConfig::ProjectPackageConfig(
     version,
     formats: formats.copy(),
     icons: icons.copy(),
+    prepare,
     resources: resources.copy(),
     sign,
     url_schemes: url_schemes.copy(),
@@ -300,6 +304,11 @@ pub fn ProjectPackageConfig::icons(
   self : ProjectPackageConfig,
 ) -> Array[String] {
   self.icons.copy()
+}
+
+///|
+pub fn ProjectPackageConfig::prepare(self : ProjectPackageConfig) -> String? {
+  self.prepare
 }
 
 ///|

--- a/config/project_decode.mbt
+++ b/config/project_decode.mbt
@@ -130,8 +130,8 @@ fn decode_package(
     None => None
     Some(Object(values)) => {
       validate_object_fields(values, "package", [
-        "product_name", "version", "formats", "icons", "resources", "sign", "url_schemes",
-        "document_types", "output", "platforms",
+        "product_name", "version", "formats", "icons", "prepare", "resources", "sign",
+        "url_schemes", "document_types", "output", "platforms",
       ])
       let formats = optional_string_array(values, "formats", "package.formats")
       let icons = rebased_paths(
@@ -154,6 +154,7 @@ fn decode_package(
           required_string(values, "version", "package.version"),
           formats~,
           icons~,
+          prepare=optional_string(values, "prepare", "package.prepare"),
           resources~,
           url_schemes~,
           sign=decode_sign(values, base_dir, "package.sign"),


### PR DESCRIPTION
## Summary

- add an optional `package.prepare` command to `proton.project.json`
- run it once from the project root after the frontend and application executable are built
- print, but do not execute, the command during `proton_cli package --dry-run`
- keep `proton_cli build` and the generic `proton_package` tool command-free

## Motivation

Some applications need to generate package-only resources or sidecar binaries that are not ordinary frontend or backend build outputs. Previously, developers had to wrap `proton_cli package` in an external orchestration script, so the declared package inputs and the command that materialized them were disconnected.

The new hook belongs to the Proton project packaging workflow: it runs after normal builds, before package inputs are validated and assembled. The standalone `proton_package` module still packages explicit, already-prepared inputs and does not execute project commands.

A failed process start or non-zero exit stops packaging with a structured CLI process error.

## Validation

- `moon fmt --check`
- `moon info`
- `moon -C config test --target native --diagnostic-limit 80`
- full Proton CLI package test set
- `node scripts/verify_generated.mjs`
