### PR TITLE
feat(permission): add unified browser permission handler

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -49,6 +49,10 @@ browser profile in an isolated `sessionData/<partition>` directory. Cookies,
 cache, IndexedDB, and other Chromium profile state are separated between
 partitions. Partition names are limited to letters, digits, `.`, `-`, and `_`.
 
+Use `App::on_permission_request` to apply one policy to certificate and media
+permission requests. It takes precedence over the specialized handlers; when
+no handler is configured, Proton denies both request types by default.
+
 `App::set_path` overrides any supported standard path before startup and
 requires an existing absolute path. `App::set_app_logs_path` accepts an
 absolute directory that Proton creates during startup; omitting the path selects

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -621,6 +621,16 @@ pub fn App::on_media_permission_request(
 }
 
 ///|
+/// Applies one policy to certificate and media permission requests.
+pub fn App::on_permission_request(
+  self : App,
+  handler : async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise,
+) -> App {
+  self.permission_handler = Some(handler)
+  self
+}
+
+///|
 /// Observes download progress and terminal states.
 pub fn App::on_download_event(
   self : App,

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -44,6 +44,7 @@ fn App::App(
     download_handler: None,
     certificate_handler: None,
     media_handler: None,
+    permission_handler: None,
     download_event_handlers: [],
     update_handlers: [],
     window_lifecycle_hooks: [],

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -74,6 +74,7 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
       download_handler=self.download_handler,
       certificate_handler=self.certificate_handler,
       media_handler=self.media_handler,
+      permission_handler=self.permission_handler,
       download_event_handlers=self.download_event_handlers,
       update_channel=resolved.update_channel,
       update_handlers=self.update_handlers,
@@ -207,6 +208,7 @@ async fn run_manifest(
   download_handler? : (async (BrowserHandle, DownloadRequest) -> DownloadDecision noraise)? = None,
   certificate_handler? : (async (BrowserHandle, CertificateError) -> BrowserPermissionDecision noraise)? = None,
   media_handler? : (async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise)? = None,
+  permission_handler? : (async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise)? = None,
   download_event_handlers? : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ] = [],
@@ -451,6 +453,7 @@ async fn run_manifest(
           download_handler,
           certificate_handler,
           media_handler,
+          permission_handler,
           download_event_handlers,
           application_identifier~,
           application_executable~,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -31,6 +31,7 @@ fn RuntimeSession::RuntimeSession(
   download_handler : (async (BrowserHandle, DownloadRequest) -> DownloadDecision noraise)?,
   certificate_handler : (async (BrowserHandle, CertificateError) -> BrowserPermissionDecision noraise)?,
   media_handler : (async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise)?,
+  permission_handler : (async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise)?,
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ],
@@ -74,6 +75,7 @@ fn RuntimeSession::RuntimeSession(
     download_handler,
     certificate_handler,
     media_handler,
+    permission_handler,
     download_event_handlers,
     close_coordinator: CloseCoordinator(),
     application_identifier,
@@ -3422,26 +3424,54 @@ fn RuntimeSession::start_browser_request(
             None => BrowserResponse::{ action: "deny", path: None, }
           }
         Certificate(url~, error_code~, ..) =>
-          match self.certificate_handler {
+          match self.permission_handler {
             Some(handler) =>
-              match handler(browser, { url, error_code, }) {
+              match
+                handler(
+                  browser,
+                  PermissionRequest::Certificate({ url, error_code, }),
+                ) {
                 BrowserPermissionDecision::Allow =>
                   BrowserResponse::{ action: "allow", path: None, }
                 BrowserPermissionDecision::Deny =>
                   BrowserResponse::{ action: "deny", path: None, }
               }
-            None => BrowserResponse::{ action: "deny", path: None, }
+            None =>
+              match self.certificate_handler {
+                Some(handler) =>
+                  match handler(browser, { url, error_code, }) {
+                    BrowserPermissionDecision::Allow =>
+                      BrowserResponse::{ action: "allow", path: None, }
+                    BrowserPermissionDecision::Deny =>
+                      BrowserResponse::{ action: "deny", path: None, }
+                  }
+                None => BrowserResponse::{ action: "deny", path: None, }
+              }
           }
         Media(origin~, permissions~, ..) =>
-          match self.media_handler {
+          match self.permission_handler {
             Some(handler) =>
-              match handler(browser, { origin, permissions, }) {
+              match
+                handler(
+                  browser,
+                  PermissionRequest::Media({ origin, permissions, }),
+                ) {
                 BrowserPermissionDecision::Allow =>
                   BrowserResponse::{ action: "allow", path: None, }
                 BrowserPermissionDecision::Deny =>
                   BrowserResponse::{ action: "deny", path: None, }
               }
-            None => BrowserResponse::{ action: "deny", path: None, }
+            None =>
+              match self.media_handler {
+                Some(handler) =>
+                  match handler(browser, { origin, permissions, }) {
+                    BrowserPermissionDecision::Allow =>
+                      BrowserResponse::{ action: "allow", path: None, }
+                    BrowserPermissionDecision::Deny =>
+                      BrowserResponse::{ action: "deny", path: None, }
+                  }
+                None => BrowserResponse::{ action: "deny", path: None, }
+              }
           }
       }
     },

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -97,6 +97,7 @@ struct App {
   mut download_handler : (async (BrowserHandle, DownloadRequest) -> DownloadDecision noraise)?
   mut certificate_handler : (async (BrowserHandle, CertificateError) -> BrowserPermissionDecision noraise)?
   mut media_handler : (async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise)?
+  mut permission_handler : (async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise)?
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
@@ -433,6 +434,7 @@ priv struct RuntimeSession {
   download_handler : (async (BrowserHandle, DownloadRequest) -> DownloadDecision noraise)?
   certificate_handler : (async (BrowserHandle, CertificateError) -> BrowserPermissionDecision noraise)?
   media_handler : (async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise)?
+  permission_handler : (async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise)?
   download_event_handlers : Array[
     async (BrowserHandle, DownloadEvent) -> Unit noraise,
   ]
@@ -996,6 +998,19 @@ pub extend MediaPermissionRequest with Eq::{not_equal, equal}
 
 ///|
 pub extend MediaPermissionRequest with Debug::{to_repr}
+
+///|
+/// A browser permission request delivered to the unified policy handler.
+pub(all) enum PermissionRequest {
+  Certificate(CertificateError)
+  Media(MediaPermissionRequest)
+} derive(Debug, Eq)
+
+///|
+pub extend PermissionRequest with Eq::{not_equal, equal}
+
+///|
+pub extend PermissionRequest with Debug::{to_repr}
 
 ///|
 pub(all) enum BrowserPermissionDecision {

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -712,6 +712,20 @@ test "session partitions validate and resolve beneath session data" {
 }
 
 ///|
+test "permission requests expose a unified certificate and media policy" {
+  let certificate = PermissionRequest::Certificate({
+    url: "https://example.test",
+    error_code: -200,
+  })
+  let media = PermissionRequest::Media({
+    origin: "https://example.test",
+    permissions: 3,
+  })
+  assert_true(certificate is PermissionRequest::Certificate(_))
+  assert_true(media is PermissionRequest::Media(_))
+}
+
+///|
 test "storage data kinds are stable and explicit" {
   assert_eq(StorageDataKind::Cookies, StorageDataKind::Cookies)
   assert_eq(StorageDataKind::HttpCache, StorageDataKind::HttpCache)


### PR DESCRIPTION
## Summary
- add `PermissionRequest` covering certificate and media requests
- add `App::on_permission_request` as a unified policy hook
- prioritize the unified handler over specialized handlers
- preserve default denial and existing specialized callbacks

## Platform impact
- reuses the existing native certificate/media request queue on macOS, Linux, and Windows
- no new native ABI or platform-specific code

## Validation
- `moon fmt`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test . --target native --diagnostic-limit 120` (174/174)
- `node scripts/verify_generated.mjs`
- `git diff --check`
