### PR TITLE
feat(facade): add web request header overrides

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -168,6 +168,8 @@ applies to every window and web contents view created by the application.
 `App::web_request_redirect_prefix` provides the corresponding fixed-target
 rewrite for matching requests; cancellation takes precedence when both rules
 match.
+Use `App::web_request_header_prefix` to override a named request header for
+matching URLs before the request is sent.
 
 Web contents views expose the same loading lifecycle events through
 `ViewEvent::DidStartLoading` and `ViewEvent::DidFinishLoad`; their

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -336,6 +336,37 @@ pub fn App::web_request_redirect_prefix(
 }
 
 ///|
+/// Overrides a request header for URLs matching `url_prefix`.
+pub fn App::web_request_header_prefix(
+  self : App,
+  url_prefix : String,
+  header_name : String,
+  header_value : String,
+) -> App {
+  let url_prefix = url_prefix.trim().to_owned()
+  let header_name = header_name.trim().to_owned()
+  if url_prefix == "" || header_name == "" {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_header_prefix",
+        message="prefix and header name must not be empty",
+      ),
+    )
+  } else if self.web_request_header_prefixes.any(item => {
+      item.0 == url_prefix && item.1 == header_name
+    }) {
+    self.validation_errors.push(
+      InvalidSetting(name="web_request_header_prefix", message="is duplicated"),
+    )
+  } else {
+    self.web_request_header_prefixes.push(
+      (url_prefix, header_name, header_value),
+    )
+  }
+  self
+}
+
+///|
 fn app_url_scheme_is_valid(scheme : String) -> Bool {
   guard scheme.length() > 0 else { return false }
   for index, char in scheme {

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -26,6 +26,7 @@ fn App::App(
     url_schemes: [],
     web_request_cancel_prefixes: [],
     web_request_redirect_prefixes: [],
+    web_request_header_prefixes: [],
     document_extensions: [],
     update_channel: None,
     command_capabilities: [],
@@ -98,6 +99,7 @@ fn App::resolved_app_config(self : App) -> ResolvedAppConfig {
     url_schemes: self.url_schemes.copy(),
     web_request_cancel_prefixes: self.web_request_cancel_prefixes.copy(),
     web_request_redirect_prefixes: self.web_request_redirect_prefixes.copy(),
+    web_request_header_prefixes: self.web_request_header_prefixes.copy(),
     document_extensions: self.document_extensions.copy(),
     update_channel: if proton_dev_mode_enabled() {
       None

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -82,6 +82,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     url_schemes=resolved.url_schemes,
     web_request_cancel_prefixes=resolved.web_request_cancel_prefixes,
     web_request_redirect_prefixes=resolved.web_request_redirect_prefixes,
+    web_request_header_prefixes=resolved.web_request_header_prefixes,
   ) catch {
     error => raise logged_runtime_failure(error)
   }
@@ -187,6 +188,7 @@ async fn run_manifest(
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -423,6 +425,7 @@ async fn run_manifest(
           url_schemes~,
           web_request_cancel_prefixes~,
           web_request_redirect_prefixes~,
+          web_request_header_prefixes~,
         )
         let application_context = session.application_context()
         let application_start = application_tasks.spawn(
@@ -613,6 +616,7 @@ fn native_window_config(
   preferences : @locale.LocalePreferences,
   web_request_cancel_prefixes : Array[String],
   web_request_redirect_prefixes : Array[(String, String)],
+  web_request_header_prefixes : Array[(String, String, String)],
 ) -> @native.WindowConfig {
   let catalog = framework_catalog(preferences)
   @native.WindowConfig(
@@ -642,6 +646,7 @@ fn native_window_config(
     bridge?,
     web_request_cancel_prefixes~,
     web_request_redirect_prefixes~,
+    web_request_header_prefixes~,
   ).with_framework_titlebar_labels(
     catalog.titlebar_minimize,
     catalog.titlebar_maximize,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -40,6 +40,7 @@ fn RuntimeSession::RuntimeSession(
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
@@ -81,6 +82,7 @@ fn RuntimeSession::RuntimeSession(
     url_schemes,
     web_request_cancel_prefixes,
     web_request_redirect_prefixes,
+    web_request_header_prefixes,
   }
 }
 
@@ -1268,6 +1270,7 @@ fn RuntimeSession::create_window(
       self.locale_preferences,
       self.web_request_cancel_prefixes,
       self.web_request_redirect_prefixes,
+      self.web_request_header_prefixes,
     ),
   ) catch {
     error => raise native_run_error("create window " + plan.id, error)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -59,6 +59,7 @@ struct App {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   document_extensions : Array[String]
   mut update_channel : ResolvedUpdateChannel?
   command_capabilities : Array[AppCommandCapability]
@@ -172,6 +173,7 @@ priv struct ResolvedAppConfig {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   document_extensions : Array[String]
   /// The update channel and the identity it updates, when configured by code.
   update_channel : ResolvedUpdateChannel?
@@ -425,6 +427,7 @@ priv struct RuntimeSession {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -743,6 +743,22 @@ test "web request redirect prefixes are validated and resolved" {
 }
 
 ///|
+test "web request header prefixes are validated and resolved" {
+  let app = html("Test", "<html></html>")
+    .identifier("dev.proton.web-request-header")
+    .web_request_header_prefix("https://api.example/", "X-Proton-Mode", "test")
+  assert_eq(app.resolved_app_config().web_request_header_prefixes, [
+    ("https://api.example/", "X-Proton-Mode", "test"),
+  ])
+  assert_true(
+    app
+    .web_request_header_prefix("https://api.example/", "X-Proton-Mode", "other")
+    .validation_error()
+    is Some(_),
+  )
+}
+
+///|
 test "debug mode uses an ephemeral endpoint unless a fixed port is explicit" {
   assert_eq(
     resolve_remote_debugging(0, None),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -554,6 +554,15 @@ pub extern "C" fn web_request_config_add_redirect_prefix(
 ) -> Int = "proton_internal_web_request_config_add_redirect_prefix"
 
 ///|
+#borrow(url_prefix, header_name, header_value)
+pub extern "C" fn web_request_config_add_header_prefix(
+  config : WebRequestConfigHandle,
+  url_prefix : Bytes,
+  header_name : Bytes,
+  header_value : Bytes,
+) -> Int = "proton_internal_web_request_config_add_header_prefix"
+
+///|
 pub extern "C" fn web_request_config_destroy(
   config : WebRequestConfigHandle,
 ) -> Unit = "proton_internal_web_request_config_destroy"

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -187,6 +187,25 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
       cef_string_clear(&destination);
     }
   }
+  if (result != 0 && request->set_header_by_name != NULL) {
+    size_t header_count = proton_web_request_config_header_count(
+        handler->session->web_request_config, url_utf8);
+    for (size_t index = 0; index < header_count; index++) {
+      const char *name = proton_web_request_config_header_name_at(
+          handler->session->web_request_config, url_utf8, index);
+      const char *value = proton_web_request_config_header_value_at(
+          handler->session->web_request_config, url_utf8, index);
+      cef_string_t name_string = {0};
+      cef_string_t value_string = {0};
+      if (name != NULL && value != NULL &&
+          cef_string_utf8_to_utf16(name, strlen(name), &name_string) &&
+          cef_string_utf8_to_utf16(value, strlen(value), &value_string)) {
+        request->set_header_by_name(request, &name_string, &value_string, 1);
+      }
+      cef_string_clear(&name_string);
+      cef_string_clear(&value_string);
+    }
+  }
   if (url != NULL) {
     cef_string_userfree_free(url);
   }

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -9,6 +9,7 @@ typedef struct {
   char *prefix;
   char *target;
 } proton_web_request_redirect_t;
+typedef struct { char *prefix; char *name; char *value; } proton_web_request_header_t;
 
 struct proton_web_request_config {
   size_t ref_count;
@@ -16,6 +17,8 @@ struct proton_web_request_config {
   size_t cancel_prefix_count;
   proton_web_request_redirect_t *redirects;
   size_t redirect_count;
+  proton_web_request_header_t *headers;
+  size_t header_count;
 };
 
 static char *proton_web_request_copy(const char *value) {
@@ -25,6 +28,34 @@ static char *proton_web_request_copy(const char *value) {
     memcpy(copy, value, length + 1);
   }
   return copy;
+}
+
+int32_t proton_internal_web_request_config_add_header_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *header_name, const char *header_value) {
+  if (config == NULL || url_prefix == NULL || header_name == NULL ||
+      header_value == NULL || url_prefix[0] == '\0' || header_name[0] == '\0')
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request header values are invalid");
+  for (size_t i = 0; i < config->header_count; i++)
+    if (strcmp(config->headers[i].prefix, url_prefix) == 0 &&
+        strcmp(config->headers[i].name, header_name) == 0)
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "web request header rule is duplicated");
+  proton_web_request_header_t *headers = (proton_web_request_header_t *)realloc(
+      config->headers, (config->header_count + 1) * sizeof(*headers));
+  char *prefix = proton_web_request_copy(url_prefix);
+  char *name = proton_web_request_copy(header_name);
+  char *value = proton_web_request_copy(header_value);
+  if (headers == NULL || prefix == NULL || name == NULL || value == NULL) {
+    free(prefix); free(name); free(value);
+    return proton_set_error(PROTON_ERR_ENGINE, "failed to allocate web request header rule");
+  }
+  config->headers = headers;
+  config->headers[config->header_count].prefix = prefix;
+  config->headers[config->header_count].name = name;
+  config->headers[config->header_count++].value = value;
+  return PROTON_OK;
 }
 
 int32_t proton_internal_web_request_config_add_redirect_prefix(
@@ -143,6 +174,57 @@ const char *proton_web_request_config_redirect_url(
   return NULL;
 }
 
+const char *proton_web_request_config_header_value(
+    const proton_web_request_config_t *config, const char *url,
+    const char *header_name) {
+  if (config == NULL || url == NULL || header_name == NULL) return NULL;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0 &&
+        strcmp(header_name, config->headers[i].name) == 0)
+      return config->headers[i].value;
+  }
+  return NULL;
+}
+
+size_t proton_web_request_config_header_count(
+    const proton_web_request_config_t *config, const char *url) {
+  size_t count = 0;
+  if (config == NULL || url == NULL) return 0;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0) count++;
+  }
+  return count;
+}
+
+static const proton_web_request_header_t *proton_web_request_config_header_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  if (config == NULL || url == NULL) return NULL;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0) {
+      if (index == 0) return &config->headers[i];
+      index--;
+    }
+  }
+  return NULL;
+}
+
+const char *proton_web_request_config_header_name_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  const proton_web_request_header_t *header =
+      proton_web_request_config_header_at(config, url, index);
+  return header != NULL ? header->name : NULL;
+}
+
+const char *proton_web_request_config_header_value_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  const proton_web_request_header_t *header =
+      proton_web_request_config_header_at(config, url, index);
+  return header != NULL ? header->value : NULL;
+}
+
 void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config) {
   if (config == NULL || config->ref_count == 0 || --config->ref_count != 0) {
@@ -157,5 +239,11 @@ void proton_internal_web_request_config_destroy(
     free(config->redirects[index].target);
   }
   free(config->redirects);
+  for (size_t index = 0; index < config->header_count; index++) {
+    free(config->headers[index].prefix);
+    free(config->headers[index].name);
+    free(config->headers[index].value);
+  }
+  free(config->headers);
   free(config);
 }

--- a/proton/internal/native/ffi/src/proton_web_request_config.h
+++ b/proton/internal/native/ffi/src/proton_web_request_config.h
@@ -17,12 +17,24 @@ PROTON_INTERNAL int32_t proton_internal_web_request_config_add_cancel_prefix(
 PROTON_INTERNAL int32_t proton_internal_web_request_config_add_redirect_prefix(
     proton_web_request_config_t *config, const char *url_prefix,
     const char *target_url);
+PROTON_INTERNAL int32_t proton_internal_web_request_config_add_header_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *header_name, const char *header_value);
 PROTON_INTERNAL void proton_web_request_config_retain(
     proton_web_request_config_t *config);
 PROTON_INTERNAL int proton_web_request_config_should_cancel(
     const proton_web_request_config_t *config, const char *url);
 PROTON_INTERNAL const char *proton_web_request_config_redirect_url(
     const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL const char *proton_web_request_config_header_value(
+    const proton_web_request_config_t *config, const char *url,
+    const char *header_name);
+PROTON_INTERNAL size_t proton_web_request_config_header_count(
+    const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL const char *proton_web_request_config_header_name_at(
+    const proton_web_request_config_t *config, const char *url, size_t index);
+PROTON_INTERNAL const char *proton_web_request_config_header_value_at(
+    const proton_web_request_config_t *config, const char *url, size_t index);
 PROTON_INTERNAL void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config);
 

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1370,8 +1370,9 @@ fn build_bridge_config(
 fn build_web_request_config(
   prefixes : Array[String],
   redirects : Array[(String, String)],
+  headers : Array[(String, String, String)],
 ) -> @native_ffi.WebRequestConfigHandle raise NativeError {
-  if prefixes.length() == 0 && redirects.length() == 0 {
+  if prefixes.length() == 0 && redirects.length() == 0 && headers.length() == 0 {
     return @native_ffi.web_request_config_null()
   }
   let out_config = Ref(@native_ffi.web_request_config_null())
@@ -1403,6 +1404,18 @@ fn build_web_request_config(
       raise native_error(status)
     }
   }
+  for item in headers {
+    let status = @native_ffi.web_request_config_add_header_prefix(
+      handle,
+      @ffi.to_cstr(item.0),
+      @ffi.to_cstr(item.1),
+      @ffi.to_cstr(item.2),
+    )
+    if status < 0 {
+      @native_ffi.web_request_config_destroy(handle)
+      raise native_error(status)
+    }
+  }
   handle
 }
 
@@ -1417,6 +1430,7 @@ pub fn Window::Window(
   let web_request_config = build_web_request_config(
     config.web_request_cancel_prefixes,
     config.web_request_redirect_prefixes,
+    config.web_request_header_prefixes,
   )
   let status = @native_ffi.window_create(
     runtime.active_handle(),

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -1465,6 +1465,7 @@ struct WindowConfig {
   bridge : BridgeConfig?
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   framework_titlebar_minimize_label : String?
   framework_titlebar_maximize_label : String?
   framework_titlebar_restore_label : String?
@@ -1562,6 +1563,7 @@ pub fn WindowConfig::WindowConfig(
   bridge? : BridgeConfig,
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> WindowConfig {
   {
     title,
@@ -1575,6 +1577,7 @@ pub fn WindowConfig::WindowConfig(
     bridge,
     web_request_cancel_prefixes,
     web_request_redirect_prefixes,
+    web_request_header_prefixes,
     framework_titlebar_minimize_label: Some("Minimize"),
     framework_titlebar_maximize_label: Some("Maximize"),
     framework_titlebar_restore_label: Some("Restore"),
@@ -1628,6 +1631,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     bridge: self.bridge,
     web_request_cancel_prefixes: self.web_request_cancel_prefixes,
     web_request_redirect_prefixes: self.web_request_redirect_prefixes,
+    web_request_header_prefixes: self.web_request_header_prefixes,
     framework_titlebar_minimize_label: Some(minimize),
     framework_titlebar_maximize_label: Some(maximize),
     framework_titlebar_restore_label: Some(restore),


### PR DESCRIPTION
## Summary
- add synchronous URL-prefix request header overrides
- preserve cancellation and redirect precedence
- validate empty and duplicate header rules

## Validation
- moon fmt --check
- moon -C proton check --target native --diagnostic-limit 120
- moon -C proton test . --target native --diagnostic-limit 120
- node scripts/verify_generated.mjs

## Limitations
Header rules are fixed and startup-declared; response observation remains a follow-up.