### PR TITLE
feat(a11y): integrate CEF accessibility state

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ bounds, visibility, z-order, navigation, DevTools, and lifecycle events. See
 Native application menus and native context menus are available on macOS,
 Windows, and Linux.
 
+Web accessibility uses Chromium's native accessibility tree. Applications
+should express semantics with HTML, ARIA, keyboard navigation, and visible
+focus. Proton follows each platform's accessibility policy by default; use
+`.accessibility(@proton.AccessibilityMode::AlwaysEnabled)` when the tree must
+remain available for the whole runtime, including automation.
+
 Titlebar overlay uses `TitlebarStyle::Overlay` and is implemented on macOS and
 Windows. Interactive controls inside a draggable region must use
 `-webkit-app-region: no-drag`. See `examples/48_titlebar_overlay`.

--- a/proton/README.md
+++ b/proton/README.md
@@ -169,6 +169,28 @@ Native dialogs, menus, title bars, and other window-bound UI are unavailable in
 headless mode. In particular, open, save, and directory dialogs fail with an
 unsupported-operation error instead of displaying unparented system UI.
 
+## Accessibility
+
+Proton uses Chromium's accessibility tree for web content. Use semantic HTML,
+ARIA, keyboard navigation, and visible focus in the renderer; Proton does not
+maintain a second backend-owned node tree. Native menus, dialogs, and window
+controls use their platform toolkit's accessibility implementation.
+
+Accessibility is automatic by default. macOS follows VoiceOver, Switch Control,
+and accessibility clients that request an enhanced user interface. Windows
+enables accessibility when a screen reader is reported or an accessibility
+client queries the window. Linux keeps the tree enabled because GTK 3 has no
+reliable process-local activity signal. Headless mode also keeps the tree
+enabled for automation. To keep it enabled unconditionally in a windowed
+application, configure the app before startup:
+
+```moonbit
+@proton.html("Accessible", "<main><h1>Hello</h1></main>")
+.identifier("dev.proton.accessible")
+.accessibility(@proton.AccessibilityMode::AlwaysEnabled)
+.run_or_abort()
+```
+
 ## Application locale
 
 `App::locale` selects an immutable application locale before native runtime

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -130,6 +130,16 @@ pub fn App::headless(self : App, enabled? : Bool = true) -> App {
 }
 
 ///|
+/// Controls when Proton enables Chromium's accessibility tree.
+///
+/// `Automatic` follows assistive-technology activity where the platform can
+/// report it. `AlwaysEnabled` keeps the tree available for the whole runtime.
+pub fn App::accessibility(self : App, mode : AccessibilityMode) -> App {
+  self.accessibility_mode_value = mode
+  self
+}
+
+///|
 /// Selects the immutable locale used by this application runtime.
 pub fn App::locale(self : App, locale : @locale.Locale) -> App {
   self.explicit_locale = Some(locale)

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -13,6 +13,7 @@ fn App::App(
     windows: [],
     debug_level_value: debug,
     headless_value: false,
+    accessibility_mode_value: AccessibilityMode::Automatic,
     application_identity: None,
     single_instance_enabled: false,
     explicit_locale: None,

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -56,6 +56,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     self.menu.map(menu => menu.to_native()),
     self.bridge_startup_timeout_value_ms,
     self.resolved_headless(),
+    self.accessibility_mode_value,
     locale_preferences,
     browser_data_dir?,
     application_name=resolved.application_name,
@@ -91,6 +92,16 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
   }
   @xlog.info(category="proton.runtime") <?
     { "message": "application runtime stopped" }
+}
+
+///|
+fn AccessibilityMode::to_native(
+  self : AccessibilityMode,
+) -> @native.AccessibilityMode {
+  match self {
+    Automatic => @native.AccessibilityMode::Automatic
+    AlwaysEnabled => @native.AccessibilityMode::AlwaysEnabled
+  }
 }
 
 ///|
@@ -140,6 +151,7 @@ async fn run_manifest(
   menu : @native.MenuBar?,
   bridge_startup_timeout_ms : Int,
   headless : Bool,
+  accessibility_mode : AccessibilityMode,
   locale_preferences : @locale.LocalePreferences,
   browser_data_dir? : String,
   application_name? : String = "Proton",
@@ -211,6 +223,7 @@ async fn run_manifest(
       accept_languages=locale_preferences.accept_languages(),
       remote_debugging~,
       headless~,
+      accessibility_mode=accessibility_mode.to_native(),
     ).with_framework_dialog_labels(catalog.dialog_ok, catalog.dialog_cancel),
   ) catch {
     error => raise native_run_error("create runtime", error)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -26,6 +26,19 @@ pub extend LastWindowClosedPolicy with Eq::{not_equal, equal}
 pub extend LastWindowClosedPolicy with Debug::{to_repr}
 
 ///|
+/// Controls when Proton enables the browser accessibility tree.
+pub(all) enum AccessibilityMode {
+  Automatic
+  AlwaysEnabled
+} derive(Eq, Debug)
+
+///|
+pub extend AccessibilityMode with Eq::{not_equal, equal}
+
+///|
+pub extend AccessibilityMode with Debug::{to_repr}
+
+///|
 /// High-level application facade for ordinary Proton apps.
 struct App {
   mut window : @manifest.WindowManifest
@@ -33,6 +46,7 @@ struct App {
   windows : Array[@manifest.AppWindowManifest]
   mut debug_level_value : Int
   mut headless_value : Bool
+  mut accessibility_mode_value : AccessibilityMode
   mut application_identity : ApplicationIdentitySource?
   mut single_instance_enabled : Bool
   mut explicit_locale : @locale.Locale?

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -713,6 +713,14 @@ test "headless mode defaults off and is configurable" {
 }
 
 ///|
+test "accessibility mode defaults to automatic and is configurable" {
+  let default_app = html("Accessibility", "<main>content</main>")
+  assert_eq(default_app.accessibility_mode_value, AccessibilityMode::Automatic)
+  let enabled = default_app.accessibility(AccessibilityMode::AlwaysEnabled)
+  assert_eq(enabled.accessibility_mode_value, AccessibilityMode::AlwaysEnabled)
+}
+
+///|
 async test "headless mode rejects titlebar overlay before runtime startup" {
   let manifest = @manifest.AppManifest(
     @manifest.WindowManifest(
@@ -734,6 +742,7 @@ async test "headless mode rejects titlebar overlay before runtime startup" {
     None,
     30000,
     true,
+    AccessibilityMode::Automatic,
     @locale.LocalePreferences::resolve(None, []),
   ) catch {
     ConfigurationError(InvalidSetting(name="headless", message~)) => {
@@ -763,6 +772,7 @@ async test "headless mode rejects native menus before runtime startup" {
     Some(menu.to_native()),
     30000,
     true,
+    AccessibilityMode::Automatic,
     @locale.LocalePreferences::resolve(None, []),
   ) catch {
     ConfigurationError(InvalidSetting(name="headless", message~)) => {

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -197,6 +197,7 @@ pub extern "C" fn runtime_create(
   dialog_cancel_label : Bytes,
   remote_debugging_port : Int,
   headless : Int,
+  accessibility_mode : Int,
   persist_session_cookies : Int,
   out_runtime : Ref[RuntimeHandle],
 ) -> Int = "proton_internal_runtime_create"

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -367,7 +367,7 @@ pub fn proton_window_stop_find_in_page_ffi(WindowHandle, Int) -> Int
 
 pub fn runtime_complete_resource_request(RuntimeHandle, Int64, Int, Bytes, Bytes, Int) -> Int
 
-pub fn runtime_create(Int, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, @ref.Ref[RuntimeHandle]) -> Int
+pub fn runtime_create(Int, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, Int, @ref.Ref[RuntimeHandle]) -> Int
 
 pub fn runtime_null() -> RuntimeHandle
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.c
@@ -24,6 +24,7 @@ struct proton_browser_registry {
   proton_browser_lifecycle_t *browsers;
   proton_browser_client_factory_fn client_factory;
   void *context;
+  cef_state_t accessibility_state;
   int shutting_down;
 };
 
@@ -52,6 +53,22 @@ static void proton_browser_lifecycle_close_bound_browser(
   cef_browser_host_t *host = lifecycle->browser->get_host(lifecycle->browser);
   if (host != NULL) {
     host->close_browser(host, lifecycle->force_close);
+    host->base.release((cef_base_ref_counted_t *)host);
+  }
+}
+
+static void proton_browser_lifecycle_apply_accessibility_state(
+    proton_browser_lifecycle_t *lifecycle) {
+  if (lifecycle == NULL || lifecycle->registry == NULL ||
+      lifecycle->browser == NULL || lifecycle->state != PROTON_BROWSER_LIVE) {
+    return;
+  }
+  cef_browser_host_t *host = lifecycle->browser->get_host(lifecycle->browser);
+  if (host != NULL) {
+    if (host->set_accessibility_state != NULL) {
+      host->set_accessibility_state(host,
+                                    lifecycle->registry->accessibility_state);
+    }
     host->base.release((cef_base_ref_counted_t *)host);
   }
 }
@@ -85,6 +102,18 @@ void proton_browser_registry_begin_shutdown(
     if (browser->role != PROTON_BROWSER_ROLE_DEVTOOLS) {
       proton_browser_lifecycle_request_close(browser, 1);
     }
+  }
+}
+
+void proton_browser_registry_set_accessibility_state(
+    proton_browser_registry_t *registry, cef_state_t state) {
+  if (registry == NULL || registry->accessibility_state == state) {
+    return;
+  }
+  registry->accessibility_state = state;
+  for (proton_browser_lifecycle_t *browser = registry->browsers;
+       browser != NULL; browser = browser->next) {
+    proton_browser_lifecycle_apply_accessibility_state(browser);
   }
 }
 
@@ -182,6 +211,7 @@ void proton_browser_lifecycle_adopt_created(
   lifecycle->browser_id = browser->get_identifier(browser);
   if (lifecycle->state == PROTON_BROWSER_CREATING) {
     lifecycle->state = PROTON_BROWSER_LIVE;
+    proton_browser_lifecycle_apply_accessibility_state(lifecycle);
   } else if (lifecycle->state == PROTON_BROWSER_CLOSING) {
     proton_browser_lifecycle_close_bound_browser(lifecycle);
   }
@@ -197,6 +227,7 @@ void proton_browser_lifecycle_on_after_created(
   lifecycle->browser_id = browser->get_identifier(browser);
   if (lifecycle->state == PROTON_BROWSER_CREATING) {
     lifecycle->state = PROTON_BROWSER_LIVE;
+    proton_browser_lifecycle_apply_accessibility_state(lifecycle);
   } else if (lifecycle->state == PROTON_BROWSER_CLOSING) {
     proton_browser_lifecycle_close_bound_browser(lifecycle);
   }

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_lifecycle.h
@@ -32,6 +32,8 @@ proton_browser_registry_create(proton_browser_client_factory_fn client_factory,
                                void *context);
 void proton_browser_registry_begin_shutdown(
     proton_browser_registry_t *registry);
+void proton_browser_registry_set_accessibility_state(
+    proton_browser_registry_t *registry, cef_state_t state);
 int proton_browser_registry_shutdown_ready(
     const proton_browser_registry_t *registry);
 void proton_browser_registry_destroy(proton_browser_registry_t *registry);

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_runtime.c
@@ -753,6 +753,10 @@ int32_t proton_engine_runtime_create(
                               "failed to allocate browser registry");
     return PROTON_ERR_ENGINE;
   }
+  /* GTK 3 has no reliable process-local assistive-technology activity signal.
+     Keep the tree available rather than silently making the app inaccessible. */
+  proton_browser_registry_set_accessibility_state(runtime->browsers,
+                                                  STATE_ENABLED);
   snprintf(runtime->dialog_ok_label, sizeof(runtime->dialog_ok_label), "%s",
            config.dialog_ok_label);
   snprintf(runtime->dialog_cancel_label,

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -40,6 +40,7 @@ typedef struct proton_engine_client proton_engine_client_t;
 struct proton_engine_runtime {
   int owns_cef_runtime;
   int headless;
+  int accessibility_mode;
   /* Set once by the first asset document and never changed, so every window
      in a runtime resolves application resources against the same root. */
   int64_t next_bridge_request_id;
@@ -53,6 +54,9 @@ struct proton_engine_runtime {
   proton_menu_bar_t *menu_definition;
   proton_browser_registry_t *browsers;
 };
+
+void proton_engine_runtime_accessibility_requested(
+    proton_engine_runtime_t *runtime);
 
 struct proton_engine_window {
   HWND hwnd;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_runtime.c
@@ -524,6 +524,7 @@ int32_t proton_engine_runtime_create(
   }
   runtime->owns_cef_runtime = 1;
   runtime->headless = config.headless;
+  runtime->accessibility_mode = config.accessibility_mode;
   runtime->next_bridge_request_id = 1;
   runtime->browsers = proton_browser_registry_create(
       proton_engine_browser_client_factory, runtime);
@@ -536,6 +537,16 @@ int32_t proton_engine_runtime_create(
                               "failed to allocate browser registry");
     return PROTON_ERR_ENGINE;
   }
+  BOOL screen_reader = FALSE;
+  cef_state_t accessibility_state = STATE_DISABLED;
+  if (runtime->accessibility_mode == PROTON_ACCESSIBILITY_ALWAYS_ENABLED ||
+      runtime->headless ||
+      (SystemParametersInfoW(SPI_GETSCREENREADER, 0, &screen_reader, 0) &&
+       screen_reader)) {
+    accessibility_state = STATE_ENABLED;
+  }
+  proton_browser_registry_set_accessibility_state(runtime->browsers,
+                                                  accessibility_state);
   snprintf(runtime->dialog_ok_label, sizeof(runtime->dialog_ok_label), "%s",
            config.dialog_ok_label);
   snprintf(runtime->dialog_cancel_label,
@@ -560,6 +571,15 @@ static void proton_engine_dispose_runtime_state(
   proton_menu_bar_destroy(runtime->menu_definition);
   proton_browser_registry_destroy(runtime->browsers);
   free(runtime);
+}
+
+void proton_engine_runtime_accessibility_requested(
+    proton_engine_runtime_t *runtime) {
+  if (runtime != NULL &&
+      runtime->accessibility_mode == PROTON_ACCESSIBILITY_AUTOMATIC) {
+    proton_browser_registry_set_accessibility_state(runtime->browsers,
+                                                    STATE_ENABLED);
+  }
 }
 
 int32_t proton_engine_runtime_destroy_ready(proton_engine_runtime_t *runtime) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -180,6 +180,11 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
     }
     break;
   }
+  case WM_GETOBJECT:
+    if (window != NULL && (LONG)lparam == OBJID_CLIENT) {
+      proton_engine_runtime_accessibility_requested(window->runtime);
+    }
+    break;
   case WM_NCCALCSIZE:
     if (window != NULL && window->titlebar_overlay && wparam == TRUE) {
       NCCALCSIZE_PARAMS *params = (NCCALCSIZE_PARAMS *)lparam;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -178,6 +178,7 @@ int32_t proton_internal_execute_process(
       use_bundled, runtime_root, helper_path, resources_dir, locales_dir,
       cache_dir, locale, accept_languages, dialog_ok_label,
       dialog_cancel_label, remote_debugging_port, headless,
+      PROTON_ACCESSIBILITY_AUTOMATIC,
       persist_session_cookies, &config);
   if (status != PROTON_OK) {
     return status;
@@ -198,6 +199,7 @@ int32_t proton_internal_runtime_create(
     const char *locale, const char *accept_languages,
     const char *dialog_ok_label, const char *dialog_cancel_label,
     int32_t remote_debugging_port, int32_t headless,
+    int32_t accessibility_mode,
     int32_t persist_session_cookies, proton_runtime_handle_t *out_runtime) {
   if (out_runtime == NULL) {
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
@@ -209,6 +211,7 @@ int32_t proton_internal_runtime_create(
       use_bundled, runtime_root, helper_path, resources_dir, locales_dir,
       cache_dir, locale, accept_languages, dialog_ok_label,
       dialog_cancel_label, remote_debugging_port, headless,
+      accessibility_mode,
       persist_session_cookies, &config);
   if (status != PROTON_OK) {
     return status;

--- a/proton/internal/native/ffi/src/proton_config.c
+++ b/proton/internal/native/ffi/src/proton_config.c
@@ -495,6 +495,7 @@ int32_t proton_config_prepare_runtime(
     const char *locale, const char *accept_languages,
     const char *dialog_ok_label, const char *dialog_cancel_label,
     int32_t remote_debugging_port, int32_t headless,
+    int32_t accessibility_mode,
     int32_t persist_session_cookies,
     proton_engine_runtime_config_t *out_config) {
   if (out_config == NULL) {
@@ -508,6 +509,11 @@ int32_t proton_config_prepare_runtime(
         PROTON_ERR_INVALID_ARGUMENT,
         "runtime remote debugging must be disabled, ephemeral, or use a port "
         "between 1024 and 65535");
+  }
+  if (accessibility_mode != PROTON_ACCESSIBILITY_AUTOMATIC &&
+      accessibility_mode != PROTON_ACCESSIBILITY_ALWAYS_ENABLED) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "invalid accessibility mode");
   }
   if (cache_dir != NULL && cache_dir[0] != '\0' &&
       !proton_path_is_absolute(cache_dir)) {
@@ -597,6 +603,7 @@ int32_t proton_config_prepare_runtime(
   }
   config.remote_debugging_port = remote_debugging_port;
   config.headless = headless != 0;
+  config.accessibility_mode = accessibility_mode;
   config.persist_session_cookies =
       config.cache_dir[0] != '\0' && persist_session_cookies != 0;
   *out_config = config;

--- a/proton/internal/native/ffi/src/proton_config.h
+++ b/proton/internal/native/ffi/src/proton_config.h
@@ -14,6 +14,7 @@ PROTON_INTERNAL int32_t proton_config_prepare_runtime(
     const char *locale, const char *accept_languages,
     const char *dialog_ok_label, const char *dialog_cancel_label,
     int32_t remote_debugging_port, int32_t headless,
+    int32_t accessibility_mode,
     int32_t persist_session_cookies,
     proton_engine_runtime_config_t *out_config);
 PROTON_INTERNAL int32_t proton_config_probe_runtime(

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -22,6 +22,11 @@ enum {
   PROTON_REMOTE_DEBUGGING_DISABLED = 0,
 };
 
+enum {
+  PROTON_ACCESSIBILITY_AUTOMATIC = 0,
+  PROTON_ACCESSIBILITY_ALWAYS_ENABLED = 1,
+};
+
 typedef struct {
   char runtime_root[PROTON_ENGINE_MAX_PATH_BYTES];
   char helper_path[PROTON_ENGINE_MAX_PATH_BYTES];
@@ -35,6 +40,7 @@ typedef struct {
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   int32_t remote_debugging_port;
   int32_t headless;
+  int32_t accessibility_mode;
   int32_t persist_session_cookies;
 } proton_engine_runtime_config_t;
 

--- a/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_support.mbt
+++ b/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_support.mbt
@@ -1,0 +1,8 @@
+///|
+extern "C" fn browser_accessibility_lifecycle_trace_ffi() -> Bytes = "proton_test_browser_accessibility_lifecycle_trace"
+
+///|
+pub fn browser_accessibility_lifecycle_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(browser_accessibility_lifecycle_trace_ffi())
+}

--- a/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_test.c
+++ b/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_test.c
@@ -1,0 +1,100 @@
+#include "../../src/engine/cef_common/browser_lifecycle.h"
+
+#include "moonbit.h"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+  cef_browser_host_t host;
+  int accessibility_calls;
+  cef_state_t accessibility_state;
+} proton_test_browser_host_t;
+
+typedef struct {
+  cef_browser_t browser;
+  proton_test_browser_host_t host;
+  int identifier;
+} proton_test_browser_t;
+
+static void CEF_CALLBACK proton_test_add_ref(cef_base_ref_counted_t *base) {
+  (void)base;
+}
+
+static int CEF_CALLBACK proton_test_release(cef_base_ref_counted_t *base) {
+  (void)base;
+  return 0;
+}
+
+static int CEF_CALLBACK proton_test_browser_identifier(cef_browser_t *self) {
+  return ((proton_test_browser_t *)self)->identifier;
+}
+
+static cef_browser_host_t *CEF_CALLBACK
+proton_test_browser_get_host(cef_browser_t *self) {
+  proton_test_browser_host_t *host = &((proton_test_browser_t *)self)->host;
+  return &host->host;
+}
+
+static void CEF_CALLBACK proton_test_set_accessibility_state(
+    cef_browser_host_t *self, cef_state_t state) {
+  proton_test_browser_host_t *host = (proton_test_browser_host_t *)self;
+  host->accessibility_calls++;
+  host->accessibility_state = state;
+}
+
+static void proton_test_browser_init(proton_test_browser_t *browser,
+                                     int identifier) {
+  memset(browser, 0, sizeof(*browser));
+  browser->browser.base.size = sizeof(browser->browser);
+  browser->browser.base.add_ref = proton_test_add_ref;
+  browser->browser.base.release = proton_test_release;
+  browser->browser.get_identifier = proton_test_browser_identifier;
+  browser->browser.get_host = proton_test_browser_get_host;
+  browser->host.host.base.size = sizeof(browser->host.host);
+  browser->host.host.base.add_ref = proton_test_add_ref;
+  browser->host.host.base.release = proton_test_release;
+  browser->host.host.set_accessibility_state =
+      proton_test_set_accessibility_state;
+  browser->identifier = identifier;
+}
+
+static moonbit_bytes_t proton_test_copy_trace(const char *trace) {
+  size_t length = strlen(trace);
+  moonbit_bytes_t result = moonbit_make_bytes((int32_t)length, 0);
+  memcpy(result, trace, length);
+  return result;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t
+proton_test_browser_accessibility_lifecycle_trace(void) {
+  proton_test_browser_t first;
+  proton_test_browser_t second;
+  proton_test_browser_init(&first, 1);
+  proton_test_browser_init(&second, 2);
+
+  proton_browser_registry_t *registry =
+      proton_browser_registry_create(NULL, NULL);
+  proton_browser_registry_set_accessibility_state(registry, STATE_ENABLED);
+  proton_browser_lifecycle_t *first_lifecycle =
+      proton_browser_lifecycle_create(registry, PROTON_BROWSER_ROLE_MAIN, NULL,
+                                      NULL);
+  proton_browser_lifecycle_on_after_created(first_lifecycle, &first.browser);
+  int first_initial_calls = first.host.accessibility_calls;
+  cef_state_t first_initial_state = first.host.accessibility_state;
+
+  proton_browser_registry_set_accessibility_state(registry, STATE_DISABLED);
+  proton_browser_lifecycle_t *second_lifecycle =
+      proton_browser_lifecycle_create(registry, PROTON_BROWSER_ROLE_VIEW, NULL,
+                                      NULL);
+  proton_browser_lifecycle_on_after_created(second_lifecycle, &second.browser);
+
+  char trace[192];
+  snprintf(trace, sizeof(trace),
+           "first_initial=%d:%d,first_updated=%d:%d,second_initial=%d:%d",
+           first_initial_calls, first_initial_state,
+           first.host.accessibility_calls, first.host.accessibility_state,
+           second.host.accessibility_calls, second.host.accessibility_state);
+  proton_browser_registry_destroy(registry);
+  return proton_test_copy_trace(trace);
+}

--- a/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/browser_lifecycle/browser_lifecycle_wbtest.mbt
@@ -1,0 +1,9 @@
+///|
+test "accessibility state reaches live and subsequently created browsers" {
+  inspect(
+    browser_accessibility_lifecycle_trace(),
+    content=(
+      #|first_initial=1:1,first_updated=2:2,second_initial=1:2
+    ),
+  )
+}

--- a/proton/internal/native/ffi/tests/browser_lifecycle/moon.pkg
+++ b/proton/internal/native/ffi/tests/browser_lifecycle/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "moonbit-community/proton/internal/native/ffi",
+  "moonbitlang/core/encoding/utf8",
+}
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "browser_lifecycle_test.c" ],
+  link: {
+    "native": { "stub-cc-flags": "${build.PROTON_NATIVE_STUB_CC_FLAGS}" },
+  },
+)

--- a/proton/internal/native/ffi_mac/mac_accessibility.objc.c
+++ b/proton/internal/native/ffi_mac/mac_accessibility.objc.c
@@ -1,0 +1,150 @@
+#if defined(__APPLE__)
+
+#import "mac_internal.h"
+
+#include "../ffi/src/engine/cef_common/message.h"
+
+static void *proton_voice_over_context = &proton_voice_over_context;
+static void *proton_switch_control_context = &proton_switch_control_context;
+
+@interface ProtonAccessibilityObserver : NSObject {
+@private
+  proton_engine_runtime_t *runtime_;
+}
+
+- (instancetype)initWithRuntime:(proton_engine_runtime_t *)runtime;
+- (void)invalidate;
+- (void)refresh;
+- (void)scheduleRefresh;
+@end
+
+// Main-thread only. Foreign accessibility callbacks dispatch before reading it.
+static ProtonAccessibilityObserver *g_accessibility_observer = nil;
+static NSUInteger g_enhanced_user_interface_requests = 0;
+
+@implementation ProtonAccessibilityObserver
+
+- (instancetype)initWithRuntime:(proton_engine_runtime_t *)runtime {
+  self = [super init];
+  if (self != nil) {
+    runtime_ = runtime;
+    NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+    [workspace addObserver:self
+                forKeyPath:@"voiceOverEnabled"
+                   options:0
+                   context:proton_voice_over_context];
+    [workspace addObserver:self
+                forKeyPath:@"switchControlEnabled"
+                   options:0
+                   context:proton_switch_control_context];
+  }
+  return self;
+}
+
+- (void)refresh {
+  proton_engine_runtime_t *runtime = runtime_;
+  if (runtime == NULL || runtime->browsers == NULL) {
+    return;
+  }
+  NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+  BOOL active = runtime->headless || [workspace isVoiceOverEnabled] ||
+                [workspace isSwitchControlEnabled] ||
+                g_enhanced_user_interface_requests > 0;
+  proton_browser_registry_set_accessibility_state(
+      runtime->browsers, active ? STATE_ENABLED : STATE_DISABLED);
+}
+
+- (void)scheduleRefresh {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self refresh];
+  });
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context {
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  if (context == proton_voice_over_context ||
+      context == proton_switch_control_context) {
+    [self scheduleRefresh];
+    return;
+  }
+  [super observeValueForKeyPath:keyPath
+                       ofObject:object
+                         change:change
+                        context:context];
+}
+
+- (void)invalidate {
+  if (runtime_ == NULL) {
+    return;
+  }
+  NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+  [workspace removeObserver:self
+                 forKeyPath:@"voiceOverEnabled"
+                    context:proton_voice_over_context];
+  [workspace removeObserver:self
+                 forKeyPath:@"switchControlEnabled"
+                    context:proton_switch_control_context];
+  runtime_ = NULL;
+}
+
+@end
+
+void proton_engine_accessibility_set_enhanced_user_interface(int enabled) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (enabled) {
+      g_enhanced_user_interface_requests++;
+    } else if (g_enhanced_user_interface_requests > 0) {
+      g_enhanced_user_interface_requests--;
+    }
+    [g_accessibility_observer refresh];
+  });
+  proton_engine_signal_wait_source(PROTON_WAIT_PLATFORM);
+}
+
+void proton_engine_runtime_stop_accessibility(
+    proton_engine_runtime_t *runtime) {
+  if (runtime == NULL || runtime->accessibility_observer == nil) {
+    return;
+  }
+  ProtonAccessibilityObserver *observer =
+      (ProtonAccessibilityObserver *)runtime->accessibility_observer;
+  if (g_accessibility_observer == observer) {
+    g_accessibility_observer = nil;
+  }
+  [observer invalidate];
+  [observer release];
+  runtime->accessibility_observer = nil;
+}
+
+int32_t proton_engine_runtime_start_accessibility(
+    proton_engine_runtime_t *runtime, int32_t mode, char *error,
+    size_t error_len) {
+  if (runtime == NULL) {
+    proton_engine_set_message(error, error_len, "runtime is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  if (mode == PROTON_ACCESSIBILITY_ALWAYS_ENABLED || runtime->headless) {
+    proton_browser_registry_set_accessibility_state(runtime->browsers,
+                                                    STATE_ENABLED);
+    return PROTON_OK;
+  }
+  ProtonAccessibilityObserver *observer =
+      [[ProtonAccessibilityObserver alloc] initWithRuntime:runtime];
+  if (observer == nil) {
+    proton_engine_set_message(error, error_len,
+                              "failed to observe accessibility state");
+    return PROTON_ERR_PLATFORM;
+  }
+  runtime->accessibility_observer = observer;
+  g_accessibility_observer = observer;
+  [observer refresh];
+  return PROTON_OK;
+}
+
+#endif

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -120,11 +120,18 @@ typedef struct {
 struct proton_engine_runtime {
   int owns_cef_runtime;
   int headless;
+  id accessibility_observer;
   int64_t next_bridge_request_id;
   char dialog_ok_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char dialog_cancel_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   proton_browser_registry_t *browsers;
 };
+
+int32_t proton_engine_runtime_start_accessibility(
+    proton_engine_runtime_t *runtime, int32_t mode, char *error,
+    size_t error_len);
+void proton_engine_runtime_stop_accessibility(proton_engine_runtime_t *runtime);
+void proton_engine_accessibility_set_enhanced_user_interface(int enabled);
 
 struct proton_engine_window {
   proton_engine_runtime_t *runtime;

--- a/proton/internal/native/ffi_mac/mac_runtime.objc.c
+++ b/proton/internal/native/ffi_mac/mac_runtime.objc.c
@@ -614,6 +614,16 @@ void CEF_CALLBACK proton_engine_osr_on_paint(
   }
   [super terminate:sender];
 }
+
+- (void)accessibilitySetValue:(id)value forAttribute:(NSString *)attribute {
+  if ([attribute isEqualToString:@"AXEnhancedUserInterface"]) {
+    proton_engine_accessibility_set_enhanced_user_interface([value boolValue]);
+  }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [super accessibilitySetValue:value forAttribute:attribute];
+#pragma clang diagnostic pop
+}
 @end
 
 static void proton_engine_ensure_appkit(void) {
@@ -850,6 +860,16 @@ int32_t proton_engine_runtime_create(
                               "failed to register proton scheme handler");
     return PROTON_ERR_ENGINE;
   }
+  int32_t accessibility_status = proton_engine_runtime_start_accessibility(
+      runtime, config.accessibility_mode, error, error_len);
+  if (accessibility_status != PROTON_OK) {
+    proton_browser_registry_destroy(runtime->browsers);
+    free(runtime);
+    proton_engine_cef_shutdown();
+    proton_engine_reset_external_message_pump();
+    g_proton_cef_runtime_active = 0;
+    return accessibility_status;
+  }
   *out_runtime = runtime;
   return PROTON_OK;
 }
@@ -862,6 +882,7 @@ int32_t proton_engine_runtime_destroy(proton_engine_runtime_t *runtime,
     return PROTON_ERR_INVALID_ARGUMENT;
   }
 
+  proton_engine_runtime_stop_accessibility(runtime);
   proton_engine_dialog_dispose_runtime(runtime);
   proton_engine_menu_clear_runtime(runtime);
   if (runtime->owns_cef_runtime) {

--- a/proton/internal/native/ffi_mac/moon.pkg
+++ b/proton/internal/native/ffi_mac/moon.pkg
@@ -3,6 +3,7 @@ supported_targets = "native"
 options(
   "is-main": false,
   "native-stub": [
+    "mac_accessibility.objc.c",
     "mac_client.objc.c",
     "mac_app_control.objc.c",
     "mac_dialog.objc.c",

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -404,6 +404,14 @@ fn runtime_config_remote_debugging(value : RemoteDebugging) -> Int {
 }
 
 ///|
+fn runtime_config_accessibility(value : AccessibilityMode) -> Int {
+  match value {
+    Automatic => 0
+    AlwaysEnabled => 1
+  }
+}
+
+///|
 fn validate_runtime_config(config : RuntimeConfig) -> Unit raise NativeError {
   match config.remote_debugging {
     Fixed(port) if port < 1024 || port > 65535 =>
@@ -483,6 +491,7 @@ pub fn Runtime::Runtime(
     runtime_config_string(config.framework_dialog_cancel_label),
     runtime_config_remote_debugging(config.remote_debugging),
     runtime_config_bool(config.headless),
+    runtime_config_accessibility(config.accessibility_mode),
     runtime_config_bool(config.persist_session_cookies),
     out_runtime,
   )

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -401,10 +401,12 @@ test "runtime config preserves typed native ABI values" {
     ],
     remote_debugging=RemoteDebugging::Ephemeral,
     headless=true,
+    accessibility_mode=AccessibilityMode::AlwaysEnabled,
   )
   assert_eq(runtime_config.helper_path, Some("cef_process.exe"))
   assert_eq(runtime_config.cache_dir, Some(cache_dir))
   assert_true(runtime_config.headless)
+  assert_eq(runtime_config.accessibility_mode, AccessibilityMode::AlwaysEnabled)
   assert_true(runtime_config.persist_session_cookies)
   assert_eq(runtime_config.locale, Some("zh-CN"))
   assert_eq(runtime_config.accept_languages, ["zh-CN", "en-US"])
@@ -416,6 +418,7 @@ test "runtime config preserves typed native ABI values" {
   assert_eq(bundled.runtime_root, None)
   assert_eq(bundled.helper_path, None)
   assert_false(bundled.headless)
+  assert_eq(bundled.accessibility_mode, AccessibilityMode::Automatic)
   assert_true(bundled.persist_session_cookies)
   assert_true(RuntimeConfig::bundled(headless=true).headless)
   assert_false(

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -101,6 +101,14 @@ pub fn NativeError::to_repr(Self) -> @debug.Repr
 pub fn NativeError::to_string(Self) -> String
 
 // Types and methods
+pub(all) enum AccessibilityMode {
+  Automatic
+  AlwaysEnabled
+} derive(Eq, @debug.Debug)
+pub fn AccessibilityMode::equal(Self, Self) -> Bool
+pub fn AccessibilityMode::not_equal(Self, Self) -> Bool
+pub fn AccessibilityMode::to_repr(Self) -> @debug.Repr
+
 pub(all) struct AppActivation {
   abi_version : Int
   urls : Array[String]
@@ -494,8 +502,8 @@ pub fn Runtime::respond_bridge_request(Self, BridgeResponse) -> Unit raise Nativ
 pub fn Runtime::set_menu(Self, MenuBar) -> Unit raise NativeError
 
 type RuntimeConfig derive(Eq, @debug.Debug)
-pub fn RuntimeConfig::RuntimeConfig(runtime_root? : String, helper_path? : String, resources_dir? : String, locales_dir? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, persist_session_cookies? : Bool) -> Self
-pub fn RuntimeConfig::bundled(helper_path? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, persist_session_cookies? : Bool) -> Self
+pub fn RuntimeConfig::RuntimeConfig(runtime_root? : String, helper_path? : String, resources_dir? : String, locales_dir? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, accessibility_mode? : AccessibilityMode, persist_session_cookies? : Bool) -> Self
+pub fn RuntimeConfig::bundled(helper_path? : String, cache_dir? : String, locale? : @locale.Locale, accept_languages? : Array[@locale.Locale], remote_debugging? : RemoteDebugging, headless? : Bool, accessibility_mode? : AccessibilityMode, persist_session_cookies? : Bool) -> Self
 pub fn RuntimeConfig::equal(Self, Self) -> Bool
 pub fn RuntimeConfig::not_equal(Self, Self) -> Bool
 pub fn RuntimeConfig::to_repr(Self) -> @debug.Repr

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -139,6 +139,18 @@ pub extend RuntimeWaitReady with Eq::{not_equal, equal}
 pub extend RuntimeWaitReady with Debug::{to_repr}
 
 ///|
+pub(all) enum AccessibilityMode {
+  Automatic = 0
+  AlwaysEnabled = 1
+} derive(Debug, Eq)
+
+///|
+pub extend AccessibilityMode with Eq::{not_equal, equal}
+
+///|
+pub extend AccessibilityMode with Debug::{to_repr}
+
+///|
 /// Inputs forwarded by a second operating-system application instance.
 pub(all) struct AppActivation {
   abi_version : Int
@@ -1409,6 +1421,7 @@ pub extend RemoteDebugging with Debug::{to_repr}
 struct RuntimeConfig {
   use_bundled : Bool
   headless : Bool
+  accessibility_mode : AccessibilityMode
   persist_session_cookies : Bool
   runtime_root : String?
   helper_path : String?
@@ -1468,11 +1481,13 @@ pub fn RuntimeConfig::RuntimeConfig(
   accept_languages? : Array[@locale.Locale] = [],
   remote_debugging? : RemoteDebugging = Disabled,
   headless? : Bool = false,
+  accessibility_mode? : AccessibilityMode = Automatic,
   persist_session_cookies? : Bool = true,
 ) -> RuntimeConfig {
   {
     use_bundled: false,
     headless,
+    accessibility_mode,
     persist_session_cookies,
     runtime_root,
     helper_path,
@@ -1500,11 +1515,13 @@ pub fn RuntimeConfig::bundled(
   accept_languages? : Array[@locale.Locale] = [],
   remote_debugging? : RemoteDebugging = Disabled,
   headless? : Bool = false,
+  accessibility_mode? : AccessibilityMode = Automatic,
   persist_session_cookies? : Bool = true,
 ) -> RuntimeConfig {
   {
     use_bundled: true,
     headless,
+    accessibility_mode,
     persist_session_cookies,
     runtime_root: None,
     helper_path,
@@ -1558,6 +1575,7 @@ pub fn RuntimeConfig::with_framework_dialog_labels(
   {
     use_bundled: self.use_bundled,
     headless: self.headless,
+    accessibility_mode: self.accessibility_mode,
     persist_session_cookies: self.persist_session_cookies,
     runtime_root: self.runtime_root,
     helper_path: self.helper_path,

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -199,7 +199,16 @@ pub fn WindowSessionError::to_repr(Self) -> @debug.Repr
 pub fn WindowSessionError::to_string(Self) -> String
 
 // Types and methods
+pub(all) enum AccessibilityMode {
+  Automatic
+  AlwaysEnabled
+} derive(Eq, @debug.Debug)
+pub fn AccessibilityMode::equal(Self, Self) -> Bool
+pub fn AccessibilityMode::not_equal(Self, Self) -> Bool
+pub fn AccessibilityMode::to_repr(Self) -> @debug.Repr
+
 type App
+pub fn App::accessibility(Self, AccessibilityMode) -> Self
 pub fn App::add_window(Self, String, String, @manifest.AppEntry, width? : Int, height? : Int, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference, open_on_start? : Bool) -> Self
 pub fn[State] App::app_lifecycle(Self, on_start~ : async (ApplicationContext) -> State, on_shutdown~ : async (State) -> Unit) -> Self
 pub fn App::bridge_startup_timeout_ms(Self, Int) -> Self


### PR DESCRIPTION
## Summary

- add `App::accessibility(...)` with automatic and always-enabled policies
- pass the accessibility policy through typed runtime creation config
- synchronize CEF accessibility state across browsers that already exist and browsers created later
- observe VoiceOver, Switch Control, and enhanced accessibility requests on macOS
- react to screen-reader state and accessibility object queries on Windows
- keep accessibility enabled on the GTK/Linux route
- document the platform behavior and add focused lifecycle coverage

## Why

CEF owns the accessibility tree generated from the page DOM and ARIA. Proton still has to decide when CEF accessibility is active, update it on the runtime owner thread, and ensure every browser follows the same state. Treating this as runtime configuration and browser-lifecycle state avoids post-creation setter races and prevents newly created browsers from missing the current policy.

This PR does not add a separate AccessKit semantic tree. Custom native or self-rendered controls remain outside this scope.

## Platform behavior

- macOS: automatic mode follows VoiceOver, Switch Control, and `AXEnhancedUserInterface` requests.
- Windows: automatic mode follows `SPI_GETSCREENREADER` and `WM_GETOBJECT` accessibility queries.
- Linux: accessibility remains enabled, matching the GTK route policy.
- Headless and explicit always-enabled mode keep CEF accessibility enabled.

## Validation

- `moon fmt --check`
- `moon -C proton test internal/native --target native --diagnostic-limit 100`
- `moon -C proton test -p moonbit-community/proton --target native --diagnostic-limit 100`
- `moon -C proton test internal/native/ffi/tests/browser_lifecycle --target native --diagnostic-limit 100`

Windows and Linux behavior is implemented but has not been exercised on those hosts in this change.