### PR TITLE
fix(package): use valid ZIP staging extension on Windows

### DIFF
--- a/package/lib/windows.mbt
+++ b/package/lib/windows.mbt
@@ -108,7 +108,7 @@ async fn verify_windows_executable(path : String) -> Unit {
 
 ///|
 async fn create_windows_zip(source : String, destination : String) -> Unit {
-  let staging = destination + ".staging"
+  let staging = destination + ".staging.zip"
   remove_tree(staging)
   errdefer (remove_tree(staging) catch { _ => () })
   let script =


### PR DESCRIPTION
## Summary

- ensure the temporary destination passed to `Compress-Archive` ends in `.zip`
- preserve staging and promotion so failed archive creation cannot replace the final artifact

Fixes #240

## Validation

- `moon -C package test lib --target native --diagnostic-limit 80`
- `moon -C package check --target native --diagnostic-limit 80`
- `moon -C package fmt --check`
- `git diff --check`

The PowerShell packaging path could not be executed on the macOS development host; the Windows CI run provides the platform validation.