### PR TITLE
feat(view): expose loading lifecycle events

### DIFF
--- a/examples/52_web_contents_view/main.mbt
+++ b/examples/52_web_contents_view/main.mbt
@@ -366,6 +366,8 @@ async fn main {
           error=Some("load failed: " + error_text),
         )
       LoadingChanged(..) => ()
+      DidStartLoading => ()
+      DidFinishLoad => ()
       FoundInPage(..) => ()
       Closed => panel_slot.val = None
     }

--- a/examples/e2e_fixtures/web_contents_view.mbt
+++ b/examples/e2e_fixtures/web_contents_view.mbt
@@ -80,6 +80,8 @@ fn web_contents_view_event_line(event : @proton.ViewEvent) -> String {
   match event {
     LoadingChanged(is_loading~) =>
       "view_loading_changed loading=" + is_loading.to_string()
+    DidStartLoading => "view_did_start_loading"
+    DidFinishLoad => "view_did_finish_load"
     Navigated(url~) => "view_navigated url=" + url
     TitleUpdated(title~) => "view_title_updated title=" + title
     LoadFailed(url~, error_code~, error_text~) =>

--- a/proton/README.md
+++ b/proton/README.md
@@ -162,6 +162,10 @@ Browser loading events include `DidStartLoading` and `DidFinishLoad`, derived
 from successive native loading snapshots; `LoadingChanged` remains available
 for consumers that prefer the boolean form.
 
+Web contents views expose the same loading lifecycle events through
+`ViewEvent::DidStartLoading` and `ViewEvent::DidFinishLoad`; their
+`LoadingChanged` event remains available as the boolean form.
+
 ## Logging
 
 Use `tonyfettes/xlog@0.4.2` directly for application logs. Proton configures the

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -690,6 +690,7 @@ fn add_view_to_running_window(
     id: view_id,
     view: created,
     document: None,
+    observed_loading: None,
   }
   running.views.push(running_view)
   running_view
@@ -3143,8 +3144,32 @@ fn RuntimeSession::dispatch_view_event(
       let handle = self.view_handle(running, view)
       let view_event = match
         (event.event_type(), event.view_event(), event.find_in_page_result()) {
-        ("view_loading_changed", Some(info), _) =>
-          ViewEvent::LoadingChanged(is_loading=info.is_loading.unwrap_or(false))
+        ("view_loading_changed", Some(info), _) => {
+          let is_loading = info.is_loading.unwrap_or(false)
+          let transition = match view.observed_loading {
+            None => []
+            Some(previous) =>
+              if !previous && is_loading {
+                [ViewEvent::DidStartLoading]
+              } else if previous && !is_loading {
+                [ViewEvent::DidFinishLoad]
+              } else {
+                []
+              }
+          }
+          view.observed_loading = Some(is_loading)
+          for transition_event in transition {
+            for handler in self.view_event_handlers {
+              ignore(
+                self.window_tasks.spawn(
+                  () => handler(handle, transition_event),
+                  no_wait=true,
+                ),
+              )
+            }
+          }
+          ViewEvent::LoadingChanged(is_loading~)
+        }
         ("view_navigated", Some(info), _) =>
           ViewEvent::Navigated(url=info.url.unwrap_or(""))
         ("view_title_updated", Some(info), _) =>

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -235,6 +235,7 @@ priv struct RunningView {
   id : String
   view : @native.View
   mut document : ResourceDocument?
+  mut observed_loading : Bool?
 }
 
 ///|
@@ -734,6 +735,8 @@ fn window_state_events(
 /// `webContents` lifecycle and page-search events.
 pub(all) enum ViewEvent {
   LoadingChanged(is_loading~ : Bool)
+  DidStartLoading
+  DidFinishLoad
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -2755,6 +2755,12 @@ test "browser loading lifecycle events are distinct" {
 }
 
 ///|
+test "view loading lifecycle events are distinct" {
+  assert_eq(ViewEvent::DidStartLoading, ViewEvent::DidStartLoading)
+  assert_eq(ViewEvent::DidFinishLoad, ViewEvent::DidFinishLoad)
+}
+
+///|
 test "cookie records preserve Electron-style session fields" {
   let cookies = cookies_from_native([
     @native.NativeCookieRecord::{


### PR DESCRIPTION
## Summary
- expose Electron-style DidStartLoading and DidFinishLoad events for WebContentsView
- derive transitions from existing native view loading snapshots
- update examples, tests, and facade documentation

## Validation
- moon fmt --check
- moon -C proton test --target native --diagnostic-limit 80
- moon -C examples build --target native --diagnostic-limit 80
- moon check --target native
- node scripts/verify_generated.mjs
- git diff --check