### PR TITLE
feat(desktop-capturer): add native window thumbnails

### DIFF
--- a/extensions/desktop_capturer/extension.mbt
+++ b/extensions/desktop_capturer/extension.mbt
@@ -76,16 +76,18 @@ fn get_sources(
     if source_type == "screen" {
       wants_screens.val = true
     }
-    if source_type != "screen" {
+    if source_type != "screen" && source_type != "window" {
       raise Unsupported(
         operation="source type",
-        detail="only the screen source type is currently supported",
+        detail="only the screen and window source types are currently supported",
       )
     }
   }
   match request.thumbnail_width {
     Some(width) if width <= 0 =>
       raise QueryFailed(detail="thumbnail width must be positive when supplied")
+    Some(width) if width > 4096 =>
+      raise QueryFailed(detail="thumbnail width must not exceed 4096")
     _ => ()
   }
   match request.thumbnail_height {
@@ -93,6 +95,8 @@ fn get_sources(
       raise QueryFailed(
         detail="thumbnail height must be positive when supplied",
       )
+    Some(height) if height > 4096 =>
+      raise QueryFailed(detail="thumbnail height must not exceed 4096")
     _ => ()
   }
   let monitor = @sys_screen_monitor.ScreenMonitor() catch {
@@ -110,7 +114,11 @@ fn get_sources(
     []
   }
   let window_sources = if wants_windows.val {
-    let text = @utf8.decode_lossy(monitor.window_sources_json()[:])
+    let thumbnail_width = request.thumbnail_width.unwrap_or(0)
+    let thumbnail_height = request.thumbnail_height.unwrap_or(0)
+    let text = @utf8.decode_lossy(
+      monitor.window_sources_json(thumbnail_width, thumbnail_height)[:],
+    )
     let wire : WindowSourcesWire = @json.from_json(@json.parse(text)) catch {
       _ => raise QueryFailed(detail="native window source payload is invalid")
     }

--- a/sys/screen_monitor/native_ffi.mbt
+++ b/sys/screen_monitor/native_ffi.mbt
@@ -29,7 +29,7 @@ extern "C" fn native_enumerate_json(handle : State) -> Bytes = "moonbit_screen_m
 extern "C" fn native_cursor_point_json(handle : State) -> Bytes = "moonbit_screen_monitor_cursor_point_json"
 
 ///|
-extern "C" fn native_window_sources_json() -> Bytes = "moonbit_screen_monitor_window_sources_json"
+extern "C" fn native_window_sources_json(width : Int, height : Int) -> Bytes = "moonbit_screen_monitor_window_sources_json"
 
 ///|
 #borrow(handle)

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -7,13 +7,66 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <wchar.h>
+#include <stdint.h>
+#include <windows.h>
 
 typedef struct window_sources_buffer {
   char *data;
   size_t length;
   size_t capacity;
   int first;
+  int width;
+  int height;
 } window_sources_buffer_t;
+
+static const char base64_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static char *capture_thumbnail(HWND hwnd, int width, int height) {
+  if (width <= 0 || height <= 0) return NULL;
+  RECT rect;
+  if (!GetWindowRect(hwnd, &rect)) return NULL;
+  int source_width = rect.right - rect.left;
+  int source_height = rect.bottom - rect.top;
+  if (source_width <= 0 || source_height <= 0) return NULL;
+  HDC source = GetWindowDC(hwnd);
+  HDC target = CreateCompatibleDC(source);
+  HBITMAP bitmap = CreateCompatibleBitmap(source, width, height);
+  if (source == NULL || target == NULL || bitmap == NULL) {
+    if (bitmap) DeleteObject(bitmap); if (target) DeleteDC(target); if (source) ReleaseDC(hwnd, source);
+    return NULL;
+  }
+  HGDIOBJ old = SelectObject(target, bitmap);
+  SetStretchBltMode(target, HALFTONE);
+  BOOL captured = PrintWindow(hwnd, target, 2);
+  if (!captured) captured = StretchBlt(target, 0, 0, width, height, source, 0, 0, source_width, source_height, SRCCOPY);
+  BITMAPINFO info; memset(&info, 0, sizeof(info));
+  info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER); info.bmiHeader.biWidth = width;
+  info.bmiHeader.biHeight = -height; info.bmiHeader.biPlanes = 1; info.bmiHeader.biBitCount = 32;
+  info.bmiHeader.biCompression = BI_RGB;
+  size_t pixels_size = (size_t)width * (size_t)height * 4;
+  unsigned char *pixels = (unsigned char *)malloc(pixels_size);
+  char *result = NULL;
+  if (captured && pixels && GetDIBits(target, bitmap, 0, (UINT)height, pixels, &info, DIB_RGB_COLORS) == (int)height) {
+    size_t raw_size = 54 + pixels_size;
+    size_t encoded_size = ((raw_size + 2) / 3) * 4;
+    result = (char *)malloc(23 + encoded_size + 1);
+    if (result) {
+      unsigned char *raw = (unsigned char *)calloc(1, raw_size);
+      if (!raw) { free(result); result = NULL; }
+      else {
+        raw[0] = 'B'; raw[1] = 'M'; uint32_t file_size = (uint32_t)raw_size;
+        memcpy(raw + 2, &file_size, 4); uint32_t offset = 54; memcpy(raw + 10, &offset, 4);
+        uint32_t header_size = 40; memcpy(raw + 14, &header_size, 4); int32_t bmp_height = -height; memcpy(raw + 18, &width, 4); memcpy(raw + 22, &bmp_height, 4);
+        uint16_t planes = 1, bits = 32; memcpy(raw + 26, &planes, 2); memcpy(raw + 28, &bits, 2); uint32_t image_size = (uint32_t)pixels_size; memcpy(raw + 34, &image_size, 4);
+        memcpy(raw + 54, pixels, pixels_size); memcpy(result, "data:image/bmp;base64,", 22);
+        size_t out = 22;
+        for (size_t i = 0; i < raw_size; i += 3) { uint32_t v = raw[i] << 16; if (i + 1 < raw_size) v |= raw[i + 1] << 8; if (i + 2 < raw_size) v |= raw[i + 2]; result[out++] = base64_table[(v >> 18) & 63]; result[out++] = base64_table[(v >> 12) & 63]; result[out++] = i + 1 < raw_size ? base64_table[(v >> 6) & 63] : '='; result[out++] = i + 2 < raw_size ? base64_table[v & 63] : '='; }
+        result[out] = '\0'; free(raw);
+      }
+    }
+  }
+  free(pixels); SelectObject(target, old); DeleteObject(bitmap); DeleteDC(target); ReleaseDC(hwnd, source); return result;
+}
 
 static int append_text(window_sources_buffer_t *buffer, const char *text) {
   size_t length = strlen(text);
@@ -66,10 +119,15 @@ static BOOL CALLBACK enumerate_window(HWND hwnd, LPARAM parameter) {
   RECT rect;
   if (!GetWindowRect(hwnd, &rect) || rect.right <= rect.left || rect.bottom <= rect.top) return TRUE;
   char item[256];
-  snprintf(item, sizeof(item), "%s{\"id\":\"window:%llu\",\"display_id\":\"\",\"x\":%ld,\"y\":%ld,\"width\":%ld,\"height\":%ld,\"thumbnail\":null,\"name\":",
+  char *thumbnail = capture_thumbnail(hwnd, buffer->width, buffer->height);
+  snprintf(item, sizeof(item), "%s{\"id\":\"window:%llu\",\"display_id\":\"\",\"x\":%ld,\"y\":%ld,\"width\":%ld,\"height\":%ld,\"thumbnail\":",
            buffer->first ? "" : ",", (unsigned long long)(uintptr_t)hwnd,
            rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
-  if (!append_text(buffer, item) || !append_json_string(buffer, title) || !append_text(buffer, "}")) return FALSE;
+  int ok = append_text(buffer, item);
+  if (ok && thumbnail) ok = append_text(buffer, "\"") && append_text(buffer, thumbnail) && append_text(buffer, "\"");
+  if (ok && !thumbnail) ok = append_text(buffer, "null");
+  ok = ok && append_text(buffer, ",\"name\":") && append_json_string(buffer, title) && append_text(buffer, "}");
+  free(thumbnail); if (!ok) return FALSE;
   buffer->first = 0;
   return TRUE;
 }
@@ -77,9 +135,9 @@ static BOOL CALLBACK enumerate_window(HWND hwnd, LPARAM parameter) {
 #endif
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbit_screen_monitor_window_sources_json(void) {
+moonbit_bytes_t moonbit_screen_monitor_window_sources_json(int32_t width, int32_t height) {
 #ifdef _WIN32
-  window_sources_buffer_t buffer = { NULL, 0, 0, 1 };
+  window_sources_buffer_t buffer = { NULL, 0, 0, 1, width, height };
   if (!append_text(&buffer, "{\"supported\":true,\"sources\":[")) {
     free(buffer.data); return moonbit_make_bytes(0, 0);
   }

--- a/sys/screen_monitor/screen_monitor.mbt
+++ b/sys/screen_monitor/screen_monitor.mbt
@@ -267,8 +267,12 @@ pub fn ScreenMonitor::cursor_point(
 /// Returns the current native window source snapshot as JSON. The payload is
 /// consumed by the desktop-capturer extension; unsupported platforms return a
 /// structured `supported: false` payload.
-pub fn ScreenMonitor::window_sources_json(_self : ScreenMonitor) -> Bytes {
-  native_window_sources_json()
+pub fn ScreenMonitor::window_sources_json(
+  _self : ScreenMonitor,
+  width : Int,
+  height : Int,
+) -> Bytes {
+  native_window_sources_json(width, height)
 }
 
 ///|


### PR DESCRIPTION
## Summary
- enable the window source type in desktopCapturer
- capture Windows window thumbnails as BMP data URLs with requested dimensions
- preserve structured unsupported behavior on macOS and Linux

## Validation
- moon fmt --check
- moon -C extensions test -p moonbit-community/proton_ext/desktop_capturer --target native --diagnostic-limit 80
- moon check --target native --diagnostic-limit 80
- node scripts/verify_generated.mjs
- node scripts/verify_release_metadata.mjs
- git diff --check

Windows runtime capture requires CI/manual verification on a Windows desktop session.