### PR TITLE
feat(facade): add web request redirect prefixes

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -165,6 +165,9 @@ for consumers that prefer the boolean form.
 Use `App::web_request_cancel_prefix` to declare synchronous request blocking
 rules before startup. Matching is case-sensitive, uses URL prefixes, and
 applies to every window and web contents view created by the application.
+`App::web_request_redirect_prefix` provides the corresponding fixed-target
+rewrite for matching requests; cancellation takes precedence when both rules
+match.
 
 Web contents views expose the same loading lifecycle events through
 `ViewEvent::DidStartLoading` and `ViewEvent::DidFinishLoad`; their

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -300,6 +300,42 @@ pub fn App::web_request_cancel_prefix(self : App, url_prefix : String) -> App {
 }
 
 ///|
+/// Redirects matching browser requests to `target_url` before loading.
+pub fn App::web_request_redirect_prefix(
+  self : App,
+  url_prefix : String,
+  target_url : String,
+) -> App {
+  let url_prefix = url_prefix.trim().to_owned()
+  let target_url = target_url.trim().to_owned()
+  if url_prefix == "" || target_url == "" {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_redirect_prefix",
+        message="prefix and target URL must not be empty",
+      ),
+    )
+  } else if self.web_request_redirect_prefixes.any(item => item.0 == url_prefix) {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_redirect_prefix",
+        message="is duplicated",
+      ),
+    )
+  } else if self.web_request_redirect_prefixes.length() >= 128 {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_redirect_prefix",
+        message="limit exceeded",
+      ),
+    )
+  } else {
+    self.web_request_redirect_prefixes.push((url_prefix, target_url))
+  }
+  self
+}
+
+///|
 fn app_url_scheme_is_valid(scheme : String) -> Bool {
   guard scheme.length() > 0 else { return false }
   for index, char in scheme {

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -25,6 +25,7 @@ fn App::App(
     menu: None,
     url_schemes: [],
     web_request_cancel_prefixes: [],
+    web_request_redirect_prefixes: [],
     document_extensions: [],
     update_channel: None,
     command_capabilities: [],
@@ -96,6 +97,7 @@ fn App::resolved_app_config(self : App) -> ResolvedAppConfig {
     },
     url_schemes: self.url_schemes.copy(),
     web_request_cancel_prefixes: self.web_request_cancel_prefixes.copy(),
+    web_request_redirect_prefixes: self.web_request_redirect_prefixes.copy(),
     document_extensions: self.document_extensions.copy(),
     update_channel: if proton_dev_mode_enabled() {
       None

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -81,6 +81,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     application_arguments~,
     url_schemes=resolved.url_schemes,
     web_request_cancel_prefixes=resolved.web_request_cancel_prefixes,
+    web_request_redirect_prefixes=resolved.web_request_redirect_prefixes,
   ) catch {
     error => raise logged_runtime_failure(error)
   }
@@ -185,6 +186,7 @@ async fn run_manifest(
   application_arguments? : Array[String] = [],
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
+  web_request_redirect_prefixes? : Array[(String, String)] = [],
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -420,6 +422,7 @@ async fn run_manifest(
           application_arguments~,
           url_schemes~,
           web_request_cancel_prefixes~,
+          web_request_redirect_prefixes~,
         )
         let application_context = session.application_context()
         let application_start = application_tasks.spawn(
@@ -609,6 +612,7 @@ fn native_window_config(
   browser : @native.BrowserPolicy,
   preferences : @locale.LocalePreferences,
   web_request_cancel_prefixes : Array[String],
+  web_request_redirect_prefixes : Array[(String, String)],
 ) -> @native.WindowConfig {
   let catalog = framework_catalog(preferences)
   @native.WindowConfig(
@@ -637,6 +641,7 @@ fn native_window_config(
     browser~,
     bridge?,
     web_request_cancel_prefixes~,
+    web_request_redirect_prefixes~,
   ).with_framework_titlebar_labels(
     catalog.titlebar_minimize,
     catalog.titlebar_maximize,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -39,6 +39,7 @@ fn RuntimeSession::RuntimeSession(
   application_arguments? : Array[String] = [],
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
+  web_request_redirect_prefixes? : Array[(String, String)] = [],
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
@@ -79,6 +80,7 @@ fn RuntimeSession::RuntimeSession(
     application_arguments,
     url_schemes,
     web_request_cancel_prefixes,
+    web_request_redirect_prefixes,
   }
 }
 
@@ -1265,6 +1267,7 @@ fn RuntimeSession::create_window(
       definition.browser_policy,
       self.locale_preferences,
       self.web_request_cancel_prefixes,
+      self.web_request_redirect_prefixes,
     ),
   ) catch {
     error => raise native_run_error("create window " + plan.id, error)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -58,6 +58,7 @@ struct App {
   mut menu : MenuBar?
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
+  web_request_redirect_prefixes : Array[(String, String)]
   document_extensions : Array[String]
   mut update_channel : ResolvedUpdateChannel?
   command_capabilities : Array[AppCommandCapability]
@@ -170,6 +171,7 @@ priv struct ResolvedAppConfig {
   instance_identifier : String?
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
+  web_request_redirect_prefixes : Array[(String, String)]
   document_extensions : Array[String]
   /// The update channel and the identity it updates, when configured by code.
   update_channel : ResolvedUpdateChannel?
@@ -422,6 +424,7 @@ priv struct RuntimeSession {
   application_arguments : Array[String]
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
+  web_request_redirect_prefixes : Array[(String, String)]
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -719,6 +719,30 @@ test "web request cancellation prefixes are validated and resolved" {
 }
 
 ///|
+test "web request redirect prefixes are validated and resolved" {
+  let app = html("Test", "<html></html>")
+    .identifier("dev.proton.web-request-redirect")
+    .web_request_redirect_prefix("https://old.example/", "https://new.example/")
+  assert_eq(app.resolved_app_config().web_request_redirect_prefixes, [
+    ("https://old.example/", "https://new.example/"),
+  ])
+  assert_true(
+    app
+    .web_request_redirect_prefix("", "https://new.example/")
+    .validation_error()
+    is Some(_),
+  )
+  assert_true(
+    app
+    .web_request_redirect_prefix(
+      "https://old.example/", "https://other.example/",
+    )
+    .validation_error()
+    is Some(_),
+  )
+}
+
+///|
 test "debug mode uses an ephemeral endpoint unless a fixed port is explicit" {
   assert_eq(
     resolve_remote_debugging(0, None),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -546,6 +546,14 @@ pub extern "C" fn web_request_config_add_cancel_prefix(
 ) -> Int = "proton_internal_web_request_config_add_cancel_prefix"
 
 ///|
+#borrow(url_prefix, target_url)
+pub extern "C" fn web_request_config_add_redirect_prefix(
+  config : WebRequestConfigHandle,
+  url_prefix : Bytes,
+  target_url : Bytes,
+) -> Int = "proton_internal_web_request_config_add_redirect_prefix"
+
+///|
 pub extern "C" fn web_request_config_destroy(
   config : WebRequestConfigHandle,
 ) -> Unit = "proton_internal_web_request_config_destroy"

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -177,6 +177,16 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
   char *url_utf8 = proton_browser_cef_string_to_utf8(url);
   int result = proton_browser_session_before_resource_load(handler->session,
                                                            url_utf8);
+  const char *redirect_url = proton_web_request_config_redirect_url(
+      handler->session->web_request_config, url_utf8);
+  if (result != 0 && redirect_url != NULL && request->set_url != NULL) {
+    cef_string_t destination = {0};
+    if (cef_string_utf8_to_utf16(redirect_url, strlen(redirect_url),
+                                 &destination)) {
+      request->set_url(request, &destination);
+      cef_string_clear(&destination);
+    }
+  }
   if (url != NULL) {
     cef_string_userfree_free(url);
   }

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -5,10 +5,17 @@
 
 enum { PROTON_WEB_REQUEST_MAX_CANCEL_PREFIXES = 128 };
 
+typedef struct {
+  char *prefix;
+  char *target;
+} proton_web_request_redirect_t;
+
 struct proton_web_request_config {
   size_t ref_count;
   char **cancel_prefixes;
   size_t cancel_prefix_count;
+  proton_web_request_redirect_t *redirects;
+  size_t redirect_count;
 };
 
 static char *proton_web_request_copy(const char *value) {
@@ -18,6 +25,40 @@ static char *proton_web_request_copy(const char *value) {
     memcpy(copy, value, length + 1);
   }
   return copy;
+}
+
+int32_t proton_internal_web_request_config_add_redirect_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *target_url) {
+  if (config == NULL || url_prefix == NULL || target_url == NULL ||
+      url_prefix[0] == '\0' || target_url[0] == '\0') {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request redirect values must not be empty");
+  }
+  if (config->redirect_count >= PROTON_WEB_REQUEST_MAX_CANCEL_PREFIXES) {
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request redirect prefix limit exceeded");
+  }
+  for (size_t index = 0; index < config->redirect_count; index++) {
+    if (strcmp(config->redirects[index].prefix, url_prefix) == 0) {
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "web request redirect prefix is duplicated");
+    }
+  }
+  proton_web_request_redirect_t *redirects = (proton_web_request_redirect_t *)realloc(
+      config->redirects, (config->redirect_count + 1) * sizeof(*redirects));
+  char *prefix = proton_web_request_copy(url_prefix);
+  char *target = proton_web_request_copy(target_url);
+  if (redirects == NULL || prefix == NULL || target == NULL) {
+    free(prefix);
+    free(target);
+    return proton_set_error(PROTON_ERR_ENGINE,
+                            "failed to allocate web request redirect");
+  }
+  config->redirects = redirects;
+  config->redirects[config->redirect_count].prefix = prefix;
+  config->redirects[config->redirect_count++].target = target;
+  return PROTON_OK;
 }
 
 proton_web_request_config_t *proton_internal_web_request_config_null(void) {
@@ -91,6 +132,17 @@ int proton_web_request_config_should_cancel(
   return 0;
 }
 
+const char *proton_web_request_config_redirect_url(
+    const proton_web_request_config_t *config, const char *url) {
+  if (config == NULL || url == NULL) return NULL;
+  for (size_t index = 0; index < config->redirect_count; index++) {
+    size_t length = strlen(config->redirects[index].prefix);
+    if (strncmp(url, config->redirects[index].prefix, length) == 0)
+      return config->redirects[index].target;
+  }
+  return NULL;
+}
+
 void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config) {
   if (config == NULL || config->ref_count == 0 || --config->ref_count != 0) {
@@ -100,5 +152,10 @@ void proton_internal_web_request_config_destroy(
     free(config->cancel_prefixes[index]);
   }
   free(config->cancel_prefixes);
+  for (size_t index = 0; index < config->redirect_count; index++) {
+    free(config->redirects[index].prefix);
+    free(config->redirects[index].target);
+  }
+  free(config->redirects);
   free(config);
 }

--- a/proton/internal/native/ffi/src/proton_web_request_config.h
+++ b/proton/internal/native/ffi/src/proton_web_request_config.h
@@ -14,9 +14,14 @@ PROTON_INTERNAL int32_t proton_internal_web_request_config_create(
     proton_web_request_config_t **out_config);
 PROTON_INTERNAL int32_t proton_internal_web_request_config_add_cancel_prefix(
     proton_web_request_config_t *config, const char *url_prefix);
+PROTON_INTERNAL int32_t proton_internal_web_request_config_add_redirect_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *target_url);
 PROTON_INTERNAL void proton_web_request_config_retain(
     proton_web_request_config_t *config);
 PROTON_INTERNAL int proton_web_request_config_should_cancel(
+    const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL const char *proton_web_request_config_redirect_url(
     const proton_web_request_config_t *config, const char *url);
 PROTON_INTERNAL void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1369,8 +1369,9 @@ fn build_bridge_config(
 ///|
 fn build_web_request_config(
   prefixes : Array[String],
+  redirects : Array[(String, String)],
 ) -> @native_ffi.WebRequestConfigHandle raise NativeError {
-  if prefixes.length() == 0 {
+  if prefixes.length() == 0 && redirects.length() == 0 {
     return @native_ffi.web_request_config_null()
   }
   let out_config = Ref(@native_ffi.web_request_config_null())
@@ -1383,6 +1384,19 @@ fn build_web_request_config(
     let status = @native_ffi.web_request_config_add_cancel_prefix(
       handle,
       @ffi.to_cstr(prefix),
+    )
+    if status < 0 {
+      @native_ffi.web_request_config_destroy(handle)
+      raise native_error(status)
+    }
+  }
+  for item in redirects {
+    let prefix = item.0
+    let target = item.1
+    let status = @native_ffi.web_request_config_add_redirect_prefix(
+      handle,
+      @ffi.to_cstr(prefix),
+      @ffi.to_cstr(target),
     )
     if status < 0 {
       @native_ffi.web_request_config_destroy(handle)
@@ -1402,6 +1416,7 @@ pub fn Window::Window(
   let bridge_config = build_bridge_config(config.bridge)
   let web_request_config = build_web_request_config(
     config.web_request_cancel_prefixes,
+    config.web_request_redirect_prefixes,
   )
   let status = @native_ffi.window_create(
     runtime.active_handle(),

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -1464,6 +1464,7 @@ struct WindowConfig {
   browser : BrowserPolicy
   bridge : BridgeConfig?
   web_request_cancel_prefixes : Array[String]
+  web_request_redirect_prefixes : Array[(String, String)]
   framework_titlebar_minimize_label : String?
   framework_titlebar_maximize_label : String?
   framework_titlebar_restore_label : String?
@@ -1560,6 +1561,7 @@ pub fn WindowConfig::WindowConfig(
   browser? : BrowserPolicy = BrowserPolicy(),
   bridge? : BridgeConfig,
   web_request_cancel_prefixes? : Array[String] = [],
+  web_request_redirect_prefixes? : Array[(String, String)] = [],
 ) -> WindowConfig {
   {
     title,
@@ -1572,6 +1574,7 @@ pub fn WindowConfig::WindowConfig(
     browser,
     bridge,
     web_request_cancel_prefixes,
+    web_request_redirect_prefixes,
     framework_titlebar_minimize_label: Some("Minimize"),
     framework_titlebar_maximize_label: Some("Maximize"),
     framework_titlebar_restore_label: Some("Restore"),
@@ -1624,6 +1627,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     browser: self.browser,
     bridge: self.bridge,
     web_request_cancel_prefixes: self.web_request_cancel_prefixes,
+    web_request_redirect_prefixes: self.web_request_redirect_prefixes,
     framework_titlebar_minimize_label: Some(minimize),
     framework_titlebar_maximize_label: Some(maximize),
     framework_titlebar_restore_label: Some(restore),


### PR DESCRIPTION
## Summary
- add synchronous URL-prefix request redirects
- keep cancellation precedence and typed native configuration
- validate empty, duplicate, and over-limit redirect rules

## Platform impact
Uses the existing cross-platform CEF resource request hook on macOS, Linux, and Windows.

## Validation
- moon fmt --check
- moon -C proton check --target native --diagnostic-limit 120
- moon -C proton test . --target native --diagnostic-limit 120
- node scripts/verify_generated.mjs

## Limitations
Redirect targets are fixed URLs declared before startup; request-header overrides and response observation remain follow-up slices.