### PR TITLE
docs(desktop-capturer): document linux thumbnail limits

### DIFF
--- a/extensions/desktop_capturer/README.md
+++ b/extensions/desktop_capturer/README.md
@@ -1,0 +1,19 @@
+# desktopCapturer
+
+The `desktopCapturer` extension exposes Electron-compatible `getSources` data
+through Proton's typed command bridge.
+
+Supported source types are `screen` and `window`:
+
+- Windows enumerates visible titled windows and captures requested window
+  thumbnails with the native GDI backend.
+- macOS enumerates displays and captures requested screen thumbnails through
+  CoreGraphics when the process has screen-recording permission.
+- Linux enumerates displays through the existing X11/RandR monitor backend.
+  Screen and window thumbnails are currently unavailable and are returned as
+  `null`; the source geometry remains usable.
+
+`thumbnail_width` and `thumbnail_height` must be supplied together, must be
+positive, and may not exceed 4096. Omitting either dimension disables thumbnail
+capture. A missing thumbnail indicates that the platform backend or required
+operating-system permission is unavailable; it is not a placeholder image.

--- a/extensions/desktop_capturer/extension_wbtest.mbt
+++ b/extensions/desktop_capturer/extension_wbtest.mbt
@@ -6,3 +6,15 @@ test "desktop capturer extension metadata" {
     "ext:desktopCapturer/getSources",
   ])
 }
+
+///|
+test "desktop capturer contract documents optional thumbnails" {
+  let request = @desktop_capturer_contract.GetSourcesRequest::{
+    types: ["screen", "window"],
+    thumbnail_width: Some(320),
+    thumbnail_height: Some(200),
+  }
+  assert_eq(request.types.length(), 2)
+  assert_eq(request.thumbnail_width, Some(320))
+  assert_eq(request.thumbnail_height, Some(200))
+}


### PR DESCRIPTION
## Summary
- document desktopCapturer source and thumbnail behavior by platform
- add a contract test covering screen/window sources and optional thumbnail dimensions
- clarify that Linux currently returns geometry with null thumbnails

## Validation
- moon fmt --check
- desktop capturer native tests
- node scripts/verify_generated.mjs
- node scripts/verify_release_metadata.mjs
- git diff --check