### PR TITLE
feat(window): expose closed event

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -152,7 +152,8 @@ on macOS and is a successful no-op on other platforms. Web contents views expose
 independent `set_zoom_percent` and `zoom_percent` controls for their own browser.
 
 Window state changes are delivered to `.on_window_event(...)` as a full
-`StateChanged` snapshot plus transition events such as `ReadyToShow`, `Moved`, `Resized`,
+`StateChanged` snapshot plus lifecycle and transition events such as `Closed`,
+`ReadyToShow`, `Moved`, `Resized`,
 `Show`, `Hide`, `Focus`, `Blur`, `Minimize`, `Restore`, `Maximize`, `Unmaximize`,
 `EnterFullScreen`, and `LeaveFullScreen`. The first native snapshot only emits
 `StateChanged`, because no previous state exists for transition detection.

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -3064,6 +3064,24 @@ fn RuntimeSession::dispatch_window_event(
 ) -> Unit raise AppRunError {
   if event.is_window_closed() {
     let window_id = event.window_id()
+    match window_id {
+      Some(window_id) =>
+        match self.find_window_by_native_id(window_id) {
+          Some(window) => {
+            let handle = self.window_handle(window)
+            for handler in self.window_event_handlers {
+              ignore(
+                self.window_tasks.spawn(
+                  () => handler(handle, Closed),
+                  no_wait=true,
+                ),
+              )
+            }
+          }
+          None => ()
+        }
+      None => ()
+    }
     runtime_session_cancel_window_bridge_tasks(self.pending_bridge, window_id)
     self.close_coordinator.cancel(window_id)
     self.cancel_browser_requests(window_id)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -658,6 +658,7 @@ pub struct WindowManager {
 /// An observed change to a running native window.
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  Closed
   ReadyToShow
   Moved
   Resized

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -3273,6 +3273,11 @@ test "window state transitions derive restore after minimize" {
 }
 
 ///|
+test "window closed is a public window event" {
+  assert_eq(WindowEvent::Closed, WindowEvent::Closed)
+}
+
+///|
 test "window size limits route live constraints through the handle" {
   let minimum_calls : Array[(Int, Int)] = []
   let maximum_calls : Array[(Int, Int)] = []

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -851,6 +851,7 @@ pub fn WindowContext::windows(Self) -> WindowManager
 
 pub(all) enum WindowEvent {
   StateChanged(WindowState)
+  Closed
   ReadyToShow
   Moved
   Resized


### PR DESCRIPTION
## Summary

- expose Electron-style `WindowEvent::Closed`
- dispatch the event before Proton retires and destroys the native window
- preserve existing bridge, browser request, resource request, and close-coordinator cleanup

## Platform impact

No new native ABI or platform-specific implementation. The event reuses the existing cross-platform native `WindowClosed` event and is delivered through the existing wake-driven event loop.

## Validation

- `moon fmt --check`
- `moon -C proton test --target native --diagnostic-limit 80` (668/668)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon check --target native`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

Pending runtime review on macOS, Windows, and Linux. Close a primary and secondary window, verify `Closed` arrives once per concrete window before stale handles are retired, and verify the configured last-window policy still applies.
