### PR TITLE
feat(power-monitor): add system idle state

### DIFF
--- a/extensions/power_monitor/contract/contract.mbt
+++ b/extensions/power_monitor/contract/contract.mbt
@@ -16,6 +16,42 @@ pub extend IdleTimeReply with ToJson::{to_json}
 pub extend IdleTimeReply with FromJson::{from_json}
 
 ///|
+/// Request for Electron-compatible idle-state classification.
+pub(all) struct IdleStateRequest {
+  idle_threshold : Int
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend IdleStateRequest with Eq::{not_equal, equal}
+
+///|
+pub extend IdleStateRequest with Debug::{to_repr}
+
+///|
+pub extend IdleStateRequest with ToJson::{to_json}
+
+///|
+pub extend IdleStateRequest with FromJson::{from_json}
+
+///|
+/// Current idle state, either `active` or `idle`.
+pub(all) struct IdleStateReply {
+  state : String
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend IdleStateReply with Eq::{not_equal, equal}
+
+///|
+pub extend IdleStateReply with Debug::{to_repr}
+
+///|
+pub extend IdleStateReply with ToJson::{to_json}
+
+///|
+pub extend IdleStateReply with FromJson::{from_json}
+
+///|
 pub(all) struct PowerSourceReply {
   source : String
   battery_percent : Int?
@@ -73,6 +109,12 @@ pub let get_idle_time : @proton_contract.Command[
   @proton_contract.EmptyRequest,
   IdleTimeReply,
 ] = extension.command("getIdleTime")
+
+///|
+pub let get_idle_state : @proton_contract.Command[
+  IdleStateRequest,
+  IdleStateReply,
+] = extension.command("getSystemIdleState")
 
 ///|
 pub let get_power_source : @proton_contract.Command[

--- a/extensions/power_monitor/extension.g.mbt
+++ b/extensions/power_monitor/extension.g.mbt
@@ -5,6 +5,7 @@
 pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRoute] {
   [
     get_idle_time_command.contract_route(),
+    get_idle_state_command.contract_route(),
     get_power_source_command.contract_route(),
   ]
 }
@@ -16,6 +17,10 @@ pub fn register_commands(
   registrar.bind(
     get_idle_time_command,
     (context, request) => get_idle_time(context, request),
+  )
+  registrar.bind(
+    get_idle_state_command,
+    (context, request) => get_idle_state(context, request),
   )
   registrar.bind(
     get_power_source_command,

--- a/extensions/power_monitor/extension.mbt
+++ b/extensions/power_monitor/extension.mbt
@@ -2,6 +2,9 @@
 let get_idle_time_command = @power_monitor_contract.get_idle_time
 
 ///|
+let get_idle_state_command = @power_monitor_contract.get_idle_state
+
+///|
 let get_power_source_command = @power_monitor_contract.get_power_source
 
 ///|
@@ -49,6 +52,35 @@ async fn get_idle_time(
     operation: "get_idle_time",
   })
   @power_monitor_contract.IdleTimeReply::{ idle_seconds: seconds, }
+}
+
+///|
+/// Classifies the current system idle state using a threshold in seconds.
+#proton.command(contract=get_idle_state_command)
+async fn get_idle_state(
+  context : @proton.CommandContext,
+  request : @power_monitor_contract.IdleStateRequest,
+) -> @power_monitor_contract.IdleStateReply {
+  guard request.idle_threshold >= 0 else {
+    raise QueryFailed(
+      operation="idle_state",
+      detail="idle threshold must not be negative",
+    )
+  }
+  let monitor = ensure_monitor()
+  let seconds = monitor.idle_seconds() catch {
+    error => raise QueryFailed(operation="idle_state", detail=error.to_string())
+  }
+  context.emit(@power_monitor_contract.activity, @power_monitor_contract.PowerMonitorActivity::{
+    operation: "get_system_idle_state",
+  })
+  @power_monitor_contract.IdleStateReply::{
+    state: if seconds >= request.idle_threshold {
+      "idle"
+    } else {
+      "active"
+    },
+  }
 }
 
 ///|

--- a/extensions/power_monitor/extension_wbtest.mbt
+++ b/extensions/power_monitor/extension_wbtest.mbt
@@ -4,7 +4,18 @@ test "power monitor extension identity matches the generated app command extensi
   assert_eq(capability.id(), "moonbit-community/proton-power-monitor")
   let spec = capability.command_spec()
   assert_eq(spec.js_namespace(), "powerMonitor")
+  assert_true(spec.op_names().contains("ext:powerMonitor/getSystemIdleState"))
   assert_false(spec.op_names().contains("ext:powerMonitor/drainEvents"))
   assert_eq(spec.scripts(), [])
   assert_true(capability.event_source() is Some(_))
+}
+
+///|
+test "power monitor idle state request preserves threshold" {
+  let request = @power_monitor_contract.IdleStateRequest::{
+    idle_threshold: 30,
+  }
+  assert_eq(request.idle_threshold, 30)
+  let reply = @power_monitor_contract.IdleStateReply::{ state: "active", }
+  assert_eq(reply.state, "active")
 }


### PR DESCRIPTION
## Summary
- add `powerMonitor.getSystemIdleState(idleThreshold)`
- classify the existing native idle-seconds query as `active` or `idle`
- validate non-negative thresholds and emit activity telemetry
- update typed contract, generated routes, and tests

## Electron alignment and platform impact
The command mirrors Electron's `powerMonitor.getSystemIdleState`. Proton currently exposes the portable `active`/`idle` states derived from the native idle-time query. Existing suspend, resume, AC, battery, lock, and unlock events are unchanged. No native ABI changes are required.

## Validation
- `moon fmt`
- `git diff --check`
- `moon -C extensions test -p moonbit-community/proton_ext moonbit-community/proton_ext/power_monitor moonbit-community/proton_ext/power_monitor/contract --target native`
- `node scripts/verify_generated.mjs`

## Known limitation
The current portable backend does not expose a separate locked-state result from the idle query; lock state remains available through the existing lock-screen events.
