### PR TITLE
fix: correct networking, storage, capture, and request rule lifetimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,10 @@ jobs:
           moon -C cli test -p moonbit-community/proton_cli moonbit-community/proton_cli/arguments moonbit-community/proton_cli/build_cmd moonbit-community/proton_cli/cef moonbit-community/proton_cli/dev moonbit-community/proton_cli/doctor moonbit-community/proton_cli/fsutil moonbit-community/proton_cli/new moonbit-community/proton_cli/output moonbit-community/proton_cli/package --target native --no-parallelize --diagnostic-limit 80
           moon -C e2e build --target native --diagnostic-limit 80
 
+      - name: Test standalone macOS safe storage cipher
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: node scripts/test_safe_storage_macos.mjs
+
       - name: Test extensions on Unix
         if: ${{ matrix.os != 'windows-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
               moonbit-community/proton_ext/desktop_capturer \
               moonbit-community/proton_ext/dialog moonbit-community/proton_ext/fs \
               moonbit-community/proton_ext/global_hotkey moonbit-community/proton_ext/keepawake \
-              moonbit-community/proton_ext/microphone \
+              moonbit-community/proton_ext/microphone moonbit-community/proton_ext/net \
               moonbit-community/proton_ext/notification moonbit-community/proton_ext/path \
               moonbit-community/proton_ext/safe_storage \
               moonbit-community/proton_ext/process \
@@ -242,7 +242,7 @@ jobs:
               moonbit-community/proton_ext/desktop_capturer \
               moonbit-community/proton_ext/dialog moonbit-community/proton_ext/fs \
               moonbit-community/proton_ext/global_hotkey moonbit-community/proton_ext/keepawake \
-              moonbit-community/proton_ext/microphone \
+              moonbit-community/proton_ext/microphone moonbit-community/proton_ext/net \
               moonbit-community/proton_ext/notification moonbit-community/proton_ext/path \
               moonbit-community/proton_ext/safe_storage \
               moonbit-community/proton_ext/process \
@@ -272,6 +272,7 @@ jobs:
             "moonbit-community/proton_ext/global_hotkey"
             "moonbit-community/proton_ext/keepawake"
             "moonbit-community/proton_ext/microphone"
+            "moonbit-community/proton_ext/net"
             "moonbit-community/proton_ext/notification"
             "moonbit-community/proton_ext/safe_storage"
             "moonbit-community/proton_ext/path"

--- a/extensions/net/extension.mbt
+++ b/extensions/net/extension.mbt
@@ -20,6 +20,10 @@ fn parse_method(meth : String) -> @http.RequestMethod raise NetError {
 /// Splits a URL into `(base_url, path)` where `base_url` has a trailing slash
 /// and is suitable for `@http.Client::Client`.
 fn split_url(url : String) -> (String, String) raise NetError {
+  let url = match url.split_once("#") {
+    Some((without_fragment, _)) => without_fragment.to_owned()
+    None => url
+  }
   let (prefix, rest) = if url.has_prefix("https://") {
     ("https://", url[8:].to_owned())
   } else if url.has_prefix("http://") {
@@ -27,26 +31,17 @@ fn split_url(url : String) -> (String, String) raise NetError {
   } else {
     raise InvalidUrl(detail="URL must start with http:// or https://")
   }
-  let delimiter = match (rest.find("/"), rest.find("?"), rest.find("#")) {
-    (None, None, None) => None
-    (Some(index), None, None) => Some(index)
-    (None, Some(index), None) => Some(index)
-    (None, None, Some(index)) => Some(index)
-    (Some(first), Some(second), None) =>
+  let delimiter = match (rest.find("/"), rest.find("?")) {
+    (None, None) => None
+    (Some(index), None) | (None, Some(index)) => Some(index)
+    (Some(first), Some(second)) =>
       Some(if first < second { first } else { second })
-    (Some(first), None, Some(second)) =>
-      Some(if first < second { first } else { second })
-    (None, Some(first), Some(second)) =>
-      Some(if first < second { first } else { second })
-    (Some(first), Some(second), Some(third)) => {
-      let first_two = if first < second { first } else { second }
-      Some(if first_two < third { first_two } else { third })
-    }
   }
   match delimiter {
     Some(delimiter) => {
       let host = rest[:delimiter].to_owned()
-      let path = rest[delimiter:].to_owned()
+      let suffix = rest[delimiter:].to_owned()
+      let path = if suffix.has_prefix("/") { suffix } else { "/" + suffix }
       if host.is_empty() {
         raise InvalidUrl(detail="URL host must not be empty")
       }

--- a/extensions/net/extension_wbtest.mbt
+++ b/extensions/net/extension_wbtest.mbt
@@ -13,19 +13,19 @@ test "response headers preserve their original spelling" {
 }
 
 ///|
-test "split_url preserves query and fragment paths without a slash" {
-  assert_eq(
-    split_url("https://example.test?query=1") catch {
-      _ => ("", "")
-    },
-    ("https://example.test/", "?query=1"),
-  )
-  assert_eq(
-    split_url("https://example.test#section") catch {
-      _ => ("", "")
-    },
-    ("https://example.test/", "#section"),
-  )
+test "split_url produces origin-form targets without fragments" {
+  for
+    pair in [
+      ("https://example.test?query=1", "/?query=1"),
+      ("https://example.test#section", "/"),
+      ("https://example.test?query=1#section", "/?query=1"),
+      ("https://example.test/path?query=1#section", "/path?query=1"),
+      ("https://example.test/path#section?ignored=1", "/path"),
+      ("https://example.test/path%23part?q=%23", "/path%23part?q=%23"),
+    ] {
+    let (url, expected) = pair
+    assert_eq(split_url(url), ("https://example.test/", expected))
+  }
 }
 
 ///|

--- a/proton/README.md
+++ b/proton/README.md
@@ -168,6 +168,8 @@ applies to every window and web contents view created by the application.
 `App::web_request_redirect_prefix` provides the corresponding fixed-target
 rewrite for matching requests; cancellation takes precedence when both rules
 match.
+Use `App::web_request_header_prefix` to override a named request header for
+matching URLs before the request is sent.
 
 Web contents views expose the same loading lifecycle events through
 `ViewEvent::DidStartLoading` and `ViewEvent::DidFinishLoad`; their

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -353,7 +353,7 @@ pub fn App::web_request_header_prefix(
       ),
     )
   } else if self.web_request_header_prefixes.any(item => {
-      item.0 == url_prefix && item.1 == header_name
+      item.0 == url_prefix && item.1.equal_ignore_ascii_case(header_name)
     }) {
     self.validation_errors.push(
       InvalidSetting(name="web_request_header_prefix", message="is duplicated"),

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -336,6 +336,37 @@ pub fn App::web_request_redirect_prefix(
 }
 
 ///|
+/// Overrides a request header for URLs matching `url_prefix`.
+pub fn App::web_request_header_prefix(
+  self : App,
+  url_prefix : String,
+  header_name : String,
+  header_value : String,
+) -> App {
+  let url_prefix = url_prefix.trim().to_owned()
+  let header_name = header_name.trim().to_owned()
+  if url_prefix == "" || header_name == "" {
+    self.validation_errors.push(
+      InvalidSetting(
+        name="web_request_header_prefix",
+        message="prefix and header name must not be empty",
+      ),
+    )
+  } else if self.web_request_header_prefixes.any(item => {
+      item.0 == url_prefix && item.1 == header_name
+    }) {
+    self.validation_errors.push(
+      InvalidSetting(name="web_request_header_prefix", message="is duplicated"),
+    )
+  } else {
+    self.web_request_header_prefixes.push(
+      (url_prefix, header_name, header_value),
+    )
+  }
+  self
+}
+
+///|
 fn app_url_scheme_is_valid(scheme : String) -> Bool {
   guard scheme.length() > 0 else { return false }
   for index, char in scheme {

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -26,6 +26,7 @@ fn App::App(
     url_schemes: [],
     web_request_cancel_prefixes: [],
     web_request_redirect_prefixes: [],
+    web_request_header_prefixes: [],
     document_extensions: [],
     update_channel: None,
     command_capabilities: [],
@@ -98,6 +99,7 @@ fn App::resolved_app_config(self : App) -> ResolvedAppConfig {
     url_schemes: self.url_schemes.copy(),
     web_request_cancel_prefixes: self.web_request_cancel_prefixes.copy(),
     web_request_redirect_prefixes: self.web_request_redirect_prefixes.copy(),
+    web_request_header_prefixes: self.web_request_header_prefixes.copy(),
     document_extensions: self.document_extensions.copy(),
     update_channel: if proton_dev_mode_enabled() {
       None

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -82,6 +82,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
     url_schemes=resolved.url_schemes,
     web_request_cancel_prefixes=resolved.web_request_cancel_prefixes,
     web_request_redirect_prefixes=resolved.web_request_redirect_prefixes,
+    web_request_header_prefixes=resolved.web_request_header_prefixes,
   ) catch {
     error => raise logged_runtime_failure(error)
   }
@@ -187,6 +188,7 @@ async fn run_manifest(
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> Unit raise AppRunError {
   let plans = planned_windows(manifest) catch {
     error => raise ConfigurationError(error)
@@ -423,6 +425,7 @@ async fn run_manifest(
           url_schemes~,
           web_request_cancel_prefixes~,
           web_request_redirect_prefixes~,
+          web_request_header_prefixes~,
         )
         let application_context = session.application_context()
         let application_start = application_tasks.spawn(
@@ -613,6 +616,7 @@ fn native_window_config(
   preferences : @locale.LocalePreferences,
   web_request_cancel_prefixes : Array[String],
   web_request_redirect_prefixes : Array[(String, String)],
+  web_request_header_prefixes : Array[(String, String, String)],
 ) -> @native.WindowConfig {
   let catalog = framework_catalog(preferences)
   @native.WindowConfig(
@@ -642,6 +646,7 @@ fn native_window_config(
     bridge?,
     web_request_cancel_prefixes~,
     web_request_redirect_prefixes~,
+    web_request_header_prefixes~,
   ).with_framework_titlebar_labels(
     catalog.titlebar_minimize,
     catalog.titlebar_maximize,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -40,6 +40,7 @@ fn RuntimeSession::RuntimeSession(
   url_schemes? : Array[String] = [],
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> RuntimeSession {
   RuntimeSession::{
     runtime,
@@ -81,6 +82,7 @@ fn RuntimeSession::RuntimeSession(
     url_schemes,
     web_request_cancel_prefixes,
     web_request_redirect_prefixes,
+    web_request_header_prefixes,
   }
 }
 
@@ -1268,6 +1270,7 @@ fn RuntimeSession::create_window(
       self.locale_preferences,
       self.web_request_cancel_prefixes,
       self.web_request_redirect_prefixes,
+      self.web_request_header_prefixes,
     ),
   ) catch {
     error => raise native_run_error("create window " + plan.id, error)

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -59,6 +59,7 @@ struct App {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   document_extensions : Array[String]
   mut update_channel : ResolvedUpdateChannel?
   command_capabilities : Array[AppCommandCapability]
@@ -172,6 +173,7 @@ priv struct ResolvedAppConfig {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   document_extensions : Array[String]
   /// The update channel and the identity it updates, when configured by code.
   update_channel : ResolvedUpdateChannel?
@@ -425,6 +427,7 @@ priv struct RuntimeSession {
   url_schemes : Array[String]
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -3623,3 +3623,24 @@ test "POSIX system locales are normalized only on Linux" {
     ["en-US"],
   )
 }
+
+///|
+test "web request header names reject ASCII case-insensitive duplicates" {
+  let app = html("Test", "<html></html>")
+    .identifier("dev.proton.header-case")
+    .web_request_header_prefix(
+      "https://api.example/Path/", "Authorization", "first",
+    )
+    .web_request_header_prefix(
+      "https://api.example/path/", "authorization", "second",
+    )
+  assert_true(app.validation_error() is None)
+  assert_true(
+    app
+    .web_request_header_prefix(
+      "https://api.example/Path/", "aUtHoRiZaTiOn", "third",
+    )
+    .validation_error()
+    is Some(_),
+  )
+}

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -743,6 +743,22 @@ test "web request redirect prefixes are validated and resolved" {
 }
 
 ///|
+test "web request header prefixes are validated and resolved" {
+  let app = html("Test", "<html></html>")
+    .identifier("dev.proton.web-request-header")
+    .web_request_header_prefix("https://api.example/", "X-Proton-Mode", "test")
+  assert_eq(app.resolved_app_config().web_request_header_prefixes, [
+    ("https://api.example/", "X-Proton-Mode", "test"),
+  ])
+  assert_true(
+    app
+    .web_request_header_prefix("https://api.example/", "X-Proton-Mode", "other")
+    .validation_error()
+    is Some(_),
+  )
+}
+
+///|
 test "debug mode uses an ephemeral endpoint unless a fixed port is explicit" {
   assert_eq(
     resolve_remote_debugging(0, None),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -554,6 +554,15 @@ pub extern "C" fn web_request_config_add_redirect_prefix(
 ) -> Int = "proton_internal_web_request_config_add_redirect_prefix"
 
 ///|
+#borrow(url_prefix, header_name, header_value)
+pub extern "C" fn web_request_config_add_header_prefix(
+  config : WebRequestConfigHandle,
+  url_prefix : Bytes,
+  header_name : Bytes,
+  header_value : Bytes,
+) -> Int = "proton_internal_web_request_config_add_header_prefix"
+
+///|
 pub extern "C" fn web_request_config_destroy(
   config : WebRequestConfigHandle,
 ) -> Unit = "proton_internal_web_request_config_destroy"

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -383,7 +383,19 @@ pub fn view_logical_id(ViewHandle) -> Int64
 
 pub fn view_null() -> ViewHandle
 
-pub fn window_create(RuntimeHandle, Bytes, Int, Int, Bytes, Int, Int, Int, Int, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, Int, Int, BridgeConfigHandle, @ref.Ref[WindowHandle]) -> Int
+pub fn web_request_config_add_cancel_prefix(WebRequestConfigHandle, Bytes) -> Int
+
+pub fn web_request_config_add_header_prefix(WebRequestConfigHandle, Bytes, Bytes, Bytes) -> Int
+
+pub fn web_request_config_add_redirect_prefix(WebRequestConfigHandle, Bytes, Bytes) -> Int
+
+pub fn web_request_config_create(@ref.Ref[WebRequestConfigHandle]) -> Int
+
+pub fn web_request_config_destroy(WebRequestConfigHandle) -> Unit
+
+pub fn web_request_config_null() -> WebRequestConfigHandle
+
+pub fn window_create(RuntimeHandle, Bytes, Int, Int, Bytes, Int, Int, Int, Int, Bytes, Bytes, Bytes, Bytes, Int, Int, Int, Int, Int, BridgeConfigHandle, WebRequestConfigHandle, @ref.Ref[WindowHandle]) -> Int
 
 pub fn window_logical_id(WindowHandle) -> Int64
 
@@ -412,6 +424,9 @@ pub type RuntimeHandle
 
 #external
 pub type ViewHandle
+
+#external
+pub type WebRequestConfigHandle
 
 #external
 pub type WindowHandle

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -103,7 +103,7 @@ typedef struct proton_browser_resource_handler {
 #else
   atomic_int refs;
 #endif
-  proton_browser_session_t *session;
+  proton_web_request_config_t *config;
 } proton_browser_resource_handler_t;
 
 static proton_browser_resource_handler_t *
@@ -134,6 +134,7 @@ static int CEF_CALLBACK proton_browser_resource_handler_release(
              1;
 #endif
   if (refs == 0) {
+    proton_internal_web_request_config_destroy(handler->config);
     free(handler);
     return 1;
   }
@@ -175,10 +176,10 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
   }
   cef_string_userfree_t url = request->get_url(request);
   char *url_utf8 = proton_browser_cef_string_to_utf8(url);
-  int result = proton_browser_session_before_resource_load(handler->session,
-                                                           url_utf8);
+  int result = !proton_web_request_config_should_cancel(handler->config,
+                                                       url_utf8);
   const char *redirect_url = proton_web_request_config_redirect_url(
-      handler->session->web_request_config, url_utf8);
+      handler->config, url_utf8);
   if (result != 0 && redirect_url != NULL && request->set_url != NULL) {
     cef_string_t destination = {0};
     if (cef_string_utf8_to_utf16(redirect_url, strlen(redirect_url),
@@ -189,12 +190,12 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
   }
   if (result != 0 && request->set_header_by_name != NULL) {
     size_t header_count = proton_web_request_config_header_count(
-        handler->session->web_request_config, url_utf8);
+        handler->config, url_utf8);
     for (size_t index = 0; index < header_count; index++) {
       const char *name = proton_web_request_config_header_name_at(
-          handler->session->web_request_config, url_utf8, index);
+          handler->config, url_utf8, index);
       const char *value = proton_web_request_config_header_value_at(
-          handler->session->web_request_config, url_utf8, index);
+          handler->config, url_utf8, index);
       cef_string_t name_string = {0};
       cef_string_t value_string = {0};
       if (name != NULL && value != NULL &&
@@ -215,7 +216,7 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
 
 static void proton_browser_resource_handler_init(
     proton_browser_resource_handler_t *handler,
-    proton_browser_session_t *session) {
+    proton_web_request_config_t *config) {
   memset(handler, 0, sizeof(*handler));
   handler->handler.base.size = sizeof(handler->handler);
   handler->handler.base.add_ref = proton_browser_resource_handler_add_ref;
@@ -231,12 +232,13 @@ static void proton_browser_resource_handler_init(
 #else
   atomic_init(&handler->refs, 1);
 #endif
-  handler->session = session;
+  handler->config = config;
+  proton_web_request_config_retain(config);
 }
 
-cef_resource_request_handler_t *proton_browser_session_resource_handler(
-    proton_browser_session_t *session) {
-  if (session == NULL) {
+cef_resource_request_handler_t *proton_browser_resource_handler_create(
+    proton_web_request_config_t *config) {
+  if (config == NULL) {
     return NULL;
   }
   proton_browser_resource_handler_t *handler =
@@ -244,22 +246,13 @@ cef_resource_request_handler_t *proton_browser_session_resource_handler(
   if (handler == NULL) {
     return NULL;
   }
-  proton_browser_resource_handler_init(handler, session);
+  proton_browser_resource_handler_init(handler, config);
   return &handler->handler;
 }
 
 proton_web_request_config_t *proton_browser_session_web_request_config(
     proton_browser_session_t *session) {
   return session != NULL ? session->web_request_config : NULL;
-}
-
-int proton_browser_session_before_resource_load(
-    proton_browser_session_t *session, const char *url) {
-  return session != NULL &&
-                 proton_web_request_config_should_cancel(
-                     session->web_request_config, url)
-             ? 0
-             : 1;
 }
 
 static proton_pdf_print_callback_t *proton_pdf_print_callback_from_base(

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -187,6 +187,25 @@ static cef_return_value_t CEF_CALLBACK proton_browser_on_before_resource_load(
       cef_string_clear(&destination);
     }
   }
+  if (result != 0 && request->set_header_by_name != NULL) {
+    size_t header_count = proton_web_request_config_header_count(
+        handler->session->web_request_config, url_utf8);
+    for (size_t index = 0; index < header_count; index++) {
+      const char *name = proton_web_request_config_header_name_at(
+          handler->session->web_request_config, url_utf8, index);
+      const char *value = proton_web_request_config_header_value_at(
+          handler->session->web_request_config, url_utf8, index);
+      cef_string_t name_string = {0};
+      cef_string_t value_string = {0};
+      if (name != NULL && value != NULL &&
+          cef_string_utf8_to_utf16(name, strlen(name), &name_string) &&
+          cef_string_utf8_to_utf16(value, strlen(value), &value_string)) {
+        request->set_header_by_name(request, &name_string, &value_string, 1);
+      }
+      cef_string_clear(&name_string);
+      cef_string_clear(&value_string);
+    }
+  }
   if (url != NULL) {
     cef_string_userfree_free(url);
   }

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -39,8 +39,8 @@ proton_browser_session_t *proton_browser_session_create(
     const proton_browser_policy_t *policy,
     proton_web_request_config_t *web_request_config,
     proton_browser_signal_fn signal, void *signal_user_data);
-cef_resource_request_handler_t *proton_browser_session_resource_handler(
-    proton_browser_session_t *session);
+cef_resource_request_handler_t *proton_browser_resource_handler_create(
+    proton_web_request_config_t *config);
 proton_web_request_config_t *proton_browser_session_web_request_config(
     proton_browser_session_t *session);
 void proton_browser_session_destroy(proton_browser_session_t *session);
@@ -50,8 +50,6 @@ void proton_browser_session_bind_lifecycle(
     proton_browser_session_t *session,
     proton_browser_lifecycle_t *lifecycle);
 
-int proton_browser_session_before_resource_load(
-    proton_browser_session_t *session, const char *url);
 
 void proton_browser_session_loading_changed(proton_browser_session_t *session,
                                              const char *url,

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -854,15 +854,19 @@ proton_engine_get_resource_request_handler(
   (void)is_download;
   (void)request_initiator;
   (void)disable_default_handling;
-  proton_engine_window_t *window = proton_engine_window_lookup_browser(browser);
-  proton_browser_session_t *session =
-      window != NULL ? window->browser_session : NULL;
-  if (session == NULL) {
-    proton_engine_view_t *view =
-        proton_engine_window_lookup_view_browser(browser);
-    session = view != NULL ? view->browser_session : NULL;
+  // GetClient returns a retained CEF reference, so configuration acquisition
+  // cannot race window/session teardown on the UI thread.
+  cef_browser_host_t *host = browser != NULL ? browser->get_host(browser) : NULL;
+  if (host == NULL) return NULL;
+  cef_client_t *cef_client = host->get_client(host);
+  cef_resource_request_handler_t *handler = NULL;
+  if (cef_client != NULL) {
+    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
+    handler = proton_browser_resource_handler_create(client->web_request_config);
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
   }
-  return proton_browser_session_resource_handler(session);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return handler;
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(
@@ -1003,6 +1007,8 @@ int CEF_CALLBACK proton_engine_client_release(
   int value =
       atomic_fetch_sub_explicit(&refs->refs, 1, memory_order_acq_rel) - 1;
   if (value <= 0) {
+    proton_engine_client_t *client = (proton_engine_client_t *)base;
+    proton_internal_web_request_config_destroy(client->web_request_config);
     free(base);
     return 1;
   }
@@ -1010,7 +1016,8 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_create(
-    proton_browser_lifecycle_t *browser_lifecycle) {
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -1020,6 +1027,8 @@ proton_engine_client_t *proton_engine_client_create(
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
   client->browser_lifecycle = browser_lifecycle;
+  client->web_request_config = web_request_config;
+  proton_web_request_config_retain(web_request_config);
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_internal.h
@@ -166,6 +166,8 @@ struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
   proton_browser_lifecycle_t *browser_lifecycle;
+  // Immutable startup rules; retained independently of the UI owner.
+  proton_web_request_config_t *web_request_config;
 };
 
 /* A web contents view: an extra child browser hosted inside a window's
@@ -202,7 +204,8 @@ void proton_engine_init_handlers(void);
 cef_app_t *proton_engine_cef_app(void);
 int proton_engine_register_scheme_factory(void);
 proton_engine_client_t *proton_engine_client_create(
-    proton_browser_lifecycle_t *browser_lifecycle);
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config);
 int CEF_CALLBACK proton_engine_client_release(
     cef_base_ref_counted_t *base);
 cef_client_t *proton_engine_browser_client_factory(

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_window.c
@@ -631,7 +631,7 @@ int32_t proton_engine_window_create(
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
   proton_engine_client_t *client = proton_engine_client_create(
-      window->browser_lifecycle);
+      window->browser_lifecycle, config.web_request_config);
   if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -620,6 +620,8 @@ int CEF_CALLBACK proton_engine_client_release(
       (proton_engine_ref_counted_t *)((char *)base + base->size);
   LONG value = InterlockedDecrement(&refs->refs);
   if (value <= 0) {
+    proton_engine_client_t *client = (proton_engine_client_t *)base;
+    proton_internal_web_request_config_destroy(client->web_request_config);
     free(base);
     return 1;
   }
@@ -627,13 +629,16 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_new(
-    proton_browser_lifecycle_t *browser_lifecycle) {
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
     return NULL;
   }
   client->browser_lifecycle = browser_lifecycle;
+  client->web_request_config = web_request_config;
+  proton_web_request_config_retain(web_request_config);
   proton_engine_init_ref_counted((cef_base_ref_counted_t *)&client->client.base,
                                  sizeof(client->client), &client->refs);
   // The registry keeps the initial client reference until CEF shutdown; CEF
@@ -1056,16 +1061,19 @@ proton_engine_get_resource_request_handler(
   (void)is_download;
   (void)request_initiator;
   (void)disable_default_handling;
-  proton_engine_window_t *window =
-      proton_engine_window_lookup_browser(browser);
-  proton_browser_session_t *session =
-      window != NULL ? window->browser_session : NULL;
-  if (session == NULL) {
-    proton_engine_view_t *view =
-        proton_engine_window_lookup_view_browser(browser);
-    session = view != NULL ? view->browser_session : NULL;
+  // GetClient returns a retained CEF reference, so configuration acquisition
+  // cannot race window/session teardown on the UI thread.
+  cef_browser_host_t *host = browser != NULL ? browser->get_host(browser) : NULL;
+  if (host == NULL) return NULL;
+  cef_client_t *cef_client = host->get_client(host);
+  cef_resource_request_handler_t *handler = NULL;
+  if (cef_client != NULL) {
+    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
+    handler = proton_browser_resource_handler_create(client->web_request_config);
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
   }
-  return proton_browser_session_resource_handler(session);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return handler;
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -231,6 +231,8 @@ struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
   proton_browser_lifecycle_t *browser_lifecycle;
+  // Immutable startup rules; retained independently of the UI owner.
+  proton_web_request_config_t *web_request_config;
 };
 
 /* A web contents view: an extra child browser hosted inside a window's client
@@ -285,7 +287,8 @@ void proton_engine_resize_browser(proton_engine_window_t *window,
                                   int width,
                                   int height);
 proton_engine_client_t *proton_engine_client_new(
-    proton_browser_lifecycle_t *browser_lifecycle);
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config);
 cef_client_t *proton_engine_browser_client_factory(
     void *context, proton_browser_lifecycle_t *browser_lifecycle);
 int CEF_CALLBACK proton_engine_client_release(cef_base_ref_counted_t *base);

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -732,7 +732,7 @@ int32_t proton_engine_window_create(
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
   proton_engine_client_t *client = proton_engine_client_new(
-      window->browser_lifecycle);
+      window->browser_lifecycle, config.web_request_config);
   if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -3,6 +3,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <stdatomic.h>
+#endif
+
 enum { PROTON_WEB_REQUEST_MAX_CANCEL_PREFIXES = 128 };
 
 typedef struct {
@@ -12,7 +18,12 @@ typedef struct {
 typedef struct { char *prefix; char *name; char *value; } proton_web_request_header_t;
 
 struct proton_web_request_config {
-  size_t ref_count;
+  // Rules are populated on the owner thread before publishing to CEF.
+#ifdef _WIN32
+  volatile LONG ref_count;
+#else
+  atomic_int ref_count;
+#endif
   char **cancel_prefixes;
   size_t cancel_prefix_count;
   proton_web_request_redirect_t *redirects;
@@ -108,7 +119,11 @@ int32_t proton_internal_web_request_config_create(
     return proton_set_error(PROTON_ERR_ENGINE,
                             "failed to allocate web request configuration");
   }
+#ifdef _WIN32
   config->ref_count = 1;
+#else
+  atomic_init(&config->ref_count, 1);
+#endif
   *out_config = config;
   return PROTON_OK;
 }
@@ -145,7 +160,11 @@ int32_t proton_internal_web_request_config_add_cancel_prefix(
 
 void proton_web_request_config_retain(proton_web_request_config_t *config) {
   if (config != NULL) {
-    config->ref_count++;
+#ifdef _WIN32
+    (void)InterlockedIncrement(&config->ref_count);
+#else
+    (void)atomic_fetch_add_explicit(&config->ref_count, 1, memory_order_relaxed);
+#endif
   }
 }
 
@@ -227,9 +246,13 @@ const char *proton_web_request_config_header_value_at(
 
 void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config) {
-  if (config == NULL || config->ref_count == 0 || --config->ref_count != 0) {
-    return;
-  }
+  if (config == NULL) return;
+#ifdef _WIN32
+  if (InterlockedDecrement(&config->ref_count) != 0) return;
+#else
+  if (atomic_fetch_sub_explicit(&config->ref_count, 1,
+                                memory_order_acq_rel) != 1) return;
+#endif
   for (size_t index = 0; index < config->cancel_prefix_count; index++) {
     free(config->cancel_prefixes[index]);
   }

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -41,6 +41,19 @@ static char *proton_web_request_copy(const char *value) {
   return copy;
 }
 
+// HTTP field names are ASCII case-insensitive, independent of the locale.
+static int proton_web_request_header_name_equal(const char *left,
+                                                 const char *right) {
+  while (*left != '\0' && *right != '\0') {
+    unsigned char a = (unsigned char)*left++;
+    unsigned char b = (unsigned char)*right++;
+    if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+    if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+    if (a != b) return 0;
+  }
+  return *left == *right;
+}
+
 int32_t proton_internal_web_request_config_add_header_prefix(
     proton_web_request_config_t *config, const char *url_prefix,
     const char *header_name, const char *header_value) {
@@ -50,7 +63,7 @@ int32_t proton_internal_web_request_config_add_header_prefix(
                             "web request header values are invalid");
   for (size_t i = 0; i < config->header_count; i++)
     if (strcmp(config->headers[i].prefix, url_prefix) == 0 &&
-        strcmp(config->headers[i].name, header_name) == 0)
+        proton_web_request_header_name_equal(config->headers[i].name, header_name))
       return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
                               "web request header rule is duplicated");
   proton_web_request_header_t *headers = (proton_web_request_header_t *)realloc(
@@ -200,7 +213,7 @@ const char *proton_web_request_config_header_value(
   for (size_t i = 0; i < config->header_count; i++) {
     size_t length = strlen(config->headers[i].prefix);
     if (strncmp(url, config->headers[i].prefix, length) == 0 &&
-        strcmp(header_name, config->headers[i].name) == 0)
+        proton_web_request_header_name_equal(header_name, config->headers[i].name))
       return config->headers[i].value;
   }
   return NULL;

--- a/proton/internal/native/ffi/src/proton_web_request_config.c
+++ b/proton/internal/native/ffi/src/proton_web_request_config.c
@@ -9,6 +9,7 @@ typedef struct {
   char *prefix;
   char *target;
 } proton_web_request_redirect_t;
+typedef struct { char *prefix; char *name; char *value; } proton_web_request_header_t;
 
 struct proton_web_request_config {
   size_t ref_count;
@@ -16,6 +17,8 @@ struct proton_web_request_config {
   size_t cancel_prefix_count;
   proton_web_request_redirect_t *redirects;
   size_t redirect_count;
+  proton_web_request_header_t *headers;
+  size_t header_count;
 };
 
 static char *proton_web_request_copy(const char *value) {
@@ -25,6 +28,34 @@ static char *proton_web_request_copy(const char *value) {
     memcpy(copy, value, length + 1);
   }
   return copy;
+}
+
+int32_t proton_internal_web_request_config_add_header_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *header_name, const char *header_value) {
+  if (config == NULL || url_prefix == NULL || header_name == NULL ||
+      header_value == NULL || url_prefix[0] == '\0' || header_name[0] == '\0')
+    return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                            "web request header values are invalid");
+  for (size_t i = 0; i < config->header_count; i++)
+    if (strcmp(config->headers[i].prefix, url_prefix) == 0 &&
+        strcmp(config->headers[i].name, header_name) == 0)
+      return proton_set_error(PROTON_ERR_INVALID_ARGUMENT,
+                              "web request header rule is duplicated");
+  proton_web_request_header_t *headers = (proton_web_request_header_t *)realloc(
+      config->headers, (config->header_count + 1) * sizeof(*headers));
+  char *prefix = proton_web_request_copy(url_prefix);
+  char *name = proton_web_request_copy(header_name);
+  char *value = proton_web_request_copy(header_value);
+  if (headers == NULL || prefix == NULL || name == NULL || value == NULL) {
+    free(prefix); free(name); free(value);
+    return proton_set_error(PROTON_ERR_ENGINE, "failed to allocate web request header rule");
+  }
+  config->headers = headers;
+  config->headers[config->header_count].prefix = prefix;
+  config->headers[config->header_count].name = name;
+  config->headers[config->header_count++].value = value;
+  return PROTON_OK;
 }
 
 int32_t proton_internal_web_request_config_add_redirect_prefix(
@@ -143,6 +174,57 @@ const char *proton_web_request_config_redirect_url(
   return NULL;
 }
 
+const char *proton_web_request_config_header_value(
+    const proton_web_request_config_t *config, const char *url,
+    const char *header_name) {
+  if (config == NULL || url == NULL || header_name == NULL) return NULL;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0 &&
+        strcmp(header_name, config->headers[i].name) == 0)
+      return config->headers[i].value;
+  }
+  return NULL;
+}
+
+size_t proton_web_request_config_header_count(
+    const proton_web_request_config_t *config, const char *url) {
+  size_t count = 0;
+  if (config == NULL || url == NULL) return 0;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0) count++;
+  }
+  return count;
+}
+
+static const proton_web_request_header_t *proton_web_request_config_header_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  if (config == NULL || url == NULL) return NULL;
+  for (size_t i = 0; i < config->header_count; i++) {
+    size_t length = strlen(config->headers[i].prefix);
+    if (strncmp(url, config->headers[i].prefix, length) == 0) {
+      if (index == 0) return &config->headers[i];
+      index--;
+    }
+  }
+  return NULL;
+}
+
+const char *proton_web_request_config_header_name_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  const proton_web_request_header_t *header =
+      proton_web_request_config_header_at(config, url, index);
+  return header != NULL ? header->name : NULL;
+}
+
+const char *proton_web_request_config_header_value_at(
+    const proton_web_request_config_t *config, const char *url, size_t index) {
+  const proton_web_request_header_t *header =
+      proton_web_request_config_header_at(config, url, index);
+  return header != NULL ? header->value : NULL;
+}
+
 void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config) {
   if (config == NULL || config->ref_count == 0 || --config->ref_count != 0) {
@@ -157,5 +239,11 @@ void proton_internal_web_request_config_destroy(
     free(config->redirects[index].target);
   }
   free(config->redirects);
+  for (size_t index = 0; index < config->header_count; index++) {
+    free(config->headers[index].prefix);
+    free(config->headers[index].name);
+    free(config->headers[index].value);
+  }
+  free(config->headers);
   free(config);
 }

--- a/proton/internal/native/ffi/src/proton_web_request_config.h
+++ b/proton/internal/native/ffi/src/proton_web_request_config.h
@@ -17,12 +17,24 @@ PROTON_INTERNAL int32_t proton_internal_web_request_config_add_cancel_prefix(
 PROTON_INTERNAL int32_t proton_internal_web_request_config_add_redirect_prefix(
     proton_web_request_config_t *config, const char *url_prefix,
     const char *target_url);
+PROTON_INTERNAL int32_t proton_internal_web_request_config_add_header_prefix(
+    proton_web_request_config_t *config, const char *url_prefix,
+    const char *header_name, const char *header_value);
 PROTON_INTERNAL void proton_web_request_config_retain(
     proton_web_request_config_t *config);
 PROTON_INTERNAL int proton_web_request_config_should_cancel(
     const proton_web_request_config_t *config, const char *url);
 PROTON_INTERNAL const char *proton_web_request_config_redirect_url(
     const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL const char *proton_web_request_config_header_value(
+    const proton_web_request_config_t *config, const char *url,
+    const char *header_name);
+PROTON_INTERNAL size_t proton_web_request_config_header_count(
+    const proton_web_request_config_t *config, const char *url);
+PROTON_INTERNAL const char *proton_web_request_config_header_name_at(
+    const proton_web_request_config_t *config, const char *url, size_t index);
+PROTON_INTERNAL const char *proton_web_request_config_header_value_at(
+    const proton_web_request_config_t *config, const char *url, size_t index);
 PROTON_INTERNAL void proton_internal_web_request_config_destroy(
     proton_web_request_config_t *config);
 

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
@@ -87,3 +87,12 @@ pub fn resource_handler_lifetime_trace() -> String {
   let _ = @ffi.proton_abi_version_ffi()
   @utf8.decode_lossy(resource_handler_lifetime_trace_ffi())
 }
+
+///|
+extern "C" fn header_case_trace_ffi() -> Bytes = "proton_test_header_case_trace"
+
+///|
+pub fn header_case_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(header_case_trace_ffi())
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_support.mbt
@@ -78,3 +78,12 @@ pub fn web_request_cancel_trace() -> String {
   let _ = @ffi.proton_abi_version_ffi()
   @utf8.decode_lossy(web_request_cancel_trace_ffi())
 }
+
+///|
+extern "C" fn resource_handler_lifetime_trace_ffi() -> Bytes = "proton_test_resource_handler_lifetime_trace"
+
+///|
+pub fn resource_handler_lifetime_trace() -> String {
+  let _ = @ffi.proton_abi_version_ffi()
+  @utf8.decode_lossy(resource_handler_lifetime_trace_ffi())
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
@@ -412,3 +412,24 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t proton_test_resource_handler_lifetime_trace(v
            continued, first_release, last_release);
   return proton_test_copy_trace(trace);
 }
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t proton_test_header_case_trace(void) {
+  proton_web_request_config_t *config = NULL;
+  if (proton_internal_web_request_config_create(&config) != PROTON_OK) {
+    return proton_test_copy_trace("setup-error");
+  }
+  int first = proton_internal_web_request_config_add_header_prefix(
+      config, "https://api.example/Path/", "Authorization", "Token AbC");
+  int duplicate = proton_internal_web_request_config_add_header_prefix(
+      config, "https://api.example/Path/", "aUtHoRiZaTiOn", "other");
+  int different_path = proton_internal_web_request_config_add_header_prefix(
+      config, "https://api.example/path/", "authorization", "second");
+  const char *value = proton_web_request_config_header_value(
+      config, "https://api.example/Path/data", "AUTHORIZATION");
+  char trace[160];
+  snprintf(trace, sizeof(trace),
+           "first=%d,duplicate=%d,different_path=%d,value=%s",
+           first, duplicate, different_path, value != NULL ? value : "(null)");
+  proton_internal_web_request_config_destroy(config);
+  return proton_test_copy_trace(trace);
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_test.c
@@ -375,3 +375,40 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t proton_test_web_request_cancel_trace(void) {
   }
   return proton_test_copy_trace(trace);
 }
+
+static cef_string_userfree_t CEF_CALLBACK proton_test_empty_request_url(
+    cef_request_t *self) {
+  (void)self;
+  return NULL;
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t proton_test_resource_handler_lifetime_trace(void) {
+  proton_web_request_config_t *config = NULL;
+  proton_browser_policy_t policy = {0};
+  if (proton_internal_web_request_config_create(&config) != PROTON_OK ||
+      proton_internal_web_request_config_add_cancel_prefix(
+          config, "https://blocked.example/") != PROTON_OK) {
+    proton_internal_web_request_config_destroy(config);
+    return proton_test_copy_trace("setup-error");
+  }
+  proton_browser_session_t *session =
+      proton_browser_session_create(&policy, config, NULL, NULL);
+  cef_resource_request_handler_t *handler =
+      proton_browser_resource_handler_create(config);
+  proton_internal_web_request_config_destroy(config);
+  proton_browser_session_destroy(session);
+  if (handler == NULL) return proton_test_copy_trace("handler-error");
+
+  // CEF may retain the handler after its UI-owned session is gone.
+  cef_request_t request = {0};
+  request.get_url = proton_test_empty_request_url;
+  handler->base.add_ref(&handler->base);
+  int first_release = handler->base.release(&handler->base);
+  int continued = handler->on_before_resource_load(
+      handler, NULL, NULL, &request, NULL) == RV_CONTINUE;
+  int last_release = handler->base.release(&handler->base);
+  char trace[100];
+  snprintf(trace, sizeof(trace), "continued=%d,first_release=%d,last_release=%d",
+           continued, first_release, last_release);
+  return proton_test_copy_trace(trace);
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
@@ -81,3 +81,11 @@ test "web request cancellation matches URL prefixes" {
     content="matching=1,nonmatching=0,case_sensitive=0,empty=-1,duplicate=-1",
   )
 }
+
+///|
+test "resource handlers survive session and configuration owner teardown" {
+  inspect(
+    resource_handler_lifetime_trace(),
+    content="continued=1,first_release=0,last_release=1",
+  )
+}

--- a/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/browser_session/browser_session_wbtest.mbt
@@ -89,3 +89,11 @@ test "resource handlers survive session and configuration owner teardown" {
     content="continued=1,first_release=0,last_release=1",
   )
 }
+
+///|
+test "header names use ASCII case-insensitive comparison but paths and values do not" {
+  inspect(
+    header_case_trace(),
+    content="first=0,duplicate=-1,different_path=0,value=Token AbC",
+  )
+}

--- a/proton/internal/native/ffi_mac/mac_client.objc.c
+++ b/proton/internal/native/ffi_mac/mac_client.objc.c
@@ -852,15 +852,19 @@ proton_engine_get_resource_request_handler(
   (void)is_download;
   (void)request_initiator;
   (void)disable_default_handling;
-  proton_engine_window_t *window = proton_engine_window_lookup_browser(browser);
-  proton_browser_session_t *session =
-      window != NULL ? window->browser_session : NULL;
-  if (session == NULL) {
-    proton_engine_view_t *view =
-        proton_engine_window_lookup_view_browser(browser);
-    session = view != NULL ? view->browser_session : NULL;
+  // GetClient returns a retained CEF reference, so configuration acquisition
+  // cannot race window/session teardown on the UI thread.
+  cef_browser_host_t *host = browser != NULL ? browser->get_host(browser) : NULL;
+  if (host == NULL) return NULL;
+  cef_client_t *cef_client = host->get_client(host);
+  cef_resource_request_handler_t *handler = NULL;
+  if (cef_client != NULL) {
+    proton_engine_client_t *client = (proton_engine_client_t *)cef_client;
+    handler = proton_browser_resource_handler_create(client->web_request_config);
+    cef_client->base.release((cef_base_ref_counted_t *)cef_client);
   }
-  return proton_browser_session_resource_handler(session);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return handler;
 }
 
 static int CEF_CALLBACK proton_engine_on_open_url_from_tab(
@@ -1001,6 +1005,8 @@ int CEF_CALLBACK proton_engine_client_release(
   int value =
       atomic_fetch_sub_explicit(&refs->refs, 1, memory_order_acq_rel) - 1;
   if (value <= 0) {
+    proton_engine_client_t *client = (proton_engine_client_t *)base;
+    proton_internal_web_request_config_destroy(client->web_request_config);
     free(base);
     return 1;
   }
@@ -1008,7 +1014,8 @@ int CEF_CALLBACK proton_engine_client_release(
 }
 
 proton_engine_client_t *proton_engine_client_create(
-    proton_browser_lifecycle_t *browser_lifecycle) {
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config) {
   proton_engine_client_t *client =
       (proton_engine_client_t *)calloc(1, sizeof(*client));
   if (client == NULL) {
@@ -1018,6 +1025,8 @@ proton_engine_client_t *proton_engine_client_create(
                                  sizeof(client->client), &client->refs);
   client->client.base.release = proton_engine_client_release;
   client->browser_lifecycle = browser_lifecycle;
+  client->web_request_config = web_request_config;
+  proton_web_request_config_retain(web_request_config);
   client->client.get_life_span_handler =
       proton_engine_client_get_life_span_handler;
   client->client.get_load_handler = proton_engine_client_get_load_handler;

--- a/proton/internal/native/ffi_mac/mac_internal.h
+++ b/proton/internal/native/ffi_mac/mac_internal.h
@@ -192,6 +192,8 @@ struct proton_engine_client {
   cef_client_t client;
   proton_engine_ref_counted_t refs;
   proton_browser_lifecycle_t *browser_lifecycle;
+  // Immutable startup rules; retained independently of the UI owner.
+  proton_web_request_config_t *web_request_config;
 };
 
 struct proton_engine_view {
@@ -229,7 +231,8 @@ void proton_engine_init_handlers(void);
 cef_app_t *proton_engine_cef_app(void);
 int proton_engine_register_scheme_factory(void);
 proton_engine_client_t *proton_engine_client_create(
-    proton_browser_lifecycle_t *browser_lifecycle);
+    proton_browser_lifecycle_t *browser_lifecycle,
+    proton_web_request_config_t *web_request_config);
 int CEF_CALLBACK proton_engine_client_release(
     cef_base_ref_counted_t *base);
 cef_client_t *proton_engine_browser_client_factory(

--- a/proton/internal/native/ffi_mac/mac_window.objc.c
+++ b/proton/internal/native/ffi_mac/mac_window.objc.c
@@ -918,7 +918,7 @@ int32_t proton_engine_window_create(
   proton_browser_session_bind_lifecycle(window->browser_session,
                                         window->browser_lifecycle);
   proton_engine_client_t *client = proton_engine_client_create(
-      window->browser_lifecycle);
+      window->browser_lifecycle, config.web_request_config);
   if (client == NULL) {
     proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
     proton_browser_lifecycle_clear_owner(window->browser_lifecycle);

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1370,8 +1370,9 @@ fn build_bridge_config(
 fn build_web_request_config(
   prefixes : Array[String],
   redirects : Array[(String, String)],
+  headers : Array[(String, String, String)],
 ) -> @native_ffi.WebRequestConfigHandle raise NativeError {
-  if prefixes.length() == 0 && redirects.length() == 0 {
+  if prefixes.length() == 0 && redirects.length() == 0 && headers.length() == 0 {
     return @native_ffi.web_request_config_null()
   }
   let out_config = Ref(@native_ffi.web_request_config_null())
@@ -1403,6 +1404,18 @@ fn build_web_request_config(
       raise native_error(status)
     }
   }
+  for item in headers {
+    let status = @native_ffi.web_request_config_add_header_prefix(
+      handle,
+      @ffi.to_cstr(item.0),
+      @ffi.to_cstr(item.1),
+      @ffi.to_cstr(item.2),
+    )
+    if status < 0 {
+      @native_ffi.web_request_config_destroy(handle)
+      raise native_error(status)
+    }
+  }
   handle
 }
 
@@ -1417,6 +1430,7 @@ pub fn Window::Window(
   let web_request_config = build_web_request_config(
     config.web_request_cancel_prefixes,
     config.web_request_redirect_prefixes,
+    config.web_request_header_prefixes,
   )
   let status = @native_ffi.window_create(
     runtime.active_handle(),

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -754,7 +754,7 @@ pub fn Window::stop_find_in_page(Self, Bool) -> Unit raise NativeError
 pub fn Window::take_bridge_failure(Self) -> BridgeDiagnostic? raise NativeError
 
 type WindowConfig derive(Eq, @debug.Debug)
-pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference, browser? : BrowserPolicy, bridge? : BridgeConfig) -> Self
+pub fn WindowConfig::WindowConfig(title? : String, width? : Int, height? : Int, initial_url? : String, size_hint? : WindowSizeHint, titlebar_style? : TitlebarStyle, theme? : WindowThemePreference, browser? : BrowserPolicy, bridge? : BridgeConfig, web_request_cancel_prefixes? : Array[String], web_request_redirect_prefixes? : Array[(String, String)], web_request_header_prefixes? : Array[(String, String, String)]) -> Self
 pub fn WindowConfig::equal(Self, Self) -> Bool
 pub fn WindowConfig::not_equal(Self, Self) -> Bool
 pub fn WindowConfig::to_repr(Self) -> @debug.Repr

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -1465,6 +1465,7 @@ struct WindowConfig {
   bridge : BridgeConfig?
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
+  web_request_header_prefixes : Array[(String, String, String)]
   framework_titlebar_minimize_label : String?
   framework_titlebar_maximize_label : String?
   framework_titlebar_restore_label : String?
@@ -1562,6 +1563,7 @@ pub fn WindowConfig::WindowConfig(
   bridge? : BridgeConfig,
   web_request_cancel_prefixes? : Array[String] = [],
   web_request_redirect_prefixes? : Array[(String, String)] = [],
+  web_request_header_prefixes? : Array[(String, String, String)] = [],
 ) -> WindowConfig {
   {
     title,
@@ -1575,6 +1577,7 @@ pub fn WindowConfig::WindowConfig(
     bridge,
     web_request_cancel_prefixes,
     web_request_redirect_prefixes,
+    web_request_header_prefixes,
     framework_titlebar_minimize_label: Some("Minimize"),
     framework_titlebar_maximize_label: Some("Maximize"),
     framework_titlebar_restore_label: Some("Restore"),
@@ -1628,6 +1631,7 @@ pub fn WindowConfig::with_framework_titlebar_labels(
     bridge: self.bridge,
     web_request_cancel_prefixes: self.web_request_cancel_prefixes,
     web_request_redirect_prefixes: self.web_request_redirect_prefixes,
+    web_request_header_prefixes: self.web_request_header_prefixes,
     framework_titlebar_minimize_label: Some(minimize),
     framework_titlebar_maximize_label: Some(maximize),
     framework_titlebar_restore_label: Some(restore),

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -254,6 +254,9 @@ pub fn App::titlebar_style(Self, TitlebarStyle) -> Self
 pub fn App::update_channel(Self, String, Array[String], check_on_launch? : Bool, freshness_days? : Int) -> Self
 pub fn App::url_scheme(Self, String) -> Self
 pub fn App::version(Self) -> String raise AppMetadataError
+pub fn App::web_request_cancel_prefix(Self, String) -> Self
+pub fn App::web_request_header_prefix(Self, String, String, String) -> Self
+pub fn App::web_request_redirect_prefix(Self, String, String) -> Self
 pub fn[State] App::window_lifecycle(Self, on_ready~ : async (WindowContext) -> State, on_close~ : async (State) -> Unit) -> Self
 pub fn App::with_view(Self, String, ViewConfig) -> Self
 
@@ -746,6 +749,8 @@ pub fn ViewConfig::ViewConfig(width~ : Int, height~ : Int, x? : Int, y? : Int, v
 
 pub(all) enum ViewEvent {
   LoadingChanged(is_loading~ : Bool)
+  DidStartLoading
+  DidFinishLoad
   Navigated(url~ : String)
   TitleUpdated(title~ : String)
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)

--- a/scripts/test_safe_storage_macos.mjs
+++ b/scripts/test_safe_storage_macos.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+// Exercise the real native cipher through the public MoonBit API without
+// reading or writing the user's Keychain. Also verify standalone module linking.
+import { mkdtempSync, cpSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+if (process.platform !== "darwin") {
+  console.log("[SKIP] macOS safe storage regression test");
+  process.exit(0);
+}
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const temporary = mkdtempSync(path.join(tmpdir(), "proton-safe-storage-"));
+try {
+  cpSync(path.join(root, "sys/safe_storage"), temporary, {
+    recursive: true,
+    filter: source => !["_build", ".mooncakes"].includes(path.basename(source)),
+  });
+  const source = path.join(temporary, "safe_storage_native.c");
+  const keychainFixture = `
+#include <Security/Security.h>
+#include <stdlib.h>
+#include <string.h>
+static OSStatus test_find_key(CFTypeRef keychain, UInt32 service_len,
+    const char *service, UInt32 account_len, const char *account,
+    UInt32 *length, void **data, SecKeychainItemRef *item) {
+  (void)keychain; (void)service_len; (void)service;
+  (void)account_len; (void)account; (void)item;
+  *length = 32;
+  *data = malloc(32);
+  if (*data == NULL) return errSecAllocate;
+  memset(*data, 0x42, 32);
+  return errSecSuccess;
+}
+static OSStatus test_free_key(SecKeychainAttributeList *attributes, void *data) {
+  (void)attributes; free(data); return errSecSuccess;
+}
+static OSStatus test_add_key(SecKeychainRef keychain, UInt32 service_len,
+    const char *service, UInt32 account_len, const char *account,
+    UInt32 length, const void *data, SecKeychainItemRef *item) {
+  (void)keychain; (void)service_len; (void)service;
+  (void)account_len; (void)account; (void)length; (void)data; (void)item;
+  abort();
+}
+#define SecKeychainFindGenericPassword test_find_key
+#define SecKeychainItemFreeContent test_free_key
+#define SecKeychainAddGenericPassword test_add_key
+`;
+  writeFileSync(source, keychainFixture + readFileSync(source, "utf8"));
+  writeFileSync(path.join(temporary, "cipher_test.mbt"), `
+///|
+test "native safe storage roundtrips padding boundaries and UTF-8" {
+  for input in ["", "a", "123456789012345", "1234567890123456",
+    "12345678901234567", "12345678901234567890123456789012", "你好 🔐"] {
+    let payload = match @proton_safe_storage.encrypt_string(input) {
+      Ok(payload) => payload
+      Err(message) => fail(message)
+    }
+    assert_eq(@proton_safe_storage.decrypt_string(payload), Ok(input))
+  }
+}
+`);
+  const result = spawnSync("moon", ["-C", temporary, "test", "--target", "native"], {
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exitCode = result.status ?? 1;
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/sys/safe_storage/README.md
+++ b/sys/safe_storage/README.md
@@ -4,3 +4,8 @@ OS-backed safe storage for native MoonBit applications. The current backend
 uses Windows DPAPI and macOS Keychain. Linux reports unsupported until a
 Secret Service backend is available; no plaintext or software-only fallback is
 used.
+
+The module supplies its own macOS Security framework link flags. Maintainers
+can run `node scripts/test_safe_storage_macos.mjs` from the repository root to
+check standalone linking and real CommonCrypto roundtrips with an isolated test
+key; this test does not access the user's Keychain.

--- a/sys/safe_storage/build.mjs
+++ b/sys/safe_storage/build.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+process.stdout.write(JSON.stringify({
+  link_configs: process.platform === "darwin"
+    ? [{ package: "moonbit-community/proton_safe_storage", link_flags: "-framework Security" }]
+    : [],
+}));

--- a/sys/safe_storage/moon.mod
+++ b/sys/safe_storage/moon.mod
@@ -17,3 +17,7 @@ preferred_target = "native"
 supported_targets = "+native"
 
 source = "."
+
+options(
+  "--moonbit-unstable-prebuild": "build.mjs",
+)

--- a/sys/safe_storage/safe_storage_native.c
+++ b/sys/safe_storage/safe_storage_native.c
@@ -63,7 +63,9 @@ moonbit_bytes_t mb_safe_storage_encrypt(moonbit_bytes_t value) {
   if (!CryptProtectData(&input, L"Proton safe storage", NULL, NULL, NULL, 0, &output)) { mb_set_error("CryptProtectData failed"); return mb_bytes(NULL, 0); }
   moonbit_bytes_t result = mb_bytes(output.pbData, output.cbData); LocalFree(output.pbData); mb_set_success(); return result;
 #elif defined(__APPLE__)
-  unsigned char key[32], iv[16]; size_t moved = 0, out_len = length + 16;
+  unsigned char key[32], iv[16];
+  // Reserve the IV separately from the ciphertext and its full padding block.
+  size_t moved = 0, out_len = sizeof(iv) + length + kCCBlockSizeAES128;
   if (!keychain_key(key) || SecRandomCopyBytes(kSecRandomDefault, 16, iv) != errSecSuccess) { mb_set_error("failed to initialize safe storage cipher"); return mb_bytes(NULL, 0); }
   unsigned char *out = malloc(out_len); if (out == NULL) { mb_set_error("safe storage allocation failed"); return mb_bytes(NULL, 0); }
   CCCryptorStatus status = CCCrypt(kCCEncrypt, kCCAlgorithmAES, kCCOptionPKCS7Padding, key, 32, iv, value, length, out + 16, out_len - 16, &moved);

--- a/sys/screen_monitor/native_windows_sources.c
+++ b/sys/screen_monitor/native_windows_sources.c
@@ -29,16 +29,29 @@ static char *capture_thumbnail(HWND hwnd, int width, int height) {
   int source_height = rect.bottom - rect.top;
   if (source_width <= 0 || source_height <= 0) return NULL;
   HDC source = GetWindowDC(hwnd);
+  if (source == NULL) return NULL;
+  HDC capture = CreateCompatibleDC(source);
   HDC target = CreateCompatibleDC(source);
+  HBITMAP full_bitmap = CreateCompatibleBitmap(source, source_width, source_height);
   HBITMAP bitmap = CreateCompatibleBitmap(source, width, height);
-  if (source == NULL || target == NULL || bitmap == NULL) {
-    if (bitmap) DeleteObject(bitmap); if (target) DeleteDC(target); if (source) ReleaseDC(hwnd, source);
+  if (capture == NULL || target == NULL || full_bitmap == NULL || bitmap == NULL) {
+    if (full_bitmap) DeleteObject(full_bitmap);
+    if (bitmap) DeleteObject(bitmap);
+    if (capture) DeleteDC(capture);
+    if (target) DeleteDC(target);
+    ReleaseDC(hwnd, source);
     return NULL;
   }
+  HGDIOBJ old_capture = SelectObject(capture, full_bitmap);
   HGDIOBJ old = SelectObject(target, bitmap);
+  BOOL printed = PrintWindow(hwnd, capture, 2);
   SetStretchBltMode(target, HALFTONE);
-  BOOL captured = PrintWindow(hwnd, target, 2);
-  if (!captured) captured = StretchBlt(target, 0, 0, width, height, source, 0, 0, source_width, source_height, SRCCOPY);
+  SetBrushOrgEx(target, 0, 0, NULL);
+  BOOL captured = StretchBlt(target, 0, 0, width, height,
+                            printed ? capture : source,
+                            0, 0, source_width, source_height, SRCCOPY);
+  // GetDIBits requires the bitmap to be deselected from every DC.
+  SelectObject(target, old);
   BITMAPINFO info; memset(&info, 0, sizeof(info));
   info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER); info.bmiHeader.biWidth = width;
   info.bmiHeader.biHeight = -height; info.bmiHeader.biPlanes = 1; info.bmiHeader.biBitCount = 32;
@@ -65,7 +78,14 @@ static char *capture_thumbnail(HWND hwnd, int width, int height) {
       }
     }
   }
-  free(pixels); SelectObject(target, old); DeleteObject(bitmap); DeleteDC(target); ReleaseDC(hwnd, source); return result;
+  free(pixels);
+  SelectObject(capture, old_capture);
+  DeleteObject(full_bitmap);
+  DeleteObject(bitmap);
+  DeleteDC(capture);
+  DeleteDC(target);
+  ReleaseDC(hwnd, source);
+  return result;
 }
 
 static int append_text(window_sources_buffer_t *buffer, const char *text) {


### PR DESCRIPTION
This fixes defects found in the recent networking, safe storage, desktop capture, and web request changes. The failures include incorrect HTTP targets, unusable macOS encryption, cropped Windows thumbnails, and request callbacks accessing a destroyed browser session.

- Normalize query-only HTTP targets to start with "/" and strip fragments without changing percent-encoded data. Add exact regression cases and include net tests in CI.
- Reserve the IV plus a full PKCS#7 padding block for macOS safe storage. Give the standalone module its own Security framework link configuration. Add an isolated macOS regression that uses a fixed Keychain fixture and the real CommonCrypto cipher without accessing the user's Keychain.
- Capture Windows windows at source dimensions before scaling to thumbnails, and deselect the output bitmap before calling GetDIBits.
- Retain startup request rules independently in CEF clients and resource handlers, with atomic configuration reference counts. IO callbacks acquire the configuration through a retained CEF client, avoiding window/session lookup during UI teardown. Existing handlers keep their rules until their final release.
- Include the header override feature from #263, preserving its commits, and reject duplicate names using ASCII case-insensitive comparison in both the facade and native configuration. Native lookup follows the same rule; URL paths and header values retain their case. For example, "Authorization" and "authorization" at the same URL prefix are now rejected instead of silently overwriting each other.

The lifetime fix is needed because retaining rules only after looking up the UI-owned session still permits a race during acquisition. The header fix is needed because HTTP field names are case-insensitive, while the original validation treated different spellings as separate rules. The merge retains the logging fixes already on main.

Validation:

- Net regression failed before the fix; all 4 net tests then passed.
- Standalone safe storage regression reproduced the missing framework and insufficient ciphertext buffer; roundtrips now pass for empty text, AES block boundaries, and UTF-8 text.
- Original safe storage source also built outside the workspace without the Keychain fixture; that executable was not run.
- Relevant net, safe storage, and desktop capturer extension tests: 7 passed.
- Facade, internal native, and browser-session tests: 218 passed, including post-session handler use and header case regression tests. Both facade and native header regressions failed before the fix.
- AddressSanitizer: the isolated post-session resource callback reproduction no longer reports use-after-free.
- macOS self-hosted CEF E2E passed, including headless shutdown, multi-window, views, and bridge scenarios.
- `moon -C examples build --target native --diagnostic-limit 80` passed.
- `moon -C proton check --target native --diagnostic-limit 80`, `moon fmt --check`, `node scripts/verify_generated.mjs`, and `git diff --check` passed.

The request ownership changes cover macOS, Linux, and Windows. Runtime validation was performed on macOS; Windows capture was not executed on a Windows desktop locally. Existing macOS SDK deprecation and deployment-version warnings remain in native compilation/linking.
