### PR TITLE
feat(native): add synchronous web request interception hook

### DIFF
--- a/proton/internal/native/ffi/moon.pkg
+++ b/proton/internal/native/ffi/moon.pkg
@@ -19,6 +19,7 @@ options(
     "src/proton_state.c",
     "src/proton_system_path.c",
     "src/proton_update.c",
+    "src/proton_web_request_config.c",
     "src/proton.c",
     "src/engine/cef_common/bridge_client.c",
     "src/engine/cef_common/bridge_lifecycle.c",

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -77,6 +77,7 @@ typedef struct proton_browser_navigation_bypass {
 
 struct proton_browser_session {
   proton_browser_policy_t policy;
+  proton_web_request_config_t *web_request_config;
   proton_browser_lifecycle_t *lifecycle;
   proton_window_id_t window;
   uint64_t next_request_id;
@@ -94,6 +95,143 @@ struct proton_browser_session {
 };
 
 static char *proton_browser_cef_string_to_utf8(const cef_string_t *value);
+
+typedef struct proton_browser_resource_handler {
+  cef_resource_request_handler_t handler;
+#ifdef _WIN32
+  volatile LONG refs;
+#else
+  atomic_int refs;
+#endif
+  proton_browser_session_t *session;
+} proton_browser_resource_handler_t;
+
+static proton_browser_resource_handler_t *
+proton_browser_resource_handler_from_base(cef_base_ref_counted_t *base) {
+  return (proton_browser_resource_handler_t *)base;
+}
+
+static void CEF_CALLBACK proton_browser_resource_handler_add_ref(
+    cef_base_ref_counted_t *base) {
+  proton_browser_resource_handler_t *handler =
+      proton_browser_resource_handler_from_base(base);
+#ifdef _WIN32
+  (void)InterlockedIncrement(&handler->refs);
+#else
+  (void)atomic_fetch_add_explicit(&handler->refs, 1, memory_order_relaxed);
+#endif
+}
+
+static int CEF_CALLBACK proton_browser_resource_handler_release(
+    cef_base_ref_counted_t *base) {
+  proton_browser_resource_handler_t *handler =
+      proton_browser_resource_handler_from_base(base);
+#ifdef _WIN32
+  LONG refs = InterlockedDecrement(&handler->refs);
+#else
+  int refs = atomic_fetch_sub_explicit(
+                 &handler->refs, 1, memory_order_acq_rel) -
+             1;
+#endif
+  if (refs == 0) {
+    free(handler);
+    return 1;
+  }
+  return 0;
+}
+
+static int CEF_CALLBACK proton_browser_resource_handler_has_one_ref(
+    cef_base_ref_counted_t *base) {
+  proton_browser_resource_handler_t *handler =
+      proton_browser_resource_handler_from_base(base);
+#ifdef _WIN32
+  return handler->refs == 1;
+#else
+  return atomic_load_explicit(&handler->refs, memory_order_acquire) == 1;
+#endif
+}
+
+static int CEF_CALLBACK proton_browser_resource_handler_has_at_least_one_ref(
+    cef_base_ref_counted_t *base) {
+  proton_browser_resource_handler_t *handler =
+      proton_browser_resource_handler_from_base(base);
+#ifdef _WIN32
+  return handler->refs > 0;
+#else
+  return atomic_load_explicit(&handler->refs, memory_order_acquire) > 0;
+#endif
+}
+
+static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
+    cef_resource_request_handler_t *self, cef_browser_t *browser,
+    cef_frame_t *frame, cef_request_t *request, cef_callback_t *callback) {
+  (void)browser;
+  (void)frame;
+  (void)callback;
+  proton_browser_resource_handler_t *handler =
+      (proton_browser_resource_handler_t *)self;
+  if (request == NULL || request->get_url == NULL) {
+    return RV_CONTINUE;
+  }
+  cef_string_userfree_t url = request->get_url(request);
+  char *url_utf8 = proton_browser_cef_string_to_utf8(url);
+  int result = proton_browser_session_before_resource_load(handler->session,
+                                                           url_utf8);
+  if (url != NULL) {
+    cef_string_userfree_free(url);
+  }
+  free(url_utf8);
+  return result == 0 ? RV_CANCEL : RV_CONTINUE;
+}
+
+static void proton_browser_resource_handler_init(
+    proton_browser_resource_handler_t *handler,
+    proton_browser_session_t *session) {
+  memset(handler, 0, sizeof(*handler));
+  handler->handler.base.size = sizeof(handler->handler);
+  handler->handler.base.add_ref = proton_browser_resource_handler_add_ref;
+  handler->handler.base.release = proton_browser_resource_handler_release;
+  handler->handler.base.has_one_ref =
+      proton_browser_resource_handler_has_one_ref;
+  handler->handler.base.has_at_least_one_ref =
+      proton_browser_resource_handler_has_at_least_one_ref;
+  handler->handler.on_before_resource_load =
+      proton_browser_on_before_resource_load;
+#ifdef _WIN32
+  handler->refs = 1;
+#else
+  atomic_init(&handler->refs, 1);
+#endif
+  handler->session = session;
+}
+
+cef_resource_request_handler_t *proton_browser_session_resource_handler(
+    proton_browser_session_t *session) {
+  if (session == NULL) {
+    return NULL;
+  }
+  proton_browser_resource_handler_t *handler =
+      (proton_browser_resource_handler_t *)calloc(1, sizeof(*handler));
+  if (handler == NULL) {
+    return NULL;
+  }
+  proton_browser_resource_handler_init(handler, session);
+  return &handler->handler;
+}
+
+proton_web_request_config_t *proton_browser_session_web_request_config(
+    proton_browser_session_t *session) {
+  return session != NULL ? session->web_request_config : NULL;
+}
+
+int proton_browser_session_before_resource_load(
+    proton_browser_session_t *session, const char *url) {
+  return session != NULL &&
+                 proton_web_request_config_should_cancel(
+                     session->web_request_config, url)
+             ? 0
+             : 1;
+}
 
 static proton_pdf_print_callback_t *proton_pdf_print_callback_from_base(
     cef_base_ref_counted_t *base) {
@@ -224,14 +362,17 @@ static int proton_browser_enqueue_event(proton_browser_session_t *session,
 }
 
 proton_browser_session_t *proton_browser_session_create(
-    const proton_browser_policy_t *policy, proton_browser_signal_fn signal,
-    void *signal_user_data) {
+    const proton_browser_policy_t *policy,
+    proton_web_request_config_t *web_request_config,
+    proton_browser_signal_fn signal, void *signal_user_data) {
   proton_browser_session_t *session =
       (proton_browser_session_t *)calloc(1, sizeof(*session));
   if (session == NULL) {
     return NULL;
   }
   session->policy = *policy;
+  session->web_request_config = web_request_config;
+  proton_web_request_config_retain(web_request_config);
   session->next_request_id = 1;
   session->next_pdf_request_id = 1;
   session->signal = signal;
@@ -298,6 +439,7 @@ void proton_browser_session_destroy(proton_browser_session_t *session) {
   }
   free(session->url);
   free(session->title);
+  proton_internal_web_request_config_destroy(session->web_request_config);
   free(session);
 }
 

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -2,12 +2,14 @@
 #define PROTON_ENGINE_CEF_COMMON_BROWSER_SESSION_H
 
 #include "proton_native.h"
+#include "../../proton_web_request_config.h"
 
 #include "include/capi/cef_browser_capi.h"
 #include "include/capi/cef_download_handler_capi.h"
 #include "include/capi/cef_permission_handler_capi.h"
 #include "include/capi/cef_request_capi.h"
 #include "include/capi/cef_request_handler_capi.h"
+#include "include/capi/cef_resource_request_handler_capi.h"
 
 #include "browser_lifecycle.h"
 
@@ -34,14 +36,22 @@ typedef struct proton_event proton_event_t;
 
 typedef void (*proton_browser_signal_fn)(void *user_data);
 proton_browser_session_t *proton_browser_session_create(
-    const proton_browser_policy_t *policy, proton_browser_signal_fn signal,
-    void *signal_user_data);
+    const proton_browser_policy_t *policy,
+    proton_web_request_config_t *web_request_config,
+    proton_browser_signal_fn signal, void *signal_user_data);
+cef_resource_request_handler_t *proton_browser_session_resource_handler(
+    proton_browser_session_t *session);
+proton_web_request_config_t *proton_browser_session_web_request_config(
+    proton_browser_session_t *session);
 void proton_browser_session_destroy(proton_browser_session_t *session);
 void proton_browser_session_bind_window(proton_browser_session_t *session,
                                          proton_window_id_t window);
 void proton_browser_session_bind_lifecycle(
     proton_browser_session_t *session,
     proton_browser_lifecycle_t *lifecycle);
+
+int proton_browser_session_before_resource_load(
+    proton_browser_session_t *session, const char *url);
 
 void proton_browser_session_loading_changed(proton_browser_session_t *session,
                                              const char *url,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -548,6 +548,11 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
 static int CEF_CALLBACK proton_engine_on_before_browse(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     cef_request_t *request, int user_gesture, int is_redirect);
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling);
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     const cef_string_t *target_url,
@@ -637,6 +642,8 @@ void proton_engine_init_handlers(void) {
       sizeof(g_request_handler.handler), &g_request_handler.refs);
   g_request_handler.handler.on_before_browse =
       proton_engine_on_before_browse;
+  g_request_handler.handler.get_resource_request_handler =
+      proton_engine_get_resource_request_handler;
   g_request_handler.handler.on_open_urlfrom_tab =
       proton_engine_on_open_url_from_tab;
   g_request_handler.handler.on_certificate_error =
@@ -833,6 +840,29 @@ static int CEF_CALLBACK proton_engine_on_before_browse(
   return proton_browser_session_before_browse(
       window != NULL ? window->browser_session : NULL, frame, request,
       user_gesture, is_redirect);
+}
+
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling) {
+  (void)self;
+  (void)frame;
+  (void)request;
+  (void)is_navigation;
+  (void)is_download;
+  (void)request_initiator;
+  (void)disable_default_handling;
+  proton_engine_window_t *window = proton_engine_window_lookup_browser(browser);
+  proton_browser_session_t *session =
+      window != NULL ? window->browser_session : NULL;
+  if (session == NULL) {
+    proton_engine_view_t *view =
+        proton_engine_window_lookup_view_browser(browser);
+    session = view != NULL ? view->browser_session : NULL;
+  }
+  return proton_browser_session_resource_handler(session);
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_view.c
@@ -419,7 +419,9 @@ int32_t proton_engine_view_create(
                                          PROTON_BROWSER_POLICY_DENY,
                                          1};
   view->browser_session = proton_browser_session_create(
-      &view_policy, proton_engine_browser_signal, NULL);
+      &view_policy,
+      proton_browser_session_web_request_config(window->browser_session),
+      proton_engine_browser_signal, NULL);
   view->events = proton_view_events_create();
   if (client == NULL || view->browser_session == NULL ||
       view->events == NULL) {

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -613,7 +613,8 @@ int32_t proton_engine_window_create(
   proton_bridge_config_retain(window->bridge_config);
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
-      &config.browser_policy, proton_engine_browser_signal, NULL);
+      &config.browser_policy, config.web_request_config,
+      proton_engine_browser_signal, NULL);
   window->browser_lifecycle = proton_browser_lifecycle_create(
       runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
   if (window->browser_session == NULL || window->browser_lifecycle == NULL) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -153,6 +153,11 @@ static void CEF_CALLBACK proton_engine_on_load_error(
 static int CEF_CALLBACK proton_engine_on_before_browse(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     cef_request_t *request, int user_gesture, int is_redirect);
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling);
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     const cef_string_t *target_url,
@@ -425,6 +430,8 @@ void proton_engine_init_app(void) {
       proton_engine_on_render_process_terminated;
   g_proton_engine_request_handler.handler.on_before_browse =
       proton_engine_on_before_browse;
+  g_proton_engine_request_handler.handler.get_resource_request_handler =
+      proton_engine_get_resource_request_handler;
   g_proton_engine_request_handler.handler.on_open_urlfrom_tab =
       proton_engine_on_open_url_from_tab;
   g_proton_engine_request_handler.handler.on_certificate_error =
@@ -1035,6 +1042,30 @@ static int CEF_CALLBACK proton_engine_on_before_browse(
   return proton_browser_session_before_browse(
       window != NULL ? window->browser_session : NULL, frame, request,
       user_gesture, is_redirect);
+}
+
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling) {
+  (void)self;
+  (void)frame;
+  (void)request;
+  (void)is_navigation;
+  (void)is_download;
+  (void)request_initiator;
+  (void)disable_default_handling;
+  proton_engine_window_t *window =
+      proton_engine_window_lookup_browser(browser);
+  proton_browser_session_t *session =
+      window != NULL ? window->browser_session : NULL;
+  if (session == NULL) {
+    proton_engine_view_t *view =
+        proton_engine_window_lookup_view_browser(browser);
+    session = view != NULL ? view->browser_session : NULL;
+  }
+  return proton_browser_session_resource_handler(session);
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(

--- a/proton/internal/native/ffi/src/engine/cef_win/win_view.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_view.c
@@ -418,7 +418,9 @@ int32_t proton_engine_view_create(
                                          PROTON_BROWSER_POLICY_DENY,
                                          1};
   view->browser_session = proton_browser_session_create(
-      &view_policy, proton_engine_browser_signal, NULL);
+      &view_policy,
+      proton_browser_session_web_request_config(window->browser_session),
+      proton_engine_browser_signal, NULL);
   view->events = proton_view_events_create();
   if (client == NULL || view->browser_session == NULL ||
       view->events == NULL) {

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -714,7 +714,8 @@ int32_t proton_engine_window_create(
   proton_bridge_config_retain(window->bridge_config);
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
-      &config.browser_policy, proton_engine_browser_signal, window);
+      &config.browser_policy, config.web_request_config,
+      proton_engine_browser_signal, window);
   window->browser_lifecycle = proton_browser_lifecycle_create(
       runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
   if (window->browser_session == NULL || window->browser_lifecycle == NULL) {

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -5,6 +5,7 @@
 #include "proton_bridge_config.h"
 #include "engine/cef_common/browser_session.h"
 #include "proton_menu.h"
+#include "proton_web_request_config.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -77,6 +78,7 @@ typedef struct {
   char titlebar_restore_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   char titlebar_close_label[PROTON_ENGINE_MAX_LABEL_BYTES];
   proton_browser_policy_t browser_policy;
+  proton_web_request_config_t *web_request_config;
   proton_bridge_config_t *bridge_config;
   int32_t max_bridge_payload_bytes;
 } proton_engine_window_config_t;

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -1,0 +1,104 @@
+#include "proton_web_request_config.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+enum { PROTON_WEB_REQUEST_MAX_CANCEL_PREFIXES = 128 };
+
+struct proton_web_request_config {
+  size_t ref_count;
+  char **cancel_prefixes;
+  size_t cancel_prefix_count;
+};
+
+static char *proton_web_request_copy(const char *value) {
+  size_t length = strlen(value);
+  char *copy = (char *)malloc(length + 1);
+  if (copy != NULL) {
+    memcpy(copy, value, length + 1);
+  }
+  return copy;
+}
+
+proton_web_request_config_t *proton_internal_web_request_config_null(void) {
+  return NULL;
+}
+
+int32_t proton_internal_web_request_config_create(
+    proton_web_request_config_t **out_config) {
+  if (out_config == NULL) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request config output is required");
+  }
+  proton_web_request_config_t *config =
+      (proton_web_request_config_t *)calloc(1, sizeof(*config));
+  if (config == NULL) {
+    return proton_set_error(PROTON_ERR_ENGINE,
+                            "failed to allocate web request configuration");
+  }
+  config->ref_count = 1;
+  *out_config = config;
+  return PROTON_OK;
+}
+
+int32_t proton_internal_web_request_config_add_cancel_prefix(
+    proton_web_request_config_t *config, const char *url_prefix) {
+  if (config == NULL || url_prefix == NULL || url_prefix[0] == '\0') {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request URL prefix must not be empty");
+  }
+  if (config->cancel_prefix_count >= PROTON_WEB_REQUEST_MAX_CANCEL_PREFIXES) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request cancellation prefix limit exceeded");
+  }
+  for (size_t index = 0; index < config->cancel_prefix_count; index++) {
+    if (strcmp(config->cancel_prefixes[index], url_prefix) == 0) {
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "web request URL prefix is duplicated");
+    }
+  }
+  char **prefixes = (char **)realloc(
+      config->cancel_prefixes,
+      (config->cancel_prefix_count + 1) * sizeof(*prefixes));
+  char *copy = proton_web_request_copy(url_prefix);
+  if (prefixes == NULL || copy == NULL) {
+    free(copy);
+    return proton_set_error(PROTON_ERR_ENGINE,
+                            "failed to allocate web request URL prefix");
+  }
+  config->cancel_prefixes = prefixes;
+  config->cancel_prefixes[config->cancel_prefix_count++] = copy;
+  return PROTON_OK;
+}
+
+void proton_web_request_config_retain(proton_web_request_config_t *config) {
+  if (config != NULL) {
+    config->ref_count++;
+  }
+}
+
+int proton_web_request_config_should_cancel(
+    const proton_web_request_config_t *config, const char *url) {
+  if (config == NULL || url == NULL) {
+    return 0;
+  }
+  for (size_t index = 0; index < config->cancel_prefix_count; index++) {
+    size_t length = strlen(config->cancel_prefixes[index]);
+    if (strncmp(url, config->cancel_prefixes[index], length) == 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void proton_internal_web_request_config_destroy(
+    proton_web_request_config_t *config) {
+  if (config == NULL || config->ref_count == 0 || --config->ref_count != 0) {
+    return;
+  }
+  for (size_t index = 0; index < config->cancel_prefix_count; index++) {
+    free(config->cancel_prefixes[index]);
+  }
+  free(config->cancel_prefixes);
+  free(config);
+}

--- a/proton/internal/native/ffi/src/proton_web_request_config.h
+++ b/proton/internal/native/ffi/src/proton_web_request_config.h
@@ -1,0 +1,24 @@
+#ifndef PROTON_WEB_REQUEST_CONFIG_H
+#define PROTON_WEB_REQUEST_CONFIG_H
+
+#include "proton_internal.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct proton_web_request_config proton_web_request_config_t;
+
+PROTON_INTERNAL proton_web_request_config_t *
+proton_internal_web_request_config_null(void);
+PROTON_INTERNAL int32_t proton_internal_web_request_config_create(
+    proton_web_request_config_t **out_config);
+PROTON_INTERNAL int32_t proton_internal_web_request_config_add_cancel_prefix(
+    proton_web_request_config_t *config, const char *url_prefix);
+PROTON_INTERNAL void proton_web_request_config_retain(
+    proton_web_request_config_t *config);
+PROTON_INTERNAL int proton_web_request_config_should_cancel(
+    const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL void proton_internal_web_request_config_destroy(
+    proton_web_request_config_t *config);
+
+#endif

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
@@ -69,3 +69,12 @@ pub fn download_command_beats_allow_trace() -> String {
   let _ = @ffi.proton_abi_version_ffi()
   @utf8.decode_lossy(download_command_beats_allow_trace_ffi())
 }
+
+///|
+extern "C" fn web_request_cancel_trace_ffi() -> Bytes = "proton_test_web_request_cancel_trace"
+
+///|
+pub fn web_request_cancel_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(web_request_cancel_trace_ffi())
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
@@ -1,4 +1,5 @@
 #include "../../src/engine/cef_common/browser_session.h"
+#include "../../src/proton_web_request_config.h"
 #include "../../src/proton_event.h"
 
 #include "moonbit.h"
@@ -168,7 +169,7 @@ static moonbit_bytes_t proton_test_download_deny_trace(
 
   proton_event_dispatch_begin();
   proton_browser_session_t *session =
-      proton_browser_session_create(&policy, NULL, NULL);
+      proton_browser_session_create(&policy, NULL, NULL, NULL);
   cef_string_t suggested_name = {0};
   (void)proton_browser_session_before_download(
       session, &download.item, &suggested_name, &before.callback);
@@ -227,7 +228,7 @@ proton_test_denied_download_policy_trace(void) {
   proton_test_before_init(&before);
   proton_test_download_init(&download, 42);
   proton_browser_session_t *session =
-      proton_browser_session_create(&policy, NULL, NULL);
+      proton_browser_session_create(&policy, NULL, NULL, NULL);
   cef_string_t suggested_name = {0};
   int handled = proton_browser_session_before_download(
       session, &download.item, &suggested_name, &before.callback);
@@ -253,7 +254,7 @@ proton_test_unpublished_download_request_trace(void) {
   proton_test_before_init(&before);
   proton_test_download_init(&download, 43);
   proton_browser_session_t *session =
-      proton_browser_session_create(&policy, NULL, NULL);
+      proton_browser_session_create(&policy, NULL, NULL, NULL);
   cef_string_t suggested_name = {0};
   int handled = proton_browser_session_before_download(
       session, &download.item, &suggested_name, &before.callback);
@@ -283,7 +284,7 @@ proton_test_download_single_completion_trace(void) {
   proton_test_download_init(&download, 44);
   proton_event_dispatch_begin();
   proton_browser_session_t *session =
-      proton_browser_session_create(&policy, NULL, NULL);
+      proton_browser_session_create(&policy, NULL, NULL, NULL);
   cef_string_t suggested_name = {0};
   (void)proton_browser_session_before_download(
       session, &download.item, &suggested_name, &before.callback);
@@ -323,7 +324,7 @@ proton_test_download_command_beats_allow_trace(void) {
   proton_test_download_init(&download, 45);
   proton_event_dispatch_begin();
   proton_browser_session_t *session =
-      proton_browser_session_create(&policy, NULL, NULL);
+      proton_browser_session_create(&policy, NULL, NULL, NULL);
   cef_string_t suggested_name = {0};
   (void)proton_browser_session_before_download(
       session, &download.item, &suggested_name, &before.callback);
@@ -342,6 +343,34 @@ proton_test_download_command_beats_allow_trace(void) {
       before.continue_calls, before.release_calls, item_callback.cancel_calls,
       item_callback.release_calls, command, status);
   if (written < 0 || (size_t)written >= sizeof(trace)) {
+    return proton_test_copy_trace("trace-error");
+  }
+  return proton_test_copy_trace(trace);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t proton_test_web_request_cancel_trace(void) {
+  proton_web_request_config_t *config = NULL;
+  int32_t create = proton_internal_web_request_config_create(&config);
+  int32_t add = proton_internal_web_request_config_add_cancel_prefix(
+      config, "https://blocked.example/assets/");
+  int32_t duplicate = proton_internal_web_request_config_add_cancel_prefix(
+      config, "https://blocked.example/assets/");
+  int32_t empty =
+      proton_internal_web_request_config_add_cancel_prefix(config, "");
+  int matching = proton_web_request_config_should_cancel(
+      config, "https://blocked.example/assets/app.js");
+  int nonmatching = proton_web_request_config_should_cancel(
+      config, "https://allowed.example/app.js");
+  int case_sensitive = proton_web_request_config_should_cancel(
+      config, "https://BLOCKED.example/assets/app.js");
+  char trace[160];
+  int written = snprintf(trace, sizeof(trace),
+                         "matching=%d,nonmatching=%d,case_sensitive=%d,empty=%d,duplicate=%d",
+                         matching, nonmatching, case_sensitive, empty,
+                         duplicate);
+  proton_internal_web_request_config_destroy(config);
+  if (create != 0 || add != 0 || written < 0 ||
+      (size_t)written >= sizeof(trace)) {
     return proton_test_copy_trace("trace-error");
   }
   return proton_test_copy_trace(trace);

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
@@ -73,3 +73,11 @@ test "download deny is remembered until its item callback arrives" {
     ),
   )
 }
+
+///|
+test "web request cancellation matches URL prefixes" {
+  inspect(
+    web_request_cancel_trace(),
+    content="matching=1,nonmatching=0,case_sensitive=0,empty=-1,duplicate=-1",
+  )
+}

--- a/proton/internal/native/ffi_mac/mac_client.objc.c
+++ b/proton/internal/native/ffi_mac/mac_client.objc.c
@@ -547,6 +547,11 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
 static int CEF_CALLBACK proton_engine_on_before_browse(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     cef_request_t *request, int user_gesture, int is_redirect);
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling);
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(
     cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
     const cef_string_t *target_url,
@@ -636,6 +641,8 @@ void proton_engine_init_handlers(void) {
       sizeof(g_request_handler.handler), &g_request_handler.refs);
   g_request_handler.handler.on_before_browse =
       proton_engine_on_before_browse;
+  g_request_handler.handler.get_resource_request_handler =
+      proton_engine_get_resource_request_handler;
   g_request_handler.handler.on_open_urlfrom_tab =
       proton_engine_on_open_url_from_tab;
   g_request_handler.handler.on_certificate_error =
@@ -831,6 +838,29 @@ static int CEF_CALLBACK proton_engine_on_before_browse(
   return proton_browser_session_before_browse(
       window != NULL ? window->browser_session : NULL, frame, request,
       user_gesture, is_redirect);
+}
+
+static cef_resource_request_handler_t *CEF_CALLBACK
+proton_engine_get_resource_request_handler(
+    cef_request_handler_t *self, cef_browser_t *browser, cef_frame_t *frame,
+    cef_request_t *request, int is_navigation, int is_download,
+    const cef_string_t *request_initiator, int *disable_default_handling) {
+  (void)self;
+  (void)frame;
+  (void)request;
+  (void)is_navigation;
+  (void)is_download;
+  (void)request_initiator;
+  (void)disable_default_handling;
+  proton_engine_window_t *window = proton_engine_window_lookup_browser(browser);
+  proton_browser_session_t *session =
+      window != NULL ? window->browser_session : NULL;
+  if (session == NULL) {
+    proton_engine_view_t *view =
+        proton_engine_window_lookup_view_browser(browser);
+    session = view != NULL ? view->browser_session : NULL;
+  }
+  return proton_browser_session_resource_handler(session);
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(

--- a/proton/internal/native/ffi_mac/mac_view.objc.c
+++ b/proton/internal/native/ffi_mac/mac_view.objc.c
@@ -547,7 +547,9 @@ int32_t proton_engine_view_create(
                                          PROTON_BROWSER_POLICY_DENY,
                                          1};
   view->browser_session = proton_browser_session_create(
-      &view_policy, proton_engine_browser_signal, NULL);
+      &view_policy,
+      proton_browser_session_web_request_config(window->browser_session),
+      proton_engine_browser_signal, NULL);
   view->events = proton_view_events_create();
   if (view->browser_session == NULL || view->events == NULL) {
     proton_browser_session_destroy(view->browser_session);

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -900,7 +900,8 @@ int32_t proton_engine_window_create(
   proton_bridge_config_retain(window->bridge_config);
   window->max_bridge_payload_bytes = config.max_bridge_payload_bytes;
   window->browser_session = proton_browser_session_create(
-      &config.browser_policy, proton_engine_browser_signal, NULL);
+      &config.browser_policy, config.web_request_config,
+      proton_engine_browser_signal, NULL);
   window->browser_lifecycle = proton_browser_lifecycle_create(
       runtime->browsers, PROTON_BROWSER_ROLE_MAIN, window, NULL);
   if (window->browser_session == NULL || window->browser_lifecycle == NULL) {


### PR DESCRIPTION
## Summary
- add a private web request configuration with URL-prefix cancellation rules
- register CEF's synchronous resource request hook on Windows, Linux, and macOS
- preserve first-match semantics, fail-open defaults, and explicit invalid-prefix errors
- propagate request configuration through browser sessions and web contents views

## Scope
This is the native groundwork slice for `session.webRequest`. The public facade builder is intentionally deferred to the next step so no API is exposed before the complete configuration path is available.

## Platform impact
- Windows, Linux, and macOS compile through the shared CEF request handler ABI.
- No platform-specific fallback behavior is introduced.

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test internal/native --target native --diagnostic-limit 120`
- `node scripts/verify_generated.mjs`
- `git diff --check`

Required CI should provide cross-platform compile coverage.
