### PR TITLE
feat(session): expose renderer termination events

### DIFF
--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -3318,6 +3318,8 @@ fn RuntimeSession::dispatch_browser_event(
                   url=info.url.unwrap_or(""),
                   status=info.error_code.unwrap_or(0),
                   received_bytes=info.received_bytes.unwrap_or(0L),
+                ),
+              )
             ("browser_renderer_process_terminated", _, Some(details), _, _) =>
               Some(
                 BrowserEvent::RendererProcessTerminated(

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -3243,16 +3243,17 @@ fn RuntimeSession::dispatch_browser_event(
     (
       event.window_id(),
       event.browser_event(),
+      event.renderer_process_termination(),
       event.find_in_page_result(),
       event.pdf_print_result(),
     ) {
-    (Some(window_id), info, find_result, pdf_result) =>
+    (Some(window_id), info, termination, find_result, pdf_result) =>
       match self.find_window_by_native_id(window_id) {
         Some(window) => {
           let browser = self.browser_handle(window)
           let observed = match
-            (event.event_type(), info, find_result, pdf_result) {
-            ("browser_loading_changed", Some(info), _, _) => {
+            (event.event_type(), info, termination, find_result, pdf_result) {
+            ("browser_loading_changed", Some(info), _, _, _) => {
               let is_loading = info.is_loading.unwrap_or(false)
               let transition = match window.observed_browser_loading {
                 None => []
@@ -3278,11 +3279,11 @@ fn RuntimeSession::dispatch_browser_event(
               }
               Some(BrowserEvent::LoadingChanged(is_loading~))
             }
-            ("browser_navigated", Some(info), _, _) =>
+            ("browser_navigated", Some(info), _, _, _) =>
               Some(BrowserEvent::Navigated(url=info.url.unwrap_or("")))
-            ("browser_title_updated", Some(info), _, _) =>
+            ("browser_title_updated", Some(info), _, _, _) =>
               Some(BrowserEvent::TitleUpdated(title=info.title.unwrap_or("")))
-            ("browser_load_failed", Some(info), _, _) =>
+            ("browser_load_failed", Some(info), _, _, _) =>
               Some(
                 BrowserEvent::LoadFailed(
                   url=info.url.unwrap_or(""),
@@ -3290,13 +3291,13 @@ fn RuntimeSession::dispatch_browser_event(
                   error_text=info.error_text.unwrap_or(""),
                 ),
               )
-            ("browser_found_in_page", _, Some(result), _) =>
+            ("browser_found_in_page", _, _, Some(result), _) =>
               Some(
                 BrowserEvent::FoundInPage(
                   result=FindInPageResult::from_native(result),
                 ),
               )
-            ("browser_pdf_print_finished", _, _, Some(result)) =>
+            ("browser_pdf_print_finished", _, _, _, Some(result)) =>
               Some(
                 BrowserEvent::PdfPrinted(result={
                   request_id: result.request_id,
@@ -3304,19 +3305,26 @@ fn RuntimeSession::dispatch_browser_event(
                   success: result.success,
                 }),
               )
-            ("browser_resource_response", Some(info), _, _) =>
+            ("browser_resource_response", Some(info), _, _, _) =>
               Some(
                 BrowserEvent::ResourceResponse(
                   url=info.url.unwrap_or(""),
                   status_code=info.error_code.unwrap_or(0),
                 ),
               )
-            ("browser_resource_completed", Some(info), _, _) =>
+            ("browser_resource_completed", Some(info), _, _, _) =>
               Some(
                 BrowserEvent::ResourceCompleted(
                   url=info.url.unwrap_or(""),
                   status=info.error_code.unwrap_or(0),
                   received_bytes=info.received_bytes.unwrap_or(0L),
+            ("browser_renderer_process_terminated", _, Some(details), _, _) =>
+              Some(
+                BrowserEvent::RendererProcessTerminated(
+                  url=details.url,
+                  status=details.status,
+                  error_code=details.error_code,
+                  detail=details.detail,
                 ),
               )
             _ => None

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -1083,6 +1083,12 @@ pub(all) enum BrowserEvent {
   PdfPrinted(result~ : PdfPrintResult)
   ResourceResponse(url~ : String, status_code~ : Int)
   ResourceCompleted(url~ : String, status~ : Int, received_bytes~ : Int64)
+  RendererProcessTerminated(
+    url~ : String,
+    status~ : Int,
+    error_code~ : Int,
+    detail~ : String
+  )
 } derive(Debug, Eq)
 
 ///|

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.c
@@ -618,6 +618,27 @@ void proton_browser_session_load_failed(proton_browser_session_t *session,
   (void)proton_browser_enqueue_event(session, event);
 }
 
+void proton_browser_session_renderer_terminated(
+    proton_browser_session_t *session, int32_t status, int32_t error_code,
+    const char *url, const char *error_text) {
+  if (session == NULL) {
+    return;
+  }
+  proton_event_t *event = proton_event_create_window(
+      PROTON_EVENT_BROWSER_RENDERER_TERMINATED, session->window);
+  if (event != NULL &&
+      (!proton_event_set_text(&event->text_a, url) ||
+       !proton_event_set_text(&event->text_b, error_text))) {
+    proton_event_destroy(event);
+    event = NULL;
+  }
+  if (event != NULL) {
+    event->int_a = status;
+    event->int_b = error_code;
+  }
+  (void)proton_browser_enqueue_event(session, event);
+}
+
 static int32_t proton_browser_session_copy_text(const char *text,
                                                 char *buffer,
                                                 int32_t buffer_len,

--- a/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
+++ b/proton/internal/native/ffi/src/engine/cef_common/browser_session.h
@@ -62,6 +62,9 @@ void proton_browser_session_load_failed(proton_browser_session_t *session,
                                         const char *url,
                                         int32_t error_code,
                                         const char *error_text);
+void proton_browser_session_renderer_terminated(
+    proton_browser_session_t *session, int32_t status, int32_t error_code,
+    const char *url, const char *error_text);
 int32_t proton_browser_session_copy_url(proton_browser_session_t *session,
                                         char *buffer, int32_t buffer_len,
                                         int32_t *out_required_len);

--- a/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_linux/linux_client.c
@@ -983,6 +983,9 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
       frame != NULL ? proton_engine_userfree_to_utf8(frame->get_url(frame))
                     : NULL;
   char *detail = proton_engine_cef_string_to_utf8(error_string);
+  proton_browser_session_renderer_terminated(
+      window->browser_session, (int32_t)status, error_code,
+      url != NULL ? url : "", detail != NULL ? detail : "");
   if (url != NULL &&
       !(window->bridge_lifecycle.outcome != NULL &&
         strcmp(window->bridge_lifecycle.outcome, "ineligible") == 0 &&

--- a/proton/internal/native/ffi/src/engine/cef_win/win_client.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_client.c
@@ -1198,6 +1198,9 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
       frame != NULL ? proton_engine_userfree_to_utf8(frame->get_url(frame))
                     : NULL;
   char *detail = proton_engine_cef_string_to_utf8(error_string);
+  proton_browser_session_renderer_terminated(
+      window->browser_session, (int32_t)status, error_code,
+      url != NULL ? url : "", detail != NULL ? detail : "");
   if (url != NULL &&
       !(window->bridge_lifecycle.outcome != NULL &&
         strcmp(window->bridge_lifecycle.outcome, "ineligible") == 0 &&

--- a/proton/internal/native/ffi/src/proton_event.h
+++ b/proton/internal/native/ffi/src/proton_event.h
@@ -56,6 +56,7 @@ typedef enum proton_event_kind {
   PROTON_EVENT_APP_ACTIVATION = 37,
   PROTON_EVENT_BROWSER_RESOURCE_RESPONSE = 38,
   PROTON_EVENT_BROWSER_RESOURCE_COMPLETED = 39,
+  PROTON_EVENT_BROWSER_RENDERER_TERMINATED = 40,
 } proton_event_kind_t;
 
 typedef struct proton_event {

--- a/proton/internal/native/ffi_mac/mac_client.objc.c
+++ b/proton/internal/native/ffi_mac/mac_client.objc.c
@@ -977,6 +977,9 @@ static void CEF_CALLBACK proton_engine_on_render_process_terminated(
       frame != NULL ? proton_engine_userfree_to_utf8(frame->get_url(frame))
                     : NULL;
   char *detail = proton_engine_cef_string_to_utf8(error_string);
+  proton_browser_session_renderer_terminated(
+      window->browser_session, (int32_t)status, error_code,
+      url != NULL ? url : "", detail != NULL ? detail : "");
   if (url != NULL &&
       !(window->bridge_lifecycle.outcome != NULL &&
         strcmp(window->bridge_lifecycle.outcome, "ineligible") == 0 &&

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -1197,6 +1197,16 @@ fn decode_native_runtime_event(
           final_update: @native_ffi.event_int(event, 3) != 0,
         }),
       )
+    40 =>
+      BrowserEvent(
+        window,
+        RendererProcessTerminated(
+          require_native_event_text(event, 0, "renderer termination URL"),
+          @native_ffi.event_int(event, 0),
+          @native_ffi.event_int(event, 1),
+          require_native_event_text(event, 1, "renderer termination detail"),
+        ),
+      )
     35 =>
       ViewEvent(
         window,

--- a/proton/internal/native/native_wbtest.mbt
+++ b/proton/internal/native/native_wbtest.mbt
@@ -194,6 +194,24 @@ test "browser page events preserve window ids and payloads" {
 }
 
 ///|
+test "renderer termination events preserve status and error code separately" {
+  let event = RuntimeEvent::BrowserEvent(
+    7L,
+    NativeBrowserEvent::RendererProcessTerminated(
+      "https://example.test/app", 2, -7, "render process crashed",
+    ),
+  )
+  assert_eq(event.event_type(), "browser_renderer_process_terminated")
+  guard event.renderer_process_termination() is Some(info) else {
+    fail("expected renderer termination payload")
+  }
+  assert_eq(info.url, "https://example.test/app")
+  assert_eq(info.status, 2)
+  assert_eq(info.error_code, -7)
+  assert_eq(info.detail, "render process crashed")
+}
+
+///|
 test "find result events preserve targets and match details" {
   let result = NativeFindInPageResult::{
     request_id: 4,

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -490,6 +490,16 @@ pub fn RemoteDebugging::equal(Self, Self) -> Bool
 pub fn RemoteDebugging::not_equal(Self, Self) -> Bool
 pub fn RemoteDebugging::to_repr(Self) -> @debug.Repr
 
+pub(all) struct RendererProcessTerminationInfo {
+  url : String
+  status : Int
+  error_code : Int
+  detail : String
+} derive(Eq, @debug.Debug)
+pub fn RendererProcessTerminationInfo::equal(Self, Self) -> Bool
+pub fn RendererProcessTerminationInfo::not_equal(Self, Self) -> Bool
+pub fn RendererProcessTerminationInfo::to_repr(Self) -> @debug.Repr
+
 type Runtime
 pub fn Runtime::Runtime(config? : RuntimeConfig) -> Self raise NativeError
 pub fn Runtime::begin_destroy(Self) -> Unit raise NativeError
@@ -532,6 +542,7 @@ pub fn RuntimeEvent::not_equal(Self, Self) -> Bool
 pub fn RuntimeEvent::notification_click(Self) -> String??
 pub fn RuntimeEvent::notification_result(Self) -> NativeNotificationResult?
 pub fn RuntimeEvent::pdf_print_result(Self) -> NativePdfPrintResult?
+pub fn RuntimeEvent::renderer_process_termination(Self) -> RendererProcessTerminationInfo?
 pub fn RuntimeEvent::resource_request(Self) -> NativeResourceRequest?
 pub fn RuntimeEvent::resource_request_cancellation(Self) -> Int64?
 pub fn RuntimeEvent::to_repr(Self) -> @debug.Repr

--- a/proton/internal/native/types.mbt
+++ b/proton/internal/native/types.mbt
@@ -465,6 +465,7 @@ enum NativeBrowserEvent {
   FindResult(NativeFindInPageResult)
   ResourceResponse(String, Int)
   ResourceCompleted(String, Int, Int64)
+  RendererProcessTerminated(String, Int, Int, String)
 } derive(Debug, Eq)
 
 ///|
@@ -807,6 +808,8 @@ pub fn RuntimeEvent::event_type(self : RuntimeEvent) -> String {
     BrowserEvent(_, FindResult(_)) => "browser_found_in_page"
     BrowserEvent(_, ResourceResponse(_, _)) => "browser_resource_response"
     BrowserEvent(_, ResourceCompleted(_, _, _)) => "browser_resource_completed"
+    BrowserEvent(_, RendererProcessTerminated(_, _, _, _)) =>
+      "browser_renderer_process_terminated"
     ViewEvent(_, _, LoadingChanged(_)) => "view_loading_changed"
     ViewEvent(_, _, Navigated(_)) => "view_navigated"
     ViewEvent(_, _, TitleUpdated(_)) => "view_title_updated"
@@ -955,6 +958,21 @@ pub fn RuntimeEvent::view_event(self : RuntimeEvent) -> ViewEventInfo? {
 }
 
 ///|
+/// The payload of a renderer process termination event.
+pub(all) struct RendererProcessTerminationInfo {
+  url : String
+  status : Int
+  error_code : Int
+  detail : String
+} derive(Debug, Eq)
+
+///|
+pub extend RendererProcessTerminationInfo with Eq::{not_equal, equal}
+
+///|
+pub extend RendererProcessTerminationInfo with Debug::{to_repr}
+
+///|
 /// Returns the main browser event payload when this event carries one.
 pub fn RuntimeEvent::browser_event(self : RuntimeEvent) -> ViewEventInfo? {
   match self {
@@ -1012,6 +1030,18 @@ pub fn RuntimeEvent::browser_event(self : RuntimeEvent) -> ViewEventInfo? {
         error_text: None,
         received_bytes: Some(bytes),
       })
+    _ => None
+  }
+}
+
+///|
+/// Returns renderer termination details when this event carries them.
+pub fn RuntimeEvent::renderer_process_termination(
+  self : RuntimeEvent,
+) -> RendererProcessTerminationInfo? {
+  match self {
+    BrowserEvent(_, RendererProcessTerminated(url, status, error_code, detail)) =>
+      Some({ url, status, error_code, detail, })
     _ => None
   }
 }

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -237,13 +237,16 @@ pub fn App::on_launch_input(Self, async (ApplicationContext, RuntimeLaunchInput)
 pub fn App::on_media_permission_request(Self, async (BrowserHandle, MediaPermissionRequest) -> BrowserPermissionDecision noraise) -> Self
 pub fn App::on_navigation_request(Self, async (BrowserHandle, NavigationRequest) -> NavigationDecision noraise) -> Self
 pub fn App::on_new_window_request(Self, async (BrowserHandle, NewWindowRequest) -> NewWindowDecision noraise) -> Self
+pub fn App::on_permission_request(Self, async (BrowserHandle, PermissionRequest) -> BrowserPermissionDecision noraise) -> Self
 pub fn App::on_update_available(Self, async (PendingUpdate) -> Unit noraise) -> Self
 pub fn App::on_view_event(Self, async (ViewHandle, ViewEvent) -> Unit noraise) -> Self
 pub fn App::on_window_close_request(Self, async (WindowHandle) -> WindowCloseDecision noraise) -> Self
 pub fn App::on_window_event(Self, async (WindowHandle, WindowEvent) -> Unit noraise) -> Self
 pub fn App::path(Self, AppPathKind) -> String raise AppPathError
+pub fn App::proxy(Self, String, bypass? : String) -> Self
 pub async fn App::run(Self) -> Unit raise AppRunError
 pub async fn App::run_or_abort(Self) -> Unit
+pub fn App::session_partition(Self, String) -> Self
 pub fn App::set_app_logs_path(Self, path? : String) -> Self raise AppPathError
 pub fn App::set_path(Self, AppPathKind, String) -> Self raise AppPathError
 pub fn App::single_instance(Self, enabled? : Bool) -> Self
@@ -331,6 +334,7 @@ pub(all) enum BrowserEvent {
   LoadFailed(url~ : String, error_code~ : Int, error_text~ : String)
   FoundInPage(result~ : FindInPageResult)
   PdfPrinted(result~ : PdfPrintResult)
+  RendererProcessTerminated(url~ : String, status~ : Int, error_code~ : Int, detail~ : String)
 } derive(Eq, @debug.Debug)
 pub fn BrowserEvent::equal(Self, Self) -> Bool
 pub fn BrowserEvent::not_equal(Self, Self) -> Bool
@@ -654,6 +658,14 @@ pub fn PendingUpdate::restart(Self) -> Unit raise
 pub fn PendingUpdate::revision(Self) -> UInt64
 pub fn PendingUpdate::size(Self) -> Int64
 pub fn PendingUpdate::version(Self) -> String
+
+pub(all) enum PermissionRequest {
+  Certificate(CertificateError)
+  Media(MediaPermissionRequest)
+} derive(Eq, @debug.Debug)
+pub fn PermissionRequest::equal(Self, Self) -> Bool
+pub fn PermissionRequest::not_equal(Self, Self) -> Bool
+pub fn PermissionRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RelaunchOptions {
   executable : String?


### PR DESCRIPTION
## Summary
- expose CEF renderer process termination as a public BrowserEvent
- preserve URL, termination status, CEF error code, and diagnostic detail
- route events through the existing native event queue on Windows, macOS, and Linux

## Validation
- moon fmt
- moon -C proton check --target native --diagnostic-limit 120
- moon -C proton test internal/native --target native --diagnostic-limit 80
- node scripts/verify_generated.mjs

Windows and Linux runtime behavior require CI/manual platform verification.