### PR TITLE
feat(facade): expose native image module

### DIFF
--- a/proton/README.md
+++ b/proton/README.md
@@ -102,6 +102,14 @@ method, and whether the configured synchronous policy will cancel it. A
 non-zero completion status represents an error; request callbacks are
 observational and do not expose mutable CEF objects across the native boundary.
 
+## Native images
+
+`@proton.native_image()` creates an Electron-style image container. Add PNG,
+JPEG, or raw RGBA bitmap representations with an explicit scale factor, query
+its logical size, and export the closest representation with `to_png`,
+`to_jpeg`, or `to_bitmap`. Call `destroy` when the image is no longer needed;
+repeated destruction is safe.
+
 ## Commands and events
 
 Register typed commands on the app builder:

--- a/proton/facade_native_image.mbt
+++ b/proton/facade_native_image.mbt
@@ -1,0 +1,115 @@
+///|
+fn native_image_error(
+  action : String,
+  error : @native.NativeError,
+) -> NativeImageError {
+  OperationFailed(action~, status=error.status(), detail=error.message())
+}
+
+///|
+/// Creates an empty native image. Add at least one representation before use.
+pub fn native_image() -> NativeImage raise NativeImageError {
+  let image = @native.NativeImage::create_empty() catch {
+    error => raise native_image_error("create native image", error)
+  }
+  { image, }
+}
+
+///|
+/// Releases the native image. Calling this method more than once is safe.
+pub fn NativeImage::destroy(self : NativeImage) -> Unit raise NativeImageError {
+  self.image.destroy() catch {
+    error => raise native_image_error("destroy native image", error)
+  }
+}
+
+///|
+/// Adds a PNG representation at the requested scale factor.
+pub fn NativeImage::add_png(
+  self : NativeImage,
+  data : Bytes,
+  scale_factor? : Double = 1.0,
+) -> Unit raise NativeImageError {
+  self.image.add_png(data, scale_factor~) catch {
+    error => raise native_image_error("add PNG representation", error)
+  }
+}
+
+///|
+/// Adds a JPEG representation at the requested scale factor.
+pub fn NativeImage::add_jpeg(
+  self : NativeImage,
+  data : Bytes,
+  scale_factor? : Double = 1.0,
+) -> Unit raise NativeImageError {
+  self.image.add_jpeg(data, scale_factor~) catch {
+    error => raise native_image_error("add JPEG representation", error)
+  }
+}
+
+///|
+/// Adds a raw 32-bit RGBA bitmap representation.
+pub fn NativeImage::add_bitmap(
+  self : NativeImage,
+  data : Bytes,
+  width : Int,
+  height : Int,
+  scale_factor? : Double = 1.0,
+) -> Unit raise NativeImageError {
+  self.image.add_bitmap(data, width, height, scale_factor~) catch {
+    error => raise native_image_error("add bitmap representation", error)
+  }
+}
+
+///|
+/// Returns whether the image has no representations.
+pub fn NativeImage::is_empty(self : NativeImage) -> Bool raise NativeImageError {
+  self.image.is_empty() catch {
+    error => raise native_image_error("read native image state", error)
+  }
+}
+
+///|
+/// Returns the density-independent image size as `(width, height)`.
+pub fn NativeImage::size(
+  self : NativeImage,
+) -> (Int, Int) raise NativeImageError {
+  self.image.size() catch {
+    error => raise native_image_error("read native image size", error)
+  }
+}
+
+///|
+/// Exports the closest representation as PNG bytes and pixel dimensions.
+pub fn NativeImage::to_png(
+  self : NativeImage,
+  scale_factor? : Double = 1.0,
+  with_transparency? : Bool = true,
+) -> (Bytes, Int, Int) raise NativeImageError {
+  self.image.to_png(scale_factor~, with_transparency~) catch {
+    error => raise native_image_error("encode native image as PNG", error)
+  }
+}
+
+///|
+/// Exports the closest representation as JPEG bytes and pixel dimensions.
+pub fn NativeImage::to_jpeg(
+  self : NativeImage,
+  scale_factor? : Double = 1.0,
+  quality? : Int = 80,
+) -> (Bytes, Int, Int) raise NativeImageError {
+  self.image.to_jpeg(scale_factor~, quality~) catch {
+    error => raise native_image_error("encode native image as JPEG", error)
+  }
+}
+
+///|
+/// Exports the closest representation as raw 32-bit RGBA bytes.
+pub fn NativeImage::to_bitmap(
+  self : NativeImage,
+  scale_factor? : Double = 1.0,
+) -> (Bytes, Int, Int) raise NativeImageError {
+  self.image.to_bitmap(scale_factor~) catch {
+    error => raise native_image_error("export native image bitmap", error)
+  }
+}

--- a/proton/facade_native_image_wbtest.mbt
+++ b/proton/facade_native_image_wbtest.mbt
@@ -1,0 +1,11 @@
+///|
+test "native image errors retain action and native detail" {
+  let error = native_image_error(
+    "encode native image",
+    @native.NativeError::Status(status=-7, message="encoding failed"),
+  )
+  inspect(
+    error.message(),
+    content="encode native image failed (-7): encoding failed",
+  )
+}

--- a/proton/facade_types.mbt
+++ b/proton/facade_types.mbt
@@ -53,6 +53,40 @@ pub extend StorageDataKind with Eq::{not_equal, equal}
 pub extend StorageDataKind with Debug::{to_repr}
 
 ///|
+/// An Electron-style native image with one or more scale representations.
+pub struct NativeImage {
+  image : @native.NativeImage
+}
+
+///|
+/// A failure while creating, reading, or converting a native image.
+pub(all) suberror NativeImageError {
+  OperationFailed(action~ : String, status~ : Int, detail~ : String)
+} derive(Debug, Eq)
+
+///|
+pub extend NativeImageError with Eq::{not_equal, equal}
+
+///|
+pub extend NativeImageError with Debug::{to_repr}
+
+///|
+pub fn NativeImageError::message(self : NativeImageError) -> String {
+  match self {
+    OperationFailed(action~, status~, detail~) =>
+      action + " failed (" + status.to_string() + "): " + detail
+  }
+}
+
+///|
+impl Show for NativeImageError with fn output(self, logger) {
+  logger.write_string(self.message())
+}
+
+///|
+pub extend NativeImageError with Show::{to_string, output}
+
+///|
 /// High-level application facade for ordinary Proton apps.
 struct App {
   mut window : @manifest.WindowManifest

--- a/proton/moon.pkg
+++ b/proton/moon.pkg
@@ -52,6 +52,8 @@ options(
     "facade_menu.mbt": [ "native" ],
     "facade_manifest.mbt": [ "native" ],
     "facade_native_types.mbt": [ "native" ],
+    "facade_native_image.mbt": [ "native" ],
+    "facade_native_image_wbtest.mbt": [ "native" ],
     "facade_notification.mbt": [ "native" ],
     "facade_paths.mbt": [ "native" ],
     "facade_permissions.mbt": [ "native" ],

--- a/proton/pkg.generated.mbti
+++ b/proton/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "moonbit-community/proton/core",
   "moonbit-community/proton/extension",
   "moonbit-community/proton/internal/locale",
+  "moonbit-community/proton/internal/native",
   "moonbit-community/proton/manifest",
   "moonbit-community/proton/updater",
   "moonbit-community/proton_contract",
@@ -25,6 +26,8 @@ pub fn file(String, String, width? : Int, height? : Int, debug? : Bool, resizabl
 pub fn html(String, String, width? : Int, height? : Int, debug? : Bool, resizable? : Bool) -> App
 
 pub fn is_packaged() -> Bool
+
+pub fn native_image() -> NativeImage raise NativeImageError
 
 pub fn resource_dir() -> String
 
@@ -154,6 +157,16 @@ pub fn LifecycleHookError::message(Self) -> String
 pub fn LifecycleHookError::output(Self, &Logger) -> Unit
 pub fn LifecycleHookError::to_repr(Self) -> @debug.Repr
 pub fn LifecycleHookError::to_string(Self) -> String
+
+pub(all) suberror NativeImageError {
+  OperationFailed(action~ : String, status~ : Int, detail~ : String)
+} derive(Eq, @debug.Debug)
+pub fn NativeImageError::equal(Self, Self) -> Bool
+pub fn NativeImageError::message(Self) -> String
+pub fn NativeImageError::not_equal(Self, Self) -> Bool
+pub fn NativeImageError::output(Self, &Logger) -> Unit
+pub fn NativeImageError::to_repr(Self) -> @debug.Repr
+pub fn NativeImageError::to_string(Self) -> String
 
 pub(all) suberror NotificationDeliveryError {
   NativeFailure(status~ : Int, detail~ : String)
@@ -573,6 +586,19 @@ pub(all) enum MenuRole {
 pub fn MenuRole::equal(Self, Self) -> Bool
 pub fn MenuRole::not_equal(Self, Self) -> Bool
 pub fn MenuRole::to_repr(Self) -> @debug.Repr
+
+pub struct NativeImage {
+  image : @native.NativeImage
+}
+pub fn NativeImage::add_bitmap(Self, Bytes, Int, Int, scale_factor? : Double) -> Unit raise NativeImageError
+pub fn NativeImage::add_jpeg(Self, Bytes, scale_factor? : Double) -> Unit raise NativeImageError
+pub fn NativeImage::add_png(Self, Bytes, scale_factor? : Double) -> Unit raise NativeImageError
+pub fn NativeImage::destroy(Self) -> Unit raise NativeImageError
+pub fn NativeImage::is_empty(Self) -> Bool raise NativeImageError
+pub fn NativeImage::size(Self) -> (Int, Int) raise NativeImageError
+pub fn NativeImage::to_bitmap(Self, scale_factor? : Double) -> (Bytes, Int, Int) raise NativeImageError
+pub fn NativeImage::to_jpeg(Self, scale_factor? : Double, quality? : Int) -> (Bytes, Int, Int) raise NativeImageError
+pub fn NativeImage::to_png(Self, scale_factor? : Double, with_transparency? : Bool) -> (Bytes, Int, Int) raise NativeImageError
 
 pub(all) enum NavigationDecision {
   Allow


### PR DESCRIPTION
## Summary
- expose Proton's existing native image implementation through the root facade
- support PNG, JPEG, and raw RGBA bitmap representations with scale factors
- provide size/empty queries and PNG/JPEG/bitmap export helpers
- translate private native failures into public `NativeImageError`

## Electron alignment
This covers the core `nativeImage` construction and representation workflow. The facade keeps the image handle opaque and does not expose CEF types.

## Platform impact
No new platform-specific code. The existing source-built native image implementation remains shared across macOS, Windows, and Linux.

## Validation
- `moon fmt --check`
- `moon -C proton check --target native --diagnostic-limit 80`
- `moon -C proton test . --target native --diagnostic-limit 80` (176 passed)
- `node scripts/verify_generated.mjs`
- `git diff --check`

Manual runtime image encode/decode verification remains pending on Windows and Linux runners.
