### PR TITLE
feat(session): add persistent partition isolation

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -44,7 +44,10 @@ temporary files, the executable/module, logs, and configured desktop, documents,
 downloads, music, pictures, and videos directories. `Assets` is available on
 Windows and Linux, and `Recent` is available on Windows. Persistent application
 paths use the reverse-DNS identifier, so changing a display name does not move
-user state.
+user state. Use `App::session_partition` with `.single_instance()` to place the
+browser profile in an isolated `sessionData/<partition>` directory. Cookies,
+cache, IndexedDB, and other Chromium profile state are separated between
+partitions. Partition names are limited to letters, digits, `.`, `-`, and `_`.
 
 `App::set_path` overrides any supported standard path before startup and
 requires an existing absolute path. `App::set_app_logs_path` accepts an

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -155,6 +155,14 @@ pub fn App::single_instance(self : App, enabled? : Bool = true) -> App {
 }
 
 ///|
+/// Uses an isolated persistent browser profile below the application's
+/// sessionData directory.
+pub fn App::session_partition(self : App, partition : String) -> App {
+  self.session_partition_value = Some(partition.trim().to_owned())
+  self
+}
+
+///|
 /// Sets the maximum time allowed for the native bridge to become ready.
 pub fn App::bridge_startup_timeout_ms(self : App, timeout_ms : Int) -> App {
   self.bridge_startup_timeout_value_ms = timeout_ms

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -16,6 +16,7 @@ fn App::App(
     accessibility_mode_value: AccessibilityMode::Automatic,
     application_identity: None,
     single_instance_enabled: false,
+    session_partition_value: None,
     explicit_locale: None,
     path_overrides: Map([]),
     electron_default_logs_path: false,
@@ -96,6 +97,7 @@ fn App::resolved_app_config(self : App) -> ResolvedAppConfig {
     } else {
       None
     },
+    session_partition: self.session_partition_value,
     url_schemes: self.url_schemes.copy(),
     web_request_cancel_prefixes: self.web_request_cancel_prefixes.copy(),
     web_request_redirect_prefixes: self.web_request_redirect_prefixes.copy(),

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -588,7 +588,35 @@ fn resolve_browser_data_dir(
     error =>
       raise InvalidSetting(name="paths.sessionData", message=error.message())
   }
-  Some(path)
+  match config.session_partition {
+    None => Some(path)
+    Some(partition) => {
+      guard session_partition_is_valid(partition) else {
+        raise InvalidSetting(
+          name="session_partition",
+          message="must contain only letters, digits, '.', '-', or '_'",
+        )
+      }
+      Some(@mbpath.Path(path).join(partition).to_string())
+    }
+  }
+}
+
+///|
+fn session_partition_is_valid(partition : String) -> Bool {
+  guard partition.length() > 0 && partition.length() <= 96 else { return false }
+  for character in partition {
+    let code = character.to_int()
+    if !((code >= 'a'.to_int() && code <= 'z'.to_int()) ||
+      (code >= 'A'.to_int() && code <= 'Z'.to_int()) ||
+      (code >= '0'.to_int() && code <= '9'.to_int()) ||
+      character == '.' ||
+      character == '-' ||
+      character == '_') {
+      return false
+    }
+  }
+  true
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -63,6 +63,7 @@ struct App {
   mut accessibility_mode_value : AccessibilityMode
   mut application_identity : ApplicationIdentitySource?
   mut single_instance_enabled : Bool
+  mut session_partition_value : String?
   mut explicit_locale : @locale.Locale?
   path_overrides : Map[String, String]
   mut electron_default_logs_path : Bool
@@ -185,6 +186,7 @@ priv struct ResolvedAppConfig {
   application_identifier : String
   instance_identifier : String?
   url_schemes : Array[String]
+  session_partition : String?
   web_request_cancel_prefixes : Array[String]
   web_request_redirect_prefixes : Array[(String, String)]
   web_request_header_prefixes : Array[(String, String, String)]

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -699,6 +699,19 @@ test "bridge startup timeout is finite and configurable" {
 }
 
 ///|
+test "session partitions validate and resolve beneath session data" {
+  let app = html("Partition", "<main />")
+    .identifier("dev.proton.partition")
+    .single_instance()
+    .session_partition("account_1")
+  let config = app.resolved_app_config()
+  assert_eq(config.session_partition, Some("account_1"))
+  assert_true(session_partition_is_valid("account-1.v2"))
+  assert_false(session_partition_is_valid("../account"))
+  assert_false(session_partition_is_valid("account/name"))
+}
+
+///|
 test "storage data kinds are stable and explicit" {
   assert_eq(StorageDataKind::Cookies, StorageDataKind::Cookies)
   assert_eq(StorageDataKind::HttpCache, StorageDataKind::HttpCache)


### PR DESCRIPTION
## Summary
- add `App::session_partition` for isolated persistent browser profiles
- store partition data below `sessionData/<partition>`
- validate partition names before runtime startup
- cover isolation configuration and invalid path characters in facade tests

## Electron alignment
This maps the persistent partition concept to Proton's single-instance browser profile. The default profile remains unchanged when no partition is configured. Ephemeral non-single-instance profiles remain ephemeral.

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test . --target native --diagnostic-limit 120` (173/173)
- `node scripts/verify_generated.mjs`
- `git diff --check`
