### PR TITLE
feat(runtime): add startup proxy configuration

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -53,6 +53,10 @@ Use `App::on_permission_request` to apply one policy to certificate and media
 permission requests. It takes precedence over the specialized handlers; when
 no handler is configured, Proton denies both request types by default.
 
+Use `App::proxy` to configure a startup-wide Chromium proxy. Proton passes the
+server and optional bypass list to CEF before startup; changing proxy settings
+while the application is running is not supported.
+
 `App::set_path` overrides any supported standard path before startup and
 requires an existing absolute path. `App::set_app_logs_path` accepts an
 absolute directory that Proton creates during startup; omitting the path selects

--- a/proton/facade_builders.mbt
+++ b/proton/facade_builders.mbt
@@ -163,6 +163,15 @@ pub fn App::session_partition(self : App, partition : String) -> App {
 }
 
 ///|
+/// Configures a startup-wide Chromium proxy. This is read when the native
+/// runtime starts and cannot be changed while the app is running.
+pub fn App::proxy(self : App, server : String, bypass? : String) -> App {
+  self.proxy_server_value = Some(server.trim().to_owned())
+  self.proxy_bypass_value = bypass.map(value => value.trim().to_owned())
+  self
+}
+
+///|
 /// Sets the maximum time allowed for the native bridge to become ready.
 pub fn App::bridge_startup_timeout_ms(self : App, timeout_ms : Int) -> App {
   self.bridge_startup_timeout_value_ms = timeout_ms

--- a/proton/facade_manifest.mbt
+++ b/proton/facade_manifest.mbt
@@ -17,6 +17,8 @@ fn App::App(
     application_identity: None,
     single_instance_enabled: false,
     session_partition_value: None,
+    proxy_server_value: None,
+    proxy_bypass_value: None,
     explicit_locale: None,
     path_overrides: Map([]),
     electron_default_logs_path: false,

--- a/proton/facade_runtime.mbt
+++ b/proton/facade_runtime.mbt
@@ -99,6 +99,14 @@ pub async fn App::run(self : App) -> Unit raise AppRunError {
   } catch {
     error => raise failure_log.logged_remaining(error)
   }
+  match self.proxy_server_value {
+    Some(server) => @env.set_env_var("PROTON_PROXY_SERVER", server)
+    None => ()
+  }
+  match self.proxy_bypass_value {
+    Some(bypass) => @env.set_env_var("PROTON_PROXY_BYPASS", bypass)
+    None => ()
+  }
 }
 
 ///|

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -64,6 +64,8 @@ struct App {
   mut application_identity : ApplicationIdentitySource?
   mut single_instance_enabled : Bool
   mut session_partition_value : String?
+  mut proxy_server_value : String?
+  mut proxy_bypass_value : String?
   mut explicit_locale : @locale.Locale?
   path_overrides : Map[String, String]
   mut electron_default_logs_path : Bool

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -167,6 +167,10 @@ static void CEF_CALLBACK proton_engine_on_before_command_line_processing(
                               "disable-backgrounding-occluded-windows");
   proton_engine_append_switch(command_line, "disable-renderer-backgrounding");
   proton_engine_append_switch(command_line, "disable-background-networking");
+  proton_engine_append_switch_with_value(command_line, "proxy-server",
+                                         getenv("PROTON_PROXY_SERVER"));
+  proton_engine_append_switch_with_value(command_line, "proxy-bypass-list",
+                                         getenv("PROTON_PROXY_BYPASS"));
   proton_engine_append_switch(command_line, "disable-component-update");
   proton_engine_append_switch(command_line, "disable-domain-reliability");
   proton_engine_append_switch(command_line, "disable-sync");

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -317,6 +317,10 @@ static void proton_engine_on_before_command_line_processing(
   // --in-process-gpu can intermittently block cef_shutdown; CI selects
   // SwiftShader through ANGLE_DEFAULT_PLATFORM when hardware GPU is absent.
   proton_engine_append_switch(command_line, "disable-background-networking");
+  proton_engine_append_switch_with_value(command_line, "proxy-server",
+                                         getenv("PROTON_PROXY_SERVER"));
+  proton_engine_append_switch_with_value(command_line, "proxy-bypass-list",
+                                         getenv("PROTON_PROXY_BYPASS"));
   proton_engine_append_switch(command_line, "disable-component-update");
   proton_engine_append_switch(command_line, "disable-domain-reliability");
   proton_engine_append_switch(command_line, "disable-sync");

--- a/proton/internal/native/ffi_mac/mac_runtime.objc.c
+++ b/proton/internal/native/ffi_mac/mac_runtime.objc.c
@@ -482,6 +482,10 @@ void proton_engine_on_before_command_line_processing(
                                            "remote-debugging-port", "0");
   }
   proton_engine_append_switch(command_line, "disable-background-networking");
+  proton_engine_append_switch_with_value(command_line, "proxy-server",
+                                         getenv("PROTON_PROXY_SERVER"));
+  proton_engine_append_switch_with_value(command_line, "proxy-bypass-list",
+                                         getenv("PROTON_PROXY_BYPASS"));
   proton_engine_append_switch(command_line, "disable-component-update");
   proton_engine_append_switch(command_line, "disable-domain-reliability");
   proton_engine_append_switch(command_line, "disable-sync");


### PR DESCRIPTION
## Summary
- add `App::proxy` for startup-wide Chromium proxy configuration
- pass proxy server and bypass list through Proton's process environment into CEF command-line setup
- apply the same behavior on Windows, Linux, and macOS
- document that runtime proxy switching is intentionally unsupported because the bundled CEF SDK exposes no request-context proxy setter

## Validation
- `moon fmt`
- `moon -C proton check --target native --diagnostic-limit 120`
- `moon -C proton test . --target native --diagnostic-limit 120` (174/174)
- `node scripts/verify_generated.mjs`
- `git diff --check`
