### PR TITLE
fix(package): repair NSIS staging and support installation scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,18 +152,21 @@ jobs:
       - name: Test Windows NSIS packaging
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          $packageOutput = Join-Path $env:RUNNER_TEMP "proton-update-windows-package"
-          moon -C package run . --target native -- `
-            --executable $env:PROTON_HELPER_PATH `
-            --product-name "Updater Test" `
-            --identifier "dev.proton.updater-test" `
-            --version "1.0.0" `
-            --format nsis `
-            --output $packageOutput
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $installer = Join-Path $packageOutput "updater-test-setup.exe"
-          if (-not (Test-Path -LiteralPath $installer)) {
-            throw "NSIS updater installer was not produced: $installer"
+          foreach ($installMode in @("currentUser", "perMachine", "both")) {
+            $packageOutput = Join-Path $env:RUNNER_TEMP "proton-update-windows-package-$installMode"
+            moon -C package run . --target native -- `
+              --executable $env:PROTON_HELPER_PATH `
+              --product-name "Updater Test" `
+              --identifier "dev.proton.updater-test" `
+              --version "1.0.0" `
+              --format nsis `
+              --nsis-install-mode $installMode `
+              --output $packageOutput
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            $installer = Join-Path $packageOutput "updater-test-setup.exe"
+            if (-not (Test-Path -LiteralPath $installer)) {
+              throw "NSIS updater installer was not produced: $installer"
+            }
           }
 
       - name: Verify generated files

--- a/README.md
+++ b/README.md
@@ -240,9 +240,39 @@ directory. Backend code resolves the same files before and after packaging with
 `package.platforms.<platform>.resources`. `package.sign.binaries` names copied
 executables that must be included in platform signing, and platform-specific
 signing targets can be appended under the matching platform block. Supported
-platform keys are `macos`, `windows`, and `linux`; platform blocks accept only
-`formats`, `resources`, and `sign`. Explicit command-line options retain the
-highest priority.
+platform keys are `macos`, `windows`, and `linux`; platform blocks accept
+`formats`, `resources`, and `sign`. The Windows block also accepts
+`nsis_install_mode`. Explicit command-line options retain the highest priority.
+
+Windows NSIS installers default to `currentUser`: no administrator privileges,
+installation under `%LOCALAPPDATA%`, and registration for the current user.
+Set `package.platforms.windows.nsis_install_mode` to `perMachine` for an
+administrator-only installation under Program Files with machine-wide
+registration, or to `both` to let the installer user choose. Like Tauri, `both`
+uses NSIS MultiUser and requests the highest available privileges, so it can
+show a UAC prompt even when the user chooses a per-user installation.
+`--nsis-install-mode currentUser|perMachine|both` overrides the project setting.
+
+**Existing releases:** Proton previously always generated machine-wide NSIS
+installers. Applications already distributed that way must explicitly retain
+`perMachine` in subsequent releases to update the existing installation:
+
+```json
+{
+  "package": {
+    "platforms": {
+      "windows": {
+        "formats": ["nsis"],
+        "nsis_install_mode": "perMachine"
+      }
+    }
+  }
+}
+```
+
+This is a fragment to merge into the existing project configuration. Fixed
+installation modes do not migrate installations between user and machine
+scope. Existing installation paths are reused within the selected scope.
 
 Use `package.prepare` when the application must generate package-only resources
 or additional binaries. Proton runs this command once from the project root

--- a/cli/package/package.mbt
+++ b/cli/package/package.mbt
@@ -47,6 +47,7 @@ struct PackagePlan {
   icons : Array[String]
   url_schemes : Array[String]
   document_types : Array[@proton_config.ProjectDocumentType]
+  nsis_install_mode : @packager.NsisInstallMode
   sign : Bool
   notarize : Bool
 } derive(Debug, Eq)
@@ -263,6 +264,10 @@ async fn build_package_plan(
     Some(frontend) => frontend.dist()
     None => None
   }
+  let nsis_install_mode = resolve_nsis_install_mode(
+    raw.package_args,
+    package_config,
+  )
   PackagePlan::{
     root: backend_root,
     app_package,
@@ -290,6 +295,7 @@ async fn build_package_plan(
       package_config.url_schemes()
     },
     document_types: package_config.document_types(),
+    nsis_install_mode,
     sign: raw.package_args.sign,
     notarize: raw.package_args.notarize,
   }
@@ -329,6 +335,25 @@ fn resolve_platform_package_config(
 }
 
 ///|
+fn resolve_nsis_install_mode(
+  arguments : @package_args.PackageArguments,
+  package_config : @proton_config.ProjectPackageConfig,
+) -> @packager.NsisInstallMode raise @packager.PackagePlanError {
+  match arguments.nsis_install_mode {
+    Some(mode) => mode
+    None =>
+      match package_config.platforms().windows() {
+        Some(windows) =>
+          windows
+          .nsis_install_mode()
+          .map(@packager.NsisInstallMode::parse)
+          .unwrap_or(CurrentUser)
+        None => CurrentUser
+      }
+  }
+}
+
+///|
 fn append_unique(values : Array[String], additions : Array[String]) -> Unit {
   for value in additions {
     if !values.contains(value) {
@@ -354,6 +379,9 @@ fn print_package_plan(plan : PackagePlan, dry_run : Bool) -> Unit {
     "  formats: " + plan.formats.map(format => format.to_string()).join(", "),
   )
   println("  output: " + plan.output)
+  if plan.formats.contains(@packager.PackageFormat::Nsis) {
+    println("  NSIS install mode: " + plan.nsis_install_mode.to_string())
+  }
   println("  prepare: " + plan.prepare.unwrap_or("none"))
   let sign_binaries = if plan.sign_binaries.length() == 0 {
     "none"
@@ -400,6 +428,7 @@ async fn execute_package_plan(plan : PackagePlan) -> (Array[String], String) {
     icons=plan.icons,
     url_schemes=plan.url_schemes,
     document_types~,
+    nsis_install_mode=plan.nsis_install_mode,
     sign=plan.sign,
     notarize=plan.notarize,
   )

--- a/cli/package/package_wbtest.mbt
+++ b/cli/package/package_wbtest.mbt
@@ -4,6 +4,41 @@ fn parse_package_args(args : Array[String]) -> RawPackageOptions raise {
 }
 
 ///|
+test "NSIS mode resolves CLI override before Windows configuration and default" {
+  let defaults = @proton_config.ProjectPackageConfig("Demo", "1.0.0")
+  let arguments = parse_package_args([]).package_args
+  assert_eq(
+    resolve_nsis_install_mode(arguments, defaults),
+    @packager.NsisInstallMode::CurrentUser,
+  )
+  for
+    entry in [
+      ("currentUser", @packager.NsisInstallMode::CurrentUser),
+      ("perMachine", @packager.NsisInstallMode::PerMachine),
+      ("both", @packager.NsisInstallMode::Both),
+    ] {
+    let (name, mode) = entry
+    let configured = @proton_config.ProjectPackageConfig(
+      "Demo",
+      "1.0.0",
+      platforms=@proton_config.ProjectPackagePlatforms(
+        windows=@proton_config.ProjectPlatformPackageConfig(
+          nsis_install_mode=name,
+        ),
+      ),
+    )
+    assert_eq(resolve_nsis_install_mode(arguments, configured), mode)
+    let cli_arguments = parse_package_args([
+        "--nsis-install-mode", "currentUser",
+      ]).package_args
+    assert_eq(
+      resolve_nsis_install_mode(cli_arguments, configured),
+      @packager.NsisInstallMode::CurrentUser,
+    )
+  }
+}
+
+///|
 test "parse package args accepts repeated formats and overrides" {
   let raw = parse_package_args([
     "--package", "desktop", "--format", "app", "--format", "zip", "--format", "dmg",

--- a/cli/package/proton_bundle.mbt
+++ b/cli/package/proton_bundle.mbt
@@ -18,6 +18,7 @@ async fn package_spec(
     icons=spec.package_spec.icons,
     url_schemes=spec.package_spec.url_schemes,
     document_types=spec.package_spec.document_types,
+    nsis_install_mode=spec.package_spec.nsis_install_mode,
     sign=spec.package_spec.sign,
     notarize=spec.package_spec.notarize,
   )

--- a/cli/package/proton_bundle_wbtest.mbt
+++ b/cli/package/proton_bundle_wbtest.mbt
@@ -22,3 +22,35 @@ async test "Proton packaging rejects a missing application executable" {
     _ => fail("expected a missing executable error")
   }
 }
+
+///|
+async test "bundle assembly preserves the requested NSIS mode" {
+  for
+    mode in [
+      @packager.NsisInstallMode::CurrentUser,
+      @packager.NsisInstallMode::PerMachine,
+      @packager.NsisInstallMode::Both,
+    ] {
+    let input = @packager.PackageSpec(
+      "app",
+      "Demo",
+      "dev.proton.demo",
+      "1.0.0",
+      [@packager.PackageFormat::Nsis],
+      "dist",
+      nsis_install_mode=mode,
+    )
+    let bundle = ProtonBundleSpec::{
+      package_spec: input,
+      base_dir: ".",
+      update_revision: 0UL,
+      frontend_dist: None,
+      resources: [],
+      sign_binaries: [],
+    }
+    // Payload assembly is independent of installer scope. This host needs no
+    // CEF fixture on disk, keeping the metadata forwarding test portable.
+    let output = package_spec(bundle, "runtime", "cef_process", Macos)
+    assert_eq(output.nsis_install_mode, mode)
+  }
+}

--- a/config/config_test.mbt
+++ b/config/config_test.mbt
@@ -113,6 +113,78 @@ test "project package rejects unknown platform overrides" {
 }
 
 ///|
+test "NSIS install modes belong only to the Windows package configuration" {
+  for mode in ["currentUser", "perMachine", "both"] {
+    let config = load_project_config_from_json(
+      {
+        "identifier": "com.example.demo",
+        "package": {
+          "product_name": "Demo",
+          "version": "1.0.0",
+          "platforms": { "windows": { "nsis_install_mode": mode } },
+        },
+      },
+      ".",
+    )
+    assert_eq(
+      config
+      .package_config()
+      .unwrap()
+      .platforms()
+      .windows()
+      .unwrap()
+      .nsis_install_mode(),
+      Some(mode),
+    )
+  }
+  let invalid = expect_config_error(() => {
+    ignore(
+      load_project_config_from_json(
+        {
+          "identifier": "com.example.demo",
+          "package": {
+            "product_name": "Demo",
+            "version": "1.0.0",
+            "platforms": { "windows": { "nsis_install_mode": "admin" } },
+          },
+        },
+        ".",
+      ),
+    )
+  })
+  assert_eq(
+    invalid,
+    UnsupportedValue(
+      path="package.platforms.windows.nsis_install_mode",
+      value="admin",
+    ),
+  )
+  for platform in ["macos", "linux"] {
+    let platforms : Map[String, Json] = Map([])
+    platforms[platform] = { "nsis_install_mode": "perMachine" }
+    let invalid = expect_config_error(() => {
+      ignore(
+        load_project_config_from_json(
+          {
+            "identifier": "com.example.demo",
+            "package": {
+              "product_name": "Demo",
+              "version": "1.0.0",
+              "platforms": platforms.to_json(),
+            },
+          },
+          ".",
+        ),
+      )
+    })
+    assert_eq(
+      invalid,
+      UnknownField(path="package.platforms." + platform + ".nsis_install_mode"),
+    )
+  }
+}
+
+///|
 test "project config rejects unknown top-level fields" {
   let source =
     #|{ "identifier": "com.example.todo", "window": { "title": "Todo" } }

--- a/config/pkg.generated.mbti
+++ b/config/pkg.generated.mbti
@@ -135,11 +135,13 @@ pub(all) struct ProjectPlatformPackageConfig {
   formats : Array[String]?
   resources : Array[String]
   sign : ProjectSignConfig?
+  nsis_install_mode : String?
 } derive(Eq, @debug.Debug)
-pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(formats? : Array[String], resources? : Array[String], sign? : ProjectSignConfig) -> Self
+pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(formats? : Array[String], resources? : Array[String], sign? : ProjectSignConfig, nsis_install_mode? : String) -> Self
 pub fn ProjectPlatformPackageConfig::equal(Self, Self) -> Bool
 pub fn ProjectPlatformPackageConfig::formats(Self) -> Array[String]?
 pub fn ProjectPlatformPackageConfig::not_equal(Self, Self) -> Bool
+pub fn ProjectPlatformPackageConfig::nsis_install_mode(Self) -> String?
 pub fn ProjectPlatformPackageConfig::resources(Self) -> Array[String]
 pub fn ProjectPlatformPackageConfig::sign(Self) -> ProjectSignConfig?
 pub fn ProjectPlatformPackageConfig::to_repr(Self) -> @debug.Repr

--- a/config/project_config.mbt
+++ b/config/project_config.mbt
@@ -114,6 +114,7 @@ pub(all) struct ProjectPlatformPackageConfig {
   formats : Array[String]?
   resources : Array[String]
   sign : ProjectSignConfig?
+  nsis_install_mode : String?
 } derive(Eq, Debug)
 
 ///|
@@ -127,6 +128,7 @@ pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(
   formats? : Array[String],
   resources? : Array[String] = [],
   sign? : ProjectSignConfig,
+  nsis_install_mode? : String,
 ) -> ProjectPlatformPackageConfig {
   ProjectPlatformPackageConfig::{
     formats: match formats {
@@ -135,6 +137,7 @@ pub fn ProjectPlatformPackageConfig::ProjectPlatformPackageConfig(
     },
     resources: resources.copy(),
     sign,
+    nsis_install_mode,
   }
 }
 
@@ -160,6 +163,14 @@ pub fn ProjectPlatformPackageConfig::sign(
   self : ProjectPlatformPackageConfig,
 ) -> ProjectSignConfig? {
   self.sign
+}
+
+///|
+/// Windows-only NSIS mode: currentUser, perMachine, or both.
+pub fn ProjectPlatformPackageConfig::nsis_install_mode(
+  self : ProjectPlatformPackageConfig,
+) -> String? {
+  self.nsis_install_mode
 }
 
 ///|

--- a/config/project_decode.mbt
+++ b/config/project_decode.mbt
@@ -212,7 +212,25 @@ fn decode_platform_package(
     None => None
     Some(Object(values)) => {
       let label = "package.platforms." + platform
-      validate_object_fields(values, label, ["formats", "resources", "sign"])
+      validate_object_fields(
+        values,
+        label,
+        if platform == "windows" {
+          ["formats", "resources", "sign", "nsis_install_mode"]
+        } else {
+          ["formats", "resources", "sign"]
+        },
+      )
+      let nsis_install_mode = optional_string(
+        values,
+        "nsis_install_mode",
+        label + ".nsis_install_mode",
+      )
+      match nsis_install_mode {
+        Some("currentUser" | "perMachine" | "both") | None => ()
+        Some(value) =>
+          raise UnsupportedValue(path=label + ".nsis_install_mode", value~)
+      }
       let formats = if values.contains("formats") {
         Some(optional_string_array(values, "formats", label + ".formats"))
       } else {
@@ -228,6 +246,7 @@ fn decode_platform_package(
             label + ".resources",
           ),
           sign?,
+          nsis_install_mode?,
         ),
       )
     }

--- a/package/README.md
+++ b/package/README.md
@@ -61,6 +61,9 @@ an existing machine-wide installation to the current user. The existing NSIS
 registry view is retained so `perMachine` can find those older installations.
 In `both` mode, `/CurrentUser` and `/AllUsers` select the scope for unattended
 installation; `/D=...` may override the directory and must be the last argument.
+Automatic updates pass the running application's directory. In `both` mode,
+the installer matches that directory to its registered scope and aborts if the
+scope is missing or ambiguous, rather than updating a different installation.
 
 The executable and `lib` package support both the wasm and native MoonBit
 targets. Windows executable icon embedding uses a native C stub; requesting an

--- a/package/README.md
+++ b/package/README.md
@@ -40,6 +40,28 @@ Supported host-native formats are macOS `app`, `zip`, and `dmg`; Windows
 When no format is specified, macOS and Windows produce `app` and `zip`, while
 Linux produces `appimage`.
 
+For Windows NSIS, `--nsis-install-mode` (or `nsis_install_mode` in the JSON
+configuration) accepts the same mode names as Tauri:
+
+| Mode | Permissions and scope |
+| --- | --- |
+| `currentUser` (default) | No elevation; `%LOCALAPPDATA%`; current-user registration and shortcuts. |
+| `perMachine` | Administrator privileges; Program Files; machine-wide registration and shortcuts. |
+| `both` | NSIS MultiUser selection page; highest available privileges, potentially prompting for elevation. |
+
+The library equivalent is `PackageSpec(..., nsis_install_mode=PerMachine)`.
+The mode affects only NSIS installers, not portable directories or ZIP files.
+Command-line options override JSON configuration. Installation and uninstall
+records, URL schemes, and shortcuts all follow the selected scope.
+
+Applications distributed using Proton's previous machine-wide default must
+explicitly select `perMachine` for subsequent releases. Fixed modes reuse
+installation paths within their own scope; they do not automatically migrate
+an existing machine-wide installation to the current user. The existing NSIS
+registry view is retained so `perMachine` can find those older installations.
+In `both` mode, `/CurrentUser` and `/AllUsers` select the scope for unattended
+installation; `/D=...` may override the directory and must be the last argument.
+
 The executable and `lib` package support both the wasm and native MoonBit
 targets. Windows executable icon embedding uses a native C stub; requesting an
 `.ico` while running the wasm build reports that unsupported operation instead

--- a/package/arguments/arguments.mbt
+++ b/package/arguments/arguments.mbt
@@ -9,6 +9,7 @@ pub(all) struct PackageArguments {
   output : String?
   icons : Array[String]
   url_schemes : Array[String]
+  nsis_install_mode : @package.NsisInstallMode?
   sign : Bool
   notarize : Bool
 } derive(Debug, Eq)
@@ -40,6 +41,10 @@ pub fn options(include_identifier? : Bool = true) -> Array[@argparse.OptionArg] 
       about="Output format: app, zip, dmg, nsis, or appimage; may be repeated",
     ),
     OptionArg("output", about="Artifact output directory"),
+    OptionArg(
+      "nsis-install-mode",
+      about="NSIS installation scope: currentUser (default), perMachine, or both",
+    ),
     OptionArg("icon", action=Append, about="Platform icon; may be repeated"),
     OptionArg(
       "url-scheme",
@@ -71,6 +76,9 @@ pub fn from_matches(
     output: first(matches.values, "output"),
     icons: values(matches.values, "icon"),
     url_schemes: values(matches.values, "url-scheme"),
+    nsis_install_mode: first(matches.values, "nsis-install-mode").map(
+      @package.NsisInstallMode::parse,
+    ),
     sign: matches.flags.get("sign").unwrap_or(false) ||
     matches.flags.get("notarize").unwrap_or(false),
     notarize: matches.flags.get("notarize").unwrap_or(false),

--- a/package/arguments/arguments_wbtest.mbt
+++ b/package/arguments/arguments_wbtest.mbt
@@ -24,3 +24,27 @@ test "shared package arguments parse metadata and repeated values" {
   assert_true(arguments.sign)
   assert_true(arguments.notarize)
 }
+
+///|
+test "NSIS install mode arguments are optional and validated" {
+  assert_eq(parse_arguments([]).nsis_install_mode, None)
+  for
+    entry in [
+      ("currentUser", @package.NsisInstallMode::CurrentUser),
+      ("perMachine", @package.NsisInstallMode::PerMachine),
+      ("both", @package.NsisInstallMode::Both),
+    ] {
+    let (name, mode) = entry
+    assert_eq(
+      parse_arguments(["--nsis-install-mode", name]).nsis_install_mode,
+      Some(mode),
+    )
+  }
+  try parse_arguments(["--nsis-install-mode", "admin"]) catch {
+    @package.PackagePlanError::UnsupportedNsisInstallMode(value~) =>
+      assert_eq(value, "admin")
+    _ => fail("expected an invalid NSIS mode")
+  } noraise {
+    _ => fail("expected argument parsing to fail")
+  }
+}

--- a/package/arguments/pkg.generated.mbti
+++ b/package/arguments/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub(all) struct PackageArguments {
   output : String?
   icons : Array[String]
   url_schemes : Array[String]
+  nsis_install_mode : @lib.NsisInstallMode?
   sign : Bool
   notarize : Bool
 } derive(Eq, @debug.Debug)

--- a/package/config.mbt
+++ b/package/config.mbt
@@ -25,6 +25,7 @@ priv struct PackageConfig {
   icons : Array[String]?
   url_schemes : Array[String]?
   document_types : Array[ConfigDocumentType]?
+  nsis_install_mode : String?
   sign : Bool?
   notarize : Bool?
 } derive(FromJson, Default)

--- a/package/lib/error.mbt
+++ b/package/lib/error.mbt
@@ -5,6 +5,7 @@ pub(all) suberror PackagePlanError {
   InvalidUrlScheme(scheme~ : String, reason~ : String)
   InvalidVersion(version~ : String, reason~ : String)
   UnsupportedFormat(format~ : String)
+  UnsupportedNsisInstallMode(value~ : String)
   DuplicateFormat(format~ : String)
   UnsupportedFormatForPlatform(format~ : String, platform~ : String)
   MissingExecutable(path~ : String)
@@ -30,6 +31,10 @@ pub fn PackagePlanError::message(self : PackagePlanError) -> String {
     InvalidVersion(version~, reason~) =>
       "invalid version " + version + ": " + reason
     UnsupportedFormat(format~) => "unsupported package format: " + format
+    UnsupportedNsisInstallMode(value~) =>
+      "unsupported NSIS install mode: " +
+      value +
+      " (expected currentUser, perMachine, or both)"
     DuplicateFormat(format~) => "duplicate package format: " + format
     UnsupportedFormatForPlatform(format~, platform~) =>
       "package format " + format + " is not supported on " + platform

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -157,6 +157,7 @@ test "Windows icon embedding reports the native-only operation" {
 fn package_test_spec(
   formats : Array[PackageFormat],
   url_schemes? : Array[String] = ["devtoys"],
+  nsis_install_mode? : NsisInstallMode = CurrentUser,
 ) -> PackageSpec {
   PackageSpec(
     "/tmp/demo",
@@ -166,6 +167,7 @@ fn package_test_spec(
     formats,
     "/tmp/dist",
     url_schemes~,
+    nsis_install_mode~,
   )
 }
 
@@ -230,7 +232,7 @@ test "NSIS script carries package identity and update behavior" {
   )
   assert_true(
     empty_script.contains(
-      "DeleteRegKey HKLM \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\dev.proton.demo\"\nSectionEnd",
+      "DeleteRegKey SHCTX \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\dev.proton.demo\"\nSectionEnd",
     ),
   )
   assert_true(
@@ -250,7 +252,7 @@ test "NSIS staging transaction leaves the working directory before moving or rem
   let (_, install) = script.split_once("Section \"Install\"\n").unwrap()
   let (transaction, _) = install
     .to_owned()
-    .split_once("  WriteRegStr HKLM")
+    .split_once("  WriteRegStr SHCTX")
     .unwrap()
   inspect(
     transaction.to_owned(),
@@ -308,18 +310,18 @@ test "NSIS URL scheme scripts share an owned command" {
   inspect(
     windows_protocol_install_script(spec, "demo-app.exe"),
     content=(
-      #|  WriteRegStr HKCU "Software\Classes\devtoys" "" "URL:devtoys"
-      #|  WriteRegStr HKCU "Software\Classes\devtoys" "URL Protocol" ""
-      #|  WriteRegStr HKCU "Software\Classes\devtoys\shell\open\command" "" "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys" "" "URL:devtoys"
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys" "URL Protocol" ""
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys\shell\open\command" "" "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
       #|
     ),
   )
   inspect(
     windows_protocol_uninstall_script(spec, "demo-app.exe"),
     content=(
-      #|  ReadRegStr $0 HKCU "Software\Classes\devtoys\shell\open\command" ""
+      #|  ReadRegStr $0 SHCTX "Software\Classes\devtoys\shell\open\command" ""
       #|  ${If} $0 == "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
-      #|    DeleteRegKey HKCU "Software\Classes\devtoys"
+      #|    DeleteRegKey SHCTX "Software\Classes\devtoys"
       #|  ${EndIf}
       #|
     ),

--- a/package/lib/package_wbtest.mbt
+++ b/package/lib/package_wbtest.mbt
@@ -242,6 +242,67 @@ test "NSIS script carries package identity and update behavior" {
 }
 
 ///|
+test "NSIS staging transaction leaves the working directory before moving or removing it" {
+  let script = windows_installer_script(
+    package_test_spec([App, Nsis]),
+    "C:\\stage\\Demo App",
+  )
+  let (_, install) = script.split_once("Section \"Install\"\n").unwrap()
+  let (transaction, _) = install
+    .to_owned()
+    .split_once("  WriteRegStr HKLM")
+    .unwrap()
+  inspect(
+    transaction.to_owned(),
+    content=(
+      #|  ; Expand the complete release beside the installed tree before moving
+      #|  ; either one. A failed extraction therefore leaves the old app intact.
+      #|  RMDir /r "$INSTDIR.proton-next"
+      #|  SetOutPath "$INSTDIR.proton-next"
+      #|  ClearErrors
+      #|  File /r "C:\stage\Demo App\*.*"
+      #|  IfErrors install_failed
+      #|  ClearErrors
+      #|  WriteUninstaller "$INSTDIR.proton-next\Uninstall.exe"
+      #|  IfErrors install_failed
+      #|  ; SetOutPath also changes the working directory, which Windows locks.
+      #|  SetOutPath "$TEMP"
+      #|
+      #|  ; Reaching a later update proves the current tree started successfully,
+      #|  ; so its predecessor is no longer needed as the recovery copy.
+      #|  RMDir /r "$INSTDIR.proton-previous"
+      #|  IfFileExists "$INSTDIR\*.*" 0 promote_update
+      #|  ; The updater names the exact process tree it is replacing. A manual
+      #|  ; reinstall has no such token and falls back to the executable name.
+      #|  ${If} $ProtonUpdate == "1"
+      #|    nsExec::Exec 'taskkill /F /T /PID "$ProtonUpdatePid"'
+      #|  ${Else}
+      #|    nsExec::Exec 'taskkill /F /T /IM "demo-app.exe"'
+      #|  ${EndIf}
+      #|  Pop $0
+      #|  Sleep 500
+      #|  ClearErrors
+      #|  Rename "$INSTDIR" "$INSTDIR.proton-previous"
+      #|  IfErrors install_failed
+      #|promote_update:
+      #|  ClearErrors
+      #|  Rename "$INSTDIR.proton-next" "$INSTDIR"
+      #|  IfErrors 0 install_complete
+      #|  Rename "$INSTDIR.proton-previous" "$INSTDIR"
+      #|  Abort "The new installation could not be moved into place."
+      #|install_failed:
+      #|  SetOutPath "$TEMP"
+      #|  RMDir /r "$INSTDIR.proton-next"
+      #|  Abort "The update could not be installed."
+      #|install_complete:
+      #|  SetOutPath "$INSTDIR"
+      #|
+      #|
+    ),
+  )
+}
+
+///|
 test "NSIS URL scheme scripts share an owned command" {
   let spec = package_test_spec([App, Nsis], url_schemes=["devtoys"])
   inspect(

--- a/package/lib/pkg.generated.mbti
+++ b/package/lib/pkg.generated.mbti
@@ -61,6 +61,7 @@ pub(all) suberror PackagePlanError {
   InvalidUrlScheme(scheme~ : String, reason~ : String)
   InvalidVersion(version~ : String, reason~ : String)
   UnsupportedFormat(format~ : String)
+  UnsupportedNsisInstallMode(value~ : String)
   DuplicateFormat(format~ : String)
   UnsupportedFormatForPlatform(format~ : String, platform~ : String)
   MissingExecutable(path~ : String)
@@ -121,6 +122,17 @@ pub struct MacosSignTarget {
 }
 pub fn MacosSignTarget::MacosSignTarget(String, runtime_options? : Bool, entitlements? : Bool, identifier? : String) -> Self
 
+pub(all) enum NsisInstallMode {
+  CurrentUser
+  PerMachine
+  Both
+} derive(Eq, @debug.Debug)
+pub fn NsisInstallMode::equal(Self, Self) -> Bool
+pub fn NsisInstallMode::not_equal(Self, Self) -> Bool
+pub fn NsisInstallMode::parse(String) -> Self raise PackagePlanError
+pub fn NsisInstallMode::to_repr(Self) -> @debug.Repr
+pub fn NsisInstallMode::to_string(Self) -> String
+
 pub struct PackageCustomization {
   macos_plist_strings : Array[MacosPlistString]
   macos_sign_targets : Array[MacosSignTarget]
@@ -175,10 +187,11 @@ pub struct PackageSpec {
   icons : Array[String]
   url_schemes : Array[String]
   document_types : Array[DocumentType]
+  nsis_install_mode : NsisInstallMode
   sign : Bool
   notarize : Bool
 } derive(Eq, @debug.Debug)
-pub fn PackageSpec::PackageSpec(String, String, String, String, Array[PackageFormat], String, payloads? : Array[Payload], icons? : Array[String], url_schemes? : Array[String], document_types? : Array[DocumentType], sign? : Bool, notarize? : Bool) -> Self
+pub fn PackageSpec::PackageSpec(String, String, String, String, Array[PackageFormat], String, payloads? : Array[Payload], icons? : Array[String], url_schemes? : Array[String], document_types? : Array[DocumentType], nsis_install_mode? : NsisInstallMode, sign? : Bool, notarize? : Bool) -> Self
 pub fn PackageSpec::equal(Self, Self) -> Bool
 pub fn PackageSpec::not_equal(Self, Self) -> Bool
 pub fn PackageSpec::to_repr(Self) -> @debug.Repr

--- a/package/lib/types.mbt
+++ b/package/lib/types.mbt
@@ -230,6 +230,41 @@ pub fn PackageCustomization::PackageCustomization(
 }
 
 ///|
+/// Windows NSIS installation scope. `Both` lets the installer user choose.
+pub(all) enum NsisInstallMode {
+  CurrentUser
+  PerMachine
+  Both
+} derive(Debug, Eq)
+
+///|
+pub extend NsisInstallMode with Eq::{not_equal, equal}
+
+///|
+pub extend NsisInstallMode with Debug::{to_repr}
+
+///|
+pub fn NsisInstallMode::parse(
+  value : String,
+) -> NsisInstallMode raise PackagePlanError {
+  match value {
+    "currentUser" => CurrentUser
+    "perMachine" => PerMachine
+    "both" => Both
+    _ => raise UnsupportedNsisInstallMode(value~)
+  }
+}
+
+///|
+pub fn NsisInstallMode::to_string(self : NsisInstallMode) -> String {
+  match self {
+    CurrentUser => "currentUser"
+    PerMachine => "perMachine"
+    Both => "both"
+  }
+}
+
+///|
 /// Complete input to the host-native packager.
 pub struct PackageSpec {
   executable : String
@@ -242,6 +277,7 @@ pub struct PackageSpec {
   icons : Array[String]
   url_schemes : Array[String]
   document_types : Array[DocumentType]
+  nsis_install_mode : NsisInstallMode
   sign : Bool
   notarize : Bool
 } derive(Debug, Eq)
@@ -264,6 +300,7 @@ pub fn PackageSpec::PackageSpec(
   icons? : Array[String] = [],
   url_schemes? : Array[String] = [],
   document_types? : Array[DocumentType] = [],
+  nsis_install_mode? : NsisInstallMode = CurrentUser,
   sign? : Bool = false,
   notarize? : Bool = false,
 ) -> PackageSpec {
@@ -278,6 +315,7 @@ pub fn PackageSpec::PackageSpec(
     icons,
     url_schemes,
     document_types,
+    nsis_install_mode,
     sign: sign || notarize,
     notarize,
   }

--- a/package/lib/windows_install_mode.mbt
+++ b/package/lib/windows_install_mode.mbt
@@ -85,3 +85,35 @@ fn windows_install_mode_init(plan : PackageSpec, uninstall : Bool) -> String {
     }
   }
 }
+
+///|
+/// Bind silent updates to the caller's /D directory, not MultiUser's default.
+fn windows_install_mode_update_init(plan : PackageSpec) -> String {
+  if plan.nsis_install_mode != Both {
+    return ""
+  }
+  let product = windows_installer_quote(plan.product_name)
+  let key = windows_installer_quote(windows_installer_registry_key(plan))
+  (
+    $|  ${If} $ProtonUpdate == "1"
+    $|    ${If} $ProtonInstallDirOverride == "placeholder\{'\\'}\{product}"
+    $|      Abort "The update installation directory is missing."
+    $|    ${EndIf}
+    $|    ReadRegStr $0 HKCU "\{key}" "InstallDir"
+    $|    ReadRegStr $1 HKLM "\{key}" "InstallDir"
+    $|    ${If} $0 == $ProtonInstallDirOverride
+    $|    ${AndIf} $1 != $ProtonInstallDirOverride
+    $|      Call MultiUser.InstallMode.CurrentUser
+    $|    ${ElseIf} $1 == $ProtonInstallDirOverride
+    $|    ${AndIf} $0 != $ProtonInstallDirOverride
+    $|      Call MultiUser.InstallMode.AllUsers
+    $|      ${If} $MultiUser.InstallMode != "AllUsers"
+    $|        Abort "The update requires administrator privileges."
+    $|      ${EndIf}
+    $|    ${Else}
+    $|      Abort "The update installation scope could not be determined."
+    $|    ${EndIf}
+    $|  ${EndIf}
+    $|
+  )
+}

--- a/package/lib/windows_install_mode.mbt
+++ b/package/lib/windows_install_mode.mbt
@@ -1,0 +1,87 @@
+///|
+/// Uses NSIS's own MultiUser support for the selectable mode, as Tauri does.
+fn windows_install_mode_header(plan : PackageSpec) -> String {
+  let product = windows_installer_quote(plan.product_name)
+  let key = windows_installer_quote(windows_installer_registry_key(plan))
+  match plan.nsis_install_mode {
+    CurrentUser =>
+      (
+        $|RequestExecutionLevel user
+        $|InstallDir "$LOCALAPPDATA\{'\\'}\{product}"
+        $|InstallDirRegKey HKCU "\{key}" "InstallDir"
+        $|
+      )
+    PerMachine =>
+      (
+        $|RequestExecutionLevel admin
+        $|InstallDir "$PROGRAMFILES64\{'\\'}\{product}"
+        $|InstallDirRegKey HKLM "\{key}" "InstallDir"
+        $|
+      )
+    Both =>
+      (
+        $|!define MULTIUSER_MUI
+        $|!define MULTIUSER_EXECUTIONLEVEL Highest
+        $|!define MULTIUSER_INSTALLMODE_COMMANDLINE
+        $|!define MULTIUSER_USE_PROGRAMFILES64
+        $|!define MULTIUSER_INSTALLMODE_INSTDIR "\{product}"
+        $|!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY "\{key}"
+        $|!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "InstallDir"
+        $|!define MULTIUSER_INSTALLMODE_FUNCTION ProtonRestoreInstallDir
+        $|!include "MultiUser.nsh"
+        $|InstallDir "placeholder\{'\\'}\{product}"
+        $|Var ProtonInstallDirOverride
+        $|
+        $|Function ProtonRestoreInstallDir
+        $|  ReadRegStr $0 SHCTX "\{key}" "InstallDir"
+        $|  ${If} $0 != ""
+        $|    StrCpy $INSTDIR $0
+        $|  ${EndIf}
+        $|  ${If} $ProtonInstallDirOverride != "placeholder\{'\\'}\{product}"
+        $|    StrCpy $INSTDIR $ProtonInstallDirOverride
+        $|  ${EndIf}
+        $|FunctionEnd
+        $|
+      )
+  }
+}
+
+///|
+fn windows_install_mode_init(plan : PackageSpec, uninstall : Bool) -> String {
+  match plan.nsis_install_mode {
+    CurrentUser =>
+      (
+        #|  SetShellVarContext current
+        #|
+      )
+    PerMachine =>
+      (
+        #|  SetShellVarContext all
+        #|
+      )
+    Both if !uninstall =>
+      (
+        #|  StrCpy $ProtonInstallDirOverride $INSTDIR
+        #|  !insertmacro MULTIUSER_INIT
+        #|
+      )
+    Both => {
+      let key = windows_installer_quote(windows_installer_registry_key(plan))
+      // A directly launched uninstaller must use its own tree's scope even
+      // when the product is installed in both HKCU and HKLM.
+      (
+        $|  !insertmacro MULTIUSER_UNINIT
+        $|  ReadRegStr $0 HKCU "\{key}" "InstallDir"
+        $|  ${If} $0 == $INSTDIR
+        $|    Call un.MultiUser.InstallMode.CurrentUser
+        $|  ${Else}
+        $|    ReadRegStr $0 HKLM "\{key}" "InstallDir"
+        $|    ${If} $0 == $INSTDIR
+        $|      Call un.MultiUser.InstallMode.AllUsers
+        $|    ${EndIf}
+        $|  ${EndIf}
+        $|
+      )
+    }
+  }
+}

--- a/package/lib/windows_install_mode_wbtest.mbt
+++ b/package/lib/windows_install_mode_wbtest.mbt
@@ -195,6 +195,25 @@ test "NSIS installation scopes wire permissions contexts and pages" {
       #|  ${AndIf} $ProtonUpdatePid == ""
       #|    Abort "The update process id is missing."
       #|  ${EndIf}
+      #|  ${If} $ProtonUpdate == "1"
+      #|    ${If} $ProtonInstallDirOverride == "placeholder\Demo App"
+      #|      Abort "The update installation directory is missing."
+      #|    ${EndIf}
+      #|    ReadRegStr $0 HKCU "Software\dev.proton.demo" "InstallDir"
+      #|    ReadRegStr $1 HKLM "Software\dev.proton.demo" "InstallDir"
+      #|    ${If} $0 == $ProtonInstallDirOverride
+      #|    ${AndIf} $1 != $ProtonInstallDirOverride
+      #|      Call MultiUser.InstallMode.CurrentUser
+      #|    ${ElseIf} $1 == $ProtonInstallDirOverride
+      #|    ${AndIf} $0 != $ProtonInstallDirOverride
+      #|      Call MultiUser.InstallMode.AllUsers
+      #|      ${If} $MultiUser.InstallMode != "AllUsers"
+      #|        Abort "The update requires administrator privileges."
+      #|      ${EndIf}
+      #|    ${Else}
+      #|      Abort "The update installation scope could not be determined."
+      #|    ${EndIf}
+      #|  ${EndIf}
       #|FunctionEnd
       #|
       #|Function un.onInit

--- a/package/lib/windows_install_mode_wbtest.mbt
+++ b/package/lib/windows_install_mode_wbtest.mbt
@@ -1,0 +1,278 @@
+///|
+test "NSIS modes use Tauri-compatible names and default to current user" {
+  assert_eq(package_test_spec([Nsis]).nsis_install_mode, CurrentUser)
+  for
+    entry in [
+      ("currentUser", CurrentUser),
+      ("perMachine", PerMachine),
+      ("both", Both),
+    ] {
+    let (name, mode) = entry
+    assert_eq(NsisInstallMode::parse(name), mode)
+    assert_eq(mode.to_string(), name)
+  }
+  try NsisInstallMode::parse("admin") catch {
+    error => assert_eq(error, UnsupportedNsisInstallMode(value="admin"))
+  } noraise {
+    _ => fail("expected an invalid NSIS mode")
+  }
+}
+
+///|
+test "NSIS installation scopes wire permissions contexts and pages" {
+  let output_path = windows_installer_quote(
+    windows_installer_staging_path(package_test_spec([Nsis])),
+  )
+  let (current_header, current_body) = windows_installer_script(
+      package_test_spec([Nsis]),
+      "C:\\stage\\Demo App",
+    )
+    .replace_all(old=output_path, new="demo-app-setup.exe")
+    .split_once("Section \"Install\"\n")
+    .unwrap()
+  inspect(
+    current_header.to_owned(),
+    content=(
+      #|Unicode true
+      #|ManifestDPIAware true
+      #|SetCompressor /SOLID lzma
+      #|
+      #|!include "FileFunc.nsh"
+      #|!include "LogicLib.nsh"
+      #|!include "MUI2.nsh"
+      #|
+      #|Var ProtonUpdate
+      #|Var ProtonUpdatePid
+      #|Name "Demo App"
+      #|OutFile "demo-app-setup.exe"
+      #|RequestExecutionLevel user
+      #|InstallDir "$LOCALAPPDATA\Demo App"
+      #|InstallDirRegKey HKCU "Software\dev.proton.demo" "InstallDir"
+      #|
+      #|VIProductVersion "1.2.3.0"
+      #|VIAddVersionKey "ProductName" "Demo App"
+      #|VIAddVersionKey "FileVersion" "1.2.3"
+      #|VIAddVersionKey "ProductVersion" "1.2.3"
+      #|VIAddVersionKey "FileDescription" "Demo App Setup"
+      #|Function .onInit
+      #|  SetShellVarContext current
+      #|  ${GetParameters} $R0
+      #|  ${GetOptions} $R0 "/PROTON-UPDATE=" $ProtonUpdate
+      #|  ${GetOptions} $R0 "/PROTON-PID=" $ProtonUpdatePid
+      #|  ${If} $ProtonUpdate == "1"
+      #|  ${AndIf} $ProtonUpdatePid == ""
+      #|    Abort "The update process id is missing."
+      #|  ${EndIf}
+      #|FunctionEnd
+      #|
+      #|Function un.onInit
+      #|  SetShellVarContext current
+      #|FunctionEnd
+      #|
+      #|!define MUI_ABORTWARNING
+      #|!insertmacro MUI_PAGE_DIRECTORY
+      #|!insertmacro MUI_PAGE_INSTFILES
+      #|!insertmacro MUI_UNPAGE_CONFIRM
+      #|!insertmacro MUI_UNPAGE_INSTFILES
+      #|!insertmacro MUI_LANGUAGE "English"
+      #|
+      #|
+    ),
+  )
+  let (machine_header, machine_body) = windows_installer_script(
+      package_test_spec([Nsis], nsis_install_mode=PerMachine),
+      "C:\\stage\\Demo App",
+    )
+    .replace_all(old=output_path, new="demo-app-setup.exe")
+    .split_once("Section \"Install\"\n")
+    .unwrap()
+  inspect(
+    machine_header.to_owned(),
+    content=(
+      #|Unicode true
+      #|ManifestDPIAware true
+      #|SetCompressor /SOLID lzma
+      #|
+      #|!include "FileFunc.nsh"
+      #|!include "LogicLib.nsh"
+      #|!include "MUI2.nsh"
+      #|
+      #|Var ProtonUpdate
+      #|Var ProtonUpdatePid
+      #|Name "Demo App"
+      #|OutFile "demo-app-setup.exe"
+      #|RequestExecutionLevel admin
+      #|InstallDir "$PROGRAMFILES64\Demo App"
+      #|InstallDirRegKey HKLM "Software\dev.proton.demo" "InstallDir"
+      #|
+      #|VIProductVersion "1.2.3.0"
+      #|VIAddVersionKey "ProductName" "Demo App"
+      #|VIAddVersionKey "FileVersion" "1.2.3"
+      #|VIAddVersionKey "ProductVersion" "1.2.3"
+      #|VIAddVersionKey "FileDescription" "Demo App Setup"
+      #|Function .onInit
+      #|  SetShellVarContext all
+      #|  ${GetParameters} $R0
+      #|  ${GetOptions} $R0 "/PROTON-UPDATE=" $ProtonUpdate
+      #|  ${GetOptions} $R0 "/PROTON-PID=" $ProtonUpdatePid
+      #|  ${If} $ProtonUpdate == "1"
+      #|  ${AndIf} $ProtonUpdatePid == ""
+      #|    Abort "The update process id is missing."
+      #|  ${EndIf}
+      #|FunctionEnd
+      #|
+      #|Function un.onInit
+      #|  SetShellVarContext all
+      #|FunctionEnd
+      #|
+      #|!define MUI_ABORTWARNING
+      #|!insertmacro MUI_PAGE_DIRECTORY
+      #|!insertmacro MUI_PAGE_INSTFILES
+      #|!insertmacro MUI_UNPAGE_CONFIRM
+      #|!insertmacro MUI_UNPAGE_INSTFILES
+      #|!insertmacro MUI_LANGUAGE "English"
+      #|
+      #|
+    ),
+  )
+  assert_eq(machine_body.to_owned(), current_body.to_owned())
+  let (both_header, both_body) = windows_installer_script(
+      package_test_spec([Nsis], nsis_install_mode=Both),
+      "C:\\stage\\Demo App",
+    )
+    .replace_all(old=output_path, new="demo-app-setup.exe")
+    .split_once("Section \"Install\"\n")
+    .unwrap()
+  inspect(
+    both_header.to_owned(),
+    content=(
+      #|Unicode true
+      #|ManifestDPIAware true
+      #|SetCompressor /SOLID lzma
+      #|
+      #|!include "FileFunc.nsh"
+      #|!include "LogicLib.nsh"
+      #|!include "MUI2.nsh"
+      #|
+      #|Var ProtonUpdate
+      #|Var ProtonUpdatePid
+      #|Name "Demo App"
+      #|OutFile "demo-app-setup.exe"
+      #|!define MULTIUSER_MUI
+      #|!define MULTIUSER_EXECUTIONLEVEL Highest
+      #|!define MULTIUSER_INSTALLMODE_COMMANDLINE
+      #|!define MULTIUSER_USE_PROGRAMFILES64
+      #|!define MULTIUSER_INSTALLMODE_INSTDIR "Demo App"
+      #|!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY "Software\dev.proton.demo"
+      #|!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "InstallDir"
+      #|!define MULTIUSER_INSTALLMODE_FUNCTION ProtonRestoreInstallDir
+      #|!include "MultiUser.nsh"
+      #|InstallDir "placeholder\Demo App"
+      #|Var ProtonInstallDirOverride
+      #|
+      #|Function ProtonRestoreInstallDir
+      #|  ReadRegStr $0 SHCTX "Software\dev.proton.demo" "InstallDir"
+      #|  ${If} $0 != ""
+      #|    StrCpy $INSTDIR $0
+      #|  ${EndIf}
+      #|  ${If} $ProtonInstallDirOverride != "placeholder\Demo App"
+      #|    StrCpy $INSTDIR $ProtonInstallDirOverride
+      #|  ${EndIf}
+      #|FunctionEnd
+      #|
+      #|VIProductVersion "1.2.3.0"
+      #|VIAddVersionKey "ProductName" "Demo App"
+      #|VIAddVersionKey "FileVersion" "1.2.3"
+      #|VIAddVersionKey "ProductVersion" "1.2.3"
+      #|VIAddVersionKey "FileDescription" "Demo App Setup"
+      #|Function .onInit
+      #|  StrCpy $ProtonInstallDirOverride $INSTDIR
+      #|  !insertmacro MULTIUSER_INIT
+      #|  ${GetParameters} $R0
+      #|  ${GetOptions} $R0 "/PROTON-UPDATE=" $ProtonUpdate
+      #|  ${GetOptions} $R0 "/PROTON-PID=" $ProtonUpdatePid
+      #|  ${If} $ProtonUpdate == "1"
+      #|  ${AndIf} $ProtonUpdatePid == ""
+      #|    Abort "The update process id is missing."
+      #|  ${EndIf}
+      #|FunctionEnd
+      #|
+      #|Function un.onInit
+      #|  !insertmacro MULTIUSER_UNINIT
+      #|  ReadRegStr $0 HKCU "Software\dev.proton.demo" "InstallDir"
+      #|  ${If} $0 == $INSTDIR
+      #|    Call un.MultiUser.InstallMode.CurrentUser
+      #|  ${Else}
+      #|    ReadRegStr $0 HKLM "Software\dev.proton.demo" "InstallDir"
+      #|    ${If} $0 == $INSTDIR
+      #|      Call un.MultiUser.InstallMode.AllUsers
+      #|    ${EndIf}
+      #|  ${EndIf}
+      #|FunctionEnd
+      #|
+      #|!define MUI_ABORTWARNING
+      #|!insertmacro MULTIUSER_PAGE_INSTALLMODE
+      #|!insertmacro MUI_PAGE_DIRECTORY
+      #|!insertmacro MUI_PAGE_INSTFILES
+      #|!insertmacro MUI_UNPAGE_CONFIRM
+      #|!insertmacro MUI_UNPAGE_INSTFILES
+      #|!insertmacro MUI_LANGUAGE "English"
+      #|
+      #|
+    ),
+  )
+  assert_eq(
+    both_body.to_owned(),
+    current_body
+    .to_owned()
+    .replace_all(
+      old="Uninstall.exe$\\\"\"",
+      new="Uninstall.exe$\\\" /$MultiUser.InstallMode\"",
+    ),
+  )
+  let (_, registration) = current_body
+    .to_owned()
+    .split_once("install_complete:\n")
+    .unwrap()
+  inspect(
+    registration.to_owned(),
+    content=(
+      #|  SetOutPath "$INSTDIR"
+      #|
+      #|  WriteRegStr SHCTX "Software\dev.proton.demo" "InstallDir" "$INSTDIR"
+      #|  WriteRegStr SHCTX "Software\dev.proton.demo" "Version" "1.2.3"
+      #|  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "DisplayName" "Demo App"
+      #|  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "DisplayVersion" "1.2.3"
+      #|  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+      #|  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "InstallLocation" "$INSTDIR"
+      #|  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "DisplayIcon" "$INSTDIR\demo-app.exe"
+      #|  WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "NoModify" 1
+      #|  WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo" "NoRepair" 1
+      #|
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys" "" "URL:devtoys"
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys" "URL Protocol" ""
+      #|  WriteRegStr SHCTX "Software\Classes\devtoys\shell\open\command" "" "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
+      #|  CreateShortCut "$SMPROGRAMS\Demo App.lnk" "$INSTDIR\demo-app.exe"
+      #|  ${If} $ProtonUpdate == "1"
+      #|    Exec '"$INSTDIR\demo-app.exe"'
+      #|    Delete /REBOOTOK "$EXEPATH"
+      #|  ${EndIf}
+      #|SectionEnd
+      #|Section "Uninstall"
+      #|  nsExec::Exec 'taskkill /F /IM "demo-app.exe"'
+      #|  Pop $0
+      #|  Delete "$SMPROGRAMS\Demo App.lnk"
+      #|  RMDir /r "$INSTDIR"
+      #|  RMDir /r "$INSTDIR.proton-previous"
+      #|  RMDir /r "$INSTDIR.proton-next"
+      #|  DeleteRegKey SHCTX "Software\dev.proton.demo"
+      #|  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\dev.proton.demo"
+      #|  ReadRegStr $0 SHCTX "Software\Classes\devtoys\shell\open\command" ""
+      #|  ${If} $0 == "$\"$INSTDIR\demo-app.exe$\" $\"%1$\""
+      #|    DeleteRegKey SHCTX "Software\Classes\devtoys"
+      #|  ${EndIf}
+      #|SectionEnd
+      #|
+    ),
+  )
+}

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -179,6 +179,9 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     #|  ${AndIf} $ProtonUpdatePid == ""
     #|    Abort "The update process id is missing."
     #|  ${EndIf}
+    #|
+  builder.write_string(windows_install_mode_update_init(plan))
+  builder <+
     #|FunctionEnd
     #|
     #|Function un.onInit

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -54,13 +54,13 @@ fn windows_protocol_install_script(
   for scheme in plan.url_schemes {
     let scheme = windows_installer_quote(scheme)
     builder <+
-      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "" "URL:\{scheme}"
+      $|  WriteRegStr SHCTX "Software\\Classes\\\{scheme}" "" "URL:\{scheme}"
     builder.write_char('\n')
     builder <+
-      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}" "URL Protocol" ""
+      $|  WriteRegStr SHCTX "Software\\Classes\\\{scheme}" "URL Protocol" ""
     builder.write_char('\n')
     builder <+
-      $|  WriteRegStr HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "\{command}"
+      $|  WriteRegStr SHCTX "Software\\Classes\\\{scheme}\\shell\\open\\command" "" "\{command}"
     builder.write_char('\n')
   }
   builder.to_string()
@@ -76,13 +76,13 @@ fn windows_protocol_uninstall_script(
   for scheme in plan.url_schemes {
     let scheme = windows_installer_quote(scheme)
     builder <+
-      $|  ReadRegStr $0 HKCU "Software\\Classes\\\{scheme}\\shell\\open\\command" ""
+      $|  ReadRegStr $0 SHCTX "Software\\Classes\\\{scheme}\\shell\\open\\command" ""
     builder.write_char('\n')
     builder <+
       $|  ${If} $0 == "\{command}"
     builder.write_char('\n')
     builder <+
-      $|    DeleteRegKey HKCU "Software\\Classes\\\{scheme}"
+      $|    DeleteRegKey SHCTX "Software\\Classes\\\{scheme}"
     builder.write_char('\n')
     builder <+
       #|  ${EndIf}
@@ -146,7 +146,6 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     #|Unicode true
     #|ManifestDPIAware true
     #|SetCompressor /SOLID lzma
-    #|RequestExecutionLevel admin
     #|
     #|!include "FileFunc.nsh"
     #|!include "LogicLib.nsh"
@@ -158,8 +157,9 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
   builder <+
     $|Name "\{product}"
     $|OutFile "\{windows_installer_quote(windows_installer_staging_path(plan))}"
-    $|InstallDir "$PROGRAMFILES64\\\{product}"
-    $|InstallDirRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "InstallDir"
+    $|
+  builder.write_string(windows_install_mode_header(plan))
+  builder <+
     $|
     $|VIProductVersion "\{windows_installer_version_quad(plan.version)}"
     $|VIAddVersionKey "ProductName" "\{product}"
@@ -169,6 +169,9 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|
   builder <+
     #|Function .onInit
+    #|
+  builder.write_string(windows_install_mode_init(plan, false))
+  builder <+
     #|  ${GetParameters} $R0
     #|  ${GetOptions} $R0 "/PROTON-UPDATE=" $ProtonUpdate
     #|  ${GetOptions} $R0 "/PROTON-PID=" $ProtonUpdatePid
@@ -178,7 +181,18 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     #|  ${EndIf}
     #|FunctionEnd
     #|
+    #|Function un.onInit
+    #|
+  builder.write_string(windows_install_mode_init(plan, true))
+  builder <+
+    #|FunctionEnd
+    #|
     #|!define MUI_ABORTWARNING
+    #|
+  if plan.nsis_install_mode == Both {
+    builder.write_string("!insertmacro MULTIUSER_PAGE_INSTALLMODE\n")
+  }
+  builder <+
     #|!insertmacro MUI_PAGE_DIRECTORY
     #|!insertmacro MUI_PAGE_INSTFILES
     #|!insertmacro MUI_UNPAGE_CONFIRM
@@ -230,15 +244,15 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|install_complete:
     $|  SetOutPath "$INSTDIR"
     $|
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "InstallDir" "$INSTDIR"
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}" "Version" "\{windows_installer_quote(plan.version)}"
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayName" "\{product}"
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayVersion" "\{windows_installer_quote(plan.version)}"
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "UninstallString" "$\\"$INSTDIR\\Uninstall.exe$\\""
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "InstallLocation" "$INSTDIR"
-    $|  WriteRegStr HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayIcon" "$INSTDIR\\\{executable}"
-    $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoModify" 1
-    $|  WriteRegDWORD HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoRepair" 1
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_installer_registry_key(plan))}" "InstallDir" "$INSTDIR"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_installer_registry_key(plan))}" "Version" "\{windows_installer_quote(plan.version)}"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayName" "\{product}"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayVersion" "\{windows_installer_quote(plan.version)}"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "UninstallString" "$\\"$INSTDIR\\Uninstall.exe$\\"\{if plan.nsis_install_mode == Both { " /$MultiUser.InstallMode" } else { "" }}"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "InstallLocation" "$INSTDIR"
+    $|  WriteRegStr SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "DisplayIcon" "$INSTDIR\\\{executable}"
+    $|  WriteRegDWORD SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoModify" 1
+    $|  WriteRegDWORD SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}" "NoRepair" 1
     $|
   builder.write_char('\n')
   builder.write_string(windows_protocol_install_script(plan, executable))
@@ -258,8 +272,8 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  RMDir /r "$INSTDIR"
     $|  RMDir /r "$INSTDIR.proton-previous"
     $|  RMDir /r "$INSTDIR.proton-next"
-    $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_installer_registry_key(plan))}"
-    $|  DeleteRegKey HKLM "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
+    $|  DeleteRegKey SHCTX "\{windows_installer_quote(windows_installer_registry_key(plan))}"
+    $|  DeleteRegKey SHCTX "\{windows_installer_quote(windows_uninstall_registry_key(plan))}"
   builder.write_char('\n')
   builder.write_string(windows_protocol_uninstall_script(plan, executable))
   builder <+

--- a/package/lib/windows_installer.mbt
+++ b/package/lib/windows_installer.mbt
@@ -198,6 +198,8 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  ClearErrors
     $|  WriteUninstaller "$INSTDIR.proton-next\\Uninstall.exe"
     $|  IfErrors install_failed
+    $|  ; SetOutPath also changes the working directory, which Windows locks.
+    $|  SetOutPath "$TEMP"
     $|
     $|  ; Reaching a later update proves the current tree started successfully,
     $|  ; so its predecessor is no longer needed as the recovery copy.
@@ -222,6 +224,7 @@ fn windows_installer_script(plan : PackageSpec, source : String) -> String {
     $|  Rename "$INSTDIR.proton-previous" "$INSTDIR"
     $|  Abort "The new installation could not be moved into place."
     $|install_failed:
+    $|  SetOutPath "$TEMP"
     $|  RMDir /r "$INSTDIR.proton-next"
     $|  Abort "The update could not be installed."
     $|install_complete:

--- a/package/main_wbtest.mbt
+++ b/package/main_wbtest.mbt
@@ -3,6 +3,28 @@ test "configuration decoding uses typed defaults" {
   let config = decode_package_config("{\"schema_version\":1}", "test.json")
   assert_eq(config.formats, None)
   assert_eq(config.sign, None)
+  assert_eq(config.nsis_install_mode, None)
+}
+
+///|
+async test "standalone NSIS configuration and command-line modes are accepted" {
+  let required_args = [
+    "--executable", "probe.exe", "--product-name", "Probe", "--identifier", "dev.proton.probe",
+    "--version", "1.0.0",
+  ]
+  let default_spec = package_spec(command().parse(argv=required_args, env={}))
+  assert_eq(
+    default_spec.nsis_install_mode,
+    @package.NsisInstallMode::CurrentUser,
+  )
+  let args = required_args.copy()
+  args.append(["--nsis-install-mode", "perMachine"])
+  let spec = package_spec(command().parse(argv=args, env={}))
+  assert_eq(spec.nsis_install_mode, @package.NsisInstallMode::PerMachine)
+  let config = decode_package_config(
+    "{\"schema_version\":1,\"nsis_install_mode\":\"both\"}", "test.json",
+  )
+  assert_eq(config.nsis_install_mode, Some("both"))
 }
 
 ///|

--- a/package/spec.mbt
+++ b/package/spec.mbt
@@ -42,6 +42,13 @@ async fn package_spec(matches : @argparse.Matches) -> @package.PackageSpec {
     icons~,
     url_schemes~,
     document_types=config.document_type_specs(),
+    nsis_install_mode=match arguments.nsis_install_mode {
+      Some(mode) => mode
+      None =>
+        config.nsis_install_mode
+        .map(@package.NsisInstallMode::parse)
+        .unwrap_or(CurrentUser)
+    },
     sign=arguments.sign || config.sign.unwrap_or(false),
     notarize=arguments.notarize || config.notarize.unwrap_or(false),
   )

--- a/proton/internal/native/ffi/src/proton_update.c
+++ b/proton/internal/native/ffi/src/proton_update.c
@@ -1587,7 +1587,8 @@ int32_t proton_update_relaunch(char *error, int32_t error_len) {
   ZeroMemory(&execute, sizeof(execute));
   execute.cbSize = sizeof(execute);
   execute.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
-  execute.lpVerb = L"runas";
+  /* Let the installer's manifest request elevation for its install mode. */
+  execute.lpVerb = L"open";
   execute.lpFile = proton_update_pending_installer_path;
   execute.lpParameters = parameters;
   execute.nShow = SW_HIDE;

--- a/proton/internal/native/ffi/src/proton_update.c
+++ b/proton/internal/native/ffi/src/proton_update.c
@@ -1579,10 +1579,26 @@ int32_t proton_update_relaunch(char *error, int32_t error_len) {
                               "no Windows installer is ready");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
-  wchar_t parameters[128];
-  _snwprintf(parameters, sizeof(parameters) / sizeof(parameters[0]),
-             L"/S /PROTON-UPDATE=1 /PROTON-PID=%lu",
-             (unsigned long)GetCurrentProcessId());
+  wchar_t exe_path[PROTON_UPDATE_MAX_PATH];
+  wchar_t install_dir[PROTON_UPDATE_MAX_PATH];
+  if (!proton_update_running_exe(exe_path, PROTON_UPDATE_MAX_PATH) ||
+      !proton_update_parent_path_w(exe_path, install_dir,
+                                   PROTON_UPDATE_MAX_PATH)) {
+    proton_update_set_message(error, error_len,
+                              "failed to determine the update installation directory");
+    return PROTON_ERR_PLATFORM;
+  }
+  /* NSIS requires /D last and unquoted, including paths containing spaces.
+     Both-mode installers also use this directory to recover the install scope. */
+  wchar_t parameters[PROTON_UPDATE_MAX_PATH + 128];
+  int written = _snwprintf(parameters, sizeof(parameters) / sizeof(parameters[0]),
+                           L"/S /PROTON-UPDATE=1 /PROTON-PID=%lu /D=%ls",
+                           (unsigned long)GetCurrentProcessId(), install_dir);
+  if (written < 0 || (size_t)written >= sizeof(parameters) / sizeof(parameters[0])) {
+    proton_update_set_message(error, error_len,
+                              "the update installer arguments are too long");
+    return PROTON_ERR_PLATFORM;
+  }
   SHELLEXECUTEINFOW execute;
   ZeroMemory(&execute, sizeof(execute));
   execute.cbSize = sizeof(execute);


### PR DESCRIPTION
## Summary

Fixes #245.

- Leave the NSIS staging directory before promotion and before failure cleanup, releasing the Windows current-directory lock.
- Add Tauri-compatible installation modes: `currentUser` (default), `perMachine`, and `both`. The selectable mode uses the standard NSIS MultiUser macros.
- Apply the selected scope consistently to installation metadata, uninstall records, URL schemes, and shortcuts. Preserve URL-scheme ownership checks.
- Expose `package.platforms.windows.nsis_install_mode` in Proton projects, `nsis_install_mode` in standalone package configuration, and `--nsis-install-mode` in both CLIs. Preserve the option through bundle assembly.
- Let the update installer manifest decide elevation instead of forcing `runas`.
- Extend the existing Windows NSIS packaging check to compile all three modes; no GUI installation test was added.

## Compatibility

The default changes from machine-wide to current-user installation. Applications already shipped with the previous Proton installer must explicitly configure `perMachine` for subsequent releases. Fixed modes do not automatically migrate existing installations across scopes.

The existing registry view is retained so machine-wide installers can find the installation path recorded by previous Proton releases. `both` requests the highest available privileges, as in Tauri, and can show a UAC prompt even for a per-user selection.

Portable packages and non-Windows installation behavior are unchanged.

## Validation

- Original staging regression: observed failing before the fix and passing after it.
- Exact generated-script snapshots cover all three scopes, initialization, uninstall context, registration, and staging/promotion ordering.
- `moon -C package test -p moonbit-community/proton_package moonbit-community/proton_package/arguments moonbit-community/proton_package/lib --target native`: 24 passed.
- `moon -C package test lib --target wasm`: 19 passed.
- `moon -C config test . --target native`: 9 passed.
- Maintainer-guide CLI test set (arguments, build_cmd, cef, dev, doctor, fsutil, new, output, package, and root): 94 passed.
- `moon -C proton test internal/native --target native`: 36 passed.
- `moon -C proton test updater --target native`: 18 passed.
- `moon check --target native`, scoped format checks, `moon info`, `node scripts/verify_generated.mjs`, and `git diff --check`: passed.
- Real scripts generated from each mode compiled with MakeNSIS 3.12 on macOS. Only the pre-existing missing LegalCopyright warning was reported.
- Both CLI help outputs expose the new option.

No Windows installer was executed locally. Windows UAC, real installation/update/uninstall, and registry/shortcut behavior still need machine-level verification; compilation and snapshots are not substitutes for that validation.
