### PR TITLE
feat(browser): expose loading lifecycle events

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -158,6 +158,10 @@ Window state changes are delivered to `.on_window_event(...)` as a full
 `EnterFullScreen`, and `LeaveFullScreen`. The first native snapshot only emits
 `StateChanged`, because no previous state exists for transition detection.
 
+Browser loading events include `DidStartLoading` and `DidFinishLoad`, derived
+from successive native loading snapshots; `LoadingChanged` remains available
+for consumers that prefer the boolean form.
+
 ## Logging
 
 Use `tonyfettes/xlog@0.4.2` directly for application logs. Proton configures the

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1280,6 +1280,7 @@ fn RuntimeSession::create_window(
     bridge_ready: !self.monitor_bridge,
     state: WindowStarting,
     observed_state: None,
+    observed_browser_loading: None,
   }
   errdefer (created_window.destroy() catch {
     error =>
@@ -3200,12 +3201,32 @@ fn RuntimeSession::dispatch_browser_event(
           let browser = self.browser_handle(window)
           let observed = match
             (event.event_type(), info, find_result, pdf_result) {
-            ("browser_loading_changed", Some(info), _, _) =>
-              Some(
-                BrowserEvent::LoadingChanged(
-                  is_loading=info.is_loading.unwrap_or(false),
-                ),
-              )
+            ("browser_loading_changed", Some(info), _, _) => {
+              let is_loading = info.is_loading.unwrap_or(false)
+              let transition = match window.observed_browser_loading {
+                None => []
+                Some(previous) =>
+                  if !previous && is_loading {
+                    [BrowserEvent::DidStartLoading]
+                  } else if previous && !is_loading {
+                    [BrowserEvent::DidFinishLoad]
+                  } else {
+                    []
+                  }
+              }
+              window.observed_browser_loading = Some(is_loading)
+              for transition_event in transition {
+                for handler in self.browser_event_handlers {
+                  ignore(
+                    self.window_tasks.spawn(
+                      () => handler(browser, transition_event),
+                      no_wait=true,
+                    ),
+                  )
+                }
+              }
+              Some(BrowserEvent::LoadingChanged(is_loading~))
+            }
             ("browser_navigated", Some(info), _, _) =>
               Some(BrowserEvent::Navigated(url=info.url.unwrap_or("")))
             ("browser_title_updated", Some(info), _, _) =>

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -227,6 +227,7 @@ priv struct RunningWindow {
   mut bridge_ready : Bool
   mut state : SessionWindowState
   mut observed_state : WindowState?
+  mut observed_browser_loading : Bool?
 }
 
 ///|
@@ -1027,6 +1028,8 @@ priv enum AppLifecycleState {
 /// An observed lifecycle change for a window's main browser page.
 pub(all) enum BrowserEvent {
   LoadingChanged(is_loading~ : Bool)
+  DidStartLoading
+  DidFinishLoad
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -2749,6 +2749,12 @@ test "app builder registers main browser lifecycle handlers" {
 }
 
 ///|
+test "browser loading lifecycle events are distinct" {
+  assert_eq(BrowserEvent::DidStartLoading, BrowserEvent::DidStartLoading)
+  assert_eq(BrowserEvent::DidFinishLoad, BrowserEvent::DidFinishLoad)
+}
+
+///|
 test "cookie records preserve Electron-style session fields" {
   let cookies = cookies_from_native([
     @native.NativeCookieRecord::{

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -321,6 +321,8 @@ pub fn BridgeDiagnostic::to_repr(Self) -> @debug.Repr
 
 pub(all) enum BrowserEvent {
   LoadingChanged(is_loading~ : Bool)
+  DidStartLoading
+  DidFinishLoad
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)


### PR DESCRIPTION
## Summary

- expose explicit browser loading lifecycle events: `DidStartLoading` and `DidFinishLoad`
- derive transitions from successive native loading snapshots without changing the native ABI
- preserve `LoadingChanged(Bool)` for existing consumers

## Electron alignment

The new events correspond to Electron `webContents` loading lifecycle usage. `LoadingChanged` remains the boolean compatibility form; the first native loading observation emits only that snapshot event because no previous state exists.

## Platform impact

No platform-specific native changes or new feature gates. The implementation uses the existing cross-platform browser loading event and the wake-driven runtime event loop.

## Validation

- `moon fmt --check`
- `moon -C proton test --target native --diagnostic-limit 80` (668/668)
- `moon -C examples build --target native --diagnostic-limit 80`
- `moon check --target native`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review

Pending runtime review on macOS, Windows, and Linux. Navigate, reload, and load failing URLs; verify `DidStartLoading` and `DidFinishLoad` occur once per boolean transition and `LoadingChanged` remains delivered.
