### PR TITLE
feat(screen-monitor): add display matching

### DIFF
--- a/extensions/screen_monitor/contract/contract.mbt
+++ b/extensions/screen_monitor/contract/contract.mbt
@@ -137,6 +137,27 @@ pub extend NearestPointRequest with ToJson::{to_json}
 pub extend NearestPointRequest with FromJson::{from_json}
 
 ///|
+/// Request rectangle for `getDisplayMatching`.
+pub(all) struct MatchingRectRequest {
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(ToJson, FromJson, Debug, Eq)
+
+///|
+pub extend MatchingRectRequest with Eq::{not_equal, equal}
+
+///|
+pub extend MatchingRectRequest with Debug::{to_repr}
+
+///|
+pub extend MatchingRectRequest with ToJson::{to_json}
+
+///|
+pub extend MatchingRectRequest with FromJson::{from_json}
+
+///|
 /// Telemetry for screen query commands, so renderers can observe which screen
 /// APIs were exercised. Follows the activity-event convention shared by the
 /// other `proton_ext` command extensions.
@@ -173,6 +194,12 @@ pub let get_display_nearest_point : @proton_contract.Command[
   NearestPointRequest,
   DisplayReply,
 ] = extension.command("getDisplayNearestPoint")
+
+///|
+pub let get_display_matching : @proton_contract.Command[
+  MatchingRectRequest,
+  DisplayReply,
+] = extension.command("getDisplayMatching")
 
 ///|
 pub let get_cursor_point : @proton_contract.Command[

--- a/extensions/screen_monitor/extension.g.mbt
+++ b/extensions/screen_monitor/extension.g.mbt
@@ -7,6 +7,7 @@ pub fn generated_extension_command_routes() -> Array[@proton_contract.ContractRo
     get_all_displays_command.contract_route(),
     get_primary_display_command.contract_route(),
     get_display_nearest_point_command.contract_route(),
+    get_display_matching_command.contract_route(),
     get_cursor_point_command.contract_route(),
   ]
 }
@@ -26,6 +27,10 @@ pub fn register_commands(
   registrar.bind(
     get_display_nearest_point_command,
     (context, request) => get_display_nearest_point(context, request),
+  )
+  registrar.bind(
+    get_display_matching_command,
+    (context, request) => get_display_matching(context, request),
   )
   registrar.bind(
     get_cursor_point_command,

--- a/extensions/screen_monitor/extension.mbt
+++ b/extensions/screen_monitor/extension.mbt
@@ -8,6 +8,9 @@ let get_primary_display_command = @screen_monitor_contract.get_primary_display
 let get_display_nearest_point_command = @screen_monitor_contract.get_display_nearest_point
 
 ///|
+let get_display_matching_command = @screen_monitor_contract.get_display_matching
+
+///|
 let get_cursor_point_command = @screen_monitor_contract.get_cursor_point
 
 ///|
@@ -128,6 +131,86 @@ async fn get_display_nearest_point(
       )
   }
   emit_activity(context, "getDisplayNearestPoint")
+  @screen_monitor_contract.DisplayReply::{
+    display: display_to_contract(display),
+  }
+}
+
+///|
+fn overlap_length(
+  a_start : Int,
+  a_size : Int,
+  b_start : Int,
+  b_size : Int,
+) -> Int {
+  let a_end = a_start + a_size
+  let b_end = b_start + b_size
+  let start = if a_start > b_start { a_start } else { b_start }
+  let end = if a_end < b_end { a_end } else { b_end }
+  if end > start {
+    end - start
+  } else {
+    0
+  }
+}
+
+///|
+fn matching_display(
+  displays : Array[@sys_screen_monitor.DisplayInfo],
+  request : @screen_monitor_contract.MatchingRectRequest,
+) -> @sys_screen_monitor.DisplayInfo? {
+  let best : Ref[@sys_screen_monitor.DisplayInfo?] = Ref(None)
+  let best_area = Ref(0)
+  for display in displays {
+    let width = overlap_length(
+      request.x,
+      request.width,
+      display.bounds.x,
+      display.bounds.width,
+    )
+    let height = overlap_length(
+      request.y,
+      request.height,
+      display.bounds.y,
+      display.bounds.height,
+    )
+    let area = width * height
+    if area > best_area.val {
+      best_area.val = area
+      best.val = Some(display)
+    }
+  }
+  best.val
+}
+
+///|
+/// Returns the display with the greatest intersection with a rectangle.
+#proton.command(contract=get_display_matching_command)
+async fn get_display_matching(
+  context : @proton.CommandContext,
+  request : @screen_monitor_contract.MatchingRectRequest,
+) -> @screen_monitor_contract.DisplayReply {
+  guard request.width > 0 && request.height > 0 else {
+    raise QueryFailed(
+      operation="display_matching",
+      detail="rectangle width and height must be positive",
+    )
+  }
+  let monitor = ensure_monitor()
+  let displays = monitor.displays() catch {
+    error =>
+      raise QueryFailed(operation="display_matching", detail=error.to_string())
+  }
+  let display = matching_display(displays, request).unwrap_or(
+    monitor.primary_display() catch {
+      error =>
+        raise QueryFailed(
+          operation="display_matching",
+          detail=error.to_string(),
+        )
+    },
+  )
+  emit_activity(context, "getDisplayMatching")
   @screen_monitor_contract.DisplayReply::{
     display: display_to_contract(display),
   }

--- a/extensions/screen_monitor/extension_wbtest.mbt
+++ b/extensions/screen_monitor/extension_wbtest.mbt
@@ -4,7 +4,20 @@ test "screen monitor extension identity matches the generated app command extens
   assert_eq(capability.id(), "moonbit-community/proton-screen-monitor")
   let spec = capability.command_spec()
   assert_eq(spec.js_namespace(), "screen")
+  assert_true(spec.op_names().contains("ext:screen/getDisplayMatching"))
   assert_false(spec.op_names().contains("ext:screen/drainEvents"))
   assert_eq(spec.scripts(), [])
   assert_true(capability.event_source() is Some(_))
+}
+
+///|
+test "screen display matching request carries rectangle geometry" {
+  let request = @screen_monitor_contract.MatchingRectRequest::{
+    x: 10,
+    y: 20,
+    width: 300,
+    height: 200,
+  }
+  assert_eq(request.width, 300)
+  assert_eq(request.height, 200)
 }

--- a/sys/screen_monitor/README.mbt.md
+++ b/sys/screen_monitor/README.mbt.md
@@ -8,6 +8,7 @@ The module mirrors Electron's `screen` module:
 - `ScreenMonitor::displays()` — `screen.getAllDisplays()`
 - `ScreenMonitor::primary_display()` — `screen.getPrimaryDisplay()`
 - `ScreenMonitor::display_nearest_point(x, y)` — `screen.getDisplayNearestPoint(...)`
+- `getDisplayMatching(rect)` — display with the greatest rectangle overlap
 - `ScreenMonitor::cursor_point()` — `screen.getCursorScreenPoint()`
 - `DisplayAdded` / `DisplayRemoved` / `DisplayMetricsChanged` events —
   `screen.on('display-added' | 'display-removed' | 'display-metrics-changed')`


### PR DESCRIPTION
## Summary
- add `screen.getDisplayMatching(rect)` to the typed extension
- select the display with the greatest bounds intersection
- fall back to the primary display when the rectangle does not overlap any display
- validate positive rectangle dimensions and update generated routes/tests/docs

## Electron alignment and platform impact
The API mirrors Electron's `screen.getDisplayMatching`. It uses the existing cross-platform display snapshots and introduces no native ABI changes. Coordinates remain physical pixels with a top-left origin, matching the existing screen module contract.

## Validation
- `moon fmt`
- `git diff --check`
- `moon -C extensions test -p moonbit-community/proton_ext moonbit-community/proton_ext/screen_monitor moonbit-community/proton_ext/screen_monitor/contract --target native`
- `node scripts/verify_generated.mjs`

## Known limitation
For rectangles outside all display bounds, Proton returns the primary display as a deterministic fallback.
