### PR TITLE
fix(windows): honor logical window sizes on high-DPI displays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           moon check --target native --deny-warn --warn-list=-20
+          moon -C proton test internal/native/ffi/tests/window_geometry --target native --diagnostic-limit 80
           moon -C package test lib --target native --diagnostic-limit 80
           moon -C codegen test lib --target wasm --diagnostic-limit 80
           moon -C cdp test -p moonbit-community/proton_cdp/client --target native --diagnostic-limit 80

--- a/proton/README.md
+++ b/proton/README.md
@@ -179,6 +179,10 @@ preserving Electron's no-op behavior on macOS and Linux.
 unconstrained, matching Electron.
 `WindowHandle::set_content_size` adjusts the renderer area while accounting for
 the native frame. `content_size` reads that area back in logical pixels.
+Window frame sizes, content sizes, and minimum/maximum size constraints use
+logical pixels on Windows too. Proton converts these lengths using the window's
+current DPI. Initial unconstrained windows are fitted to their monitor's work
+area before they are shown; explicit fixed/minimum size hints take precedence.
 `set_menu` replaces or clears the runtime menu, `set_icon` loads a native icon
 from a file path, and `set_parent` establishes a native owner/transient or modal
 relationship. `set_window_button_visibility` controls standard title-bar buttons

--- a/proton/facade_session.mbt
+++ b/proton/facade_session.mbt
@@ -1882,8 +1882,13 @@ pub fn WindowHandle::center(
 ) -> Unit raise WindowSessionError {
   let state = self.state()
   let monitor = state.monitor
-  let x = monitor.work_x + (monitor.work_width - state.width) / 2
-  let y = monitor.work_y + (monitor.work_height - state.height) / 2
+  let (width, height) = @native.window_size_in_screen_coordinates(
+    state.width,
+    state.height,
+    monitor.scale_factor_percent,
+  )
+  let x = monitor.work_x + (monitor.work_width - width) / 2
+  let y = monitor.work_y + (monitor.work_height - height) / 2
   self.set_position(x, y)
 }
 

--- a/proton/facade_wbtest.mbt
+++ b/proton/facade_wbtest.mbt
@@ -3223,6 +3223,39 @@ test "window center uses the current monitor work area and frame size" {
 }
 
 ///|
+#cfg(platform="windows")
+test "window center converts logical lengths without scaling monitor origins" {
+  let position_calls : Array[(Int, Int)] = []
+  let window = test_window_handle("main", 17L, position_calls~, window_state=WindowState::{
+    x: -3000,
+    y: 100,
+    width: 800,
+    height: 600,
+    monitor: WindowMonitor::{
+      x: -3840,
+      y: 0,
+      width: 3840,
+      height: 2160,
+      work_x: -3840,
+      work_y: 40,
+      work_width: 3840,
+      work_height: 2120,
+      scale_factor_percent: 250,
+    },
+    zoom_percent: 100,
+    visible: true,
+    focused: true,
+    minimized: false,
+    maximized: false,
+    fullscreen: false,
+    always_on_top: false,
+    theme: WindowTheme::Light,
+  })
+  window.center()
+  assert_eq(position_calls, [(-2920, 350)])
+}
+
+///|
 test "window bounds read and write use Electron coordinate order" {
   let position_calls : Array[(Int, Int)] = []
   let size_calls : Array[(Int, Int)] = []

--- a/proton/internal/native/ffi/src/engine/cef_win/win_geometry.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_geometry.h
@@ -1,0 +1,56 @@
+#ifndef PROTON_WIN_GEOMETRY_H
+#define PROTON_WIN_GEOMETRY_H
+
+#include <limits.h>
+#include <stdint.h>
+#include <windows.h>
+
+/* Only window-local lengths are converted here. Virtual-desktop origins
+ * must not be scaled by an arbitrary monitor's DPI. */
+static inline UINT proton_win_window_dpi(HWND hwnd) {
+  UINT dpi = GetDpiForWindow(hwnd);
+  return dpi != 0 ? dpi : USER_DEFAULT_SCREEN_DPI;
+}
+
+static inline int proton_win_pixels(int logical, UINT dpi) {
+  int64_t pixels = ((int64_t)logical * dpi + 48) / 96;
+  return pixels > INT_MAX ? INT_MAX : (int)pixels;
+}
+
+static inline int proton_win_logical(int pixels, UINT dpi) {
+  return MulDiv(pixels, USER_DEFAULT_SCREEN_DPI, (int)dpi);
+}
+
+/* Fit a new, unconstrained window without assuming the monitor starts at 0,0.
+ * Explicit fixed/minimum size hints take precedence over work-area fitting. */
+static inline RECT proton_win_initial_rect(RECT frame, RECT work, int width,
+                                           int height, int size_hint) {
+  if (size_hint != 1 && size_hint != 2) {
+    width = min(width, work.right - work.left);
+    height = min(height, work.bottom - work.top);
+  }
+  frame.left = max(work.left, min(frame.left, work.right - width));
+  frame.top = max(work.top, min(frame.top, work.bottom - height));
+  frame.right = frame.left + width;
+  frame.bottom = frame.top + height;
+  return frame;
+}
+
+static inline BOOL proton_win_initialize_geometry(HWND hwnd, int width,
+                                                  int height, int size_hint) {
+  UINT dpi = proton_win_window_dpi(hwnd);
+  RECT frame;
+  MONITORINFO info = {.cbSize = sizeof(MONITORINFO)};
+  HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+  if (!GetWindowRect(hwnd, &frame) || !GetMonitorInfoW(monitor, &info)) {
+    return FALSE;
+  }
+  frame =
+      proton_win_initial_rect(frame, info.rcWork, proton_win_pixels(width, dpi),
+                              proton_win_pixels(height, dpi), size_hint);
+  return SetWindowPos(hwnd, NULL, frame.left, frame.top,
+                      frame.right - frame.left, frame.bottom - frame.top,
+                      SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+#endif

--- a/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_internal.h
@@ -66,6 +66,8 @@ struct proton_engine_window {
   proton_bridge_config_t *bridge_config;
   int32_t max_bridge_payload_bytes;
   proton_engine_bridge_lifecycle_t bridge_lifecycle;
+  /* Logical frame dimensions, including fixed-size tracking constraints.
+   * HWND/CEF rectangles and saved WINDOWPLACEMENT remain physical pixels. */
   int width;
   int height;
   int headless;

--- a/proton/internal/native/ffi/src/engine/cef_win/win_window.c
+++ b/proton/internal/native/ffi/src/engine/cef_win/win_window.c
@@ -1,6 +1,7 @@
 #if defined(_WIN32)
 
 #include "win_internal.h"
+#include "win_geometry.h"
 #include "../../proton_config.h"
 #include "../../proton_event.h"
 
@@ -213,6 +214,7 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
   case WM_GETMINMAXINFO:
     if (window != NULL) {
       bool handled = false;
+      UINT dpi = proton_win_window_dpi(hwnd);
       MINMAXINFO *minmax = (MINMAXINFO *)lparam;
       if (window->titlebar_overlay) {
       HMONITOR monitor =
@@ -233,23 +235,23 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
         }
       }
       if (!window->resizable) {
-        minmax->ptMinTrackSize.x = window->width;
-        minmax->ptMinTrackSize.y = window->height;
+        minmax->ptMinTrackSize.x = proton_win_pixels(window->width, dpi);
+        minmax->ptMinTrackSize.y = proton_win_pixels(window->height, dpi);
         handled = true;
       }
       if (window->resizable && window->min_width > 0) {
-        minmax->ptMinTrackSize.x = window->min_width;
-        minmax->ptMinTrackSize.y = window->min_height;
+        minmax->ptMinTrackSize.x = proton_win_pixels(window->min_width, dpi);
+        minmax->ptMinTrackSize.y = proton_win_pixels(window->min_height, dpi);
         handled = true;
       }
       if (window->resizable && window->max_width > 0) {
-        minmax->ptMaxTrackSize.x = window->max_width;
-        minmax->ptMaxTrackSize.y = window->max_height;
+        minmax->ptMaxTrackSize.x = proton_win_pixels(window->max_width, dpi);
+        minmax->ptMaxTrackSize.y = proton_win_pixels(window->max_height, dpi);
         handled = true;
       }
       if (!window->resizable) {
-        minmax->ptMaxTrackSize.x = window->width;
-        minmax->ptMaxTrackSize.y = window->height;
+        minmax->ptMaxTrackSize.x = proton_win_pixels(window->width, dpi);
+        minmax->ptMaxTrackSize.y = proton_win_pixels(window->height, dpi);
         handled = true;
       }
       if (handled) {
@@ -262,13 +264,15 @@ static LRESULT CALLBACK proton_engine_window_proc(HWND hwnd,
       proton_engine_signal_wait_source(window->runtime,
                                        PROTON_WAIT_PLATFORM);
     }
-    if (window != NULL && window->titlebar_overlay) {
+    if (window != NULL) {
       RECT *suggested = (RECT *)lparam;
       SetWindowPos(hwnd, NULL, suggested->left, suggested->top,
                    suggested->right - suggested->left,
                    suggested->bottom - suggested->top,
                    SWP_NOZORDER | SWP_NOACTIVATE);
-      proton_engine_overlay_apply_frame(hwnd);
+      if (window->titlebar_overlay) {
+        proton_engine_overlay_apply_frame(hwnd);
+      }
       RECT client;
       if (GetClientRect(hwnd, &client)) {
         proton_engine_resize_browser(window, client.right - client.left,
@@ -768,6 +772,22 @@ int32_t proton_engine_window_create(
       proton_internal_bridge_config_destroy(window->bridge_config);
       free(window);
       proton_engine_set_message(error, error_len, "window creation failed");
+      return PROTON_ERR_PLATFORM;
+    }
+    /* CreateWindowEx chooses the monitor while the window is still hidden.
+     * Resolve its actual DPI before showing it; CEF/Win32 use physical pixels,
+     * whereas the application config and size constraints use logical pixels. */
+    if (!proton_win_initialize_geometry(window->hwnd, config.width,
+                                         config.height, config.size_hint)) {
+      DestroyWindow(window->hwnd);
+      window->hwnd = NULL;
+      proton_browser_lifecycle_creation_failed(window->browser_lifecycle);
+      proton_browser_lifecycle_clear_owner(window->browser_lifecycle);
+      proton_browser_session_destroy(window->browser_session);
+      proton_internal_bridge_config_destroy(window->bridge_config);
+      free(window);
+      proton_engine_set_message(error, error_len,
+                                "failed to initialize window geometry");
       return PROTON_ERR_PLATFORM;
     }
     proton_engine_window_refresh_non_client_theme(window, 0);
@@ -1421,13 +1441,23 @@ int32_t proton_engine_window_set_size(proton_engine_window_t *window,
                               "width and height must be positive");
     return PROTON_ERR_INVALID_ARGUMENT;
   }
+  int previous_width = window->width;
+  int previous_height = window->height;
   window->width = width;
   window->height = height;
   if (window->headless) {
     proton_engine_resize_browser(window, width, height);
   } else {
-    SetWindowPos(window->hwnd, NULL, 0, 0, width, height,
-                 SWP_NOMOVE | SWP_NOZORDER);
+    UINT dpi = proton_win_window_dpi(window->hwnd);
+    if (!SetWindowPos(window->hwnd, NULL, 0, 0,
+                       proton_win_pixels(width, dpi),
+                       proton_win_pixels(height, dpi),
+                       SWP_NOMOVE | SWP_NOZORDER)) {
+      window->width = previous_width;
+      window->height = previous_height;
+      proton_engine_set_message(error, error_len, "failed to resize window");
+      return PROTON_ERR_PLATFORM;
+    }
   }
   return PROTON_OK;
 }
@@ -1449,16 +1479,37 @@ int32_t proton_engine_window_set_content_size(
     proton_engine_resize_browser(window, width, height);
     return PROTON_OK;
   }
-  RECT desired = {0, 0, width, height};
-  DWORD style = (DWORD)GetWindowLongPtrW(window->hwnd, GWL_STYLE);
-  DWORD ex_style = (DWORD)GetWindowLongPtrW(window->hwnd, GWL_EXSTYLE);
-  if (!AdjustWindowRectEx(&desired, style, FALSE, ex_style)) {
-    proton_engine_set_message(error, error_len, "failed to calculate window frame");
+  UINT dpi = proton_win_window_dpi(window->hwnd);
+  RECT frame, client;
+  /* Measure the current non-client area, including a menu and the custom
+   * overlay frame. AdjustWindowRectEx would add a caption the overlay removes. */
+  if (!GetWindowRect(window->hwnd, &frame) ||
+      !GetClientRect(window->hwnd, &client)) {
+    proton_engine_set_message(error, error_len, "failed to read window frame");
     return PROTON_ERR_PLATFORM;
   }
-  return proton_engine_window_set_size(window, desired.right - desired.left,
-                                       desired.bottom - desired.top, error,
-                                       error_len);
+  int64_t desired_width = (int64_t)proton_win_pixels(width, dpi) +
+                          (frame.right - frame.left) - (client.right - client.left);
+  int64_t desired_height = (int64_t)proton_win_pixels(height, dpi) +
+                           (frame.bottom - frame.top) - (client.bottom - client.top);
+  if (desired_width > INT_MAX || desired_height > INT_MAX) {
+    proton_engine_set_message(error, error_len, "content size exceeds window limits");
+    return PROTON_ERR_INVALID_ARGUMENT;
+  }
+  int frame_width = (int)desired_width;
+  int frame_height = (int)desired_height;
+  int previous_width = window->width;
+  int previous_height = window->height;
+  window->width = proton_win_logical(frame_width, dpi);
+  window->height = proton_win_logical(frame_height, dpi);
+  if (!SetWindowPos(window->hwnd, NULL, 0, 0, frame_width, frame_height,
+                     SWP_NOMOVE | SWP_NOZORDER)) {
+    window->width = previous_width;
+    window->height = previous_height;
+    proton_engine_set_message(error, error_len, "failed to resize content area");
+    return PROTON_ERR_PLATFORM;
+  }
+  return PROTON_OK;
 }
 
 int32_t proton_engine_window_get_content_size(
@@ -1478,8 +1529,9 @@ int32_t proton_engine_window_get_content_size(
     proton_engine_set_message(error, error_len, "failed to read client area");
     return PROTON_ERR_PLATFORM;
   }
-  *out_width = rect.right - rect.left;
-  *out_height = rect.bottom - rect.top;
+  UINT dpi = proton_win_window_dpi(window->hwnd);
+  *out_width = proton_win_logical(rect.right - rect.left, dpi);
+  *out_height = proton_win_logical(rect.bottom - rect.top, dpi);
   return PROTON_OK;
 }
 
@@ -1637,8 +1689,9 @@ int32_t proton_engine_window_apply(
                                   "failed to read current window frame");
         return PROTON_ERR_PLATFORM;
       }
-      window->width = frame.right - frame.left;
-      window->height = frame.bottom - frame.top;
+      UINT dpi = proton_win_window_dpi(window->hwnd);
+      window->width = proton_win_logical(frame.right - frame.left, dpi);
+      window->height = proton_win_logical(frame.bottom - frame.top, dpi);
     }
     DWORD style = window->fullscreen
                       ? window->windowed_style
@@ -1886,8 +1939,9 @@ int32_t proton_engine_window_get_state(
   }
   out_state->x = frame.left;
   out_state->y = frame.top;
-  out_state->width = frame.right - frame.left;
-  out_state->height = frame.bottom - frame.top;
+  UINT dpi = proton_win_window_dpi(window->hwnd);
+  out_state->width = proton_win_logical(frame.right - frame.left, dpi);
+  out_state->height = proton_win_logical(frame.bottom - frame.top, dpi);
   out_state->monitor_x = info.rcMonitor.left;
   out_state->monitor_y = info.rcMonitor.top;
   out_state->monitor_width = info.rcMonitor.right - info.rcMonitor.left;
@@ -1896,7 +1950,6 @@ int32_t proton_engine_window_get_state(
   out_state->work_y = info.rcWork.top;
   out_state->work_width = info.rcWork.right - info.rcWork.left;
   out_state->work_height = info.rcWork.bottom - info.rcWork.top;
-  UINT dpi = GetDpiForWindow(window->hwnd);
   out_state->scale_factor_percent =
       dpi > 0 ? (int32_t)((dpi * 100 + 48) / 96) : 100;
   out_state->visible = IsWindowVisible(window->hwnd) ? 1 : 0;

--- a/proton/internal/native/ffi/tests/window_geometry/moon.pkg
+++ b/proton/internal/native/ffi/tests/window_geometry/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/proton/internal/native/ffi",
+} for "wbtest"
+
+supported_targets = "native"
+
+options(
+  "native-stub": [ "window_geometry_test.c" ],
+  link: {
+    "native": { "stub-cc-flags": "${build.PROTON_NATIVE_STUB_CC_FLAGS}" },
+  },
+)

--- a/proton/internal/native/ffi/tests/window_geometry/pkg.generated.mbti
+++ b/proton/internal/native/ffi/tests/window_geometry/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbit-community/proton/internal/native/ffi/tests/window_geometry"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/proton/internal/native/ffi/tests/window_geometry/window_geometry_test.c
+++ b/proton/internal/native/ffi/tests/window_geometry/window_geometry_test.c
@@ -1,0 +1,146 @@
+#if defined(_WIN32)
+
+#include "../../src/engine/cef_win/win_geometry.h"
+#include "../../src/engine/cef_win/win_internal.h"
+
+/* Return the failing C line to the MoonBit assertion, preserving fixture
+ * cleanup. */
+#define CHECK(condition)                                                       \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      result = __LINE__;                                                       \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+int32_t proton_test_window_dpi_conversion(void) {
+  int result = 0;
+  const UINT dpis[] = {96, 144, 240};
+  const int widths[] = {1120, 1680, 2800};
+  const int heights[] = {760, 1140, 1900};
+  for (int i = 0; i < 3; ++i) {
+    CHECK(proton_win_pixels(1120, dpis[i]) == widths[i]);
+    CHECK(proton_win_pixels(760, dpis[i]) == heights[i]);
+    CHECK(proton_win_logical(widths[i], dpis[i]) == 1120);
+    CHECK(proton_win_logical(heights[i], dpis[i]) == 760);
+    CHECK(proton_win_logical(proton_win_pixels(503, dpis[i]), dpis[i]) == 503);
+  }
+  CHECK(proton_win_pixels(INT_MAX, 240) == INT_MAX);
+cleanup:
+  return result;
+}
+
+int32_t proton_test_window_initial_placement(void) {
+  int result = 0;
+  RECT work = {-1920, 40, 0, 1080};
+  RECT frame = {-200, 800, 920, 1560};
+  RECT fitted = proton_win_initial_rect(frame, work, 2800, 1900, 0);
+  CHECK(EqualRect(&fitted, &work));
+  fitted = proton_win_initial_rect(frame, work, 600, 400, 0);
+  CHECK(fitted.left == -600 && fitted.top == 680);
+  CHECK(fitted.right == 0 && fitted.bottom == 1080);
+  fitted = proton_win_initial_rect(frame, work, 2800, 1900, 1);
+  CHECK(fitted.right - fitted.left == 2800);
+  CHECK(fitted.bottom - fitted.top == 1900);
+  fitted = proton_win_initial_rect(frame, work, 2800, 1900, 2);
+  CHECK(fitted.right - fitted.left == 2800);
+  fitted = proton_win_initial_rect(frame, work, 2800, 1900, 3);
+  CHECK(EqualRect(&fitted, &work));
+cleanup:
+  return result;
+}
+
+static LRESULT CALLBACK geometry_window_proc(HWND hwnd, UINT message,
+                                             WPARAM wparam, LPARAM lparam) {
+  if (message == WM_NCCREATE) {
+    CREATESTRUCTW *create = (CREATESTRUCTW *)lparam;
+    SetWindowLongPtrW(hwnd, GWLP_USERDATA, (LONG_PTR)create->lpCreateParams);
+  }
+  if (message == WM_NCCALCSIZE && wparam == TRUE &&
+      GetWindowLongPtrW(hwnd, GWLP_USERDATA) != 0) {
+    NCCALCSIZE_PARAMS *params = (NCCALCSIZE_PARAMS *)lparam;
+    LONG top = params->rgrc[0].top;
+    LRESULT result = DefWindowProcW(hwnd, message, wparam, lparam);
+    if (result != 0)
+      return result;
+    params->rgrc[0].top = top;
+    return 0;
+  }
+  return DefWindowProcW(hwnd, message, wparam, lparam);
+}
+
+int32_t proton_test_window_native_sizes(int32_t overlay) {
+  int result = 0;
+  HWND hwnd = NULL;
+  ATOM window_class = 0;
+  HINSTANCE instance = GetModuleHandleW(NULL);
+  DPI_AWARENESS_CONTEXT previous =
+      SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+  CHECK(previous != NULL);
+  WNDCLASSW cls = {0};
+  cls.lpfnWndProc = geometry_window_proc;
+  cls.hInstance = instance;
+  cls.lpszClassName = L"ProtonWindowGeometryTest";
+  window_class = RegisterClassW(&cls);
+  CHECK(window_class != 0);
+  hwnd = CreateWindowExW(0, cls.lpszClassName, L"Proton geometry test",
+                         WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 400,
+                         300, NULL, NULL, instance, (void *)(INT_PTR)overlay);
+  CHECK(hwnd != NULL);
+  UINT dpi = GetDpiForWindow(hwnd);
+  CHECK(dpi >= 96);
+  CHECK(proton_win_initialize_geometry(hwnd, 1120, 760, 0));
+  CHECK(!IsWindowVisible(hwnd));
+  MONITORINFO info = {.cbSize = sizeof(MONITORINFO)};
+  CHECK(GetMonitorInfoW(MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST),
+                        &info));
+  RECT frame, client;
+  CHECK(GetWindowRect(hwnd, &frame));
+  CHECK(frame.right - frame.left == min(proton_win_pixels(1120, dpi),
+                                        info.rcWork.right - info.rcWork.left));
+  CHECK(frame.bottom - frame.top ==
+        min(proton_win_pixels(760, dpi), info.rcWork.bottom - info.rcWork.top));
+  CHECK(frame.left >= info.rcWork.left && frame.right <= info.rcWork.right);
+  CHECK(frame.top >= info.rcWork.top && frame.bottom <= info.rcWork.bottom);
+
+  proton_engine_window_t window = {0};
+  window.hwnd = hwnd;
+  window.resizable = 1;
+  window.titlebar_overlay = overlay;
+  char error[256] = {0};
+  CHECK(proton_engine_window_set_size(&window, 640, 480, error,
+                                      sizeof(error)) == PROTON_OK);
+  CHECK(GetWindowRect(hwnd, &frame));
+  CHECK(frame.right - frame.left == proton_win_pixels(640, dpi));
+  CHECK(frame.bottom - frame.top == proton_win_pixels(480, dpi));
+  proton_engine_window_state_t state;
+  CHECK(proton_engine_window_get_state(&window, &state, error, sizeof(error)) ==
+        PROTON_OK);
+  CHECK(state.width == 640 && state.height == 480);
+
+  CHECK(proton_engine_window_set_content_size(&window, 503, 307, error,
+                                              sizeof(error)) == PROTON_OK);
+  CHECK(GetClientRect(hwnd, &client));
+  CHECK(client.right == proton_win_pixels(503, dpi));
+  CHECK(client.bottom == proton_win_pixels(307, dpi));
+  int32_t width, height;
+  CHECK(proton_engine_window_get_content_size(&window, &width, &height, error,
+                                              sizeof(error)) == PROTON_OK);
+  CHECK(width == 503 && height == 307);
+  /* Repeating a logical-size request must not scale the previous size again. */
+  CHECK(proton_engine_window_set_content_size(&window, 503, 307, error,
+                                              sizeof(error)) == PROTON_OK);
+  RECT repeated;
+  CHECK(GetClientRect(hwnd, &repeated));
+  CHECK(EqualRect(&client, &repeated));
+cleanup:
+  if (hwnd != NULL)
+    DestroyWindow(hwnd);
+  if (window_class != 0)
+    UnregisterClassW(L"ProtonWindowGeometryTest", instance);
+  if (previous != NULL)
+    SetThreadDpiAwarenessContext(previous);
+  return result;
+}
+
+#endif

--- a/proton/internal/native/ffi/tests/window_geometry/window_geometry_wbtest.mbt
+++ b/proton/internal/native/ffi/tests/window_geometry/window_geometry_wbtest.mbt
@@ -1,0 +1,40 @@
+///|
+test "geometry fixture links the native runtime" {
+  assert_eq(@ffi.proton_abi_version_ffi(), 1)
+}
+
+///|
+#cfg(platform="windows")
+extern "C" fn conversion_test() -> Int = "proton_test_window_dpi_conversion"
+
+///|
+#cfg(platform="windows")
+extern "C" fn placement_test() -> Int = "proton_test_window_initial_placement"
+
+///|
+#cfg(platform="windows")
+extern "C" fn native_size_test(overlay : Int) -> Int = "proton_test_window_native_sizes"
+
+///|
+#cfg(platform="windows")
+test "Windows sizes round trip at 100, 150, and 250 percent" {
+  assert_eq(conversion_test(), 0)
+}
+
+///|
+#cfg(platform="windows")
+test "initial placement fits the work area and respects explicit size hints" {
+  assert_eq(placement_test(), 0)
+}
+
+///|
+#cfg(platform="windows")
+test "native window frame and content sizes use logical pixels" {
+  assert_eq(native_size_test(0), 0)
+}
+
+///|
+#cfg(platform="windows")
+test "overlay content sizing measures the actual non-client area" {
+  assert_eq(native_size_test(1), 0)
+}

--- a/proton/internal/native/pkg.generated.mbti
+++ b/proton/internal/native/pkg.generated.mbti
@@ -78,6 +78,8 @@ pub fn update_stage_begin_for_current_app(Int64, UInt64) -> UpdateStage raise Na
 
 pub fn web_contents_view_supported() -> Bool
 
+pub fn window_size_in_screen_coordinates(Int, Int, Int) -> (Int, Int)
+
 // Errors
 pub(all) suberror NativeError {
   Status(status~ : Int, message~ : String)

--- a/proton/internal/native/window_geometry.mbt
+++ b/proton/internal/native/window_geometry.mbt
@@ -1,0 +1,25 @@
+///|
+/// Converts logical frame lengths to the units used by native screen positions.
+/// Windows screen/work-area rectangles remain physical pixels; monitor origins
+/// cannot be divided by the current window's DPI in a mixed-DPI desktop.
+#cfg(platform="windows")
+pub fn window_size_in_screen_coordinates(
+  width : Int,
+  height : Int,
+  scale_factor_percent : Int,
+) -> (Int, Int) {
+  (
+    ((width.to_int64() * scale_factor_percent.to_int64() + 50L) / 100L).to_int(),
+    ((height.to_int64() * scale_factor_percent.to_int64() + 50L) / 100L).to_int(),
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+pub fn window_size_in_screen_coordinates(
+  width : Int,
+  height : Int,
+  _ : Int,
+) -> (Int, Int) {
+  (width, height)
+}


### PR DESCRIPTION
Fixes #287.

On Windows at 250% scaling, an initial 1120 x 760 window was created as 1120 x 760 physical pixels, leaving only about 435 x 298 logical pixels for the renderer. Convert logical frame dimensions using the window's actual DPI before showing it, fitting unconstrained windows to the monitor work area. Explicit fixed/minimum size hints retain precedence.

Apply the same conversion to frame/content size setters and getters and tracking constraints. Measure the live non-client area for content sizing so overlay titlebars do not acquire a phantom native caption. Handle WM_DPICHANGED for both titlebar styles. Preserve existing Windows screen origins/work-area coordinates and convert window lengths when centering, avoiding a new centering regression; broader mixed-DPI virtual-desktop coordinate normalization is outside this change. The public facade signatures are unchanged.

Validation:

- Windows geometry tests: 5/5 passed, including 100%/150%/250% conversion, negative monitor origins, work-area fitting, and real hidden Win32 frame/content sizing at the host's 240 DPI. Added these tests to Windows CI.
- Existing native package tests: 39/39 passed.
- Window centering tests: 2/2 passed, including a 250% monitor at a negative desktop origin.
- Full facade tests: 176/177 passed. The unrelated `temporary path resolution uses platform environment precedence` assertion in facade_app_info_wbtest.mbt compares Windows-normalized backslashes with `/private/tmp/app` and fails on this host; the test and path implementation are unchanged.
- `moon check --target native --deny-warn --warn-list=-20` and `moon fmt --check` passed. Ran `moon -C proton info`; retained only the intended private-native interface addition and the new test package interface. The non-Windows centering helper was also type-checked with its cfg guard temporarily removed, then restored.
- Built examples 01_run, 48_titlebar_overlay and 62_window_size_limits plus the source-matched CEF helper. Real CEF smoke at 240 DPI: 01_run requests 800 x 600 and measures 2000 x 1500 physical pixels; Overlay requests 800 x 520 and measures 2000 x 1300. Test windows were closed afterwards.
- `moon -C e2e run test --target native --diagnostic-limit 80 -- --windowed-close` passed.

Still needs manual validation across monitors with different DPI and after an RDP reconnect. macOS/Linux execution is left to CI. The native dependency build emits an existing async EINVAL macro-redefinition warning on this Windows SDK.
