### PR TITLE
fix(e2e): separate CDP discovery and session timeouts

### DIFF
--- a/e2e/test/app_commands_probe.mbt
+++ b/e2e/test/app_commands_probe.mbt
@@ -539,8 +539,8 @@ async fn[X] connect_page_matching_expression(
   description : String,
   timeout : Int,
 ) -> @page.Page {
-  let mut elapsed = 0
-  while elapsed <= timeout {
+  let deadline = @async.now() + timeout.to_int64()
+  while @async.now() <= deadline {
     let targets = discover_targets_for_poll(cdp_target_from(target))
     for info in targets {
       if info.target_type == "page" &&
@@ -548,24 +548,25 @@ async fn[X] connect_page_matching_expression(
           page_url_matches(info.url, url) ||
           (allow_prefix && info.url.has_prefix(url))
         ) {
-        let page = Some(
-          @page.Page::connect(
-            tasks,
-            cdp_target_from(target),
-            target_id=info.target_id,
-            timeout_ms=cdp_start_poll_timeout_ms,
-          ),
-        ) catch {
-          _ => None
+        let page = match info.web_socket_debugger_url {
+          Some(web_socket_url) =>
+            Some(
+              @page.Page::connect_web_socket(
+                tasks,
+                web_socket_url,
+                timeout_ms=timeout,
+              ),
+            ) catch {
+              _ => None
+            }
+          None => None
         }
         match page {
           Some(page) => {
             let ready = Some(
-              run_e2e_operation_with_timeout(
-                cdp_start_poll_timeout_ms,
-                description,
-                () => evaluate_bool(page, expression, false),
-              ),
+              run_e2e_operation_with_timeout(timeout, description, () => {
+                evaluate_bool(page, expression, false)
+              }),
             ) catch {
               _ => None
             }
@@ -579,7 +580,6 @@ async fn[X] connect_page_matching_expression(
       }
     }
     @async.sleep(100)
-    elapsed = elapsed + 100
   }
   fail("timed out waiting for " + description)
 }

--- a/e2e/test/devtools_scenario.mbt
+++ b/e2e/test/devtools_scenario.mbt
@@ -78,8 +78,8 @@ async fn wait_for_devtools_targets(
     match (host, devtools) {
       (Some(host), Some(devtools)) => return (host, devtools)
       _ => {
-        @async.sleep(cdp_start_poll_timeout_ms)
-        elapsed = elapsed + cdp_start_poll_timeout_ms
+        @async.sleep(cdp_discovery_poll_timeout_ms)
+        elapsed = elapsed + cdp_discovery_poll_timeout_ms
       }
     }
   }

--- a/e2e/test/env.mbt
+++ b/e2e/test/env.mbt
@@ -7,13 +7,13 @@ fn env_or(name : String, default : String) -> String {
 }
 
 ///|
-let cdp_start_poll_timeout_ms = 250
+let cdp_discovery_poll_timeout_ms = 250
 
 ///|
 async fn discover_targets_for_poll(
   target : @client.CdpTarget,
 ) -> Array[@client.CdpDiscoveredTarget] {
-  let result = @async.with_timeout_opt(cdp_start_poll_timeout_ms, () => {
+  let result = @async.with_timeout_opt(cdp_discovery_poll_timeout_ms, () => {
     @client.discover_targets(target)
   }) catch {
     _ => None

--- a/e2e/test/orchestration.mbt
+++ b/e2e/test/orchestration.mbt
@@ -383,12 +383,12 @@ async fn wait_for_spawned_app_cdp(
     }
     let browser_web_socket_url = Some(
       run_e2e_operation_with_timeout(
-        cdp_start_poll_timeout_ms,
+        cdp_discovery_poll_timeout_ms,
         "CDP browser endpoint probe",
         () => {
           @client.wait_for_browser_endpoint(
             endpoint,
-            timeout_ms=cdp_start_poll_timeout_ms,
+            timeout_ms=cdp_discovery_poll_timeout_ms,
           )
         },
       ),
@@ -406,7 +406,7 @@ async fn wait_for_spawned_app_cdp(
         @async.sleep(100)
         elapsed = elapsed + 100
       }
-      None => elapsed = elapsed + cdp_start_poll_timeout_ms
+      None => elapsed = elapsed + cdp_discovery_poll_timeout_ms
     }
   }
   if browser_ready {
@@ -512,8 +512,8 @@ async fn wait_for_page_target_closed(
     if !targets.any(info => info.target_id == target_id) {
       return
     }
-    @async.sleep(cdp_start_poll_timeout_ms)
-    elapsed = elapsed + cdp_start_poll_timeout_ms
+    @async.sleep(cdp_discovery_poll_timeout_ms)
+    elapsed = elapsed + cdp_discovery_poll_timeout_ms
   }
   fail(
     "CDP page target did not close within " +

--- a/e2e/test/process_lifecycle.mbt
+++ b/e2e/test/process_lifecycle.mbt
@@ -345,7 +345,7 @@ async fn wait_for_cdp_endpoint_stop(endpoint : String, timeout : Int) -> Unit {
       ignore(
         @client.wait_for_browser_endpoint(
           endpoint,
-          timeout_ms=cdp_start_poll_timeout_ms,
+          timeout_ms=cdp_discovery_poll_timeout_ms,
         ),
       )
       true
@@ -355,7 +355,7 @@ async fn wait_for_cdp_endpoint_stop(endpoint : String, timeout : Int) -> Unit {
     if !running {
       return
     }
-    elapsed = elapsed + cdp_start_poll_timeout_ms
+    elapsed = elapsed + cdp_discovery_poll_timeout_ms
   }
   fail("CDP endpoint did not stop: " + endpoint)
 }
@@ -496,46 +496,65 @@ async fn connect_spawned_page(
   timeout : Int,
   title? : String,
 ) -> @page.Page {
-  let mut elapsed = 0
-  while elapsed <= timeout {
+  let deadline = @async.now() + timeout.to_int64()
+  let mut last_error : String? = None
+  while @async.now() <= deadline {
     match app_exit_code(app.process) {
       Some(code) =>
         fail(
-          "scenario app exited before a page target was ready: code=" +
+          "scenario app exited before the page connection: code=" +
           code.to_string() +
-          app_output_suffix(app.output_path),
+          app_diagnostic_suffix(app),
         )
       None => ()
     }
-    let page = Some(
-      run_e2e_operation_with_timeout(
-        cdp_start_poll_timeout_ms,
-        "CDP page connection probe",
-        () => {
-          @page.Page::connect(
-            tasks,
-            cdp_target_from(target),
-            title?,
-            timeout_ms=cdp_start_poll_timeout_ms,
-          )
-        },
-      ),
-    ) catch {
-      _ => None
-    }
-    match page {
-      Some(page) => return page
-      None => {
-        @async.sleep(100)
-        elapsed = elapsed + 100
+    let targets = discover_targets_for_poll(cdp_target_from(target))
+    let mut web_socket_url : String? = None
+    for info in targets {
+      if info.target_type == "page" &&
+        (title is None || title == Some(info.title)) {
+        match info.web_socket_debugger_url {
+          Some(url) => {
+            web_socket_url = Some(url)
+            break
+          }
+          None => ()
+        }
       }
     }
+    match web_socket_url {
+      Some(web_socket_url) => {
+        let page = Some(
+          @page.Page::connect_web_socket(
+            tasks,
+            web_socket_url,
+            timeout_ms=timeout,
+          ),
+        ) catch {
+          error => {
+            last_error = Some(error.to_string())
+            None
+          }
+        }
+        match page {
+          Some(page) => return page
+          None => ()
+        }
+      }
+      None => ()
+    }
+    @async.sleep(100)
+  }
+  let error_suffix = match last_error {
+    Some(error) => "\nLast CDP connection error: " + error
+    None => ""
   }
   fail(
-    "CDP page target did not become ready within " +
+    "CDP page target did not become connectable within " +
     timeout.to_string() +
     "ms" +
-    app_output_suffix(app.output_path),
+    error_suffix +
+    app_diagnostic_suffix(app),
   )
 }
 


### PR DESCRIPTION
## Summary

- reserve the short 250 ms timeout for polling CDP target discovery
- connect directly to the discovered target WebSocket to avoid a second discovery race
- give CDP session initialization the scenario timeout instead of repeatedly cancelling it after 250 ms
- preserve the last connection error in timeout diagnostics

## Root cause

The Windows E2E harness reused its 250 ms discovery polling interval as the timeout for the entire `Page::connect` sequence. That sequence includes target discovery, the WebSocket handshake, and CDP initialization commands. A valid initialization taking longer than 250 ms was cancelled and silently retried against a target that CEF could replace during startup. The final cancellation could then surface only as `PageLifecycleError.Closed`, incorrectly suggesting a browser shutdown lifecycle failure.

This change separates the two timing responsibilities. It fixes the E2E startup race; it does not change Proton or CEF browser lifecycle behavior.

## Validation

- `moon fmt`
- `moon info`
- `moon -C e2e run test --target native --diagnostic-limit 200 -- --self-hosted`
- deterministic diagnosis with a valid CDP response delayed beyond the former 250 ms session timeout