### PR TITLE
feat(session): clear certificate exceptions

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -50,6 +50,8 @@ cache, IndexedDB, and other Chromium profile state are separated between
 partitions. Partition names are limited to letters, digits, `.`, `-`, and `_`.
 `SessionHandle::clear_auth_cache` clears Chromium's cached HTTP authentication
 credentials without clearing cookies or the HTTP cache.
+`SessionHandle::clear_certificate_exceptions` clears remembered certificate
+exception decisions for the same request context.
 
 Use `App::on_permission_request` to apply one policy to certificate and media
 permission requests. It takes precedence over the specialized handlers; when

--- a/proton/facade_cookie.mbt
+++ b/proton/facade_cookie.mbt
@@ -186,6 +186,14 @@ pub fn SessionHandle::clear_auth_cache(
 }
 
 ///|
+/// Clears stored certificate exception decisions for this session.
+pub fn SessionHandle::clear_certificate_exceptions(
+  self : SessionHandle,
+) -> Unit raise WindowSessionError {
+  (self.clear_certificate_exceptions)()
+}
+
+///|
 /// Clears the selected live session storage categories.
 pub fn SessionHandle::clear_storage_data(
   self : SessionHandle,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1024,6 +1024,11 @@ fn RuntimeSession::session_handle(
         window.clear_auth_cache()
       })
     },
+    clear_certificate_exceptions: () => {
+      self.control_window(id, native_id, "clear certificate exceptions in", window => {
+        window.clear_certificate_exceptions()
+      })
+    },
     clear_storage_data: kind => {
       self.control_window(id, native_id, "clear storage in", window => {
         match kind {

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -586,6 +586,7 @@ pub struct SessionHandle {
   flush_cookie_store : () -> Unit raise WindowSessionError
   clear_http_cache : () -> Unit raise WindowSessionError
   clear_http_auth_cache : () -> Unit raise WindowSessionError
+  clear_certificate_exceptions : () -> Unit raise WindowSessionError
   clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -190,6 +190,7 @@ fn test_window_handle(
       flush_cookie_store: fn() {  },
       clear_http_cache: fn() {  },
       clear_http_auth_cache: fn() {  },
+      clear_certificate_exceptions: fn() {  },
       clear_storage_data: fn(_kind) {  },
     },
   }
@@ -2929,6 +2930,7 @@ async test "session handle routes cookie and cache operations" {
     flush_cookie_store: () => calls.push("flush"),
     clear_http_cache: () => calls.push("clear_cache"),
     clear_http_auth_cache: () => calls.push("clear_auth_cache"),
+    clear_certificate_exceptions: () => calls.push("clear_cert_exceptions"),
     clear_storage_data: _kind => calls.push("clear_storage"),
   }
   ignore(
@@ -2946,6 +2948,7 @@ async test "session handle routes cookie and cache operations" {
   session.flush_cookies()
   session.clear_cache()
   session.clear_auth_cache()
+  session.clear_certificate_exceptions()
   session.clear_storage_data(StorageDataKind::AllSupported)
   debug_inspect(
     calls,
@@ -2957,6 +2960,7 @@ async test "session handle routes cookie and cache operations" {
       #|  "flush",
       #|  "clear_cache",
       #|  "clear_auth_cache",
+      #|  "clear_cert_exceptions",
       #|  "clear_storage",
       #|]
     ),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -1289,6 +1289,11 @@ pub extern "C" fn proton_window_clear_auth_cache_ffi(
 ) -> Int = "proton_window_clear_auth_cache"
 
 ///|
+pub extern "C" fn proton_window_clear_certificate_exceptions_ffi(
+  window : WindowHandle,
+) -> Int = "proton_window_clear_certificate_exceptions"
+
+///|
 #borrow(out_image)
 pub extern "C" fn proton_image_create_empty_ffi(
   out_image : Ref[ImageHandle],

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -393,6 +393,7 @@ int32_t proton_window_cookie_flush(proton_window_handle_t window);
 /* Clear the HTTP cache for the window's request context. Fire-and-forget. */
 int32_t proton_window_clear_cache(proton_window_handle_t window);
 int32_t proton_window_clear_auth_cache(proton_window_handle_t window);
+int32_t proton_window_clear_certificate_exceptions(proton_window_handle_t window);
 
 /* Enumerates connected displays into caller-owned integer storage. Each
    display occupies 11 fields in the order consumed by the MoonBit wrapper. */

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -235,6 +235,8 @@ pub fn proton_window_clear_bridge_failure_ffi(WindowHandle) -> Int
 
 pub fn proton_window_clear_cache_ffi(WindowHandle) -> Int
 
+pub fn proton_window_clear_certificate_exceptions_ffi(WindowHandle) -> Int
+
 pub fn proton_window_close_ffi(WindowHandle) -> Int
 
 pub fn proton_window_cookie_begin_get_ffi(WindowHandle, Bytes, Int, @ref.Ref[Int64]) -> Int

--- a/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
@@ -738,6 +738,34 @@ int32_t proton_engine_window_clear_cache(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_clear_certificate_exceptions(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_t *browser = proton_engine_window_browser(window);
+  if (browser == NULL) {
+    proton_engine_set_message(error, error_len, "window browser is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    proton_engine_set_message(error, error_len, "browser host is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  cef_request_context_t *context = host->get_request_context(host);
+  if (context == NULL) {
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_engine_set_message(error, error_len, "request context is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  context->clear_certificate_exceptions(context, NULL);
+  context->base.base.release((cef_base_ref_counted_t *)context);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
 int32_t proton_engine_window_clear_auth_cache(proton_engine_window_t *window,
                                               char *error, size_t error_len) {
   if (window == NULL) {

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -2928,6 +2928,22 @@ int32_t proton_window_clear_auth_cache(proton_window_handle_t window) {
   return PROTON_OK;
 }
 
+int32_t proton_window_clear_certificate_exceptions(proton_window_handle_t window) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "certificate exceptions require native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_clear_certificate_exceptions(
+      slot->engine_window, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_internal_view_create(
     proton_window_handle_t window, int32_t x, int32_t y, int32_t width,
     int32_t height, int32_t visible, int32_t z_order, const char *initial_url,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -564,6 +564,8 @@ int32_t proton_engine_window_clear_cache(proton_engine_window_t *window,
                                          char *error, size_t error_len);
 int32_t proton_engine_window_clear_auth_cache(proton_engine_window_t *window,
                                               char *error, size_t error_len);
+int32_t proton_engine_window_clear_certificate_exceptions(
+    proton_engine_window_t *window, char *error, size_t error_len);
 
 /* Releases any pending cookie-get state associated with the window. Called
    during window destruction so async cookie visits do not outlive their

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2827,6 +2827,18 @@ pub fn Window::clear_auth_cache(self : Window) -> Unit raise NativeError {
 }
 
 ///|
+/// Clears stored certificate exception decisions for the request context.
+pub fn Window::clear_certificate_exceptions(
+  self : Window,
+) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_clear_certificate_exceptions_ffi(
+      self.live_handle(),
+    ),
+  )
+}
+
+///|
 /// Creates an empty native image. Use `add_png`, `add_jpeg`, or `add_bitmap`
 /// to add a representation at a given scale factor, then query with `is_empty`
 /// or `size`, and export with `to_png`, `to_jpeg`, or `to_bitmap`.

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -701,6 +701,7 @@ pub fn Window::browser_is_focused(Self) -> Bool raise NativeError
 pub fn Window::browser_state(Self) -> BrowserState raise NativeError
 pub fn Window::clear_auth_cache(Self) -> Unit raise NativeError
 pub fn Window::clear_cache(Self) -> Unit raise NativeError
+pub fn Window::clear_certificate_exceptions(Self) -> Unit raise NativeError
 pub fn Window::close(Self) -> Unit raise NativeError
 pub fn Window::content_size(Self) -> (Int, Int) raise NativeError
 pub fn Window::cookie_begin_get(Self, String?, Bool) -> Int64 raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -720,10 +720,12 @@ pub struct SessionHandle {
   flush_cookie_store : () -> Unit raise WindowSessionError
   clear_http_cache : () -> Unit raise WindowSessionError
   clear_http_auth_cache : () -> Unit raise WindowSessionError
+  clear_certificate_exceptions : () -> Unit raise WindowSessionError
   clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 pub fn SessionHandle::clear_auth_cache(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::clear_cache(Self) -> Unit raise WindowSessionError
+pub fn SessionHandle::clear_certificate_exceptions(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::clear_storage_data(Self, StorageDataKind) -> Unit raise WindowSessionError
 pub fn SessionHandle::delete_cookies(Self, url? : String, name? : String) -> Unit raise WindowSessionError
 pub fn SessionHandle::flush_cookies(Self) -> Unit raise WindowSessionError


### PR DESCRIPTION
## Summary
- add SessionHandle::clear_certificate_exceptions
- clear CEF request-context certificate exception decisions
- keep cookies, HTTP cache, and auth credentials unchanged

## Validation
- moon fmt --check
- moon -C proton check --target native --diagnostic-limit 80
- moon -C proton test . --target native --diagnostic-limit 80 (175 passed)
- node scripts/verify_generated.mjs
- git diff --check

## Platform impact
Uses the shared CEF request-context API across macOS, Windows, and Linux.