### PR TITLE
feat(desktop-capturer): capture screen thumbnails

### DIFF
--- a/extensions/desktop_capturer/extension.mbt
+++ b/extensions/desktop_capturer/extension.mbt
@@ -39,6 +39,7 @@ fn window_source_from_wire(
 ///|
 fn source_from_display(
   d : @sys_screen_monitor.DisplayInfo,
+  thumbnail : String?,
 ) -> @desktop_capturer_contract.Source {
   @desktop_capturer_contract.Source::{
     id: "screen:" + d.id.to_string(),
@@ -52,7 +53,7 @@ fn source_from_display(
     y: d.bounds.y,
     width: d.bounds.width,
     height: d.bounds.height,
-    thumbnail: None,
+    thumbnail,
   }
 }
 
@@ -109,7 +110,25 @@ fn get_sources(
     }
   }
   let screen_sources = if wants_screens.val {
-    displays.map(source_from_display)
+    let thumbnail_width = request.thumbnail_width.unwrap_or(0)
+    let thumbnail_height = request.thumbnail_height.unwrap_or(0)
+    displays.map(fn(display) {
+      let thumbnail = if thumbnail_width > 0 && thumbnail_height > 0 {
+        let bytes = monitor.display_thumbnail(
+          display.id,
+          thumbnail_width,
+          thumbnail_height,
+        )
+        if bytes.length() > 0 {
+          Some(@utf8.decode_lossy(bytes[:]))
+        } else {
+          None
+        }
+      } else {
+        None
+      }
+      source_from_display(display, thumbnail)
+    })
   } else {
     []
   }

--- a/sys/screen_monitor/native_ffi.mbt
+++ b/sys/screen_monitor/native_ffi.mbt
@@ -32,6 +32,13 @@ extern "C" fn native_cursor_point_json(handle : State) -> Bytes = "moonbit_scree
 extern "C" fn native_window_sources_json(width : Int, height : Int) -> Bytes = "moonbit_screen_monitor_window_sources_json"
 
 ///|
+extern "C" fn native_display_thumbnail(
+  display_id : Int,
+  width : Int,
+  height : Int,
+) -> Bytes = "moonbit_screen_monitor_display_thumbnail"
+
+///|
 #borrow(handle)
 extern "C" fn native_nearest_display_json(
   handle : State,

--- a/sys/screen_monitor/native_macos.c
+++ b/sys/screen_monitor/native_macos.c
@@ -4,6 +4,7 @@
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Screen enumeration, cursor location, and hot-plug reconfiguration arrive
@@ -48,6 +49,14 @@ typedef proton_cg_error (*proton_cg_display_remove_reconfiguration_fn)(
 typedef proton_cf_type_ref (*proton_cg_event_create_fn)(uint32_t);
 typedef proton_cg_point_t (*proton_cg_event_get_location_fn)(proton_cf_type_ref);
 typedef void (*proton_cf_release_fn)(proton_cf_type_ref);
+typedef proton_cf_type_ref (*proton_cg_display_create_image_fn)(
+    proton_cg_direct_display_id);
+typedef proton_cf_type_ref (*proton_cg_color_space_create_device_rgb_fn)(void);
+typedef proton_cf_type_ref (*proton_cg_bitmap_context_create_fn)(
+    void *, size_t, size_t, size_t, size_t, proton_cf_type_ref, uint32_t);
+typedef void (*proton_cg_context_draw_image_fn)(proton_cf_type_ref,
+                                                proton_cg_rect,
+                                                proton_cf_type_ref);
 
 static struct {
   proton_cg_get_active_display_list_fn get_active_display_list;
@@ -60,6 +69,10 @@ static struct {
   proton_cg_event_create_fn event_create;
   proton_cg_event_get_location_fn event_get_location;
   proton_cf_release_fn release;
+  proton_cg_display_create_image_fn display_create_image;
+  proton_cg_color_space_create_device_rgb_fn color_space_create_device_rgb;
+  proton_cg_bitmap_context_create_fn bitmap_context_create;
+  proton_cg_context_draw_image_fn context_draw_image;
   int32_t loaded;
   int32_t ready;
 } g_mac;
@@ -117,6 +130,16 @@ static int32_t screen_monitor_load_mac_symbols(void) {
       (proton_cg_event_get_location_fn)dlsym(core_graphics,
                                              "CGEventGetLocation");
   g_mac.release = (proton_cf_release_fn)dlsym(core_foundation, "CFRelease");
+  g_mac.display_create_image = (proton_cg_display_create_image_fn)dlsym(
+      core_graphics, "CGDisplayCreateImage");
+  g_mac.color_space_create_device_rgb =
+      (proton_cg_color_space_create_device_rgb_fn)dlsym(
+          core_graphics, "CGColorSpaceCreateDeviceRGB");
+  g_mac.bitmap_context_create =
+      (proton_cg_bitmap_context_create_fn)dlsym(core_graphics,
+                                                "CGBitmapContextCreate");
+  g_mac.context_draw_image = (proton_cg_context_draw_image_fn)dlsym(
+      core_graphics, "CGContextDrawImage");
   g_mac.ready = g_mac.get_active_display_list != NULL &&
                 g_mac.display_bounds != NULL &&
                 g_mac.display_is_main != NULL && g_mac.pixels_wide != NULL &&
@@ -126,6 +149,91 @@ static int32_t screen_monitor_load_mac_symbols(void) {
                 g_mac.event_create != NULL && g_mac.event_get_location != NULL &&
                 g_mac.release != NULL;
   return g_mac.ready;
+}
+
+static const char screen_monitor_base64_table[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbit_screen_monitor_display_thumbnail(int32_t display_id,
+                                                         int32_t width,
+                                                         int32_t height) {
+  if (width <= 0 || height <= 0 || !screen_monitor_load_mac_symbols() ||
+      g_mac.display_create_image == NULL ||
+      g_mac.color_space_create_device_rgb == NULL ||
+      g_mac.bitmap_context_create == NULL || g_mac.context_draw_image == NULL) {
+    return moonbit_make_bytes(0, 0);
+  }
+  size_t pixel_size = (size_t)width * (size_t)height * 4;
+  if (pixel_size / 4 != (size_t)width * (size_t)height) {
+    return moonbit_make_bytes(0, 0);
+  }
+  unsigned char *pixels = (unsigned char *)calloc(1, pixel_size);
+  proton_cf_type_ref image =
+      g_mac.display_create_image((proton_cg_direct_display_id)display_id);
+  proton_cf_type_ref color_space = g_mac.color_space_create_device_rgb();
+  proton_cf_type_ref context = NULL;
+  if (pixels != NULL && image != NULL && color_space != NULL) {
+    context = g_mac.bitmap_context_create(pixels, (size_t)width,
+                                          (size_t)height, 8,
+                                          (size_t)width * 4, color_space,
+                                          1u | 0x4000u);
+  }
+  if (context == NULL) {
+    if (image != NULL) g_mac.release(image);
+    if (color_space != NULL) g_mac.release(color_space);
+    free(pixels);
+    return moonbit_make_bytes(0, 0);
+  }
+  proton_cg_rect bounds = {0, 0, (proton_cg_float)width,
+                           (proton_cg_float)height};
+  g_mac.context_draw_image(context, bounds, image);
+  for (size_t i = 0; i < pixel_size; i += 4) {
+    unsigned char red = pixels[i];
+    pixels[i] = pixels[i + 2];
+    pixels[i + 2] = red;
+  }
+  size_t raw_size = 54 + pixel_size;
+  size_t encoded_size = ((raw_size + 2) / 3) * 4;
+  unsigned char *raw = (unsigned char *)calloc(1, raw_size);
+  moonbit_bytes_t result = moonbit_make_bytes(0, 0);
+  if (raw != NULL && raw_size <= UINT32_MAX) {
+    uint32_t file_size = (uint32_t)raw_size;
+    uint32_t offset = 54;
+    uint32_t header_size = 40;
+    int32_t bitmap_height = -height;
+    uint16_t planes = 1;
+    uint16_t bits = 32;
+    uint32_t image_size = (uint32_t)pixel_size;
+    raw[0] = 'B'; raw[1] = 'M';
+    memcpy(raw + 2, &file_size, 4); memcpy(raw + 10, &offset, 4);
+    memcpy(raw + 14, &header_size, 4); memcpy(raw + 18, &width, 4);
+    memcpy(raw + 22, &bitmap_height, 4); memcpy(raw + 26, &planes, 2);
+    memcpy(raw + 28, &bits, 2); memcpy(raw + 34, &image_size, 4);
+    memcpy(raw + 54, pixels, pixel_size);
+    result = moonbit_make_bytes((int32_t)(22 + encoded_size), 0);
+    memcpy(result, "data:image/bmp;base64,", 22);
+    size_t out = 22;
+    for (size_t i = 0; i < raw_size; i += 3) {
+      uint32_t value = (uint32_t)raw[i] << 16;
+      if (i + 1 < raw_size) value |= (uint32_t)raw[i + 1] << 8;
+      if (i + 2 < raw_size) value |= raw[i + 2];
+      result[out++] = screen_monitor_base64_table[(value >> 18) & 63];
+      result[out++] = screen_monitor_base64_table[(value >> 12) & 63];
+      result[out++] = i + 1 < raw_size
+                          ? screen_monitor_base64_table[(value >> 6) & 63]
+                          : '=';
+      result[out++] = i + 2 < raw_size
+                          ? screen_monitor_base64_table[value & 63]
+                          : '=';
+    }
+  }
+  free(raw);
+  g_mac.release(context);
+  g_mac.release(color_space);
+  g_mac.release(image);
+  free(pixels);
+  return result;
 }
 
 void screen_monitor_platform_init(screen_monitor_state_t *state) {

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -156,7 +156,7 @@ moonbit_bytes_t moonbit_screen_monitor_window_sources_json(int32_t width, int32_
 #endif
 }
 
-#ifndef __APPLE__
+#if !defined(_WIN32) && !defined(__APPLE__)
 MOONBIT_FFI_EXPORT
 moonbit_bytes_t moonbit_screen_monitor_display_thumbnail(int32_t display_id,
                                                          int32_t width,

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -155,3 +155,15 @@ moonbit_bytes_t moonbit_screen_monitor_window_sources_json(int32_t width, int32_
   return result;
 #endif
 }
+
+#ifndef __APPLE__
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbit_screen_monitor_display_thumbnail(int32_t display_id,
+                                                         int32_t width,
+                                                         int32_t height) {
+  (void)display_id;
+  (void)width;
+  (void)height;
+  return moonbit_make_bytes(0, 0);
+}
+#endif

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -156,7 +156,7 @@ moonbit_bytes_t moonbit_screen_monitor_window_sources_json(int32_t width, int32_
 #endif
 }
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(__APPLE__)
 MOONBIT_FFI_EXPORT
 moonbit_bytes_t moonbit_screen_monitor_display_thumbnail(int32_t display_id,
                                                          int32_t width,

--- a/sys/screen_monitor/pkg.generated.mbti
+++ b/sys/screen_monitor/pkg.generated.mbti
@@ -66,6 +66,7 @@ pub fn ScreenMonitor::ScreenMonitor() -> Self raise ScreenMonitorError
 pub fn ScreenMonitor::cursor_point(Self) -> Point raise ScreenMonitorError
 pub fn ScreenMonitor::destroy(Self) -> Unit
 pub fn ScreenMonitor::display_nearest_point(Self, Int, Int) -> DisplayInfo raise ScreenMonitorError
+pub fn ScreenMonitor::display_thumbnail(Self, Int, Int, Int) -> Bytes
 pub fn ScreenMonitor::displays(Self) -> Array[DisplayInfo] raise ScreenMonitorError
 pub fn ScreenMonitor::drain_events(Self) -> Array[ScreenMonitorEvent]
 pub fn ScreenMonitor::primary_display(Self) -> DisplayInfo raise ScreenMonitorError

--- a/sys/screen_monitor/screen_monitor.mbt
+++ b/sys/screen_monitor/screen_monitor.mbt
@@ -276,6 +276,18 @@ pub fn ScreenMonitor::window_sources_json(
 }
 
 ///|
+/// Captures a display thumbnail as a BMP data URL. An empty byte string means
+/// that capture is unavailable or was denied by the operating system.
+pub fn ScreenMonitor::display_thumbnail(
+  _self : ScreenMonitor,
+  display_id : Int,
+  width : Int,
+  height : Int,
+) -> Bytes {
+  native_display_thumbnail(display_id, width, height)
+}
+
+///|
 /// Starts the event watch backend. The backend is best-effort: a platform that
 /// cannot watch (for example Linux without an X11 display or RandR) records the
 /// failure on the native side and returns `BackendUnavailable`, leaving polling


### PR DESCRIPTION
## Summary
- capture macOS display thumbnails through CoreGraphics
- expose display thumbnail capture through the private screen monitor FFI
- preserve empty thumbnails when capture is unavailable or denied

## Validation
- moon fmt --check
- desktop capturer native tests
- moon check --target native --diagnostic-limit 80
- node scripts/verify_generated.mjs
- node scripts/verify_release_metadata.mjs
- git diff --check

Windows and Linux use the explicit empty-thumbnail fallback in this slice.