### PR TITLE
feat(desktop-capturer): enumerate native window sources

### DIFF
--- a/extensions/desktop_capturer/contract/contract.mbt
+++ b/extensions/desktop_capturer/contract/contract.mbt
@@ -10,6 +10,10 @@ pub(all) struct Source {
   id : String
   name : String
   display_id : String
+  x : Int
+  y : Int
+  width : Int
+  height : Int
   thumbnail : String?
 } derive(ToJson, FromJson, Debug, Eq)
 

--- a/extensions/desktop_capturer/extension.mbt
+++ b/extensions/desktop_capturer/extension.mbt
@@ -2,6 +2,41 @@
 let get_sources_command = @desktop_capturer_contract.get_sources
 
 ///|
+struct WindowSourcesWire {
+  supported : Bool
+  sources : Array[WindowSourceWire]
+  error : String?
+} derive(FromJson)
+
+///|
+struct WindowSourceWire {
+  id : String
+  display_id : String
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+  thumbnail : String?
+  name : String
+} derive(FromJson)
+
+///|
+fn window_source_from_wire(
+  source : WindowSourceWire,
+) -> @desktop_capturer_contract.Source {
+  @desktop_capturer_contract.Source::{
+    id: source.id,
+    name: source.name,
+    display_id: source.display_id,
+    x: source.x,
+    y: source.y,
+    width: source.width,
+    height: source.height,
+    thumbnail: source.thumbnail,
+  }
+}
+
+///|
 fn source_from_display(
   d : @sys_screen_monitor.DisplayInfo,
 ) -> @desktop_capturer_contract.Source {
@@ -13,6 +48,10 @@ fn source_from_display(
       "Display " + d.id.to_string()
     },
     display_id: d.id.to_string(),
+    x: d.bounds.x,
+    y: d.bounds.y,
+    width: d.bounds.width,
+    height: d.bounds.height,
     thumbnail: None,
   }
 }
@@ -28,12 +67,14 @@ fn get_sources(
       detail="at least one source type is required",
     )
   }
+  let wants_windows = Ref(false)
+  let wants_screens = Ref(false)
   for source_type in request.types {
     if source_type == "window" {
-      raise Unsupported(
-        operation="window",
-        detail="window sources are not available in the initial desktopCapturer slice",
-      )
+      wants_windows.val = true
+    }
+    if source_type == "screen" {
+      wants_screens.val = true
     }
     if source_type != "screen" {
       raise Unsupported(
@@ -63,9 +104,29 @@ fn get_sources(
       raise QueryFailed(detail=error.to_string())
     }
   }
+  let screen_sources = if wants_screens.val {
+    displays.map(source_from_display)
+  } else {
+    []
+  }
+  let window_sources = if wants_windows.val {
+    let text = @utf8.decode_lossy(monitor.window_sources_json()[:])
+    let wire : WindowSourcesWire = @json.from_json(@json.parse(text)) catch {
+      _ => raise QueryFailed(detail="native window source payload is invalid")
+    }
+    if !wire.supported {
+      raise Unsupported(
+        operation="window",
+        detail=wire.error.unwrap_or("window sources are unavailable"),
+      )
+    }
+    wire.sources.map(window_source_from_wire)
+  } else {
+    []
+  }
   monitor.destroy()
   @desktop_capturer_contract.GetSourcesReply::{
-    sources: displays.map(source_from_display),
+    sources: screen_sources + window_sources,
   }
 }
 

--- a/extensions/desktop_capturer/moon.pkg
+++ b/extensions/desktop_capturer/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8",
   "moonbit-community/proton_screen_monitor" @sys_screen_monitor,
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,

--- a/sys/screen_monitor/moon.pkg
+++ b/sys/screen_monitor/moon.pkg
@@ -12,5 +12,6 @@ options(
     "native_windows.c",
     "native_macos.c",
     "native_linux.c",
+    "native_windows_sources.c",
   ],
 )

--- a/sys/screen_monitor/native_ffi.mbt
+++ b/sys/screen_monitor/native_ffi.mbt
@@ -29,6 +29,9 @@ extern "C" fn native_enumerate_json(handle : State) -> Bytes = "moonbit_screen_m
 extern "C" fn native_cursor_point_json(handle : State) -> Bytes = "moonbit_screen_monitor_cursor_point_json"
 
 ///|
+extern "C" fn native_window_sources_json() -> Bytes = "moonbit_screen_monitor_window_sources_json"
+
+///|
 #borrow(handle)
 extern "C" fn native_nearest_display_json(
   handle : State,

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -1,0 +1,99 @@
+#include "native_stub.h"
+
+#include <string.h>
+
+#ifdef _WIN32
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <wchar.h>
+
+typedef struct window_sources_buffer {
+  char *data;
+  size_t length;
+  size_t capacity;
+  int first;
+} window_sources_buffer_t;
+
+static int append_text(window_sources_buffer_t *buffer, const char *text) {
+  size_t length = strlen(text);
+  if (buffer->length + length + 1 > buffer->capacity) {
+    size_t capacity = buffer->capacity == 0 ? 1024 : buffer->capacity * 2;
+    while (capacity < buffer->length + length + 1) capacity *= 2;
+    char *data = (char *)realloc(buffer->data, capacity);
+    if (data == NULL) return 0;
+    buffer->data = data;
+    buffer->capacity = capacity;
+  }
+  memcpy(buffer->data + buffer->length, text, length);
+  buffer->length += length;
+  buffer->data[buffer->length] = '\0';
+  return 1;
+}
+
+static int append_json_string(window_sources_buffer_t *buffer, const wchar_t *value) {
+  int needed = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
+  if (needed <= 0) return 0;
+  char *utf8 = (char *)malloc((size_t)needed);
+  if (utf8 == NULL) return 0;
+  if (WideCharToMultiByte(CP_UTF8, 0, value, -1, utf8, needed, NULL, NULL) <= 0) {
+    free(utf8);
+    return 0;
+  }
+  if (!append_text(buffer, "\"")) { free(utf8); return 0; }
+  for (char *cursor = utf8; *cursor != '\0'; cursor++) {
+    char escaped[3] = { 0, 0, 0 };
+    if (*cursor == '\\' || *cursor == '"') {
+      escaped[0] = '\\'; escaped[1] = *cursor;
+      if (!append_text(buffer, escaped)) { free(utf8); return 0; }
+    } else if ((unsigned char)*cursor < 0x20) {
+      if (!append_text(buffer, " ")) { free(utf8); return 0; }
+    } else {
+      escaped[0] = *cursor;
+      if (!append_text(buffer, escaped)) { free(utf8); return 0; }
+    }
+  }
+  free(utf8);
+  return append_text(buffer, "\"");
+}
+
+static BOOL CALLBACK enumerate_window(HWND hwnd, LPARAM parameter) {
+  window_sources_buffer_t *buffer = (window_sources_buffer_t *)parameter;
+  if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) return TRUE;
+  wchar_t title[512];
+  int length = GetWindowTextW(hwnd, title, 512);
+  if (length <= 0) return TRUE;
+  RECT rect;
+  if (!GetWindowRect(hwnd, &rect) || rect.right <= rect.left || rect.bottom <= rect.top) return TRUE;
+  char item[256];
+  snprintf(item, sizeof(item), "%s{\"id\":\"window:%llu\",\"display_id\":\"\",\"x\":%ld,\"y\":%ld,\"width\":%ld,\"height\":%ld,\"thumbnail\":null,\"name\":",
+           buffer->first ? "" : ",", (unsigned long long)(uintptr_t)hwnd,
+           rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+  if (!append_text(buffer, item) || !append_json_string(buffer, title) || !append_text(buffer, "}")) return FALSE;
+  buffer->first = 0;
+  return TRUE;
+}
+
+#endif
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbit_screen_monitor_window_sources_json(void) {
+#ifdef _WIN32
+  window_sources_buffer_t buffer = { NULL, 0, 0, 1 };
+  if (!append_text(&buffer, "{\"supported\":true,\"sources\":[")) {
+    free(buffer.data); return moonbit_make_bytes(0, 0);
+  }
+  EnumWindows(enumerate_window, (LPARAM)&buffer);
+  if (!append_text(&buffer, "]}")) { free(buffer.data); return moonbit_make_bytes(0, 0); }
+  moonbit_bytes_t result = moonbit_make_bytes((int32_t)buffer.length, 0);
+  memcpy(result, buffer.data, buffer.length);
+  free(buffer.data);
+  return result;
+#else
+  const char *unsupported = "{\"supported\":false,\"sources\":[],\"error\":\"window sources are not implemented on this platform\"}";
+  size_t length = strlen(unsupported);
+  moonbit_bytes_t result = moonbit_make_bytes((int32_t)length, 0);
+  memcpy(result, unsupported, length);
+  return result;
+#endif
+}

--- a/sys/screen_monitor/pkg.generated.mbti
+++ b/sys/screen_monitor/pkg.generated.mbti
@@ -71,6 +71,7 @@ pub fn ScreenMonitor::drain_events(Self) -> Array[ScreenMonitorEvent]
 pub fn ScreenMonitor::primary_display(Self) -> DisplayInfo raise ScreenMonitorError
 pub fn ScreenMonitor::start_watching(Self) -> Unit raise ScreenMonitorError
 pub fn ScreenMonitor::stop_watching(Self) -> Unit raise ScreenMonitorError
+pub fn ScreenMonitor::window_sources_json(Self) -> Bytes
 
 pub enum ScreenMonitorEvent {
   DisplayAdded

--- a/sys/screen_monitor/screen_monitor.mbt
+++ b/sys/screen_monitor/screen_monitor.mbt
@@ -264,6 +264,14 @@ pub fn ScreenMonitor::cursor_point(
 }
 
 ///|
+/// Returns the current native window source snapshot as JSON. The payload is
+/// consumed by the desktop-capturer extension; unsupported platforms return a
+/// structured `supported: false` payload.
+pub fn ScreenMonitor::window_sources_json(_self : ScreenMonitor) -> Bytes {
+  native_window_sources_json()
+}
+
+///|
 /// Starts the event watch backend. The backend is best-effort: a platform that
 /// cannot watch (for example Linux without an X11 display or RandR) records the
 /// failure on the native side and returns `BackendUnavailable`, leaving polling


### PR DESCRIPTION
## Summary
- extend the desktop-capturer source contract with window bounds
- enumerate visible, titled Windows windows through explicit Unicode Win32 APIs
- preserve structured unsupported responses on macOS/Linux until their native window APIs are added
- keep thumbnails explicitly null until real capture backends are implemented

## Electron alignment
- `desktopCapturer.getSources({ types: ["window"] })` now returns native window source metadata on Windows
- sources include stable `window:<HWND>` ids, titles, display ids, and physical bounds
- thumbnail capture remains a follow-up; Proton never returns placeholder image data

## Platform impact
- Windows: native implementation using `EnumWindows`, `GetWindowTextW`, `GetWindowRect`, `IsWindowVisible`, and `IsIconic`
- macOS/Linux: explicit unsupported response for window sources
- no ANSI Win32 APIs are used

## Validation
- `moon fmt --check`
- `moon -C extensions test -p moonbit-community/proton_ext/desktop_capturer --target native --diagnostic-limit 80`
- `moon check --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- `node scripts/verify_release_metadata.mjs`
- `git diff --check`

## Follow-up
- add macOS ScreenCaptureKit/CGWindow and Linux X11/portal window enumeration
- add real thumbnails and permission-aware capture behavior on each platform
