### PR TITLE
feat(session): add storage data clearing

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -247,3 +247,7 @@ targets the issuing page (emit remains an alias); WindowContext::events returns
 an explicit destination for that window. Broadcast by retaining only the
 destinations your application intends to notify and releasing them with their
 window lifecycle. Events are live, best-effort notifications, not replayable state.
+
+`SessionHandle::clear_storage_data` supports `Cookies`, `HttpCache`, and
+`AllSupported`. Profile-directory categories such as IndexedDB and
+localStorage are intentionally not cleared while a CEF session is live.

--- a/proton/facade_cookie.mbt
+++ b/proton/facade_cookie.mbt
@@ -176,3 +176,12 @@ pub fn SessionHandle::clear_cache(
 ) -> Unit raise WindowSessionError {
   (self.clear_http_cache)()
 }
+
+///|
+/// Clears the selected live session storage categories.
+pub fn SessionHandle::clear_storage_data(
+  self : SessionHandle,
+  kind : StorageDataKind,
+) -> Unit raise WindowSessionError {
+  (self.clear_storage_data)(kind)
+}

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1017,6 +1017,21 @@ fn RuntimeSession::session_handle(
         window.clear_cache()
       })
     },
+    clear_storage_data: kind => {
+      self.control_window(id, native_id, "clear storage in", window => {
+        match kind {
+          Cookies | AllSupported => {
+            window.cookie_delete(None, None)
+            window.cookie_flush()
+          }
+          HttpCache => ()
+        }
+        match kind {
+          HttpCache | AllSupported => window.clear_cache()
+          Cookies => ()
+        }
+      })
+    },
   }
 }
 

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -39,6 +39,20 @@ pub extend AccessibilityMode with Eq::{not_equal, equal}
 pub extend AccessibilityMode with Debug::{to_repr}
 
 ///|
+/// Selects browser storage that can be cleared from a live Proton session.
+pub(all) enum StorageDataKind {
+  Cookies
+  HttpCache
+  AllSupported
+} derive(Eq, Debug)
+
+///|
+pub extend StorageDataKind with Eq::{not_equal, equal}
+
+///|
+pub extend StorageDataKind with Debug::{to_repr}
+
+///|
 /// High-level application facade for ordinary Proton apps.
 struct App {
   mut window : @manifest.WindowManifest
@@ -565,6 +579,7 @@ pub struct SessionHandle {
   remove_cookies : (String?, String?) -> Unit raise WindowSessionError
   flush_cookie_store : () -> Unit raise WindowSessionError
   clear_http_cache : () -> Unit raise WindowSessionError
+  clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 
 ///|

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -189,6 +189,7 @@ fn test_window_handle(
       remove_cookies: fn(_url, _name) {  },
       flush_cookie_store: fn() {  },
       clear_http_cache: fn() {  },
+      clear_storage_data: fn(_kind) {  },
     },
   }
   WindowHandle::{
@@ -695,6 +696,13 @@ test "bridge startup timeout is finite and configurable" {
     }
     _ => fail("expected invalid timeout setting")
   }
+}
+
+///|
+test "storage data kinds are stable and explicit" {
+  assert_eq(StorageDataKind::Cookies, StorageDataKind::Cookies)
+  assert_eq(StorageDataKind::HttpCache, StorageDataKind::HttpCache)
+  assert_eq(StorageDataKind::AllSupported, StorageDataKind::AllSupported)
 }
 
 ///|
@@ -2872,6 +2880,7 @@ async test "session handle routes cookie and cache operations" {
     },
     flush_cookie_store: () => calls.push("flush"),
     clear_http_cache: () => calls.push("clear_cache"),
+    clear_storage_data: _kind => calls.push("clear_storage"),
   }
   ignore(
     session.get_cookies(url="https://example.test/", include_http_only=true),
@@ -2887,6 +2896,7 @@ async test "session handle routes cookie and cache operations" {
   session.delete_cookies(url="https://example.test/", name="token")
   session.flush_cookies()
   session.clear_cache()
+  session.clear_storage_data(StorageDataKind::AllSupported)
   debug_inspect(
     calls,
     content=(
@@ -2896,6 +2906,7 @@ async test "session handle routes cookie and cache operations" {
       #|  "delete:https://example.test/:token",
       #|  "flush",
       #|  "clear_cache",
+      #|  "clear_storage",
       #|]
     ),
   )

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -705,13 +705,24 @@ pub struct SessionHandle {
   remove_cookies : (String?, String?) -> Unit raise WindowSessionError
   flush_cookie_store : () -> Unit raise WindowSessionError
   clear_http_cache : () -> Unit raise WindowSessionError
+  clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 pub fn SessionHandle::clear_cache(Self) -> Unit raise WindowSessionError
+pub fn SessionHandle::clear_storage_data(Self, StorageDataKind) -> Unit raise WindowSessionError
 pub fn SessionHandle::delete_cookies(Self, url? : String, name? : String) -> Unit raise WindowSessionError
 pub fn SessionHandle::flush_cookies(Self) -> Unit raise WindowSessionError
 pub async fn SessionHandle::get_cookies(Self, url? : String, include_http_only? : Bool) -> Array[Cookie] raise WindowSessionError
 pub fn SessionHandle::set_cookie(Self, String, String, String, domain? : String, path? : String, secure? : Bool, http_only? : Bool, same_site? : CookieSameSite) -> Unit raise WindowSessionError
 pub fn SessionHandle::window_id(Self) -> String
+
+pub(all) enum StorageDataKind {
+  Cookies
+  HttpCache
+  AllSupported
+} derive(Eq, @debug.Debug)
+pub fn StorageDataKind::equal(Self, Self) -> Bool
+pub fn StorageDataKind::not_equal(Self, Self) -> Bool
+pub fn StorageDataKind::to_repr(Self) -> @debug.Repr
 
 pub(all) enum TitlebarStyle {
   Default


### PR DESCRIPTION
## Summary
- add `SessionHandle::clear_storage_data` for live sessions
- support `Cookies`, `HttpCache`, and `AllSupported`
- flush the cookie store after cookie deletion and reuse the existing HTTP cache clear path
- document the intentional limitation that active profile-directory categories such as IndexedDB, localStorage, and service workers are not deleted

## Platform impact
- reuses the existing cross-platform session control path; no new native ABI or platform-specific code
- Windows, macOS, and Linux compile coverage is required in CI

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test . --target native --diagnostic-limit 120` (172/172)
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review
- Runtime verification of storage clearing on Windows/Linux remains CI/platform follow-up.
