### PR TITLE
fix(native): complete macOS window close teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,14 @@ jobs:
               --diagnostic-limit 200 -- --self-hosted
           fi
 
+      - name: Run macOS windowed close e2e
+        if: ${{ matrix.os == 'macos-latest' }}
+        timeout-minutes: 5
+        env:
+          PROTON_BRIDGE_E2E_TIMEOUT_MS: 60000
+          MOON_CC: cc
+        run: moon -C e2e run test --target native --diagnostic-limit 200 -- --windowed-close
+
       - name: List Unix example binaries
         if: ${{ matrix.os != 'windows-latest' }}
         run: find ./_build -type f -perm -111 | xargs ls -lh

--- a/e2e/test/main.mbt
+++ b/e2e/test/main.mbt
@@ -4,6 +4,11 @@ async fn main {
     run_scenario_app_child()
     return
   }
+  if @env.args().contains("--windowed-close") {
+    run_windowed_close_probe(repository_root(), timeout_ms())
+    println("Windowed-close Proton E2E passed")
+    return
+  }
   if @env.args().contains("--self-hosted") {
     run_self_hosted_scenarios()
     println("Self-hosted Proton E2E passed")

--- a/e2e/test/scenario_app.mbt
+++ b/e2e/test/scenario_app.mbt
@@ -10,6 +10,7 @@ async fn run_scenario_app_child() -> Unit {
     Some("45_bridge_multi_window") => @e2e_fixtures.run_multi_window()
     Some("52_web_contents_view") => @e2e_fixtures.run_web_contents_view()
     Some("54_devtools") => @e2e_fixtures.run_devtools()
+    Some("windowed_close") => @e2e_fixtures.run_windowed_close()
     Some("56_i18n") => @e2e_fixtures.run_i18n()
     Some("46_asset_sidecar_resources") => @e2e_fixtures.run_asset_sidecar()
     Some("42_attribute_codegen_commands") =>

--- a/e2e/test/windowed_close_scenario.mbt
+++ b/e2e/test/windowed_close_scenario.mbt
@@ -1,0 +1,45 @@
+///|
+async fn spawn_windowed_close_probe(
+  group : @async.TaskGroup[Unit],
+  root : String,
+  output_root : String,
+  cdp_port : Int,
+) -> SpawnedScenarioApp {
+  let (program, args) = scenario_app_command()
+  let output_path = join_path(output_root, "windowed-close.log")
+  let output = @process.redirect_to_file(
+    output_path,
+    create_mode=@fs.CreateOrTruncate,
+  )
+  let env = app_process_env(root, output_root, "windowed_close", cdp_port)
+  env["PROTON_HEADLESS"] = "0"
+  let process = @process.spawn(
+    group,
+    program,
+    args,
+    cwd=root,
+    extra_env=env,
+    stdout=output,
+    stderr=output,
+    cancel_handler=app_cancel_handler(),
+    no_wait=true,
+  )
+  SpawnedScenarioApp::{ process, output_path, }
+}
+
+///|
+async fn run_windowed_close_probe(root : String, timeout : Int) -> Unit {
+  let output_root = @fs.tmpdir(prefix="proton-e2e-windowed-close-")
+  defer remove_dev_extension_tree(output_root)
+  install_scenario_helper(root, output_root)
+  run_e2e_operation_with_timeout(timeout + 2000, "windowed browser close", () => {
+    let port = choose_cdp_port()
+    @async.with_task_group(group => {
+      let app = spawn_windowed_close_probe(group, root, output_root, port)
+      let mut stopped = false
+      defer (if !stopped { app.process.cancel() })
+      wait_for_app_exit(app, timeout)
+      stopped = true
+    })
+  })
+}

--- a/examples/e2e_fixtures/scenarios.mbt
+++ b/examples/e2e_fixtures/scenarios.mbt
@@ -390,6 +390,51 @@ pub async fn run_devtools() -> Unit {
 }
 
 ///|
+pub async fn run_windowed_close() -> Unit {
+  @proton.html(
+    "Proton Windowed Close",
+    "<h1>Windowed close lifecycle</h1>",
+    width=640,
+    height=480,
+  )
+  .window_lifecycle(
+    on_ready=context => {
+      let handle = context.handle()
+      ignore(
+        context
+        .task_group()
+        .spawn(
+          () => {
+            let mut attempts = 0
+            while !handle.is_visible() && attempts < 100 {
+              @async.sleep(10)
+              attempts = attempts + 1
+            }
+            guard handle.is_visible() else {
+              abort("window did not become visible before close")
+            }
+            handle.focus()
+            attempts = 0
+            while !handle.is_focused() && attempts < 100 {
+              @async.sleep(10)
+              attempts = attempts + 1
+            }
+            guard handle.is_focused() else {
+              abort("window did not become focused before close")
+            }
+            handle.close()
+          },
+          no_wait=true,
+        ),
+      )
+    },
+    on_close=fn(_) { () },
+  )
+  .identifier("dev.proton.e2e-fixtures")
+  .run_or_abort()
+}
+
+///|
 let i18n_resource : String =
   #|<!doctype html>
   #|<html><head><meta charset="utf-8"><title>Proton I18n E2E</title></head>

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -442,18 +442,21 @@ static void proton_engine_window_commit_appkit_close(
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
 
   // A windowed CEF browser completes close only after CefBrowserHostView is
-  // destroyed. Detach and release the host view explicitly so its dealloc can
-  // deliver WindowDestroyed; replacing the parent content view alone leaves
-  // the browser partially closed.
+  // destroyed. AppKit may still route responder and hierarchy callbacks to
+  // the browser view during windowWillClose, so detach it from both before
+  // dropping the retain that lets its dealloc deliver WindowDestroyed.
+  [native_window makeFirstResponder:nil];
   if (browser_view != nil) {
     [browser_view removeFromSuperview];
-    [browser_view release];
   }
   window->browser_view = nil;
   [native_window setDelegate:nil];
   NSView *empty_content_view = [[NSView alloc] initWithFrame:NSZeroRect];
   [native_window setContentView:empty_content_view];
   [empty_content_view release];
+  if (browser_view != nil) {
+    [browser_view release];
+  }
   [native_window autorelease];
 }
 
@@ -627,9 +630,6 @@ static void proton_engine_window_update_zoom_button(
     proton_browser_lifecycle_request_close(window->browser_lifecycle, 0);
   }
   host->base.release((cef_base_ref_counted_t *)host);
-  if (allow_close) {
-    proton_engine_window_commit_appkit_close(window, native_window);
-  }
   proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
   return allow_close ? YES : NO;
 }


### PR DESCRIPTION
## Summary

- defer macOS browser view teardown until `windowWillClose`
- detach the active responder and view hierarchy before releasing `CefBrowserHostView`
- add a focused macOS windowed-close regression that waits for a visible, focused window and runs once in CI

## Why

Closing a visible macOS window could leave the CEF browser partially closed. `OnBeforeClose` never arrived, `app.run()` did not return, and the external message pump spun at high CPU.

## Validation

- `moon fmt --check`
- `node scripts/verify_generated.mjs`
- `moon -C e2e build --target native --diagnostic-limit 200`
- `moon -C proton check --target native --diagnostic-limit 80`
- `MBT_PROTON_E2E_TIMEOUT_MS=10000 moon -C e2e run test --target native --diagnostic-limit 200 -- --windowed-close` (one local GUI run)