### PR TITLE
fix(logging): retain process logs and preserve application filtering

### DIFF
--- a/extensions/desktop_capturer/contract/contract.mbt
+++ b/extensions/desktop_capturer/contract/contract.mbt
@@ -6,6 +6,18 @@ pub(all) struct GetSourcesRequest {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+pub extend GetSourcesRequest with ToJson::{to_json}
+
+///|
+pub extend GetSourcesRequest with FromJson::{from_json}
+
+///|
+pub extend GetSourcesRequest with Debug::{to_repr}
+
+///|
+pub extend GetSourcesRequest with Eq::{not_equal, equal}
+
+///|
 pub(all) struct Source {
   id : String
   name : String
@@ -18,9 +30,33 @@ pub(all) struct Source {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+pub extend Source with ToJson::{to_json}
+
+///|
+pub extend Source with FromJson::{from_json}
+
+///|
+pub extend Source with Debug::{to_repr}
+
+///|
+pub extend Source with Eq::{not_equal, equal}
+
+///|
 pub(all) struct GetSourcesReply {
   sources : Array[Source]
 } derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend GetSourcesReply with ToJson::{to_json}
+
+///|
+pub extend GetSourcesReply with FromJson::{from_json}
+
+///|
+pub extend GetSourcesReply with Debug::{to_repr}
+
+///|
+pub extend GetSourcesReply with Eq::{not_equal, equal}
 
 ///|
 pub let get_sources : @proton_contract.Command[

--- a/extensions/desktop_capturer/error.mbt
+++ b/extensions/desktop_capturer/error.mbt
@@ -5,6 +5,12 @@ pub(all) suberror DesktopCapturerError {
 } derive(Debug, Eq)
 
 ///|
+pub extend DesktopCapturerError with Debug::{to_repr}
+
+///|
+pub extend DesktopCapturerError with Eq::{not_equal, equal}
+
+///|
 pub fn DesktopCapturerError::message(self : DesktopCapturerError) -> String {
   match self {
     Unsupported(operation~, detail~) =>

--- a/extensions/desktop_capturer/extension.mbt
+++ b/extensions/desktop_capturer/extension.mbt
@@ -9,6 +9,9 @@ struct WindowSourcesWire {
 } derive(FromJson)
 
 ///|
+pub extend WindowSourcesWire with FromJson::{from_json}
+
+///|
 struct WindowSourceWire {
   id : String
   display_id : String
@@ -19,6 +22,9 @@ struct WindowSourceWire {
   thumbnail : String?
   name : String
 } derive(FromJson)
+
+///|
+pub extend WindowSourceWire with FromJson::{from_json}
 
 ///|
 fn window_source_from_wire(

--- a/extensions/safe_storage/contract/contract.mbt
+++ b/extensions/safe_storage/contract/contract.mbt
@@ -4,9 +4,33 @@ pub(all) struct EncryptRequest {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+pub extend EncryptRequest with ToJson::{to_json}
+
+///|
+pub extend EncryptRequest with FromJson::{from_json}
+
+///|
+pub extend EncryptRequest with Debug::{to_repr}
+
+///|
+pub extend EncryptRequest with Eq::{not_equal, equal}
+
+///|
 pub(all) struct EncryptReply {
   encrypted : String
 } derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend EncryptReply with ToJson::{to_json}
+
+///|
+pub extend EncryptReply with FromJson::{from_json}
+
+///|
+pub extend EncryptReply with Debug::{to_repr}
+
+///|
+pub extend EncryptReply with Eq::{not_equal, equal}
 
 ///|
 pub(all) struct DecryptRequest {
@@ -14,14 +38,50 @@ pub(all) struct DecryptRequest {
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+pub extend DecryptRequest with ToJson::{to_json}
+
+///|
+pub extend DecryptRequest with FromJson::{from_json}
+
+///|
+pub extend DecryptRequest with Debug::{to_repr}
+
+///|
+pub extend DecryptRequest with Eq::{not_equal, equal}
+
+///|
 pub(all) struct DecryptReply {
   value : String
 } derive(ToJson, FromJson, Debug, Eq)
 
 ///|
+pub extend DecryptReply with ToJson::{to_json}
+
+///|
+pub extend DecryptReply with FromJson::{from_json}
+
+///|
+pub extend DecryptReply with Debug::{to_repr}
+
+///|
+pub extend DecryptReply with Eq::{not_equal, equal}
+
+///|
 pub(all) struct AvailabilityReply {
   available : Bool
 } derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend AvailabilityReply with ToJson::{to_json}
+
+///|
+pub extend AvailabilityReply with FromJson::{from_json}
+
+///|
+pub extend AvailabilityReply with Debug::{to_repr}
+
+///|
+pub extend AvailabilityReply with Eq::{not_equal, equal}
 
 ///|
 pub let encrypt : @proton_contract.Command[EncryptRequest, EncryptReply] = extension.command(

--- a/extensions/safe_storage/error.mbt
+++ b/extensions/safe_storage/error.mbt
@@ -4,6 +4,12 @@ pub(all) suberror SafeStorageError {
 } derive(Debug, Eq)
 
 ///|
+pub extend SafeStorageError with Debug::{to_repr}
+
+///|
+pub extend SafeStorageError with Eq::{not_equal, equal}
+
+///|
 pub fn SafeStorageError::message(self : SafeStorageError) -> String {
   match self {
     OperationFailed(detail~) => "safe storage operation failed: " + detail

--- a/proton/README.md
+++ b/proton/README.md
@@ -174,6 +174,11 @@ their platform log directory; direct launches and `proton_cli dev` use stderr.
 `MOON_XLOG` controls filtering and `PROTON_LOG_OUTPUT` selects `file` or
 `stderr`; file output requires packaged application metadata. Application
 categories should use `app.*`; `proton.*` is reserved for framework diagnostics.
+Logging is initialized once per process and remains active after `App::run`
+returns or raises, so application error handling continues writing to the same
+output. Subsequent runs preserve the current handler and filtering settings.
+Runtime failures are logged with their full diagnostics before displaying an
+error dialog.
 
 ## Headless mode
 

--- a/proton/README.md
+++ b/proton/README.md
@@ -171,7 +171,10 @@ Web contents views expose the same loading lifecycle events through
 Use `tonyfettes/xlog@0.4.2` directly for application logs. Proton configures the
 global logger before native runtime creation. Packaged applications write to
 their platform log directory; direct launches and `proton_cli dev` use stderr.
-`MOON_XLOG` controls filtering and `PROTON_LOG_OUTPUT` selects `file` or
+xlog initializes filtering from `MOON_XLOG` (default: `Info`). Proton preserves
+the global logger's level and category rules, including application overrides,
+and follows xlog's handling of invalid `MOON_XLOG` values.
+`PROTON_LOG_OUTPUT` selects `file` or
 `stderr`; file output requires packaged application metadata. Application
 categories should use `app.*`; `proton.*` is reserved for framework diagnostics.
 Logging is initialized once per process and remains active after `App::run`

--- a/proton/facade_logging.mbt
+++ b/proton/facade_logging.mbt
@@ -4,13 +4,6 @@ let runtime_logging_started : Ref[Bool] = Ref(false)
 ///|
 async fn start_runtime_logging(directory : String) -> Unit raise AppRunError {
   guard !runtime_logging_started.val else { return }
-  let config = @xlog.Config::from_env(level=@xlog.Warn) catch {
-    error =>
-      raise LoggingInitializationFailed(
-        detail="invalid MOON_XLOG configuration: " +
-          xlog_config_error_message(error),
-      )
-  }
   let packaged = packaged_application_manifest_path() is Some(_)
   let output = match @env.get_env_var("PROTON_LOG_OUTPUT") {
     None => if packaged { "file" } else { "stderr" }
@@ -37,7 +30,7 @@ async fn start_runtime_logging(directory : String) -> Unit raise AppRunError {
         detail="PROTON_LOG_OUTPUT must be stderr or file, got: " + value,
       )
   }
-  @logging.configure(selected, config) catch {
+  @logging.configure(selected) catch {
     error =>
       raise LoggingInitializationFailed(detail=@debug.render(Repr(error)))
   }
@@ -77,14 +70,5 @@ async fn ensure_log_directory(path : String) -> Unit raise AppRunError {
 fn log_path_is_directory(path : String) -> Bool {
   @mbfs.is_dir(path) catch {
     _ => false
-  }
-}
-
-///|
-fn xlog_config_error_message(error : @xlog.ConfigError) -> String {
-  match error {
-    @xlog.ConfigError::InvalidCategory(value) => "invalid category: " + value
-    @xlog.ConfigError::InvalidDirective(value) => "invalid directive: " + value
-    @xlog.ConfigError::InvalidLevel(value) => "invalid level: " + value
   }
 }

--- a/proton/facade_logging.mbt
+++ b/proton/facade_logging.mbt
@@ -1,7 +1,9 @@
 ///|
-async fn start_runtime_logging(
-  directory : String,
-) -> @logging.RuntimeLogging raise AppRunError {
+let runtime_logging_started : Ref[Bool] = Ref(false)
+
+///|
+async fn start_runtime_logging(directory : String) -> Unit raise AppRunError {
+  guard !runtime_logging_started.val else { return }
   let config = @xlog.Config::from_env(level=@xlog.Warn) catch {
     error =>
       raise LoggingInitializationFailed(
@@ -35,10 +37,11 @@ async fn start_runtime_logging(
         detail="PROTON_LOG_OUTPUT must be stderr or file, got: " + value,
       )
   }
-  @logging.RuntimeLogging(selected, config) catch {
+  @logging.configure(selected, config) catch {
     error =>
       raise LoggingInitializationFailed(detail=@debug.render(Repr(error)))
   }
+  runtime_logging_started.val = true
 }
 
 ///|

--- a/proton/facade_logging_wbtest.mbt
+++ b/proton/facade_logging_wbtest.mbt
@@ -37,12 +37,14 @@ test "runtime failure logging retains operation status and reason without duplic
     entry.fields.get("error"),
     Some(Json::string("runtime failed during create window (-7): owner closed")),
   )
-  failure_log.report_remaining(error)
+  ignore(failure_log.logged_remaining(error))
   assert_eq(capture.entries.length(), 1)
-  failure_log.report_remaining(
-    CleanupFailed(primary=Some(error.message()), failures=[
-      RuntimeDestroy(status=-8, detail="runtime busy"),
-    ]),
+  ignore(
+    failure_log.logged_remaining(
+      CleanupFailed(primary=Some(error.message()), failures=[
+        RuntimeDestroy(status=-8, detail="runtime busy"),
+      ]),
+    ),
   )
   assert_eq(capture.entries.length(), 2)
   assert_eq(
@@ -73,7 +75,7 @@ test "runtime failures outside the dialog path retain complete diagnostics" {
   let error = ConfigurationError(
     InvalidSetting(name="browser_data_dir", message="not a directory"),
   )
-  failure_log.report_remaining(error)
+  ignore(failure_log.logged_remaining(error))
   assert_eq(capture.entries.length(), 1)
   assert_eq(
     capture.entries[0].fields.get("error"),

--- a/proton/facade_logging_wbtest.mbt
+++ b/proton/facade_logging_wbtest.mbt
@@ -1,0 +1,110 @@
+///|
+priv struct RuntimeLogCapture {
+  entries : Array[@xlog.Entry]
+}
+
+///|
+impl @xlog.Handler for RuntimeLogCapture with fn handle(self, entry) {
+  self.entries.push(entry)
+}
+
+///|
+test "runtime failure logging retains operation status and reason without duplicates" {
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  let capture = RuntimeLogCapture::{ entries: [], }
+  logger.set_handler(capture)
+  logger.set_config(@xlog.Config(level=@xlog.Error))
+  let failure_log = RuntimeFailureLog::{ primary_logged: false, }
+  let error = RuntimeOperationFailed(
+    action="create window",
+    status=-7,
+    detail="owner closed",
+  )
+  failure_log.report_primary(error)
+  assert_eq(capture.entries.length(), 1)
+  let entry = capture.entries[0]
+  assert_true(entry.level == @xlog.Error)
+  assert_eq(entry.category, Some("proton.runtime"))
+  assert_eq(
+    entry.fields.get("code"),
+    Some(Json::string("runtime_operation_failed")),
+  )
+  assert_eq(
+    entry.fields.get("error"),
+    Some(Json::string("runtime failed during create window (-7): owner closed")),
+  )
+  failure_log.report_remaining(error)
+  assert_eq(capture.entries.length(), 1)
+  failure_log.report_remaining(
+    CleanupFailed(primary=Some(error.message()), failures=[
+      RuntimeDestroy(status=-8, detail="runtime busy"),
+    ]),
+  )
+  assert_eq(capture.entries.length(), 2)
+  assert_eq(
+    capture.entries[1].fields.get("code"),
+    Some(Json::string("cleanup_failed")),
+  )
+  assert_eq(
+    capture.entries[1].fields.get("error"),
+    Some(
+      Json::string(
+        "application teardown failed\n- failed to destroy runtime (-8): runtime busy",
+      ),
+    ),
+  )
+}
+
+///|
+test "runtime failures outside the dialog path retain complete diagnostics" {
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  let capture = RuntimeLogCapture::{ entries: [], }
+  logger.set_handler(capture)
+  logger.set_config(@xlog.Config(level=@xlog.Error))
+  let failure_log = RuntimeFailureLog::{ primary_logged: false, }
+  let error = ConfigurationError(
+    InvalidSetting(name="browser_data_dir", message="not a directory"),
+  )
+  failure_log.report_remaining(error)
+  assert_eq(capture.entries.length(), 1)
+  assert_eq(
+    capture.entries[0].fields.get("error"),
+    Some(
+      Json::string(
+        "application configuration failed: browser_data_dir: not a directory",
+      ),
+    ),
+  )
+}
+
+///|
+async test "repeated runtime logging startup preserves application changes" {
+  let logger = @xlog.global()
+  let was_started = runtime_logging_started.val
+  defer {
+    runtime_logging_started.val = was_started
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  runtime_logging_started.val = false
+  start_runtime_logging("")
+  let capture = RuntimeLogCapture::{ entries: [], }
+  logger.set_handler(capture)
+  logger.set_config(@xlog.Config(level=@xlog.Error))
+  start_runtime_logging("")
+  @xlog.warn() <? { "message": "filtered" }
+  @xlog.error() <? { "message": "application handler retained" }
+  assert_eq(capture.entries.length(), 1)
+  assert_eq(
+    capture.entries[0].fields.get("message"),
+    Some(Json::string("application handler retained")),
+  )
+}

--- a/proton/facade_logging_wbtest.mbt
+++ b/proton/facade_logging_wbtest.mbt
@@ -110,3 +110,39 @@ async test "repeated runtime logging startup preserves application changes" {
     Some(Json::string("application handler retained")),
   )
 }
+
+///|
+async test "first runtime logging startup preserves root and category filtering" {
+  let logger = @xlog.global()
+  let was_started = runtime_logging_started.val
+  defer {
+    runtime_logging_started.val = was_started
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  for level in [@xlog.Debug, @xlog.Error] {
+    let config = @xlog.Config(level=@xlog.Warn)
+    config.set_category_level("app.verbose", @xlog.Trace)
+    config.set_category_level("app.quiet", @xlog.Fatal)
+    logger.set_config(config)
+    logger.set_level(level)
+    runtime_logging_started.val = false
+    start_runtime_logging("")
+    let capture = RuntimeLogCapture::{ entries: [], }
+    logger.set_handler(capture)
+    @xlog.debug() <? { "message": "root debug" }
+    @xlog.warn() <? { "message": "root warn" }
+    @xlog.error() <? { "message": "root error" }
+    @xlog.trace(category="app.verbose.child") <? { "message": "category trace" }
+    @xlog.error(category="app.quiet.child") <? { "message": "filtered" }
+    let messages = capture.entries.map(entry => {
+      entry.fields.get("message").unwrap()
+    })
+    let expected : Array[Json] = if level == @xlog.Debug {
+      ["root debug", "root warn", "root error", "category trace"]
+    } else {
+      ["root error", "category trace"]
+    }
+    assert_eq(messages, expected)
+  }
+}

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -11,87 +11,93 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
   if self.create_logs_path {
     ensure_log_directory(log_directory)
   }
-  let logging = start_runtime_logging(log_directory)
-  defer logging.close()
-  @xlog.info(category="proton.runtime") <?
-    { "message": "application runtime starting" }
-  let browser_data_dir = resolve_browser_data_dir(self, resolved) catch {
-    error => raise ConfigurationError(error)
-  }
-  let locale_preferences = resolve_locale_preferences(self.explicit_locale)
-  let application_executable = executable_path() catch {
-    error =>
-      raise RuntimeOperationFailed(
-        action="resolve application executable",
-        status=-1,
-        detail=error.message(),
-      )
-  }
-  let process_arguments = @env.args()
-  let application_arguments = if process_arguments.length() > 1 {
-    process_arguments[1:].to_owned()
-  } else {
-    []
-  }
-  let app_instance = match acquire_app_instance(resolved) {
-    Some(@native.AppInstanceAcquire::Forwarded) => {
-      @xlog.info(category="proton.runtime") <?
-        { "message": "application activation forwarded to primary instance" }
-      return
+  start_runtime_logging(log_directory)
+  let failure_log = RuntimeFailureLog::{ primary_logged: false, }
+  try {
+    @xlog.info(category="proton.runtime") <?
+      { "message": "application runtime starting" }
+    let browser_data_dir = resolve_browser_data_dir(self, resolved) catch {
+      error => raise ConfigurationError(error)
     }
-    Some(@native.AppInstanceAcquire::Primary(instance)) => Some(instance)
-    None => None
+    let locale_preferences = resolve_locale_preferences(self.explicit_locale)
+    let application_executable = executable_path() catch {
+      error =>
+        raise RuntimeOperationFailed(
+          action="resolve application executable",
+          status=-1,
+          detail=error.message(),
+        )
+    }
+    let process_arguments = @env.args()
+    let application_arguments = if process_arguments.length() > 1 {
+      process_arguments[1:].to_owned()
+    } else {
+      []
+    }
+    let app_instance = match acquire_app_instance(resolved) {
+      Some(@native.AppInstanceAcquire::Forwarded) => {
+        @xlog.info(category="proton.runtime") <?
+          { "message": "application activation forwarded to primary instance" }
+        return
+      }
+      Some(@native.AppInstanceAcquire::Primary(instance)) => Some(instance)
+      None => None
+    }
+    errdefer (match app_instance {
+      Some(instance) => destroy_app_instance(instance) catch { _ => () }
+      None => ()
+    })
+    run_manifest(
+      resolved.manifest,
+      resolved.permission_base_path,
+      self.command_capabilities,
+      self.extension_capabilities,
+      self.application_lifecycle_hooks,
+      self.window_lifecycle_hooks,
+      self.menu.map(menu => menu.to_native()),
+      self.bridge_startup_timeout_value_ms,
+      self.resolved_headless(),
+      self.accessibility_mode_value,
+      locale_preferences,
+      browser_data_dir?,
+      application_name=resolved.application_name,
+      app_instance~,
+      last_window_closed_policy=self.last_window_closed_policy_value,
+      launch_input_handlers=self.launch_input_handlers,
+      planned_views=self.planned_views.map(view => (view.0, view.1.to_native())),
+      window_event_handlers=self.window_event_handlers,
+      view_event_handlers=self.view_event_handlers,
+      browser_event_handlers=self.browser_event_handlers,
+      window_close_handler=self.window_close_handler,
+      navigation_handler=self.navigation_handler,
+      new_window_handler=self.new_window_handler,
+      download_handler=self.download_handler,
+      certificate_handler=self.certificate_handler,
+      media_handler=self.media_handler,
+      download_event_handlers=self.download_event_handlers,
+      update_channel=resolved.update_channel,
+      update_handlers=self.update_handlers,
+      application_identifier=resolved.application_identifier,
+      application_executable~,
+      application_arguments~,
+      url_schemes=resolved.url_schemes,
+      failure_log~,
+    )
+    match app_instance {
+      Some(instance) => destroy_app_instance(instance)
+      None => ()
+    }
+    @native.process_run_relaunches() catch {
+      error => raise native_run_error("relaunch application", error)
+    }
+    @xlog.info(category="proton.runtime") <?
+      { "message": "application runtime stopped" }
+  } catch {
+    error => {
+      failure_log.report_remaining(error)
+      raise error
+    }
   }
-  errdefer (match app_instance {
-    Some(instance) => destroy_app_instance(instance) catch { _ => () }
-    None => ()
-  })
-  run_manifest(
-    resolved.manifest,
-    resolved.permission_base_path,
-    self.command_capabilities,
-    self.extension_capabilities,
-    self.application_lifecycle_hooks,
-    self.window_lifecycle_hooks,
-    self.menu.map(menu => menu.to_native()),
-    self.bridge_startup_timeout_value_ms,
-    self.resolved_headless(),
-    self.accessibility_mode_value,
-    locale_preferences,
-    browser_data_dir?,
-    application_name=resolved.application_name,
-    app_instance~,
-    last_window_closed_policy=self.last_window_closed_policy_value,
-    launch_input_handlers=self.launch_input_handlers,
-    planned_views=self.planned_views.map(view => (view.0, view.1.to_native())),
-    window_event_handlers=self.window_event_handlers,
-    view_event_handlers=self.view_event_handlers,
-    browser_event_handlers=self.browser_event_handlers,
-    window_close_handler=self.window_close_handler,
-    navigation_handler=self.navigation_handler,
-    new_window_handler=self.new_window_handler,
-    download_handler=self.download_handler,
-    certificate_handler=self.certificate_handler,
-    media_handler=self.media_handler,
-    download_event_handlers=self.download_event_handlers,
-    update_channel=resolved.update_channel,
-    update_handlers=self.update_handlers,
-    application_identifier=resolved.application_identifier,
-    application_executable~,
-    application_arguments~,
-    url_schemes=resolved.url_schemes,
-  ) catch {
-    error => raise logged_runtime_failure(error)
-  }
-  match app_instance {
-    Some(instance) => destroy_app_instance(instance)
-    None => ()
-  }
-  @native.process_run_relaunches() catch {
-    error => raise native_run_error("relaunch application", error)
-  }
-  @xlog.info(category="proton.runtime") <?
-    { "message": "application runtime stopped" }
 }
 
 ///|
@@ -105,13 +111,39 @@ fn AccessibilityMode::to_native(
 }
 
 ///|
-fn logged_runtime_failure(error : AppRunError) -> AppRunError {
+fn log_runtime_failure(error : AppRunError) -> Unit {
   @xlog.error(category="proton.runtime") <?
     {
       "message": "application runtime failed",
       "code": app_run_error_log_code(error),
+      "error": error.message(),
     }
-  error
+}
+
+///|
+priv struct RuntimeFailureLog {
+  mut primary_logged : Bool
+}
+
+///|
+fn RuntimeFailureLog::report_primary(
+  self : RuntimeFailureLog,
+  error : AppRunError,
+) -> Unit {
+  log_runtime_failure(error)
+  self.primary_logged = true
+}
+
+///|
+fn RuntimeFailureLog::report_remaining(
+  self : RuntimeFailureLog,
+  error : AppRunError,
+) -> Unit {
+  if !self.primary_logged {
+    log_runtime_failure(error)
+  } else if error is CleanupFailed(failures~, ..) {
+    log_runtime_failure(CleanupFailed(primary=None, failures~))
+  }
 }
 
 ///|
@@ -183,6 +215,9 @@ async fn run_manifest(
   application_executable? : String = "",
   application_arguments? : Array[String] = [],
   url_schemes? : Array[String] = [],
+  failure_log? : RuntimeFailureLog = RuntimeFailureLog::{
+    primary_logged: false,
+  },
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -476,6 +511,7 @@ async fn run_manifest(
   } catch {
     error => {
       let primary = normalize_async_run_error(error)
+      failure_log.report_primary(primary)
       if !headless {
         show_app_run_failure(
           runtime,

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -93,10 +93,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     @xlog.info(category="proton.runtime") <?
       { "message": "application runtime stopped" }
   } catch {
-    error => {
-      failure_log.report_remaining(error)
-      raise error
-    }
+    error => raise failure_log.logged_remaining(error)
   }
 }
 
@@ -135,15 +132,16 @@ fn RuntimeFailureLog::report_primary(
 }
 
 ///|
-fn RuntimeFailureLog::report_remaining(
+fn RuntimeFailureLog::logged_remaining(
   self : RuntimeFailureLog,
   error : AppRunError,
-) -> Unit {
+) -> AppRunError {
   if !self.primary_logged {
     log_runtime_failure(error)
   } else if error is CleanupFailed(failures~, ..) {
     log_runtime_failure(CleanupFailed(primary=None, failures~))
   }
+  error
 }
 
 ///|

--- a/proton/internal/logging/logging.mbt
+++ b/proton/internal/logging/logging.mbt
@@ -14,10 +14,6 @@ extern "C" fn file_is_open(file : FileHandle) -> Bool = "proton_logging_file_is_
 extern "C" fn write_file(file : FileHandle, data : Bytes) -> Int = "proton_logging_write_file"
 
 ///|
-#borrow(file)
-extern "C" fn close_file(file : FileHandle) -> Unit = "proton_logging_close_file"
-
-///|
 #borrow(data)
 extern "C" fn write_stderr(data : Bytes) -> Int = "proton_logging_write_stderr"
 
@@ -84,40 +80,19 @@ pub(all) enum Output {
 }
 
 ///|
-pub struct RuntimeLogging {
-  close_handler : () -> Unit
-  mut closed : Bool
-}
-
-///|
-pub fn RuntimeLogging::RuntimeLogging(
+/// Install process-wide logging. The global logger retains the handler after
+/// this call returns; replacing it allows the file's GC finalizer to close it.
+pub fn configure(
   output : Output,
   config : @xlog.Config,
-) -> RuntimeLogging raise LoggingError {
-  let logger = @xlog.global()
-  match output {
-    Stderr => {
-      logger.set_config(config)
-      logger.set_handler(StderrHandler::{ failed: false, })
-      RuntimeLogging::{ close_handler: fn() { () }, closed: false, }
-    }
-    File(path) => {
-      let file = FileHandler(path)
-      logger.set_config(config)
-      logger.set_handler(file)
-      RuntimeLogging::{
-        close_handler: fn() { close_file(file.file) },
-        closed: false,
-      }
-    }
+) -> Unit raise LoggingError {
+  let handler : &@xlog.Handler = match output {
+    Stderr => (StderrHandler::{ failed: false, } : &@xlog.Handler)
+    File(path) => (FileHandler(path) : &@xlog.Handler)
   }
-}
-
-///|
-pub fn RuntimeLogging::close(self : RuntimeLogging) -> Unit {
-  guard !self.closed else { return }
-  self.closed = true
-  (self.close_handler)()
+  let logger = @xlog.global()
+  logger.set_config(config)
+  logger.set_handler(handler)
 }
 
 ///|

--- a/proton/internal/logging/logging.mbt
+++ b/proton/internal/logging/logging.mbt
@@ -80,18 +80,15 @@ pub(all) enum Output {
 }
 
 ///|
-/// Install process-wide logging. The global logger retains the handler after
+/// Install process-wide output without changing filtering settings.
+/// The global logger retains the handler after
 /// this call returns; replacing it allows the file's GC finalizer to close it.
-pub fn configure(
-  output : Output,
-  config : @xlog.Config,
-) -> Unit raise LoggingError {
+pub fn configure(output : Output) -> Unit raise LoggingError {
   let handler : &@xlog.Handler = match output {
     Stderr => (StderrHandler::{ failed: false, } : &@xlog.Handler)
     File(path) => (FileHandler(path) : &@xlog.Handler)
   }
   let logger = @xlog.global()
-  logger.set_config(config)
   logger.set_handler(handler)
 }
 

--- a/proton/internal/logging/logging_io.c
+++ b/proton/internal/logging/logging_io.c
@@ -109,11 +109,6 @@ MOONBIT_FFI_EXPORT int32_t proton_logging_write_file(
   return fflush(handle->file) == 0 ? 0 : -1;
 }
 
-MOONBIT_FFI_EXPORT void
-proton_logging_close_file(proton_logging_file_t *handle) {
-  proton_logging_close_handle(handle);
-}
-
 MOONBIT_FFI_EXPORT int32_t proton_logging_write_stderr(moonbit_bytes_t data) {
   int32_t length = Moonbit_array_length(data);
   if (length > 0 &&

--- a/proton/internal/logging/logging_wbtest.mbt
+++ b/proton/internal/logging/logging_wbtest.mbt
@@ -15,7 +15,7 @@ suberror LoggingProbeError {
 
 ///|
 fn run_logging_probe(path : String, fail~ : Bool) -> Unit raise {
-  configure(Output::File(path), @xlog.Config(level=@xlog.Warn))
+  configure(Output::File(path))
   @xlog.warn(category="proton.test") <? { "message": "runtime probe" }
   if fail {
     raise Failed("runtime failed during create window (-7): owner closed")
@@ -29,6 +29,7 @@ test "file logging remains active after runtime return and error propagation" {
     logger.set_handler(@xlog.Stdout())
     logger.set_config(@xlog.Config())
   }
+  logger.set_config(@xlog.Config(level=@xlog.Warn))
   for fail in [false, true] {
     let path = ".proton-logging-test-" +
       current_process_id().to_string() +
@@ -69,7 +70,7 @@ test "failed logging initialization preserves the current handler and filtering"
   logger.set_handler(capture)
   logger.set_config(@xlog.Config(level=@xlog.Error))
   let failed = try {
-    configure(Output::File(""), @xlog.Config(level=@xlog.Trace))
+    configure(Output::File(""))
     false
   } catch {
     OpenFile(..) => true

--- a/proton/internal/logging/logging_wbtest.mbt
+++ b/proton/internal/logging/logging_wbtest.mbt
@@ -1,14 +1,82 @@
 ///|
-test "file handler writes through the configured xlog root" {
-  let path = ".proton-logging-test-" + current_process_id().to_string() + ".log"
-  defer (@fs.remove_file(path) catch { _ => () })
-  let logging = RuntimeLogging(
-    Output::File(path),
-    @xlog.Config(level=@xlog.Warn),
-  )
-  @xlog.warn(category="proton.test") <? { "message": "handler probe" }
-  logging.close()
-  let contents = @fs.read_file_to_string(path)
-  assert_true(contents.contains("category=proton.test"))
-  assert_true(contents.contains("message=\"handler probe\""))
+priv struct CaptureHandler {
+  messages : Array[Json]
+}
+
+///|
+impl @xlog.Handler for CaptureHandler with fn handle(self, entry) {
+  self.messages.push(entry.fields.get("message").unwrap())
+}
+
+///|
+suberror LoggingProbeError {
+  Failed(String)
+}
+
+///|
+fn run_logging_probe(path : String, fail~ : Bool) -> Unit raise {
+  configure(Output::File(path), @xlog.Config(level=@xlog.Warn))
+  @xlog.warn(category="proton.test") <? { "message": "runtime probe" }
+  if fail {
+    raise Failed("runtime failed during create window (-7): owner closed")
+  }
+}
+
+///|
+test "file logging remains active after runtime return and error propagation" {
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  for fail in [false, true] {
+    let path = ".proton-logging-test-" +
+      current_process_id().to_string() +
+      "-" +
+      fail.to_string() +
+      ".log"
+    defer (@fs.remove_file(path) catch { _ => () })
+    try {
+      run_logging_probe(path, fail~)
+      @xlog.error() <? { "message": "application shutdown complete" }
+    } catch {
+      Failed(detail) => @xlog.error() <? { "message": detail }
+      error => raise error
+    }
+    let contents = @fs.read_file_to_string(path)
+    assert_true(contents.contains("category=proton.test"))
+    assert_true(contents.contains("message=\"runtime probe\""))
+    assert_true(
+      contents.contains(
+        if fail {
+          "runtime failed during create window (-7): owner closed"
+        } else {
+          "application shutdown complete"
+        },
+      ),
+    )
+  }
+}
+
+///|
+test "failed logging initialization preserves the current handler and filtering" {
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(@xlog.Config())
+  }
+  let capture = CaptureHandler::{ messages: [], }
+  logger.set_handler(capture)
+  logger.set_config(@xlog.Config(level=@xlog.Error))
+  let failed = try {
+    configure(Output::File(""), @xlog.Config(level=@xlog.Trace))
+    false
+  } catch {
+    OpenFile(..) => true
+    _ => false
+  }
+  assert_true(failed)
+  @xlog.warn() <? { "message": "filtered" }
+  @xlog.error() <? { "message": "after initialization failure" }
+  assert_eq(capture.messages, [Json::string("after initialization failure")])
 }

--- a/proton/internal/logging/pkg.generated.mbti
+++ b/proton/internal/logging/pkg.generated.mbti
@@ -7,6 +7,8 @@ import {
 }
 
 // Values
+pub fn configure(Output, @xlog.Config) -> Unit raise LoggingError
+
 pub fn current_process_id() -> Int
 
 // Errors
@@ -21,13 +23,6 @@ pub(all) enum Output {
   Stderr
   File(String)
 }
-
-pub struct RuntimeLogging {
-  close_handler : () -> Unit
-  mut closed : Bool
-}
-pub fn RuntimeLogging::RuntimeLogging(Output, @xlog.Config) -> Self raise LoggingError
-pub fn RuntimeLogging::close(Self) -> Unit
 
 // Type aliases
 

--- a/proton/internal/logging/pkg.generated.mbti
+++ b/proton/internal/logging/pkg.generated.mbti
@@ -3,11 +3,10 @@ package "moonbit-community/proton/internal/logging"
 
 import {
   "moonbitlang/core/debug",
-  "tonyfettes/xlog",
 }
 
 // Values
-pub fn configure(Output, @xlog.Config) -> Unit raise LoggingError
+pub fn configure(Output) -> Unit raise LoggingError
 
 pub fn current_process_id() -> Int
 


### PR DESCRIPTION
Proton closes its runtime log file before returning failures to application code, leaving the global logger pointing at a closed handler. A caller that catches the error and logs its full details silently loses that diagnostic. Runtime failures are also logged only after the error dialog and cleanup, with just an error classification. Startup additionally replaces application filtering with a new configuration whose default is Warn.

Initialize logging once per process and retain the output after `App::run` returns or raises. Configure only the handler, preserving the application's root level and category rules; xlog continues to own `MOON_XLOG` parsing and its Info default. Later runs preserve application changes to the logger. This uses the existing xlog 0.4.2 dependency and does not require the separate xlog state-restoration PR.

Record the full primary error before showing the failure dialog, avoid logging it again when propagated, and append cleanup failures separately. Cover other failures after logging initialization with the outer reporting boundary. Document the process-wide logging lifetime and filtering behavior.

The branch preserves separate commits for the logging fix, cleanup of 39 MoonBit warnings, and preservation of application filtering. Warning cleanup makes existing trait method promotion explicit in desktop capturer and safe storage, and expresses error logging as an error-returning helper before rethrowing.

Validation:

- Regression tests reproduced lost post-runtime logging and overwritten startup filtering before their fixes.
- Final native facade and logging tests: 169 passed.
- Native facade, logging, desktop capturer, and safe storage tests after warning cleanup: 171 passed.
- `moon -C proton check --target native --diagnostic-limit 200`: passed without MoonBit warnings.
- `node scripts/verify_generated.mjs`: passed after warning cleanup; the later filtering change does not touch generation inputs.
- `git diff --check`: passed.

Native test linking still reports the existing macOS toolchain deployment-version mismatch (runtime objects built for macOS 26.0, linked for 12.0). No GUI dialog validation or Windows/Linux runtime validation was performed.
