### PR TITLE
feat(window): align Electron window state events

### DIFF
--- a/examples/52_web_contents_view/main.mbt
+++ b/examples/52_web_contents_view/main.mbt
@@ -350,6 +350,7 @@ async fn main {
             }
           None => ()
         }
+      _ => ()
     }
   })
   .on_view_event(async fn(_view, event) noraise {

--- a/proton/README.md
+++ b/proton/README.md
@@ -152,7 +152,7 @@ on macOS and is a successful no-op on other platforms. Web contents views expose
 independent `set_zoom_percent` and `zoom_percent` controls for their own browser.
 
 Window state changes are delivered to `.on_window_event(...)` as a full
-`StateChanged` snapshot plus transition events such as `Moved`, `Resized`,
+`StateChanged` snapshot plus transition events such as `ReadyToShow`, `Moved`, `Resized`,
 `Show`, `Hide`, `Focus`, `Blur`, `Minimize`, `Restore`, `Maximize`, `Unmaximize`,
 `EnterFullScreen`, and `LeaveFullScreen`. The first native snapshot only emits
 `StateChanged`, because no previous state exists for transition detection.

--- a/proton/README.md
+++ b/proton/README.md
@@ -151,6 +151,12 @@ relationship. `set_window_button_visibility` controls standard title-bar buttons
 on macOS and is a successful no-op on other platforms. Web contents views expose
 independent `set_zoom_percent` and `zoom_percent` controls for their own browser.
 
+Window state changes are delivered to `.on_window_event(...)` as a full
+`StateChanged` snapshot plus transition events such as `Moved`, `Resized`,
+`Show`, `Hide`, `Focus`, `Blur`, `Minimize`, `Restore`, `Maximize`, `Unmaximize`,
+`EnterFullScreen`, and `LeaveFullScreen`. The first native snapshot only emits
+`StateChanged`, because no previous state exists for transition detection.
+
 ## Logging
 
 Use `tonyfettes/xlog@0.4.2` directly for application logs. Proton configures the

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1279,6 +1279,7 @@ fn RuntimeSession::create_window(
     asset_root,
     bridge_ready: !self.monitor_bridge,
     state: WindowStarting,
+    observed_state: None,
   }
   errdefer (created_window.destroy() catch {
     error =>
@@ -1714,6 +1715,24 @@ pub fn WindowHandle::bounds(
 }
 
 ///|
+/// Returns the window's `(x, y)` position in logical screen pixels.
+pub fn WindowHandle::position(
+  self : WindowHandle,
+) -> (Int, Int) raise WindowSessionError {
+  let state = (self.read_window_state)()
+  (state.x, state.y)
+}
+
+///|
+/// Returns the window's `(width, height)` frame size in logical pixels.
+pub fn WindowHandle::size(
+  self : WindowHandle,
+) -> (Int, Int) raise WindowSessionError {
+  let state = (self.read_window_state)()
+  (state.width, state.height)
+}
+
+///|
 /// Sets `(x, y, width, height)` in logical screen pixels, matching Electron's
 /// `setBounds` coordinate order.
 pub fn WindowHandle::set_bounds(
@@ -1746,6 +1765,38 @@ pub fn WindowHandle::restore(
   self : WindowHandle,
 ) -> Unit raise WindowSessionError {
   (self.restore_window)()
+}
+
+///|
+/// Reports whether the window is currently minimized.
+pub fn WindowHandle::is_minimized(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().minimized
+}
+
+///|
+/// Reports whether the window is currently maximized.
+pub fn WindowHandle::is_maximized(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().maximized
+}
+
+///|
+/// Reports whether the window is currently fullscreen.
+pub fn WindowHandle::is_fullscreen(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().fullscreen
+}
+
+///|
+/// Reports whether the window is currently kept above other windows.
+pub fn WindowHandle::is_always_on_top(
+  self : WindowHandle,
+) -> Bool raise WindowSessionError {
+  (self.read_window_state)().always_on_top
 }
 
 ///|
@@ -3025,15 +3076,18 @@ fn RuntimeSession::dispatch_window_event(
       match self.find_window_by_native_id(window_id) {
         Some(window) => {
           let handle = self.window_handle(window)
-          for handler in self.window_event_handlers {
-            ignore(
-              self.window_tasks.spawn(
-                () => {
-                  handler(handle, StateChanged(WindowState::from_native(state)))
-                },
-                no_wait=true,
-              ),
-            )
+          let current = WindowState::from_native(state)
+          let events = window_state_events(window.observed_state, current)
+          window.observed_state = Some(current)
+          for event in events {
+            for handler in self.window_event_handlers {
+              ignore(
+                self.window_tasks.spawn(
+                  () => handler(handle, event),
+                  no_wait=true,
+                ),
+              )
+            }
           }
         }
         None => ()

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -226,6 +226,7 @@ priv struct RunningWindow {
   asset_root : String?
   mut bridge_ready : Bool
   mut state : SessionWindowState
+  mut observed_state : WindowState?
 }
 
 ///|
@@ -657,6 +658,18 @@ pub struct WindowManager {
 /// An observed change to a running native window.
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  Moved
+  Resized
+  Show
+  Hide
+  Focus
+  Blur
+  Minimize
+  Restore
+  Maximize
+  Unmaximize
+  EnterFullScreen
+  LeaveFullScreen
 } derive(Debug, Eq)
 
 ///|
@@ -664,6 +677,54 @@ pub extend WindowEvent with Eq::{not_equal, equal}
 
 ///|
 pub extend WindowEvent with Debug::{to_repr}
+
+///|
+/// Derives Electron-style window transition events from two state snapshots.
+/// The full `StateChanged` snapshot is always emitted after transition events.
+fn window_state_events(
+  previous : WindowState?,
+  current : WindowState,
+) -> Array[WindowEvent] {
+  let events : Array[WindowEvent] = []
+  match previous {
+    None => ()
+    Some(previous) => {
+      if previous.x != current.x || previous.y != current.y {
+        events.push(Moved)
+      }
+      if previous.width != current.width || previous.height != current.height {
+        events.push(Resized)
+      }
+      if !previous.visible && current.visible {
+        events.push(Show)
+      } else if previous.visible && !current.visible {
+        events.push(Hide)
+      }
+      if !previous.focused && current.focused {
+        events.push(Focus)
+      } else if previous.focused && !current.focused {
+        events.push(Blur)
+      }
+      if !previous.minimized && current.minimized {
+        events.push(Minimize)
+      } else if previous.minimized && !current.minimized {
+        events.push(Restore)
+      }
+      if !previous.maximized && current.maximized {
+        events.push(Maximize)
+      } else if previous.maximized && !current.maximized {
+        events.push(Unmaximize)
+      }
+      if !previous.fullscreen && current.fullscreen {
+        events.push(EnterFullScreen)
+      } else if previous.fullscreen && !current.fullscreen {
+        events.push(LeaveFullScreen)
+      }
+    }
+  }
+  events.push(StateChanged(current))
+  events
+}
 
 ///|
 /// An observed change to a running web contents view, following Electron

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -658,6 +658,7 @@ pub struct WindowManager {
 /// An observed change to a running native window.
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  ReadyToShow
   Moved
   Resized
   Show
@@ -687,7 +688,7 @@ fn window_state_events(
 ) -> Array[WindowEvent] {
   let events : Array[WindowEvent] = []
   match previous {
-    None => ()
+    None => if current.visible { events.push(ReadyToShow) }
     Some(previous) => {
       if previous.x != current.x || previous.y != current.y {
         events.push(Moved)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -3192,6 +3192,39 @@ test "window state transitions derive Electron-style events" {
 }
 
 ///|
+test "first visible window state emits ready to show" {
+  let monitor = WindowMonitor::{
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    work_x: 0,
+    work_y: 0,
+    work_width: 1920,
+    work_height: 1080,
+    scale_factor_percent: 100,
+  }
+  let state = WindowState::{
+    x: 0,
+    y: 0,
+    width: 640,
+    height: 480,
+    monitor,
+    zoom_percent: 100,
+    visible: true,
+    focused: false,
+    minimized: false,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: WindowTheme::Light,
+  }
+  let events = window_state_events(None, state)
+  assert_eq(events[0], WindowEvent::ReadyToShow)
+  assert_eq(events[1], WindowEvent::StateChanged(state))
+}
+
+///|
 test "window state transitions derive restore after minimize" {
   let monitor = WindowMonitor::{
     x: 0,

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -3103,6 +3103,143 @@ test "window bounds read and write use Electron coordinate order" {
 }
 
 ///|
+test "window state queries expose Electron geometry and flags" {
+  let window = test_window_handle("main", 17L, window_state=WindowState::{
+    x: 120,
+    y: 80,
+    width: 800,
+    height: 600,
+    monitor: WindowMonitor::{
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+      work_x: 0,
+      work_y: 0,
+      work_width: 1920,
+      work_height: 1080,
+      scale_factor_percent: 100,
+    },
+    zoom_percent: 100,
+    visible: true,
+    focused: true,
+    minimized: true,
+    maximized: false,
+    fullscreen: true,
+    always_on_top: true,
+    theme: WindowTheme::Dark,
+  })
+  assert_eq(window.position(), (120, 80))
+  assert_eq(window.size(), (800, 600))
+  assert_true(window.is_minimized())
+  assert_false(window.is_maximized())
+  assert_true(window.is_fullscreen())
+  assert_true(window.is_always_on_top())
+}
+
+///|
+test "window state transitions derive Electron-style events" {
+  let monitor = WindowMonitor::{
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    work_x: 0,
+    work_y: 0,
+    work_width: 1920,
+    work_height: 1080,
+    scale_factor_percent: 100,
+  }
+  let previous = WindowState::{
+    x: 10,
+    y: 20,
+    width: 640,
+    height: 480,
+    monitor,
+    zoom_percent: 100,
+    visible: false,
+    focused: false,
+    minimized: false,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: WindowTheme::Light,
+  }
+  let current = WindowState::{
+    x: 30,
+    y: 20,
+    width: 800,
+    height: 480,
+    monitor,
+    zoom_percent: 100,
+    visible: true,
+    focused: true,
+    minimized: false,
+    maximized: true,
+    fullscreen: true,
+    always_on_top: false,
+    theme: WindowTheme::Light,
+  }
+  let events = window_state_events(Some(previous), current)
+  assert_eq(events.length(), 7)
+  assert_eq(events[0], WindowEvent::Moved)
+  assert_eq(events[1], WindowEvent::Resized)
+  assert_eq(events[2], WindowEvent::Show)
+  assert_eq(events[3], WindowEvent::Focus)
+  assert_eq(events[4], WindowEvent::Maximize)
+  assert_eq(events[5], WindowEvent::EnterFullScreen)
+  assert_eq(events[6], WindowEvent::StateChanged(current))
+}
+
+///|
+test "window state transitions derive restore after minimize" {
+  let monitor = WindowMonitor::{
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    work_x: 0,
+    work_y: 0,
+    work_width: 1920,
+    work_height: 1080,
+    scale_factor_percent: 100,
+  }
+  let previous = WindowState::{
+    x: 0,
+    y: 0,
+    width: 640,
+    height: 480,
+    monitor,
+    zoom_percent: 100,
+    visible: true,
+    focused: false,
+    minimized: true,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: WindowTheme::Light,
+  }
+  let current = WindowState::{
+    x: previous.x,
+    y: previous.y,
+    width: previous.width,
+    height: previous.height,
+    monitor: previous.monitor,
+    zoom_percent: previous.zoom_percent,
+    visible: previous.visible,
+    focused: previous.focused,
+    minimized: false,
+    maximized: previous.maximized,
+    fullscreen: previous.fullscreen,
+    always_on_top: previous.always_on_top,
+    theme: previous.theme,
+  }
+  let events = window_state_events(Some(previous), current)
+  assert_eq(events[0], WindowEvent::Restore)
+  assert_eq(events[1], WindowEvent::StateChanged(current))
+}
+
+///|
 test "window size limits route live constraints through the handle" {
   let minimum_calls : Array[(Int, Int)] = []
   let maximum_calls : Array[(Int, Int)] = []

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -851,6 +851,18 @@ pub fn WindowContext::windows(Self) -> WindowManager
 
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  Moved
+  Resized
+  Show
+  Hide
+  Focus
+  Blur
+  Minimize
+  Restore
+  Maximize
+  Unmaximize
+  EnterFullScreen
+  LeaveFullScreen
 } derive(Eq, @debug.Debug)
 pub fn WindowEvent::equal(Self, Self) -> Bool
 pub fn WindowEvent::not_equal(Self, Self) -> Bool
@@ -924,10 +936,15 @@ pub fn WindowHandle::flash_frame(Self, Bool) -> Unit raise WindowSessionError
 pub fn WindowHandle::focus(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::hide(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::id(Self) -> String
+pub fn WindowHandle::is_always_on_top(Self) -> Bool raise WindowSessionError
 pub fn WindowHandle::is_focused(Self) -> Bool raise WindowSessionError
+pub fn WindowHandle::is_fullscreen(Self) -> Bool raise WindowSessionError
+pub fn WindowHandle::is_maximized(Self) -> Bool raise WindowSessionError
+pub fn WindowHandle::is_minimized(Self) -> Bool raise WindowSessionError
 pub fn WindowHandle::is_visible(Self) -> Bool raise WindowSessionError
 pub fn WindowHandle::maximize(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::minimize(Self) -> Unit raise WindowSessionError
+pub fn WindowHandle::position(Self) -> (Int, Int) raise WindowSessionError
 pub fn WindowHandle::remove_view(Self, String) -> Unit raise WindowSessionError
 pub fn WindowHandle::restore(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::set_always_on_top(Self, Bool) -> Unit raise WindowSessionError
@@ -965,6 +982,7 @@ pub fn WindowHandle::set_window_button_visibility(Self, Bool) -> Unit raise Wind
 pub fn WindowHandle::set_zoom_percent(Self, Int) -> Unit raise WindowSessionError
 pub fn WindowHandle::show(Self) -> Unit raise WindowSessionError
 pub fn WindowHandle::show_inactive(Self) -> Unit raise WindowSessionError
+pub fn WindowHandle::size(Self) -> (Int, Int) raise WindowSessionError
 pub fn WindowHandle::state(Self) -> WindowState raise WindowSessionError
 pub fn WindowHandle::view(Self, String) -> ViewHandle?
 pub fn WindowHandle::views(Self) -> Array[ViewHandle]

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -851,6 +851,7 @@ pub fn WindowContext::windows(Self) -> WindowManager
 
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  ReadyToShow
   Moved
   Resized
   Show


### PR DESCRIPTION
## Summary

- expose Electron-style window geometry and state queries on `WindowHandle`
- derive window transition events from successive native `WindowState` snapshots
- add `ReadyToShow` when a window is first observed visible after bridge/lifecycle startup
- keep the full `StateChanged(WindowState)` snapshot event for consumers that need complete state

## Electron alignment

Aligned behaviors include `position`, `size`, minimized/maximized/fullscreen/always-on-top queries, and the window events `ready-to-show`, `move`, `resize`, `show`, `hide`, `focus`, `blur`, `minimize`, `restore`, `maximize`, `unmaximize`, `enter-full-screen`, and `leave-full-screen`.

`ReadyToShow` is intentionally emitted from the first visible native snapshot after Proton has completed bridge and lifecycle startup. A first hidden snapshot emits only `StateChanged`; Proton does not infer a transition without a previous native state.

## Platform impact

The implementation reuses the existing cross-platform native window state ABI and adds no platform-specific native code or new runtime feature gates. macOS was compiled and tested locally. Windows and Linux use the same shared ABI path and require desktop runtime review for event timing.

## Files and generated outputs

- public facade and event derivation: `proton/facade_types.mbt`, `proton/facade_session.mbt`
- regression tests: `proton/facade_wbtest.mbt`
- public generated interface: `proton/pkg.generated.mbti`
- example compatibility update: `examples/52_web_contents_view/main.mbt`
- API documentation: `proton/README.md`

## Validation

- `moon fmt --check`
- `moon -C proton test --target native --diagnostic-limit 80` (660/660)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon check --target native`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

Pending desktop runtime review on macOS, Windows, and Linux. Exercise move, resize, show/hide, focus/blur, minimize/restore, maximize/unmaximize, fullscreen enter/leave, and verify that `ReadyToShow` occurs once for each window after startup.
