### PR TITLE
feat(session): add connection lifecycle control

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -52,6 +52,8 @@ partitions. Partition names are limited to letters, digits, `.`, `-`, and `_`.
 credentials without clearing cookies or the HTTP cache.
 `SessionHandle::clear_certificate_exceptions` clears remembered certificate
 exception decisions for the same request context.
+`SessionHandle::close_all_connections` closes active and idle Chromium network
+connections for the session without clearing cookies or cache data.
 
 Use `App::on_permission_request` to apply one policy to certificate and media
 permission requests. It takes precedence over the specialized handlers; when

--- a/proton/facade_cookie.mbt
+++ b/proton/facade_cookie.mbt
@@ -194,6 +194,14 @@ pub fn SessionHandle::clear_certificate_exceptions(
 }
 
 ///|
+/// Closes active and idle Chromium network connections for this session.
+pub fn SessionHandle::close_all_connections(
+  self : SessionHandle,
+) -> Unit raise WindowSessionError {
+  (self.close_all_connections)()
+}
+
+///|
 /// Clears the selected live session storage categories.
 pub fn SessionHandle::clear_storage_data(
   self : SessionHandle,

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1029,6 +1029,11 @@ fn RuntimeSession::session_handle(
         window.clear_certificate_exceptions()
       })
     },
+    close_all_connections: () => {
+      self.control_window(id, native_id, "close connections in", window => {
+        window.close_all_connections()
+      })
+    },
     clear_storage_data: kind => {
       self.control_window(id, native_id, "clear storage in", window => {
         match kind {

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -587,6 +587,7 @@ pub struct SessionHandle {
   clear_http_cache : () -> Unit raise WindowSessionError
   clear_http_auth_cache : () -> Unit raise WindowSessionError
   clear_certificate_exceptions : () -> Unit raise WindowSessionError
+  close_all_connections : () -> Unit raise WindowSessionError
   clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -191,6 +191,7 @@ fn test_window_handle(
       clear_http_cache: fn() {  },
       clear_http_auth_cache: fn() {  },
       clear_certificate_exceptions: fn() {  },
+      close_all_connections: fn() {  },
       clear_storage_data: fn(_kind) {  },
     },
   }
@@ -2943,6 +2944,7 @@ async test "session handle routes cookie and cache operations" {
     clear_http_cache: () => calls.push("clear_cache"),
     clear_http_auth_cache: () => calls.push("clear_auth_cache"),
     clear_certificate_exceptions: () => calls.push("clear_cert_exceptions"),
+    close_all_connections: () => calls.push("close_connections"),
     clear_storage_data: _kind => calls.push("clear_storage"),
   }
   ignore(
@@ -2961,6 +2963,7 @@ async test "session handle routes cookie and cache operations" {
   session.clear_cache()
   session.clear_auth_cache()
   session.clear_certificate_exceptions()
+  session.close_all_connections()
   session.clear_storage_data(StorageDataKind::AllSupported)
   debug_inspect(
     calls,
@@ -2973,6 +2976,7 @@ async test "session handle routes cookie and cache operations" {
       #|  "clear_cache",
       #|  "clear_auth_cache",
       #|  "clear_cert_exceptions",
+      #|  "close_connections",
       #|  "clear_storage",
       #|]
     ),

--- a/proton/internal/native/ffi/ffi.mbt
+++ b/proton/internal/native/ffi/ffi.mbt
@@ -1294,6 +1294,11 @@ pub extern "C" fn proton_window_clear_certificate_exceptions_ffi(
 ) -> Int = "proton_window_clear_certificate_exceptions"
 
 ///|
+pub extern "C" fn proton_window_close_all_connections_ffi(
+  window : WindowHandle,
+) -> Int = "proton_window_close_all_connections"
+
+///|
 #borrow(out_image)
 pub extern "C" fn proton_image_create_empty_ffi(
   out_image : Ref[ImageHandle],

--- a/proton/internal/native/ffi/include/proton_native.h
+++ b/proton/internal/native/ffi/include/proton_native.h
@@ -394,6 +394,7 @@ int32_t proton_window_cookie_flush(proton_window_handle_t window);
 int32_t proton_window_clear_cache(proton_window_handle_t window);
 int32_t proton_window_clear_auth_cache(proton_window_handle_t window);
 int32_t proton_window_clear_certificate_exceptions(proton_window_handle_t window);
+int32_t proton_window_close_all_connections(proton_window_handle_t window);
 
 /* Enumerates connected displays into caller-owned integer storage. Each
    display occupies 11 fields in the order consumed by the MoonBit wrapper. */

--- a/proton/internal/native/ffi/pkg.generated.mbti
+++ b/proton/internal/native/ffi/pkg.generated.mbti
@@ -236,6 +236,7 @@ pub fn proton_window_clear_bridge_failure_ffi(WindowHandle) -> Int
 pub fn proton_window_clear_cache_ffi(WindowHandle) -> Int
 
 pub fn proton_window_clear_certificate_exceptions_ffi(WindowHandle) -> Int
+pub fn proton_window_close_all_connections_ffi(WindowHandle) -> Int
 
 pub fn proton_window_close_ffi(WindowHandle) -> Int
 

--- a/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
+++ b/proton/internal/native/ffi/src/engine/cef_common/cookie_cache.c
@@ -794,6 +794,34 @@ int32_t proton_engine_window_clear_auth_cache(proton_engine_window_t *window,
   return PROTON_OK;
 }
 
+int32_t proton_engine_window_close_all_connections(
+    proton_engine_window_t *window, char *error, size_t error_len) {
+  if (window == NULL) {
+    proton_engine_set_message(error, error_len, "window is required");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  cef_browser_t *browser = proton_engine_window_browser(window);
+  if (browser == NULL) {
+    proton_engine_set_message(error, error_len, "window browser is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  cef_browser_host_t *host = browser->get_host(browser);
+  if (host == NULL) {
+    proton_engine_set_message(error, error_len, "browser host is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  cef_request_context_t *context = host->get_request_context(host);
+  if (context == NULL) {
+    host->base.release((cef_base_ref_counted_t *)host);
+    proton_engine_set_message(error, error_len, "request context is not available");
+    return PROTON_ERR_ENGINE;
+  }
+  context->close_all_connections(context, NULL);
+  context->base.base.release((cef_base_ref_counted_t *)context);
+  host->base.release((cef_base_ref_counted_t *)host);
+  return PROTON_OK;
+}
+
 void proton_engine_window_cookie_cleanup(proton_engine_window_t *window) {
   if (window == NULL) {
     return;

--- a/proton/internal/native/ffi/src/proton.c
+++ b/proton/internal/native/ffi/src/proton.c
@@ -2944,6 +2944,22 @@ int32_t proton_window_clear_certificate_exceptions(proton_window_handle_t window
   return PROTON_OK;
 }
 
+int32_t proton_window_close_all_connections(proton_window_handle_t window) {
+  proton_window_slot_t *slot = NULL;
+  int32_t status = proton_get_window(window, &slot);
+  if (status != PROTON_OK) return status;
+  if (slot->engine_window == NULL) {
+    return proton_set_error(PROTON_ERR_UNSUPPORTED,
+                            "connection operations require native engine");
+  }
+  char engine_error[512] = {0};
+  status = proton_engine_window_close_all_connections(
+      slot->engine_window, engine_error, sizeof(engine_error));
+  if (status != PROTON_OK) return proton_set_engine_status(status, engine_error);
+  g_last_error[0] = '\0';
+  return PROTON_OK;
+}
+
 int32_t proton_internal_view_create(
     proton_window_handle_t window, int32_t x, int32_t y, int32_t width,
     int32_t height, int32_t visible, int32_t z_order, const char *initial_url,

--- a/proton/internal/native/ffi/src/proton_engine.h
+++ b/proton/internal/native/ffi/src/proton_engine.h
@@ -566,6 +566,8 @@ int32_t proton_engine_window_clear_auth_cache(proton_engine_window_t *window,
                                               char *error, size_t error_len);
 int32_t proton_engine_window_clear_certificate_exceptions(
     proton_engine_window_t *window, char *error, size_t error_len);
+int32_t proton_engine_window_close_all_connections(
+    proton_engine_window_t *window, char *error, size_t error_len);
 
 /* Releases any pending cookie-get state associated with the window. Called
    during window destruction so async cookie visits do not outlive their

--- a/proton/internal/native/native.mbt
+++ b/proton/internal/native/native.mbt
@@ -2848,6 +2848,14 @@ pub fn Window::clear_certificate_exceptions(
 }
 
 ///|
+/// Closes active and idle Chromium connections for this window's session.
+pub fn Window::close_all_connections(self : Window) -> Unit raise NativeError {
+  check_status(
+    @native_ffi.proton_window_close_all_connections_ffi(self.live_handle()),
+  )
+}
+
+///|
 /// Creates an empty native image. Use `add_png`, `add_jpeg`, or `add_bitmap`
 /// to add a representation at a given scale factor, then query with `is_empty`
 /// or `size`, and export with `to_png`, `to_jpeg`, or `to_bitmap`.

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -703,6 +703,7 @@ pub fn Window::clear_auth_cache(Self) -> Unit raise NativeError
 pub fn Window::clear_cache(Self) -> Unit raise NativeError
 pub fn Window::clear_certificate_exceptions(Self) -> Unit raise NativeError
 pub fn Window::close(Self) -> Unit raise NativeError
+pub fn Window::close_all_connections(Self) -> Unit raise NativeError
 pub fn Window::content_size(Self) -> (Int, Int) raise NativeError
 pub fn Window::cookie_begin_get(Self, String?, Bool) -> Int64 raise NativeError
 pub fn Window::cookie_delete(Self, String?, String?) -> Unit raise NativeError

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -722,12 +722,14 @@ pub struct SessionHandle {
   clear_http_cache : () -> Unit raise WindowSessionError
   clear_http_auth_cache : () -> Unit raise WindowSessionError
   clear_certificate_exceptions : () -> Unit raise WindowSessionError
+  close_all_connections : () -> Unit raise WindowSessionError
   clear_storage_data : (StorageDataKind) -> Unit raise WindowSessionError
 }
 pub fn SessionHandle::clear_auth_cache(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::clear_cache(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::clear_certificate_exceptions(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::clear_storage_data(Self, StorageDataKind) -> Unit raise WindowSessionError
+pub fn SessionHandle::close_all_connections(Self) -> Unit raise WindowSessionError
 pub fn SessionHandle::delete_cookies(Self, url? : String, name? : String) -> Unit raise WindowSessionError
 pub fn SessionHandle::flush_cookies(Self) -> Unit raise WindowSessionError
 pub async fn SessionHandle::get_cookies(Self, url? : String, include_http_only? : Bool) -> Array[Cookie] raise WindowSessionError


### PR DESCRIPTION
## Summary
- add `SessionHandle::close_all_connections()` for active and idle Chromium connections
- route the operation through the existing public facade and private native CEF request context
- preserve fire-and-forget semantics and explicit unsupported/native errors

## Electron alignment
Covers Electron's `session.closeAllConnections()` responsibility. Dynamic proxy mutation and DNS resolution are intentionally separate follow-ups because the shipped CEF C API does not expose a portable runtime proxy setter and DNS requires a larger async completion contract.

## Platform impact
Uses the shared CEF request-context implementation on macOS, Windows, and Linux. No platform-specific code or packaging changes.

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test . --target native --diagnostic-limit 80` (175 passed)
- `node scripts/verify_generated.mjs`
- `git diff --check`

Manual runtime verification remains pending on Windows and Linux runners.
