### PR TITLE
feat(facade): expose web request cancellation prefixes

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -162,6 +162,10 @@ Browser loading events include `DidStartLoading` and `DidFinishLoad`, derived
 from successive native loading snapshots; `LoadingChanged` remains available
 for consumers that prefer the boolean form.
 
+Use `App::web_request_cancel_prefix` to declare synchronous request blocking
+rules before startup. Matching is case-sensitive, uses URL prefixes, and
+applies to every window and web contents view created by the application.
+
 Web contents views expose the same loading lifecycle events through
 `ViewEvent::DidStartLoading` and `ViewEvent::DidFinishLoad`; their
 `LoadingChanged` event remains available as the boolean form.

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -272,6 +272,34 @@ pub fn App::url_scheme(self : App, scheme : String) -> App {
 }
 
 ///|
+/// Cancels browser requests whose URL starts with `url_prefix`.
+///
+/// Matching is case-sensitive and applies to every browser session created
+/// by this application, including secondary windows and web contents views.
+pub fn App::web_request_cancel_prefix(self : App, url_prefix : String) -> App {
+  let url_prefix = url_prefix.trim().to_owned()
+  if url_prefix == "" {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_cancel_prefix",
+        message="must not be empty",
+      ),
+    )
+  } else if self.web_request_cancel_prefixes.contains(url_prefix) {
+    self.validation_errors.push(
+      InvalidSetting(name="web_request_cancel_prefix", message="is duplicated"),
+    )
+  } else if self.web_request_cancel_prefixes.length() >= 128 {
+    self.validation_errors.push(
+      InvalidSetting(name="web_request_cancel_prefix", message="limit exceeded"),
+    )
+  } else {
+    self.web_request_cancel_prefixes.push(url_prefix)
+  }
+  self
+}
+
+///|
 fn app_url_scheme_is_valid(scheme : String) -> Bool {
   guard scheme.length() > 0 else { return false }
   for index, char in scheme {

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -24,6 +24,7 @@ fn App::App(
     last_window_closed_policy_value: LastWindowClosedPolicy::Quit,
     menu: None,
     url_schemes: [],
+    web_request_cancel_prefixes: [],
     document_extensions: [],
     update_channel: None,
     command_capabilities: [],
@@ -94,6 +95,7 @@ fn App::resolved_app_config(self : App) -> ResolvedAppConfig {
       None
     },
     url_schemes: self.url_schemes.copy(),
+    web_request_cancel_prefixes: self.web_request_cancel_prefixes.copy(),
     document_extensions: self.document_extensions.copy(),
     update_channel: if proton_dev_mode_enabled() {
       None

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -80,6 +80,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     application_executable~,
     application_arguments~,
     url_schemes=resolved.url_schemes,
+    web_request_cancel_prefixes=resolved.web_request_cancel_prefixes,
   ) catch {
     error => raise logged_runtime_failure(error)
   }
@@ -183,6 +184,7 @@ async fn run_manifest(
   application_executable? : String = "",
   application_arguments? : Array[String] = [],
   url_schemes? : Array[String] = [],
+  web_request_cancel_prefixes? : Array[String] = [],
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -417,6 +419,7 @@ async fn run_manifest(
           application_executable~,
           application_arguments~,
           url_schemes~,
+          web_request_cancel_prefixes~,
         )
         let application_context = session.application_context()
         let application_start = application_tasks.spawn(
@@ -605,6 +608,7 @@ fn native_window_config(
   bridge : @native.BridgeConfig?,
   browser : @native.BrowserPolicy,
   preferences : @locale.LocalePreferences,
+  web_request_cancel_prefixes : Array[String],
 ) -> @native.WindowConfig {
   let catalog = framework_catalog(preferences)
   @native.WindowConfig(
@@ -632,6 +636,7 @@ fn native_window_config(
     },
     browser~,
     bridge?,
+    web_request_cancel_prefixes~,
   ).with_framework_titlebar_labels(
     catalog.titlebar_minimize,
     catalog.titlebar_maximize,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -38,6 +38,7 @@ fn RuntimeSession::RuntimeSession(
   application_executable? : String = "",
   application_arguments? : Array[String] = [],
   url_schemes? : Array[String] = [],
+  web_request_cancel_prefixes? : Array[String] = [],
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
@@ -77,6 +78,7 @@ fn RuntimeSession::RuntimeSession(
     application_executable,
     application_arguments,
     url_schemes,
+    web_request_cancel_prefixes,
   }
 }
 
@@ -1262,6 +1264,7 @@ fn RuntimeSession::create_window(
       definition.bridge,
       definition.browser_policy,
       self.locale_preferences,
+      self.web_request_cancel_prefixes,
     ),
   ) catch {
     error => raise native_run_error("create window " + plan.id, error)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -57,6 +57,7 @@ struct App {
   mut last_window_closed_policy_value : LastWindowClosedPolicy
   mut menu : MenuBar?
   url_schemes : Array[String]
+  web_request_cancel_prefixes : Array[String]
   document_extensions : Array[String]
   mut update_channel : ResolvedUpdateChannel?
   command_capabilities : Array[AppCommandCapability]
@@ -168,6 +169,7 @@ priv struct ResolvedAppConfig {
   application_identifier : String
   instance_identifier : String?
   url_schemes : Array[String]
+  web_request_cancel_prefixes : Array[String]
   document_extensions : Array[String]
   /// The update channel and the identity it updates, when configured by code.
   update_channel : ResolvedUpdateChannel?
@@ -419,6 +421,7 @@ priv struct RuntimeSession {
   application_executable : String
   application_arguments : Array[String]
   url_schemes : Array[String]
+  web_request_cancel_prefixes : Array[String]
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -698,6 +698,27 @@ test "bridge startup timeout is finite and configurable" {
 }
 
 ///|
+test "web request cancellation prefixes are validated and resolved" {
+  let app = html("Test", "<html></html>")
+    .identifier("dev.proton.web-request")
+    .web_request_cancel_prefix("https://blocked.example/")
+  assert_eq(app.resolved_app_config().web_request_cancel_prefixes, [
+    "https://blocked.example/",
+  ])
+  match app.web_request_cancel_prefix("").validation_error() {
+    Some(InvalidSetting(name~, message~)) => {
+      assert_eq(name, "web_request_cancel_prefix")
+      assert_eq(message, "must not be empty")
+    }
+    _ => fail("expected empty prefix validation error")
+  }
+  assert_true(
+    app.web_request_cancel_prefix("https://blocked.example/").validation_error()
+    is Some(_),
+  )
+}
+
+///|
 test "debug mode uses an ephemeral endpoint unless a fixed port is explicit" {
   assert_eq(
     resolve_remote_debugging(0, None),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -37,6 +37,10 @@ pub type MenuConfigHandle
 pub type BridgeConfigHandle
 
 ///|
+#external
+pub type WebRequestConfigHandle
+
+///|
 pub extern "C" fn runtime_null() -> RuntimeHandle = "proton_runtime_null"
 
 ///|
@@ -56,6 +60,9 @@ pub extern "C" fn menu_config_null() -> MenuConfigHandle = "proton_internal_menu
 
 ///|
 pub extern "C" fn bridge_config_null() -> BridgeConfigHandle = "proton_internal_bridge_config_null"
+
+///|
+pub extern "C" fn web_request_config_null() -> WebRequestConfigHandle = "proton_internal_web_request_config_null"
 
 ///|
 pub extern "C" fn window_logical_id(window : WindowHandle) -> Int64 = "proton_window_logical_id"
@@ -467,6 +474,7 @@ pub extern "C" fn window_create(
   media_policy : Int,
   devtools : Int,
   bridge_config : BridgeConfigHandle,
+  web_request_config : WebRequestConfigHandle,
   out_window : Ref[WindowHandle],
 ) -> Int = "proton_internal_window_create"
 
@@ -523,6 +531,24 @@ pub extern "C" fn bridge_config_add_initialization_unit(
 
 ///|
 pub extern "C" fn bridge_config_destroy(config : BridgeConfigHandle) -> Unit = "proton_internal_bridge_config_destroy"
+
+///|
+#borrow(out_config)
+pub extern "C" fn web_request_config_create(
+  out_config : Ref[WebRequestConfigHandle],
+) -> Int = "proton_internal_web_request_config_create"
+
+///|
+#borrow(url_prefix)
+pub extern "C" fn web_request_config_add_cancel_prefix(
+  config : WebRequestConfigHandle,
+  url_prefix : Bytes,
+) -> Int = "proton_internal_web_request_config_add_cancel_prefix"
+
+///|
+pub extern "C" fn web_request_config_destroy(
+  config : WebRequestConfigHandle,
+) -> Unit = "proton_internal_web_request_config_destroy"
 
 ///|
 pub extern "C" fn proton_window_destroy_ffi(window : WindowHandle) -> Int = "proton_window_destroy"

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -709,7 +709,9 @@ int32_t proton_internal_window_create(
     const char *titlebar_restore_label, const char *titlebar_close_label,
     int32_t new_window_policy, int32_t download_policy,
     int32_t certificate_policy, int32_t media_policy, int32_t devtools,
-    proton_bridge_config_t *bridge_config, proton_window_handle_t *out_window) {
+    proton_bridge_config_t *bridge_config,
+    proton_web_request_config_t *web_request_config,
+    proton_window_handle_t *out_window) {
   proton_runtime_slot_t *runtime_slot = NULL;
   int32_t status = proton_get_runtime(runtime, &runtime_slot);
   if (status != PROTON_OK) {
@@ -725,7 +727,7 @@ int32_t proton_internal_window_create(
       theme_preference, navigation_policy, titlebar_minimize_label,
       titlebar_maximize_label, titlebar_restore_label, titlebar_close_label,
       new_window_policy, download_policy, certificate_policy, media_policy,
-      devtools, bridge_config, &config);
+      devtools, bridge_config, web_request_config, &config);
   if (status != PROTON_OK) {
     return status;
   }

--- a/proton/internal/native/ffi/src/proton_config.c
+++ b/proton/internal/native/ffi/src/proton_config.c
@@ -678,6 +678,7 @@ int32_t proton_config_prepare_window(
     int32_t new_window_policy, int32_t download_policy,
     int32_t certificate_policy, int32_t media_policy, int32_t devtools,
     proton_bridge_config_t *bridge_config,
+    proton_web_request_config_t *web_request_config,
     proton_engine_window_config_t *out_config) {
   if (out_config == NULL || title == NULL || initial_url == NULL) {
     return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
@@ -721,6 +722,7 @@ int32_t proton_config_prepare_window(
   config.titlebar_overlay = titlebar_overlay != 0;
   config.theme_preference =
       (proton_window_theme_preference_t)theme_preference;
+  config.web_request_config = web_request_config;
   if ((titlebar_minimize_label != NULL && titlebar_minimize_label[0] != '\0' &&
        !proton_copy_config_text(config.titlebar_minimize_label,
                                 sizeof(config.titlebar_minimize_label),

--- a/proton/internal/native/ffi/src/proton_config.h
+++ b/proton/internal/native/ffi/src/proton_config.h
@@ -28,6 +28,7 @@ PROTON_INTERNAL int32_t proton_config_prepare_window(
     int32_t new_window_policy, int32_t download_policy,
     int32_t certificate_policy, int32_t media_policy, int32_t devtools,
     proton_bridge_config_t *bridge_config,
+    proton_web_request_config_t *web_request_config,
     proton_engine_window_config_t *out_config);
 PROTON_INTERNAL bool proton_parse_color_argb(const char *text,
                                              uint32_t *out_color);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1367,6 +1367,32 @@ fn build_bridge_config(
 }
 
 ///|
+fn build_web_request_config(
+  prefixes : Array[String],
+) -> @native_ffi.WebRequestConfigHandle raise NativeError {
+  if prefixes.length() == 0 {
+    return @native_ffi.web_request_config_null()
+  }
+  let out_config = Ref(@native_ffi.web_request_config_null())
+  let status = @native_ffi.web_request_config_create(out_config)
+  if status < 0 {
+    raise native_error(status)
+  }
+  let handle = out_config.val
+  for prefix in prefixes {
+    let status = @native_ffi.web_request_config_add_cancel_prefix(
+      handle,
+      @ffi.to_cstr(prefix),
+    )
+    if status < 0 {
+      @native_ffi.web_request_config_destroy(handle)
+      raise native_error(status)
+    }
+  }
+  handle
+}
+
+///|
 pub fn Window::Window(
   runtime : Runtime,
   config? : WindowConfig = WindowConfig(),
@@ -1374,6 +1400,9 @@ pub fn Window::Window(
   validate_window_config(config)
   let out_window = Ref(@native_ffi.window_null())
   let bridge_config = build_bridge_config(config.bridge)
+  let web_request_config = build_web_request_config(
+    config.web_request_cancel_prefixes,
+  )
   let status = @native_ffi.window_create(
     runtime.active_handle(),
     @ffi.to_cstr(config.title),
@@ -1394,9 +1423,11 @@ pub fn Window::Window(
     browser_policy_code(config.browser.media),
     runtime_config_bool(config.browser.devtools),
     bridge_config,
+    web_request_config,
     out_window,
   )
   @native_ffi.bridge_config_destroy(bridge_config)
+  @native_ffi.web_request_config_destroy(web_request_config)
   if status < 0 {
     raise native_error(status)
   } else {

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -1463,6 +1463,7 @@ struct WindowConfig {
   theme_preference : WindowThemePreference
   browser : BrowserPolicy
   bridge : BridgeConfig?
+  web_request_cancel_prefixes : Array[String]
   framework_titlebar_minimize_label : String?
   framework_titlebar_maximize_label : String?
   framework_titlebar_restore_label : String?
@@ -1558,6 +1559,7 @@ pub fn WindowConfig::WindowConfig(
   theme? : WindowThemePreference = WindowThemePreference::System,
   browser? : BrowserPolicy = BrowserPolicy(),
   bridge? : BridgeConfig,
+  web_request_cancel_prefixes? : Array[String] = [],
 ) -> WindowConfig {
   {
     title,
@@ -1569,6 +1571,7 @@ pub fn WindowConfig::WindowConfig(
     theme_preference: theme,
     browser,
     bridge,
+    web_request_cancel_prefixes,
     framework_titlebar_minimize_label: Some("Minimize"),
     framework_titlebar_maximize_label: Some("Maximize"),
     framework_titlebar_restore_label: Some("Restore"),
@@ -1620,6 +1623,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     theme_preference: self.theme_preference,
     browser: self.browser,
     bridge: self.bridge,
+    web_request_cancel_prefixes: self.web_request_cancel_prefixes,
     framework_titlebar_minimize_label: Some(minimize),
     framework_titlebar_maximize_label: Some(maximize),
     framework_titlebar_restore_label: Some(restore),


### PR DESCRIPTION
## Summary
- expose App::web_request_cancel_prefix for synchronous URL-prefix cancellation
- thread typed configuration through the public facade into all window/view sessions
- validate empty, duplicate, and over-limit prefixes

## Platform impact
Uses the existing cross-platform native web request hook; no new platform-specific behavior.

## Validation
- moon fmt --check
- moon -C proton check --target native --diagnostic-limit 120
- moon -C proton test . --target native --diagnostic-limit 120
- node scripts/verify_generated.mjs

## Limitations
This slice supports cancellation only. Redirects, request-header overrides, and response observation remain follow-up slices.