### PR TITLE
chore(screen-monitor): refresh generated interface

### DIFF
--- a/sys/screen_monitor/pkg.generated.mbti
+++ b/sys/screen_monitor/pkg.generated.mbti
@@ -71,7 +71,7 @@ pub fn ScreenMonitor::drain_events(Self) -> Array[ScreenMonitorEvent]
 pub fn ScreenMonitor::primary_display(Self) -> DisplayInfo raise ScreenMonitorError
 pub fn ScreenMonitor::start_watching(Self) -> Unit raise ScreenMonitorError
 pub fn ScreenMonitor::stop_watching(Self) -> Unit raise ScreenMonitorError
-pub fn ScreenMonitor::window_sources_json(Self) -> Bytes
+pub fn ScreenMonitor::window_sources_json(Self, Int, Int) -> Bytes
 
 pub enum ScreenMonitorEvent {
   DisplayAdded


### PR DESCRIPTION
## Summary
- synchronize the generated ScreenMonitor interface with the window source thumbnail dimensions

## Validation
- moon fmt --check
- desktop capturer native tests
- node scripts/verify_generated.mjs
- node scripts/verify_release_metadata.mjs
- git diff --check