### PR TITLE
fix(logging): target macOS 12

### DIFF
--- a/proton/build.mjs
+++ b/proton/build.mjs
@@ -78,6 +78,7 @@ function platformConfig(cefRoot) {
   if (process.platform === "darwin") {
     const deploymentFlag = `-mmacosx-version-min=${macosDeploymentTarget}`;
     return {
+      deploymentTargetFlags: deploymentFlag,
       stubFlags: appendFlags(deploymentFlag, commonStubFlags),
       macObjcFlags: appendFlags(
         deploymentFlag,
@@ -104,6 +105,7 @@ function platformConfig(cefRoot) {
 
   if (process.platform === "win32") {
     return {
+      deploymentTargetFlags: "",
       stubFlags: commonStubFlags,
       macObjcFlags: "",
       loaderFlags: "",
@@ -120,6 +122,7 @@ function platformConfig(cefRoot) {
     const libs = pkgConfig(["--libs", "gtk+-3.0", "x11"]);
     const releaseDir = path.join(cefRoot, "Release");
     return {
+      deploymentTargetFlags: "",
       stubFlags: appendFlags("-DOS_LINUX=1 -DCEF_X11=1", commonStubFlags, cflags),
       macObjcFlags: "",
       loaderFlags: "",
@@ -145,6 +148,7 @@ export function createNativeLinkConfig(env = readPayloadEnv()) {
   const config = platformConfig(cefRoot);
   return {
     vars: {
+      PROTON_DEPLOYMENT_TARGET_CC_FLAGS: config.deploymentTargetFlags,
       PROTON_NATIVE_STUB_CC_FLAGS: config.stubFlags,
       PROTON_MAC_OBJC_STUB_CC_FLAGS: config.macObjcFlags,
       PROTON_CEF_LOADER_CC_FLAGS: config.loaderFlags,

--- a/proton/internal/logging/moon.pkg
+++ b/proton/internal/logging/moon.pkg
@@ -12,5 +12,8 @@ supported_targets = "native"
 options(
   "is-main": false,
   "native-stub": [ "logging_io.c" ],
+  link: {
+    "native": { "stub-cc-flags": "${build.PROTON_DEPLOYMENT_TARGET_CC_FLAGS}" },
+  },
   targets: { "logging.mbt": [ "native" ], "logging_wbtest.mbt": [ "native" ] },
 )


### PR DESCRIPTION
## Summary

- expose the macOS deployment target as a CEF-independent native-stub build variable
- apply that variable to the Proton logging I/O stub
- keep CEF include paths and API definitions out of the logging package

## Problem

The application links for macOS 12, but `proton/internal/logging/logging_io.o` was still compiled with the host SDK default and recorded `minos 26.0`. The existing deployment flag was only consumed by the CEF C, Objective-C, and loader packages; the independent logging native stub was omitted.

This was reproducible after forcing the object to rebuild, so it was not stale build output.

## Validation

- rebuilt `examples/01_run` for the native target
- verified `logging_io.o` with `otool -l`: `minos 12.0`, SDK 26.5
- confirmed the linker no longer warns about `logging_io.o`
- `moon -C proton test internal/logging --target native --diagnostic-limit 40`
- `moon fmt --check`
- `git diff --check`

Warnings for native objects owned by MoonBit runtime, `moonbitlang/async`, and `moonbitlang/x` remain outside this Proton-local fix.
