### PR TITLE
feat(clipboard): add clear command

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -57,7 +57,7 @@ to another renderer target is rejected for the calling page.
 - `fs`: host filesystem helper definitions
 - `path`: path transform helper definitions
 - `dialog`: native dialog helper definitions
-- `clipboard`: clipboard helper definitions
+- `clipboard`: read, write, and clear plain text in the system clipboard
 - `shell`: open/reveal host path helper definitions
 - `notification`: macOS system notifications and notification-click events
 - `tray`: native tray icon lifecycle, tooltip/icon updates, flat context menus,

--- a/extensions/clipboard/clipboard.mbt
+++ b/extensions/clipboard/clipboard.mbt
@@ -35,3 +35,12 @@ fn write_clipboard_text(
     Err(error) => raise WriteFailed(detail=error)
   }
 }
+
+///|
+fn clear_clipboard() -> @clipboard_contract.ClearReply raise ClipboardError {
+  ensure_supported()
+  match @sys_clipboard.write_text("") {
+    Ok(_) => @clipboard_contract.ClearReply::{ cleared: true, }
+    Err(error) => raise WriteFailed(detail=error)
+  }
+}

--- a/extensions/clipboard/contract/contract.mbt
+++ b/extensions/clipboard/contract/contract.mbt
@@ -33,6 +33,22 @@ pub extend WriteTextRequest with ToJson::{to_json}
 pub extend WriteTextRequest with FromJson::{from_json}
 
 ///|
+/// Request to clear the native clipboard.
+pub(all) struct ClearRequest {} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend ClearRequest with Eq::{not_equal, equal}
+
+///|
+pub extend ClearRequest with Debug::{to_repr}
+
+///|
+pub extend ClearRequest with ToJson::{to_json}
+
+///|
+pub extend ClearRequest with FromJson::{from_json}
+
+///|
 /// Current plain-text clipboard contents.
 pub(all) struct ReadTextReply {
   text : String?
@@ -69,6 +85,24 @@ pub extend WriteTextReply with ToJson::{to_json}
 pub extend WriteTextReply with FromJson::{from_json}
 
 ///|
+/// Result of clearing the clipboard.
+pub(all) struct ClearReply {
+  cleared : Bool
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend ClearReply with Eq::{not_equal, equal}
+
+///|
+pub extend ClearReply with Debug::{to_repr}
+
+///|
+pub extend ClearReply with ToJson::{to_json}
+
+///|
+pub extend ClearReply with FromJson::{from_json}
+
+///|
 /// One completed clipboard operation.
 pub(all) struct ClipboardActivity {
   operation : String
@@ -95,6 +129,11 @@ pub let read_text : @proton_contract.Command[ReadTextRequest, ReadTextReply] = e
 ///|
 pub let write_text : @proton_contract.Command[WriteTextRequest, WriteTextReply] = extension.command(
   "writeText",
+)
+
+///|
+pub let clear : @proton_contract.Command[ClearRequest, ClearReply] = extension.command(
+  "clear",
 )
 
 ///|

--- a/extensions/clipboard/extension.g.mbt
+++ b/extensions/clipboard/extension.g.mbt
@@ -6,6 +6,7 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
   [
     read_text_command.contract_route(),
     write_text_command.contract_route(),
+    clear_command.contract_route(),
   ]
 }
 
@@ -20,5 +21,9 @@ pub fn register_commands(
   registrar.bind(
     write_text_command,
     (context, request) => write_text(context, request),
+  )
+  registrar.bind(
+    clear_command,
+    (context, request) => clear(context, request),
   )
 }

--- a/extensions/clipboard/extension.mbt
+++ b/extensions/clipboard/extension.mbt
@@ -5,6 +5,9 @@ let read_text_command = @clipboard_contract.read_text
 let write_text_command = @clipboard_contract.write_text
 
 ///|
+let clear_command = @clipboard_contract.clear
+
+///|
 /// Reads plain text from the native clipboard.
 #proton.command(contract=read_text_command)
 async fn read_text(
@@ -30,6 +33,21 @@ async fn write_text(
   context.emit(@clipboard_contract.activity, @clipboard_contract.ClipboardActivity::{
     operation: "writeText",
     text_length: Some(request.text.length()),
+  })
+  reply
+}
+
+///|
+/// Clears the native clipboard.
+#proton.command(contract=clear_command)
+async fn clear(
+  context : @proton.CommandContext,
+  _request : @clipboard_contract.ClearRequest,
+) -> @clipboard_contract.ClearReply {
+  let reply = clear_clipboard()
+  context.emit(@clipboard_contract.activity, @clipboard_contract.ClipboardActivity::{
+    operation: "clear",
+    text_length: Some(0),
   })
   reply
 }

--- a/extensions/clipboard/extension_wbtest.mbt
+++ b/extensions/clipboard/extension_wbtest.mbt
@@ -14,6 +14,14 @@ test "clipboard metadata constants match generated app command extension" {
   let spec = extension().command_spec()
   assert_eq(spec.js_namespace(), "clipboard")
   assert_eq(spec.op_names(), [
-    "ext:clipboard/readText", "ext:clipboard/writeText",
+    "ext:clipboard/readText", "ext:clipboard/writeText", "ext:clipboard/clear",
   ])
+}
+
+///|
+test "clipboard clear contract uses an empty request and boolean reply" {
+  let request = @clipboard_contract.ClearRequest::{ }
+  inspect(request.to_json(), content="Object({})")
+  let reply = @clipboard_contract.ClearReply::{ cleared: true, }
+  inspect(reply.to_json(), content="Object({cleared: True})")
 }


### PR DESCRIPTION
## Summary
- add typed `clipboard.clear` command aligned with Electron `clipboard.clear()`
- reuse the existing cross-platform native text write path with an empty string
- emit `clipboard.activity` with `operation: "clear"` and `text_length: 0`
- update generated command routes, contract tests, and extension documentation

## Behavior and platform impact
The command returns `{ cleared: true }` after the existing clipboard backend accepts an empty text write. It inherits the current Windows, macOS, and Linux backend availability and error behavior. No new native ABI or platform-specific code is introduced.

## Validation
- `moon fmt --check`
- `moon -C extensions test -p moonbit-community/proton_ext moonbit-community/proton_ext/clipboard moonbit-community/proton_ext/clipboard/contract --target native`
- `moon test -p moonbit-community/proton_clipboard --target native`
- `moon -C proton check --target native --diagnostic-limit 80`
- `node scripts/verify_generated.mjs`
- `git diff --check`

## Manual review
Runtime clipboard interaction remains covered by the existing clipboard examples; this change adds the missing clear command and activity event without changing their setup or capability grant.

## Known limitations
As with the existing clipboard extension, Linux requires one of the supported clipboard tools to be available on `PATH`.
